### PR TITLE
EMO-462: give burst-test shutdown bounds CI headroom

### DIFF
--- a/crates/cooldis-kernel/src/adapters/app_server/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/tests.rs
@@ -282,21 +282,25 @@ async fn concurrent_new_thread_turn_burst_surfaces_no_history_lock_errors() {
         failures
     };
 
-    let burst_result = tokio::time::timeout(std::time::Duration::from_secs(60), burst).await;
+    // Timeouts here are hang detectors, not performance assertions: shutdown of
+    // 200 threads does O(n) serialized history writes and took >10s on a 2-core
+    // CI runner, so bounds carry an order of magnitude of headroom over the
+    // fast-path time.
+    let burst_result = tokio::time::timeout(std::time::Duration::from_secs(120), burst).await;
     let task_shutdown_result =
-        tokio::time::timeout(std::time::Duration::from_secs(10), tasks.shutdown()).await;
+        tokio::time::timeout(std::time::Duration::from_secs(60), tasks.shutdown()).await;
     let shutdown_result = tokio::time::timeout(
-        std::time::Duration::from_secs(10),
+        std::time::Duration::from_secs(60),
         app.inner.supervisor.shutdown_all(),
     )
     .await;
     drop(app);
     let cleanup_result = std::fs::remove_dir_all(root);
 
-    let failures = burst_result.expect("200 in-process new-thread turns exceeded the 60s bound");
-    task_shutdown_result.expect("new-thread turn task shutdown exceeded the 10s bound");
+    let failures = burst_result.expect("200 in-process new-thread turns exceeded the 120s bound");
+    task_shutdown_result.expect("new-thread turn task shutdown exceeded the 60s bound");
     shutdown_result
-        .expect("app-server shutdown exceeded the 10s bound")
+        .expect("app-server shutdown exceeded the 60s bound")
         .unwrap();
     cleanup_result.unwrap();
     assert!(


### PR DESCRIPTION
## Summary
- The 200-thread burst regression flaked on CI: the burst passed, but `supervisor.shutdown_all()` exceeded the test's 10s bound. Shutdown is sequential per thread and each shutdown's history writes serialize behind the EMO-462 writer gate, so the tail is O(n) and blows past 10s on a 2-core runner.
- Bounds are hang detectors, not performance assertions: raised to an order of magnitude above fast-path time (120s burst, 60s task/supervisor shutdown), with a comment recording the policy.
- Underlying shutdown latency scaling tracked in EMO-465.

## Test plan
- [x] Focused test green locally (8.7s)
- [x] Full `-p cooldis --lib` suite green (904 passed)
- [x] Pre-push hook (full verify: clippy, workspace suite, smokes) green

Made with [Cursor](https://cursor.com)