### PR TITLE
KT-33: witness Telegram reactions as ingress with observe_only default

### DIFF
--- a/crates/cooldis-io-pgqrs/src/lib.rs
+++ b/crates/cooldis-io-pgqrs/src/lib.rs
@@ -18,6 +18,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 const INGRESS_PAYLOAD_KIND: &str = "cooldis.ingress.v1";
 const DEFAULT_QUEUE_NAME: &str = "cooldis-ingress";
+const INGRESS_QUEUE_MAX_OBJECT_DEPTH: usize = 16;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PgqrsQueueConfig {
@@ -76,7 +77,10 @@ impl PgqrsIngressQueue {
     pub async fn connect(config: PgqrsQueueConfig) -> IoResult<Self> {
         ensure_sqlite_file_exists(&config.dsn)?;
 
-        let store = pgqrs::connect(&config.dsn).await.map_err(queue_error)?;
+        let store_config = pgqrs_store_config(&config.dsn);
+        let store = pgqrs::connect_with_config(&store_config)
+            .await
+            .map_err(queue_error)?;
         pgqrs::admin(&store).install().await.map_err(queue_error)?;
 
         match pgqrs::admin(&store).create_queue(&config.queue_name).await {
@@ -84,13 +88,10 @@ impl PgqrsIngressQueue {
             Err(err) => return Err(queue_error(err)),
         }
 
-        let producer = pgqrs::store::Store::producer_ephemeral(
-            &store,
-            &config.queue_name,
-            pgqrs::store::Store::config(&store),
-        )
-        .await
-        .map_err(queue_error)?;
+        let producer =
+            pgqrs::store::Store::producer_ephemeral(&store, &config.queue_name, &store_config)
+                .await
+                .map_err(queue_error)?;
         let consumer = pgqrs::store::Store::consumer_ephemeral(&store, &config.queue_name)
             .await
             .map_err(queue_error)?;
@@ -124,6 +125,13 @@ impl PgqrsIngressQueue {
         )
         .await
     }
+}
+
+fn pgqrs_store_config(dsn: &str) -> pgqrs::Config {
+    let mut config = pgqrs::Config::default();
+    config.dsn = dsn.to_string();
+    config.validation_config.max_object_depth = INGRESS_QUEUE_MAX_OBJECT_DEPTH;
+    config
 }
 
 #[async_trait]

--- a/crates/cooldis-io-telegram/src/lib.rs
+++ b/crates/cooldis-io-telegram/src/lib.rs
@@ -12,7 +12,9 @@ use cooldis_io_core::{
     IngressContent, IngressEnvelope, IngressSink, IoActor, IoAttachment, IoConversation,
     IoDedupeKey, IoError, IoProtocolAdapter, IoProtocolCapabilities, IoResult, IoSource, IoTarget,
 };
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer, de::DeserializeOwned, ser::SerializeStruct,
+};
 use serde_json::{Value as JsonValue, json};
 use std::collections::BTreeMap;
 
@@ -137,6 +139,14 @@ impl TelegramNormalizer {
             )));
         }
 
+        if let Some(reaction) = update.message_reaction.as_ref() {
+            return Ok(Some(self.envelope_from_message_reaction(
+                update.update_id,
+                reaction,
+                received_at_ms,
+            )));
+        }
+
         if let Some(callback) = update.callback_query.as_ref() {
             let Some(message) = callback.message.as_ref() else {
                 return Ok(None);
@@ -187,6 +197,43 @@ impl TelegramNormalizer {
 
         envelope.actor = actor.or_else(|| actor_from_message(message));
         envelope.attachments = message_attachments(message);
+        envelope
+    }
+
+    fn envelope_from_message_reaction(
+        &self,
+        update_id: i64,
+        reaction: &TelegramMessageReactionUpdated,
+        received_at_ms: u64,
+    ) -> IngressEnvelope {
+        let source = self.source();
+        let mut envelope = IngressEnvelope::new(
+            source.clone(),
+            conversation_from_chat(&reaction.chat, None),
+            IngressContent::Event {
+                kind: "telegram.message_reaction".to_string(),
+                payload: json!({
+                    "message_id": reaction.message_id,
+                    "old_reaction": reaction.old_reaction,
+                    "new_reaction": reaction.new_reaction,
+                }),
+            },
+            received_at_ms,
+        )
+        .with_dedupe_key(IoDedupeKey::for_source(
+            &source,
+            format!("update:{update_id}"),
+        ))
+        .with_metadata("telegram_update_id", update_id.to_string())
+        .with_metadata("telegram_update_kind", "message_reaction")
+        .with_metadata("telegram_message_id", reaction.message_id.to_string())
+        .with_metadata("telegram_message_date", reaction.date.to_string());
+
+        envelope.actor = reaction
+            .user
+            .as_ref()
+            .map(actor_from_user)
+            .or_else(|| reaction.actor_chat.as_ref().map(actor_from_chat));
         envelope
     }
 }
@@ -466,7 +513,24 @@ pub struct TelegramUpdate {
     #[serde(default)]
     pub edited_channel_post: Option<TelegramMessage>,
     #[serde(default)]
+    pub message_reaction: Option<TelegramMessageReactionUpdated>,
+    #[serde(default)]
     pub callback_query: Option<TelegramCallbackQuery>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct TelegramMessageReactionUpdated {
+    pub chat: TelegramChat,
+    pub message_id: i64,
+    #[serde(default)]
+    pub user: Option<TelegramUser>,
+    #[serde(default)]
+    pub actor_chat: Option<TelegramChat>,
+    pub date: i64,
+    #[serde(default)]
+    pub old_reaction: Vec<TelegramReactionType>,
+    #[serde(default)]
+    pub new_reaction: Vec<TelegramReactionType>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -597,10 +661,65 @@ pub struct TelegramSendStickerRequest {
     pub disable_notification: Option<bool>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TelegramReactionType {
     Emoji { emoji: String },
+    CustomEmoji { custom_emoji_id: String },
+    Other(JsonValue),
+}
+
+impl Serialize for TelegramReactionType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Emoji { emoji } => {
+                let mut state = serializer.serialize_struct("TelegramReactionType", 2)?;
+                state.serialize_field("type", "emoji")?;
+                state.serialize_field("emoji", emoji)?;
+                state.end()
+            }
+            Self::CustomEmoji { custom_emoji_id } => {
+                let mut state = serializer.serialize_struct("TelegramReactionType", 2)?;
+                state.serialize_field("type", "custom_emoji")?;
+                state.serialize_field("custom_emoji_id", custom_emoji_id)?;
+                state.end()
+            }
+            Self::Other(value) => value.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for TelegramReactionType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = JsonValue::deserialize(deserializer)?;
+        if let Some(object) = value.as_object() {
+            match object.get("type").and_then(JsonValue::as_str) {
+                Some("emoji") if object.len() == 2 => {
+                    if let Some(emoji) = object.get("emoji").and_then(JsonValue::as_str) {
+                        return Ok(Self::Emoji {
+                            emoji: emoji.to_string(),
+                        });
+                    }
+                }
+                Some("custom_emoji") if object.len() == 2 => {
+                    if let Some(custom_emoji_id) =
+                        object.get("custom_emoji_id").and_then(JsonValue::as_str)
+                    {
+                        return Ok(Self::CustomEmoji {
+                            custom_emoji_id: custom_emoji_id.to_string(),
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(Self::Other(value))
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -1147,6 +1266,196 @@ mod tests {
                 .map(String::as_str),
             Some("callback_query")
         );
+    }
+
+    #[test]
+    fn normalizes_message_reaction_as_event() {
+        let update: TelegramUpdate = serde_json::from_value(json!({
+            "update_id": 1002,
+            "message_reaction": {
+                "chat": {
+                    "id": 123,
+                    "type": "private",
+                    "first_name": "Ada"
+                },
+                "message_id": 555,
+                "user": {
+                    "id": 44,
+                    "is_bot": false,
+                    "first_name": "Lin",
+                    "username": "lin"
+                },
+                "date": 1777000003,
+                "old_reaction": [
+                    { "type": "emoji", "emoji": "👍" }
+                ],
+                "new_reaction": [
+                    { "type": "custom_emoji", "custom_emoji_id": "custom-1" },
+                    { "type": "emoji", "emoji": "❤️" }
+                ]
+            }
+        }))
+        .unwrap();
+
+        let envelope = TelegramNormalizer::new("main")
+            .normalize_update(&update, 1)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            envelope
+                .actor
+                .as_ref()
+                .map(|actor| actor.external_actor_id.as_str()),
+            Some("telegram:user:44")
+        );
+        assert!(matches!(
+            envelope.content,
+            IngressContent::Event { ref kind, ref payload }
+                if kind == "telegram.message_reaction"
+                    && payload["message_id"] == 555
+                    && payload["old_reaction"] == json!([{ "type": "emoji", "emoji": "👍" }])
+                    && payload["new_reaction"] == json!([
+                        { "type": "custom_emoji", "custom_emoji_id": "custom-1" },
+                        { "type": "emoji", "emoji": "❤️" }
+                    ])
+        ));
+        assert_eq!(
+            envelope
+                .metadata
+                .get("telegram_update_kind")
+                .map(String::as_str),
+            Some("message_reaction")
+        );
+        assert_eq!(
+            envelope
+                .metadata
+                .get("telegram_message_id")
+                .map(String::as_str),
+            Some("555")
+        );
+    }
+
+    #[test]
+    fn message_reaction_unknown_reaction_type_stays_opaque() {
+        let update: TelegramUpdate = serde_json::from_value(json!({
+            "update_id": 1003,
+            "message_reaction": {
+                "chat": { "id": 123, "type": "private" },
+                "message_id": 556,
+                "date": 1777000004,
+                "old_reaction": [],
+                "new_reaction": [
+                    {
+                        "type": "paid",
+                        "emoji": "⭐",
+                        "amount": 1
+                    }
+                ]
+            }
+        }))
+        .unwrap();
+
+        let envelope = TelegramNormalizer::new("main")
+            .normalize_update(&update, 1)
+            .unwrap()
+            .unwrap();
+
+        assert!(matches!(
+            envelope.content,
+            IngressContent::Event { ref kind, ref payload }
+                if kind == "telegram.message_reaction"
+                    && payload["new_reaction"] == json!([
+                        {
+                            "type": "paid",
+                            "emoji": "⭐",
+                            "amount": 1
+                        }
+            ])
+        ));
+    }
+
+    #[test]
+    fn message_reaction_missing_actor_and_unknown_chat_type_still_normalizes() {
+        let update: TelegramUpdate = serde_json::from_value(json!({
+            "update_id": 1004,
+            "message_reaction": {
+                "chat": { "id": 123, "type": "forumish" },
+                "message_id": 557,
+                "date": 1777000005,
+                "old_reaction": [],
+                "new_reaction": []
+            }
+        }))
+        .unwrap();
+
+        let envelope = TelegramNormalizer::new("main")
+            .normalize_update(&update, 1)
+            .unwrap()
+            .unwrap();
+
+        assert!(envelope.actor.is_none());
+        assert_eq!(envelope.conversation.kind, ConversationKind::Group);
+        assert_eq!(
+            envelope
+                .conversation
+                .metadata
+                .get("telegram_chat_type")
+                .map(String::as_str),
+            Some("forumish")
+        );
+        assert!(matches!(
+            envelope.content,
+            IngressContent::Event { ref kind, ref payload }
+                if kind == "telegram.message_reaction"
+                    && payload["old_reaction"] == json!([])
+                    && payload["new_reaction"] == json!([])
+        ));
+    }
+
+    #[test]
+    fn message_reaction_emoji_egress_serializes_in_derived_field_order() {
+        let request = TelegramSetMessageReactionRequest {
+            chat_id: TelegramChatId::Id(123),
+            message_id: 555,
+            reaction: vec![TelegramReactionType::Emoji {
+                emoji: "👍".to_string(),
+            }],
+        };
+
+        assert_eq!(
+            serde_json::to_string(&request).unwrap(),
+            r#"{"chat_id":123,"message_id":555,"reaction":[{"type":"emoji","emoji":"👍"}]}"#
+        );
+    }
+
+    #[test]
+    fn message_reaction_other_round_trips_opaque_json() {
+        let source = json!({
+            "type": "paid",
+            "emoji": "⭐",
+            "amount": 1,
+            "nested": { "ok": true }
+        });
+
+        let reaction: TelegramReactionType = serde_json::from_value(source.clone()).unwrap();
+
+        assert!(matches!(reaction, TelegramReactionType::Other(_)));
+        assert_eq!(serde_json::to_value(&reaction).unwrap(), source);
+    }
+
+    #[test]
+    fn message_reaction_known_type_with_extra_fields_stays_opaque() {
+        let source = json!({
+            "type": "emoji",
+            "emoji": "👍",
+            "future_field": "kept"
+        });
+
+        let reaction: TelegramReactionType = serde_json::from_value(source.clone()).unwrap();
+
+        assert!(matches!(reaction, TelegramReactionType::Other(_)));
+        assert_eq!(serde_json::to_value(&reaction).unwrap(), source);
     }
 
     #[test]

--- a/crates/cooldis-kernel/src/daemon/daemon_config.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_config.rs
@@ -9,6 +9,18 @@ use std::path::{Path, PathBuf};
 const DEFAULT_SQLITE_QUEUE_PATH: &str = ".cooldis/queue/ingress.sqlite";
 const DEFAULT_SERVICE_LABEL: &str = "com.cooldis.daemon";
 const DEFAULT_TELEGRAM_WEBHOOK_PATH: &str = "/telegram";
+const ROUTE_POLICY_VALUES: &[&str] = &[
+    "queue_per_conversation",
+    "observe_only",
+    "reject",
+    "steer",
+    "steer_when_active",
+    "interrupt",
+    "interrupt_on_new_dm",
+    "fork",
+    "fork_on_new_dm",
+    "coalesce_bursts",
+];
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LoadedCooldisDaemonConfig {
@@ -367,6 +379,8 @@ pub struct CooldisIoRouteConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reaction_policy: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub threading: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_ref: Option<String>,
@@ -412,9 +426,28 @@ impl CooldisIoRouteConfig {
         if let Some(ingress) = &self.ingress {
             ingress.validate(&format!("io.routes.{}", self.id), errors);
         }
+        if let Some(policy) = &self.policy {
+            validate_route_policy(&format!("io.routes.{}", self.id), "policy", policy, errors);
+        }
+        if let Some(policy) = &self.reaction_policy {
+            validate_route_policy(
+                &format!("io.routes.{}", self.id),
+                "reaction_policy",
+                policy,
+                errors,
+            );
+        }
         if self.policy.as_deref() == Some("coalesce_bursts") && self.coalesce_bursts.is_none() {
             errors.push(format!(
                 "io.routes.{}.policy coalesce_bursts requires coalesce_bursts config",
+                self.id
+            ));
+        }
+        if self.reaction_policy.as_deref() == Some("coalesce_bursts")
+            && self.coalesce_bursts.is_none()
+        {
+            errors.push(format!(
+                "io.routes.{}.reaction_policy coalesce_bursts requires coalesce_bursts config",
                 self.id
             ));
         }
@@ -471,6 +504,16 @@ impl CooldisIoRouteConfig {
             ingress.resolve_paths(base);
         }
     }
+}
+
+fn validate_route_policy(scope: &str, field: &str, policy: &str, errors: &mut Vec<String>) {
+    if ROUTE_POLICY_VALUES.contains(&policy) {
+        return;
+    }
+    errors.push(format!(
+        "{scope}.{field} must be one of {}, got {policy:?}",
+        ROUTE_POLICY_VALUES.join(", ")
+    ));
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/cooldis-kernel/src/daemon/daemon_config/tests.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_config/tests.rs
@@ -113,6 +113,7 @@ fn invalid_egress_projection_regex_reports_rule_index() {
         kind: "websocket.tui".to_string(),
         enabled: true,
         policy: None,
+        reaction_policy: None,
         threading: None,
         agent_ref: None,
         coalesce_bursts: None,
@@ -144,6 +145,7 @@ fn validates_route_agent_ref_syntax() {
         kind: "websocket.tui".to_string(),
         enabled: true,
         policy: None,
+        reaction_policy: None,
         threading: None,
         agent_ref: Some("karl-dev".to_string()),
         coalesce_bursts: None,
@@ -172,6 +174,7 @@ fn validates_coalesce_bursts_route_config() {
         kind: "websocket.tui".to_string(),
         enabled: true,
         policy: Some("steer_when_active".to_string()),
+        reaction_policy: None,
         threading: None,
         agent_ref: None,
         coalesce_bursts: Some(CooldisCoalesceBurstsConfig {
@@ -483,6 +486,7 @@ fn validates_bad_queue_and_route_config() {
         kind: "".to_string(),
         enabled: true,
         policy: None,
+        reaction_policy: None,
         threading: None,
         agent_ref: None,
         coalesce_bursts: None,
@@ -575,6 +579,7 @@ fn validates_telegram_route_shape() {
         kind: "telegram.bot".to_string(),
         enabled: true,
         policy: None,
+        reaction_policy: None,
         threading: None,
         agent_ref: None,
         coalesce_bursts: None,
@@ -599,6 +604,34 @@ fn validates_telegram_route_shape() {
 }
 
 #[test]
+fn invalid_reaction_policy_names_field() {
+    let mut config = CooldisDaemonConfig::default();
+    config.io.routes.push(CooldisIoRouteConfig {
+        id: "telegram-main".to_string(),
+        kind: "telegram.bot".to_string(),
+        enabled: false,
+        policy: None,
+        reaction_policy: Some("wake_everything".to_string()),
+        agent_ref: None,
+        threading: None,
+        coalesce_bursts: None,
+        ingress: None,
+        egress_projection: Vec::new(),
+        typing_simulation: None,
+        egress_retry: CooldisEgressRetryConfig::default(),
+        telegram: None,
+        metadata: BTreeMap::new(),
+    });
+
+    let errors = config.validation_errors();
+
+    assert!(errors.iter().any(|error| {
+        error.contains("io.routes.telegram-main.reaction_policy")
+            && error.contains("wake_everything")
+    }));
+}
+
+#[test]
 fn validates_single_clock_tick_route() {
     let mut config = CooldisDaemonConfig::default();
     for id in ["clock-main", "clock-backup"] {
@@ -607,6 +640,7 @@ fn validates_single_clock_tick_route() {
             kind: "clock.tick".to_string(),
             enabled: true,
             policy: None,
+            reaction_policy: None,
             threading: None,
             agent_ref: None,
             coalesce_bursts: None,

--- a/crates/cooldis-kernel/src/daemon/daemon_io.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_io.rs
@@ -21,7 +21,7 @@ use cooldis_io_core::{
     IoResult, IoTarget, IoTurnInput, KernelIoBridge, KernelIoReceipt, LeasedIngressEnvelope,
     ProviderPolicy, ResolvedIoTarget, ThreadAddress,
 };
-use cooldis_io_telegram::{TelegramUpdate, TelegramWebhookAdapter};
+use cooldis_io_telegram::{TELEGRAM_PROTOCOL, TelegramUpdate, TelegramWebhookAdapter};
 use regex::{Captures, Regex};
 use rusqlite::{OptionalExtension, params};
 use serde::{Deserialize, Serialize};
@@ -864,12 +864,15 @@ impl CooldisDaemonIoBridge {
     ) -> IoResult<AdmissionDecision> {
         let input = IoTurnInput::from_envelope(envelope, target);
         let turn_id = format!("turn-{}", uuid::Uuid::now_v7());
-        match envelope
+        let policy = envelope
             .metadata
             .get("cooldis_route_policy")
             .map(String::as_str)
-            .unwrap_or("queue_per_conversation")
-        {
+            .unwrap_or("queue_per_conversation");
+        match policy {
+            "queue_per_conversation" | "coalesce_bursts" => {
+                Ok(AdmissionDecision::queue(turn_id, input))
+            }
             "observe_only" => Ok(AdmissionDecision::ObserveOnly {
                 reason: "route policy observe_only".to_string(),
             }),
@@ -894,7 +897,7 @@ impl CooldisDaemonIoBridge {
                 child_key: turn_id,
                 input,
             }),
-            _ => Ok(AdmissionDecision::queue(turn_id, input)),
+            other => Err(IoError::Bridge(format!("unknown route policy {other:?}"))),
         }
     }
 
@@ -1885,7 +1888,9 @@ impl IngressSink for DirectRuntimeIngressSink {
 pub struct RouteIngressSink {
     inner: Arc<dyn IngressSink>,
     route_id: String,
+    route_kind: String,
     policy: Option<String>,
+    reaction_policy: Option<String>,
     threading: Option<String>,
     agent_ref: Option<String>,
     coalesce_bursts: Option<CooldisCoalesceBurstsConfig>,
@@ -1896,7 +1901,9 @@ impl RouteIngressSink {
         Self {
             inner,
             route_id: route.id.clone(),
+            route_kind: route.kind.clone(),
             policy: route.policy.clone(),
+            reaction_policy: route.reaction_policy.clone(),
             threading: route.threading.clone(),
             agent_ref: route.agent_ref.clone(),
             coalesce_bursts: route.coalesce_bursts,
@@ -1910,10 +1917,17 @@ impl IngressSink for RouteIngressSink {
         envelope
             .metadata
             .insert("cooldis_route_id".to_string(), self.route_id.clone());
-        if let Some(policy) = &self.policy {
+        let is_reaction = self.route_kind == TELEGRAM_PROTOCOL
+            && is_telegram_message_reaction_envelope(&envelope);
+        let effective_policy = if is_reaction {
+            Some(self.reaction_policy.as_deref().unwrap_or("observe_only"))
+        } else {
+            self.policy.as_deref()
+        };
+        if let Some(policy) = effective_policy {
             envelope
                 .metadata
-                .insert("cooldis_route_policy".to_string(), policy.clone());
+                .insert("cooldis_route_policy".to_string(), policy.to_string());
         }
         if let Some(threading) = &self.threading {
             envelope
@@ -1925,7 +1939,9 @@ impl IngressSink for RouteIngressSink {
                 .metadata
                 .insert(ROUTE_AGENT_REF_METADATA.to_string(), agent_ref.clone());
         }
-        if let Some(coalesce) = self.coalesce_bursts {
+        if route_coalesce_applies(effective_policy)
+            && let Some(coalesce) = self.coalesce_bursts
+        {
             envelope
                 .metadata
                 .insert("cooldis_coalesce_bursts".to_string(), "true".to_string());
@@ -1940,6 +1956,22 @@ impl IngressSink for RouteIngressSink {
         }
         self.inner.submit(envelope).await
     }
+}
+
+fn route_coalesce_applies(policy: Option<&str>) -> bool {
+    !matches!(policy, Some("observe_only" | "reject"))
+}
+
+fn is_telegram_message_reaction_envelope(envelope: &IngressEnvelope) -> bool {
+    envelope.source.protocol == TELEGRAM_PROTOCOL
+        && matches!(
+            &envelope.content,
+            IngressContent::Event { kind, .. } if kind == "telegram.message_reaction"
+        )
+        && envelope
+            .metadata
+            .get("telegram_update_kind")
+            .is_some_and(|kind| kind == "message_reaction")
 }
 
 pub struct CooldisDaemonQueueWorker {

--- a/crates/cooldis-kernel/src/daemon/daemon_io/tests.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_io/tests.rs
@@ -180,6 +180,36 @@ fn telegram_queue_envelope_with_update(text: &str, update_id: &str) -> IngressEn
     .with_metadata("telegram_message_id", "555")
 }
 
+fn telegram_message_reaction_update(
+    update_id: i64,
+    message_id: i64,
+    emoji: &str,
+) -> TelegramUpdate {
+    serde_json::from_value(json!({
+        "update_id": update_id,
+        "message_reaction": {
+            "chat": {
+                "id": 123,
+                "type": "private",
+                "first_name": "Ada"
+            },
+            "message_id": message_id,
+            "user": {
+                "id": 42,
+                "is_bot": false,
+                "first_name": "Ada",
+                "username": "ada"
+            },
+            "date": 1777000000,
+            "old_reaction": [],
+            "new_reaction": [
+                { "type": "emoji", "emoji": emoji }
+            ]
+        }
+    }))
+    .unwrap()
+}
+
 fn coalesce_envelope(
     text: &str,
     update_id: &str,
@@ -307,6 +337,7 @@ fn route_with_egress_and_retry(
         kind: "telegram.bot".to_string(),
         enabled: true,
         policy: None,
+        reaction_policy: None,
         threading: None,
         agent_ref: None,
         coalesce_bursts: None,
@@ -857,6 +888,28 @@ async fn wait_for_user_text(
     }
 }
 
+async fn wait_for_user_text_containing(
+    bridge: &CooldisDaemonIoBridge,
+    coordinates: &ThreadCoordinates,
+    expected: &str,
+) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        if user_texts_for(bridge, coordinates)
+            .await
+            .iter()
+            .any(|text| text.contains(expected))
+        {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for user text containing {expected:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
 fn admission_source_ids(event: &crate::EventRecord) -> Vec<String> {
     event.payload["source_ingress_event_ids"]
         .as_array()
@@ -1392,6 +1445,203 @@ async fn queue_worker_processes_sqlite_backed_envelope() {
         EgressKind::AssistantMessage { ref text } if text.contains("hello queue")
     ));
     let _ = std::fs::remove_file(db);
+}
+
+#[tokio::test]
+async fn telegram_reaction_ingress_defaults_observe_only_without_turn() {
+    let root = test_root("reaction-observe");
+    let (server, bridge, _rx) = test_bridge_at_root(&root).await;
+    let session_store_path = server.session_store_path().to_path_buf();
+    let mut route = route_with_egress(Vec::new(), None);
+    route.policy = Some("queue_per_conversation".to_string());
+    let sink = Arc::new(RouteIngressSink::new(bridge.direct_sink(), &route));
+    let adapter = TelegramWebhookAdapter::new("main");
+
+    let ack = adapter
+        .submit_update(
+            sink.as_ref(),
+            &telegram_message_reaction_update(7101, 555, "👍"),
+            now_ms(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert!(ack.accepted);
+    let coordinates = only_thread_coordinates(&bridge).await;
+    let control_events = control_events_for(&session_store_path, &coordinates).await;
+    let ingress = control_events
+        .iter()
+        .find(|event| event.kind == crate::EventKind::IoIngressReceived)
+        .unwrap();
+    assert_eq!(ingress.payload["external_message_id"].as_str(), Some("555"));
+    let admission = control_events
+        .iter()
+        .find(|event| event.kind == crate::EventKind::AdmissionDecided)
+        .unwrap();
+    assert_eq!(admission.payload["decision"].as_str(), Some("observe"));
+    let thread_events = thread_events_for(&session_store_path, &coordinates).await;
+    assert_eq!(
+        thread_events
+            .iter()
+            .filter(|event| event.kind == crate::EventKind::TurnSubmitted)
+            .count(),
+        0
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn telegram_reaction_policy_queue_starts_turn_with_event_payload() {
+    let root = test_root("reaction-queue");
+    let (server, bridge, _rx) = test_bridge_at_root(&root).await;
+    let session_store_path = server.session_store_path().to_path_buf();
+    let mut route = route_with_egress(Vec::new(), None);
+    route.policy = Some("observe_only".to_string());
+    route.reaction_policy = Some("queue_per_conversation".to_string());
+    let sink = Arc::new(RouteIngressSink::new(bridge.direct_sink(), &route));
+    let adapter = TelegramWebhookAdapter::new("main");
+
+    let ack = adapter
+        .submit_update(
+            sink.as_ref(),
+            &telegram_message_reaction_update(7102, 556, "❤️"),
+            now_ms(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert!(ack.accepted);
+    let coordinates = only_thread_coordinates(&bridge).await;
+    let control_events = control_events_for(&session_store_path, &coordinates).await;
+    let admission = control_events
+        .iter()
+        .find(|event| event.kind == crate::EventKind::AdmissionDecided)
+        .unwrap();
+    assert_eq!(admission.payload["decision"].as_str(), Some("queue"));
+    wait_for_user_text_containing(&bridge, &coordinates, "telegram.message_reaction").await;
+    wait_for_user_text_containing(&bridge, &coordinates, "\"message_id\":556").await;
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn telegram_reaction_policy_does_not_change_message_updates() {
+    let envelopes = Arc::new(TokioMutex::new(Vec::new()));
+    let capture = Arc::new(CaptureSink {
+        envelopes: envelopes.clone(),
+    });
+    let mut route = route_with_egress(Vec::new(), None);
+    route.policy = Some("queue_per_conversation".to_string());
+    route.reaction_policy = Some("observe_only".to_string());
+    let sink = RouteIngressSink::new(capture, &route);
+
+    sink.submit(
+        telegram_queue_envelope("ordinary").with_metadata("telegram_update_kind", "message"),
+    )
+    .await
+    .unwrap();
+
+    let captured = envelopes.lock().await;
+    assert_eq!(
+        captured[0]
+            .metadata
+            .get("cooldis_route_policy")
+            .map(String::as_str),
+        Some("queue_per_conversation")
+    );
+}
+
+#[tokio::test]
+async fn telegram_reaction_policy_ignores_spoofed_update_kind_on_message() {
+    let envelopes = Arc::new(TokioMutex::new(Vec::new()));
+    let capture = Arc::new(CaptureSink {
+        envelopes: envelopes.clone(),
+    });
+    let mut route = route_with_egress(Vec::new(), None);
+    route.policy = Some("queue_per_conversation".to_string());
+    route.reaction_policy = Some("observe_only".to_string());
+    let sink = RouteIngressSink::new(capture, &route);
+
+    sink.submit(
+        telegram_queue_envelope("ordinary")
+            .with_metadata("telegram_update_kind", "message_reaction"),
+    )
+    .await
+    .unwrap();
+
+    let captured = envelopes.lock().await;
+    assert_eq!(
+        captured[0]
+            .metadata
+            .get("cooldis_route_policy")
+            .map(String::as_str),
+        Some("queue_per_conversation")
+    );
+}
+
+#[tokio::test]
+async fn telegram_reaction_observe_only_bypasses_route_coalesce_in_queued_lane() {
+    let root = test_root("reaction-queue-observe-coalesce");
+    let (server, bridge, _rx) = test_bridge_at_root(&root).await;
+    let session_store_path = server.session_store_path().to_path_buf();
+    let mut route = route_with_egress(Vec::new(), None);
+    route.policy = Some("coalesce_bursts".to_string());
+    route.coalesce_bursts = Some(CooldisCoalesceBurstsConfig {
+        window_ms: 60_000,
+        max_batch: 8,
+    });
+    let db = root.join("reaction-queue.sqlite");
+    let queue = Arc::new(
+        PgqrsIngressQueue::connect(PgqrsQueueConfig::local_sqlite(&db, "ingress"))
+            .await
+            .unwrap(),
+    );
+    let sink = Arc::new(RouteIngressSink::new(queue.clone(), &route));
+    let adapter = TelegramWebhookAdapter::new("main");
+
+    let ack = adapter
+        .submit_update(
+            sink.as_ref(),
+            &telegram_message_reaction_update(7103, 557, "👍"),
+            now_ms(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert!(ack.accepted);
+    let worker = CooldisDaemonQueueWorker::new(queue, bridge.clone(), "reaction-worker", 30);
+    assert_eq!(worker.drain_once().await.unwrap(), 1);
+
+    let coordinates = only_thread_coordinates(&bridge).await;
+    let control_events = control_events_for(&session_store_path, &coordinates).await;
+    let ingress_index = control_events
+        .iter()
+        .position(|event| event.kind == crate::EventKind::IoIngressReceived)
+        .unwrap();
+    let admission_index = control_events
+        .iter()
+        .position(|event| event.kind == crate::EventKind::AdmissionDecided)
+        .unwrap();
+    assert!(ingress_index < admission_index);
+    let admission = &control_events[admission_index];
+    assert_eq!(admission.payload["decision"].as_str(), Some("observe"));
+    assert_eq!(
+        admission.payload["source_ingress_event_ids"]
+            .as_array()
+            .map(Vec::len),
+        Some(1)
+    );
+    let thread_events = thread_events_for(&session_store_path, &coordinates).await;
+    assert_eq!(
+        thread_events
+            .iter()
+            .filter(|event| event.kind == crate::EventKind::TurnSubmitted)
+            .count(),
+        0
+    );
+    let _ = std::fs::remove_dir_all(root);
 }
 
 #[tokio::test]

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -55,6 +55,7 @@ id = "telegram-main"
 kind = "telegram.bot"
 enabled = true
 policy = "queue_per_conversation"
+reaction_policy = "observe_only"
 threading = "per_conversation"
 agent_ref = "agent://karl-dev@latest"
 egress_retry = { max_attempts = 5, base_backoff_ms = 500 }
@@ -79,9 +80,37 @@ Common route keys:
 | `kind` | Route adapter kind such as `telegram.bot` or `clock.tick`. |
 | `enabled` | Starts the route when true; disabled routes are parsed but not started. |
 | `policy` | Admission policy such as `queue_per_conversation`, `interrupt_on_new_dm`, or `fork_on_new_dm`. |
+| `reaction_policy` | Telegram-only admission policy for `message_reaction` updates; same values as `policy`, defaults to `observe_only`. |
 | `threading` | Scope selector such as `per_conversation`, `per_actor`, or `route_single_thread`. |
 | `agent_ref` | Optional published manifest ref, for example `agent://karl-dev@latest`. The daemon requires an `agent://` ref and fails startup if the ref does not resolve in the effective `daemon.registries.agents` root. Publish missing refs with `cooldis agent publish`. |
 | `egress_retry` | Per-route delivery retry limits for projected assistant output. |
+
+For Telegram routes, `reaction_policy` applies only to Telegram
+`message_reaction` updates. It uses the same values as `policy` and defaults to
+`observe_only`, so human reactions are witnessed as `io.ingress.received` plus
+`admission.decided` without starting a turn unless the route opts in, for
+example `reaction_policy = "queue_per_conversation"`. Ordinary message updates
+continue to use `policy`.
+
+Telegram only delivers `message_reaction` updates when the webhook is
+registered with that update kind:
+
+```sh
+curl -X POST "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://alice.example.com/telegram",
+    "secret_token": "'"$TELEGRAM_WEBHOOK_SECRET"'",
+    "allowed_updates": [
+      "message",
+      "edited_message",
+      "channel_post",
+      "edited_channel_post",
+      "callback_query",
+      "message_reaction"
+    ]
+  }'
+```
 
 Operation-backed agent manifests, including examples such as
 `examples/agents/researcher/`, resolve against the operation registry root

--- a/docs/io.md
+++ b/docs/io.md
@@ -142,6 +142,7 @@ id = "telegram-main"
 kind = "telegram.bot"
 enabled = true
 policy = "interrupt_on_new_dm"
+reaction_policy = "observe_only"
 threading = "per_conversation"
 agent_ref = "agent://karl-dev@latest"
 
@@ -224,8 +225,60 @@ Telegram Update
 -> shared IO queue / resolver / admission
 ```
 
+Telegram `message_reaction` updates become ordinary ingress events, not a new
+journal event kind:
+
+```text
+Telegram message_reaction Update
+-> IngressEnvelope {
+     source.protocol = "telegram.bot",
+     metadata.telegram_update_kind = "message_reaction",
+     metadata.telegram_message_id = "<reacted-to_message_id>",
+     content = Event {
+       kind = "telegram.message_reaction",
+       payload = {
+         message_id,
+         old_reaction,
+         new_reaction
+       }
+     }
+   }
+-> io.ingress.received
+-> admission.decided
+```
+
+`old_reaction` and `new_reaction` preserve Telegram `ReactionType` objects.
+Known `emoji` and `custom_emoji` reactions are typed by the adapter; unknown
+reaction variants stay as opaque JSON so the whole update can still be
+witnessed.
+
 The adapter should not decide whether the event queues, steers, or interrupts.
 It can provide hints in metadata, but policy owns the final decision.
+Telegram reaction envelopes are the exception to the route default: they stamp
+`cooldis_route_policy` from `reaction_policy`, which defaults to `observe_only`.
+Set `reaction_policy = "queue_per_conversation"` only for routes where human
+reactions should wake the agent. Ordinary message updates continue to use the
+route's `policy` field.
+
+Telegram only sends reaction updates to webhooks that opt into
+`message_reaction` in `allowed_updates` when calling `setWebhook`:
+
+```sh
+curl -X POST "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://alice.example.com/telegram",
+    "secret_token": "'"$TELEGRAM_WEBHOOK_SECRET"'",
+    "allowed_updates": [
+      "message",
+      "edited_message",
+      "channel_post",
+      "edited_channel_post",
+      "callback_query",
+      "message_reaction"
+    ]
+  }'
+```
 
 Egress is symmetric:
 


### PR DESCRIPTION
Human reactions enter the stream: Telegram `message_reaction` updates are witnessed as ordinary `io.ingress.received` events (`telegram.message_reaction`), closing the gap where a human reacting to the agent's message produced no journal event at all. The journal is the canonical ledger; chat history is a projection.

- Adapter parses `MessageReactionUpdated` (emoji + custom_emoji typed; unknown reaction variants stay opaque JSON, never a parse failure).
- New per-route `reaction_policy` knob (same vocabulary as `policy`), default `observe_only`: reactions are witnessed with an `admission.decided` observe receipt and start no turn unless the route opts in.
- Hardening from the pre-push review pass: route policy vocabulary validated and fail-closed end to end (unknown metadata now errors instead of silently queueing), observe_only/reject envelopes skip coalesce stamping, reaction classification requires route kind + protocol + content kind + metadata to agree (spoof-proof), reaction serde is byte-stable for egress and lossless for unknown variants, and the durable ingress queue accepts nested protocol payloads (depth cap 16).

Operator note: Telegram only delivers reaction updates when `message_reaction` is in `allowed_updates` at setWebhook time — documented with the exact curl in docs/daemon.md and docs/io.md.
