### PR TITLE
EMO-472: fail-closed Telegram webhook authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,6 +758,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "subtle",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",

--- a/crates/cooldis-kernel/Cargo.toml
+++ b/crates/cooldis-kernel/Cargo.toml
@@ -40,6 +40,7 @@ rusqlite = { version = "0.32.1", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+subtle = "2"
 thiserror = "2"
 tokio = { version = "1", features = ["io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-tungstenite = "0.28"

--- a/crates/cooldis-kernel/src/cli/daemon.rs
+++ b/crates/cooldis-kernel/src/cli/daemon.rs
@@ -355,12 +355,18 @@ pub(super) async fn start_telegram_route(
             route.id
         ))
     })?;
+    let secret_token = telegram.secret_token_value()?.ok_or_else(|| {
+        usage_error(format!(
+            "telegram route {} requires telegram.secret_token or telegram.secret_token_env",
+            route.id
+        ))
+    })?;
     let server = TelegramWebhookServer::bind(
         TelegramWebhookServerConfig {
             route_id: route.id.clone(),
             listen,
             path: telegram.path.clone(),
-            secret_token: telegram.secret_token_value()?,
+            secret_token,
         },
         sink,
     )

--- a/crates/cooldis-kernel/src/daemon/daemon_config.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_config.rs
@@ -514,9 +514,11 @@ impl CooldisIoRouteConfig {
         }
         if self.kind == "telegram.bot" {
             match &self.telegram {
-                Some(telegram) => {
-                    telegram.validate(&format!("io.routes.{}.telegram", self.id), errors)
-                }
+                Some(telegram) => telegram.validate(
+                    &format!("io.routes.{}.telegram", self.id),
+                    self.enabled,
+                    errors,
+                ),
                 None if self.enabled => errors.push(format!(
                     "io.routes {:?} kind telegram.bot requires a telegram webhook config",
                     self.id
@@ -633,7 +635,7 @@ impl Default for CooldisTelegramRouteConfig {
 }
 
 impl CooldisTelegramRouteConfig {
-    fn validate(&self, scope: &str, errors: &mut Vec<String>) {
+    fn validate(&self, scope: &str, enabled: bool, errors: &mut Vec<String>) {
         if self
             .listen
             .as_deref()
@@ -660,6 +662,11 @@ impl CooldisTelegramRouteConfig {
             .is_some_and(|value| value.trim().is_empty())
         {
             errors.push(format!("{scope}.secret_token_env cannot be empty"));
+        }
+        if enabled && self.secret_token.is_none() && self.secret_token_env.is_none() {
+            errors.push(format!(
+                "{scope}.secret_token or secret_token_env is required when the route is enabled"
+            ));
         }
         if self
             .bot_token

--- a/crates/cooldis-kernel/src/daemon/daemon_config/tests.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_config/tests.rs
@@ -767,7 +767,7 @@ fn validates_telegram_route_shape() {
         telegram: Some(CooldisTelegramRouteConfig {
             listen: Some("127.0.0.1:9000".to_string()),
             path: "telegram".to_string(),
-            secret_token: None,
+            secret_token: Some("secret".to_string()),
             secret_token_env: None,
             bot_token: None,
             bot_token_env: None,
@@ -778,6 +778,42 @@ fn validates_telegram_route_shape() {
 
     let errors = config.validation_errors();
     assert!(errors.iter().any(|error| error.contains("path")));
+}
+
+#[test]
+fn enabled_telegram_route_requires_webhook_secret() {
+    let mut config = CooldisDaemonConfig::default();
+    config.io.routes.push(CooldisIoRouteConfig {
+        id: "telegram-main".to_string(),
+        kind: "telegram.bot".to_string(),
+        enabled: true,
+        policy: None,
+        content_policies: None,
+        threading: None,
+        agent_ref: None,
+        coalesce_bursts: None,
+        ingress: None,
+        egress_projection: Vec::new(),
+        typing_simulation: None,
+        egress_retry: CooldisEgressRetryConfig::default(),
+        telegram: Some(CooldisTelegramRouteConfig {
+            listen: Some("127.0.0.1:9000".to_string()),
+            path: "/telegram".to_string(),
+            secret_token: None,
+            secret_token_env: None,
+            bot_token: None,
+            bot_token_env: None,
+            api_base: None,
+        }),
+        metadata: BTreeMap::new(),
+    });
+
+    let err = config.validate().unwrap_err().to_string();
+    assert!(err.contains("io.routes.telegram-main.telegram"));
+    assert!(err.contains("secret_token or secret_token_env is required"));
+
+    config.io.routes[0].enabled = false;
+    assert!(config.validate().is_ok());
 }
 
 #[test]

--- a/crates/cooldis-kernel/src/daemon/daemon_io.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_io.rs
@@ -40,21 +40,27 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Value, Value as JsonValue, json};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::future::Future;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use subtle::ConstantTimeEq;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{Mutex, RwLock};
-use tokio::task::JoinHandle;
+use tokio::task::{JoinHandle, JoinSet};
 
 const DEFAULT_QUEUE_BATCH: usize = 16;
 const DEFAULT_WORKER_POLL_MS: u64 = 250;
 const DEFAULT_EGRESS_PROJECTOR_POLL_MS: u64 = 250;
 const MAX_HTTP_HEADER_BYTES: usize = 16 * 1024;
 const MAX_HTTP_BODY_BYTES: usize = 4 * 1024 * 1024;
+const MAX_TELEGRAM_WEBHOOK_REQUESTS: usize = 128;
+const TELEGRAM_WEBHOOK_HEAD_TIMEOUT: Duration = Duration::from_secs(10);
+const TELEGRAM_WEBHOOK_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const HTTP_RESPONSE_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
 const MAX_TYPING_SIMULATION_DELAY: Duration = Duration::from_secs(8);
 const IO_EGRESS_PROJECTOR_DISCHARGED_BY: &str = "projector:io-egress";
 const IO_EGRESS_PROJECTOR_FUNCTION: &str = "delivery/v1";
@@ -5314,11 +5320,13 @@ pub struct TelegramWebhookServerConfig {
     pub route_id: String,
     pub listen: String,
     pub path: String,
-    pub secret_token: Option<String>,
+    pub secret_token: String,
 }
 
 pub struct TelegramWebhookServer {
-    config: TelegramWebhookServerConfig,
+    route_id: String,
+    path: String,
+    secret_token_hash: [u8; 32],
     listener: TcpListener,
     sink: Arc<dyn IngressSink>,
 }
@@ -5328,6 +5336,12 @@ impl TelegramWebhookServer {
         config: TelegramWebhookServerConfig,
         sink: Arc<dyn IngressSink>,
     ) -> CooldisResult<Self> {
+        if config.secret_token.trim().is_empty() {
+            return Err(CooldisError::RuntimeFactory(format!(
+                "Telegram webhook route {} requires a non-empty secret_token",
+                config.route_id
+            )));
+        }
         let listener = TcpListener::bind(&config.listen).await.map_err(|err| {
             CooldisError::RuntimeFactory(format!(
                 "failed to bind Telegram webhook route {} on {}: {err}",
@@ -5335,7 +5349,9 @@ impl TelegramWebhookServer {
             ))
         })?;
         Ok(Self {
-            config,
+            route_id: config.route_id,
+            path: config.path,
+            secret_token_hash: Sha256::digest(config.secret_token.as_bytes()).into(),
             listener,
             sink,
         })
@@ -5348,34 +5364,110 @@ impl TelegramWebhookServer {
     }
 
     pub async fn serve(self) -> CooldisResult<()> {
-        let adapter = Arc::new(TelegramWebhookAdapter::new(self.config.route_id.clone()));
+        let adapter = Arc::new(TelegramWebhookAdapter::new(self.route_id));
+        let mut requests = JoinSet::new();
         loop {
-            let (stream, _) = self.listener.accept().await.map_err(|err| {
-                CooldisError::RuntimeFactory(format!(
-                    "failed to accept Telegram webhook connection: {err}"
-                ))
-            })?;
-            let config = self.config.clone();
-            let sink = self.sink.clone();
-            let adapter = adapter.clone();
-            tokio::spawn(async move {
-                if let Err(err) =
-                    handle_telegram_webhook_connection(stream, config, adapter, sink).await
-                {
-                    eprintln!("cooldis Telegram webhook request failed: {err}");
+            tokio::select! {
+                accepted = self.listener.accept(), if requests.len() < MAX_TELEGRAM_WEBHOOK_REQUESTS => {
+                    let (stream, _) = accepted.map_err(|err| {
+                        CooldisError::RuntimeFactory(format!(
+                            "failed to accept Telegram webhook connection: {err}"
+                        ))
+                    })?;
+                    let path = self.path.clone();
+                    let secret_token_hash = self.secret_token_hash;
+                    let sink = self.sink.clone();
+                    let adapter = adapter.clone();
+                    requests.spawn(async move {
+                        telegram_webhook_request_with_timeout(handle_telegram_webhook_connection(
+                            stream,
+                            path,
+                            secret_token_hash,
+                            adapter,
+                            sink,
+                        ))
+                        .await
+                    });
                 }
-            });
+                completed = requests.join_next(), if !requests.is_empty() => {
+                    report_telegram_webhook_request_completion(completed);
+                }
+            }
         }
+    }
+}
+
+async fn telegram_webhook_request_with_timeout(
+    request: impl Future<Output = CooldisResult<()>>,
+) -> CooldisResult<()> {
+    tokio::time::timeout(TELEGRAM_WEBHOOK_REQUEST_TIMEOUT, request)
+        .await
+        .map_err(|_| {
+            CooldisError::RuntimeFactory("Telegram webhook request timed out".to_string())
+        })?
+}
+
+fn report_telegram_webhook_request_completion(
+    completed: Option<Result<CooldisResult<()>, tokio::task::JoinError>>,
+) {
+    match completed {
+        Some(Ok(Err(err))) => eprintln!("cooldis Telegram webhook request failed: {err}"),
+        Some(Err(err)) => eprintln!("cooldis Telegram webhook request task failed: {err}"),
+        Some(Ok(Ok(()))) | None => {}
     }
 }
 
 async fn handle_telegram_webhook_connection(
     mut stream: TcpStream,
-    config: TelegramWebhookServerConfig,
+    path: String,
+    secret_token_hash: [u8; 32],
     adapter: Arc<TelegramWebhookAdapter>,
     sink: Arc<dyn IngressSink>,
 ) -> CooldisResult<()> {
-    let request = match read_http_request(&mut stream).await {
+    let request_head = match read_http_request_head(&mut stream).await {
+        Ok(request) => request,
+        Err(_) => {
+            write_telegram_auth_failure(&mut stream).await?;
+            return Ok(());
+        }
+    };
+
+    let actual_token_hash = Sha256::digest(
+        request_head
+            .headers
+            .get("x-telegram-bot-api-secret-token")
+            .map_or(b"".as_slice(), |value| value.as_bytes()),
+    );
+    let token_present = subtle::Choice::from(u8::from(
+        request_head
+            .headers
+            .contains_key("x-telegram-bot-api-secret-token"),
+    ));
+    let token_matches = actual_token_hash.as_slice().ct_eq(&secret_token_hash);
+    if !bool::from(token_present & token_matches) {
+        write_telegram_auth_failure(&mut stream).await?;
+        return Ok(());
+    }
+
+    if request_head.method != "POST" {
+        write_json_response(
+            &mut stream,
+            405,
+            json!({ "ok": false, "error": "method_not_allowed" }),
+        )
+        .await?;
+        return Ok(());
+    }
+    if request_head.path != path {
+        write_json_response(
+            &mut stream,
+            404,
+            json!({ "ok": false, "error": "not_found" }),
+        )
+        .await?;
+        return Ok(());
+    }
+    let body = match read_http_request_body(&mut stream, request_head).await {
         Ok(request) => request,
         Err(err) => {
             write_json_response(
@@ -5388,41 +5480,7 @@ async fn handle_telegram_webhook_connection(
         }
     };
 
-    if request.method != "POST" {
-        write_json_response(
-            &mut stream,
-            405,
-            json!({ "ok": false, "error": "method_not_allowed" }),
-        )
-        .await?;
-        return Ok(());
-    }
-    if request.path != config.path {
-        write_json_response(
-            &mut stream,
-            404,
-            json!({ "ok": false, "error": "not_found" }),
-        )
-        .await?;
-        return Ok(());
-    }
-    if let Some(secret_token) = config.secret_token.as_deref() {
-        let actual = request
-            .headers
-            .get("x-telegram-bot-api-secret-token")
-            .map(String::as_str);
-        if actual != Some(secret_token) {
-            write_json_response(
-                &mut stream,
-                401,
-                json!({ "ok": false, "error": "unauthorized" }),
-            )
-            .await?;
-            return Ok(());
-        }
-    }
-
-    let update: TelegramUpdate = serde_json::from_slice(&request.body).map_err(|err| {
+    let update: TelegramUpdate = serde_json::from_slice(&body).map_err(|err| {
         CooldisError::RuntimeFactory(format!("failed to decode Telegram update JSON: {err}"))
     })?;
     match adapter
@@ -5450,20 +5508,43 @@ async fn handle_telegram_webhook_connection(
     Ok(())
 }
 
-#[derive(Debug)]
-struct HttpRequest {
+struct HttpRequestHead {
     method: String,
     path: String,
     headers: HashMap<String, String>,
-    body: Vec<u8>,
+    buffered_body: Vec<u8>,
 }
 
-async fn read_http_request(stream: &mut TcpStream) -> CooldisResult<HttpRequest> {
+async fn read_http_request_head<R>(stream: &mut R) -> CooldisResult<HttpRequestHead>
+where
+    R: AsyncRead + Unpin,
+{
+    tokio::time::timeout(
+        TELEGRAM_WEBHOOK_HEAD_TIMEOUT,
+        read_http_request_head_inner(stream),
+    )
+    .await
+    .map_err(|_| {
+        CooldisError::RuntimeFactory("Telegram webhook request head timed out".to_string())
+    })?
+}
+
+async fn read_http_request_head_inner<R>(stream: &mut R) -> CooldisResult<HttpRequestHead>
+where
+    R: AsyncRead + Unpin,
+{
     let mut buffer = Vec::new();
     let header_end;
     loop {
+        let remaining = MAX_HTTP_HEADER_BYTES.saturating_sub(buffer.len());
+        if remaining == 0 {
+            return Err(CooldisError::RuntimeFactory(
+                "HTTP headers are too large".to_string(),
+            ));
+        }
         let mut chunk = [0_u8; 1024];
-        let read = stream.read(&mut chunk).await.map_err(|err| {
+        let read_len = remaining.min(chunk.len());
+        let read = stream.read(&mut chunk[..read_len]).await.map_err(|err| {
             CooldisError::RuntimeFactory(format!("failed to read HTTP request: {err}"))
         })?;
         if read == 0 {
@@ -5475,11 +5556,6 @@ async fn read_http_request(stream: &mut TcpStream) -> CooldisResult<HttpRequest>
         if let Some(index) = find_header_end(&buffer) {
             header_end = index;
             break;
-        }
-        if buffer.len() > MAX_HTTP_HEADER_BYTES {
-            return Err(CooldisError::RuntimeFactory(
-                "HTTP headers are too large".to_string(),
-            ));
         }
     }
 
@@ -5511,7 +5587,20 @@ async fn read_http_request(stream: &mut TcpStream) -> CooldisResult<HttpRequest>
         headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
     }
 
-    let content_length = headers
+    Ok(HttpRequestHead {
+        method,
+        path,
+        headers,
+        buffered_body: buffer[header_end + 4..].to_vec(),
+    })
+}
+
+async fn read_http_request_body(
+    stream: &mut TcpStream,
+    request: HttpRequestHead,
+) -> CooldisResult<Vec<u8>> {
+    let content_length = request
+        .headers
         .get("content-length")
         .map(|value| {
             value.parse::<usize>().map_err(|err| {
@@ -5526,8 +5615,7 @@ async fn read_http_request(stream: &mut TcpStream) -> CooldisResult<HttpRequest>
         ));
     }
 
-    let body_start = header_end + 4;
-    let mut body = buffer[body_start..].to_vec();
+    let mut body = request.buffered_body;
     while body.len() < content_length {
         let mut chunk = vec![0_u8; content_length - body.len()];
         let read = stream.read(&mut chunk).await.map_err(|err| {
@@ -5542,12 +5630,11 @@ async fn read_http_request(stream: &mut TcpStream) -> CooldisResult<HttpRequest>
     }
     body.truncate(content_length);
 
-    Ok(HttpRequest {
-        method,
-        path,
-        headers,
-        body,
-    })
+    Ok(body)
+}
+
+async fn write_telegram_auth_failure(stream: &mut TcpStream) -> CooldisResult<()> {
+    write_json_response(stream, 401, json!({ "ok": false, "error": "unauthorized" })).await
 }
 
 async fn write_json_response(
@@ -5576,6 +5663,19 @@ Connection: close\r\n\
     stream.write_all(response.as_bytes()).await.map_err(|err| {
         CooldisError::RuntimeFactory(format!("failed to write HTTP response: {err}"))
     })?;
+    stream.shutdown().await.map_err(|err| {
+        CooldisError::RuntimeFactory(format!("failed to close HTTP response: {err}"))
+    })?;
+    let mut discard = [0_u8; 1024];
+    let _ = tokio::time::timeout(HTTP_RESPONSE_DRAIN_TIMEOUT, async {
+        loop {
+            match stream.read(&mut discard).await {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {}
+            }
+        }
+    })
+    .await;
     Ok(())
 }
 

--- a/crates/cooldis-kernel/src/daemon/daemon_io/tests.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_io/tests.rs
@@ -70,6 +70,11 @@ struct CaptureSink {
     envelopes: Arc<TokioMutex<Vec<IngressEnvelope>>>,
 }
 
+struct BlockingSink {
+    entered: Notify,
+    release: Notify,
+}
+
 struct FailFirstCaptureSink {
     attempts: AtomicUsize,
     envelopes: TokioMutex<Vec<IngressEnvelope>>,
@@ -81,6 +86,15 @@ impl IngressSink for CaptureSink {
         let ack = IngressAck::accepted(&envelope);
         self.envelopes.lock().await.push(envelope);
         Ok(ack)
+    }
+}
+
+#[async_trait]
+impl IngressSink for BlockingSink {
+    async fn submit(&self, envelope: IngressEnvelope) -> IoResult<IngressAck> {
+        self.entered.notify_one();
+        self.release.notified().await;
+        Ok(IngressAck::accepted(&envelope))
     }
 }
 
@@ -8183,7 +8197,7 @@ async fn telegram_webhook_accepts_update_and_uses_sink() {
             route_id: "main".to_string(),
             listen: "127.0.0.1:0".to_string(),
             path: "/telegram".to_string(),
-            secret_token: Some("secret".to_string()),
+            secret_token: "secret".to_string(),
         },
         sink,
     )
@@ -8215,6 +8229,130 @@ async fn telegram_webhook_accepts_update_and_uses_sink() {
 }
 
 #[tokio::test]
+async fn telegram_webhook_auth_is_uniform_and_precedes_routing_and_payload_parsing() {
+    let envelopes = Arc::new(TokioMutex::new(Vec::new()));
+    let sink = Arc::new(CaptureSink {
+        envelopes: envelopes.clone(),
+    });
+    let server = TelegramWebhookServer::bind(
+        TelegramWebhookServerConfig {
+            route_id: "main".to_string(),
+            listen: "127.0.0.1:0".to_string(),
+            path: "/telegram".to_string(),
+            secret_token: "secret".to_string(),
+        },
+        sink,
+    )
+    .await
+    .unwrap();
+    let addr = server.local_addr().unwrap();
+    tokio::spawn(server.serve());
+
+    let missing = post_raw_json(addr, "/telegram", None, "{").await;
+    let wrong = post_raw_json(addr, "/telegram", Some("wrong"), "{}").await;
+    let hidden_route = post_raw_json(addr, "/not-telegram", None, "{}").await;
+    let oversized_head = send_raw_request(
+        addr,
+        format!(
+            "POST /telegram HTTP/1.1\r\nHost: {addr}\r\nX-Telegram-Bot-Api-Secret-Token: secret\r\nX-Padding: {}\r\nContent-Length: 2\r\n\r\n{{}}",
+            "a".repeat(MAX_HTTP_HEADER_BYTES)
+        ),
+    )
+    .await;
+
+    assert!(missing.starts_with("HTTP/1.1 401 Unauthorized"));
+    assert_eq!(wrong, missing);
+    assert_eq!(hidden_route, missing);
+    assert_eq!(oversized_head, missing);
+    assert!(envelopes.lock().await.is_empty());
+
+    let accepted = post_json(
+        addr,
+        "/telegram",
+        Some("secret"),
+        json!({
+            "update_id": 1001,
+            "message": {
+                "message_id": 557,
+                "chat": { "id": 789, "type": "private" },
+                "date": 1777000000,
+                "text": "authenticated webhook"
+            }
+        }),
+    )
+    .await;
+
+    assert!(accepted.starts_with("HTTP/1.1 200 OK"));
+    assert_eq!(envelopes.lock().await.len(), 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn telegram_webhook_times_out_a_stalled_request_head() {
+    let (mut reader, mut writer) = tokio::io::duplex(1024);
+    writer
+        .write_all(b"POST /telegram HTTP/1.1\r\nHost: localhost\r\n")
+        .await
+        .unwrap();
+    let result = tokio::time::timeout(Duration::from_secs(60), read_http_request_head(&mut reader))
+        .await
+        .expect("request-head deadline did not fire within the hang-detector bound");
+    let Err(err) = result else {
+        panic!("partial request head unexpectedly parsed");
+    };
+    assert!(err.to_string().contains("request head timed out"));
+    drop(writer);
+}
+
+#[tokio::test]
+async fn telegram_webhook_serve_cancellation_aborts_accepted_requests() {
+    let sink = Arc::new(BlockingSink {
+        entered: Notify::new(),
+        release: Notify::new(),
+    });
+    let server = TelegramWebhookServer::bind(
+        TelegramWebhookServerConfig {
+            route_id: "main".to_string(),
+            listen: "127.0.0.1:0".to_string(),
+            path: "/telegram".to_string(),
+            secret_token: "secret".to_string(),
+        },
+        sink.clone(),
+    )
+    .await
+    .unwrap();
+    let addr = server.local_addr().unwrap();
+    let server_task = tokio::spawn(server.serve());
+    let entered = sink.entered.notified();
+    let response_task = tokio::spawn(post_json(
+        addr,
+        "/telegram",
+        Some("secret"),
+        json!({
+            "update_id": 1002,
+            "message": {
+                "message_id": 558,
+                "chat": { "id": 790, "type": "private" },
+                "date": 1777000000,
+                "text": "cancel this request"
+            }
+        }),
+    ));
+
+    tokio::time::timeout(Duration::from_secs(5), entered)
+        .await
+        .expect("request did not reach the sink");
+    server_task.abort();
+    server_task.await.unwrap_err();
+    sink.release.notify_one();
+
+    let response = tokio::time::timeout(Duration::from_secs(5), response_task)
+        .await
+        .expect("accepted connection did not close after server cancellation")
+        .unwrap();
+    assert!(response.is_empty());
+}
+
+#[tokio::test]
 async fn telegram_webhook_queue_mode_writes_to_sqlite() {
     let db = std::env::temp_dir()
         .join("cooldis-daemon-io-tests")
@@ -8229,7 +8367,7 @@ async fn telegram_webhook_queue_mode_writes_to_sqlite() {
             route_id: "main".to_string(),
             listen: "127.0.0.1:0".to_string(),
             path: "/telegram".to_string(),
-            secret_token: None,
+            secret_token: "secret".to_string(),
         },
         queue.clone(),
     )
@@ -8241,7 +8379,7 @@ async fn telegram_webhook_queue_mode_writes_to_sqlite() {
     let response = post_json(
         addr,
         "/telegram",
-        None,
+        Some("secret"),
         json!({
             "update_id": 1000,
             "message": {
@@ -8286,5 +8424,33 @@ async fn post_json(
     stream.write_all(request.as_bytes()).await.unwrap();
     let mut response = String::new();
     stream.read_to_string(&mut response).await.unwrap();
+    response
+}
+
+async fn post_raw_json(addr: SocketAddr, path: &str, secret: Option<&str>, body: &str) -> String {
+    let mut request = format!(
+        "POST {path} HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n",
+        body.len()
+    );
+    if let Some(secret) = secret {
+        request.push_str(&format!("X-Telegram-Bot-Api-Secret-Token: {secret}\r\n"));
+    }
+    request.push_str("\r\n");
+    request.push_str(body);
+
+    send_raw_request(addr, request).await
+}
+
+async fn send_raw_request(addr: SocketAddr, request: String) -> String {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    stream.write_all(request.as_bytes()).await.unwrap();
+    let mut response = String::new();
+    if let Err(err) = stream.read_to_string(&mut response).await {
+        assert_eq!(err.kind(), std::io::ErrorKind::ConnectionReset);
+        assert!(
+            !response.is_empty(),
+            "connection reset before HTTP response"
+        );
+    }
     response
 }

--- a/crates/cooldis-kernel/tests/smokes/cooldis-restart-smoke.rs
+++ b/crates/cooldis-kernel/tests/smokes/cooldis-restart-smoke.rs
@@ -15,6 +15,7 @@ use uuid::Uuid;
 
 const ROUTE_ID: &str = "restart-smoke";
 const WEBHOOK_PATH: &str = "/ingress";
+const WEBHOOK_SECRET: &str = "restart-smoke-secret";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -484,6 +485,7 @@ threading = "per_conversation"
 listen = "{webhook_addr}"
 path = "{WEBHOOK_PATH}"
 bot_token = "restart-smoke-token"
+secret_token = "{WEBHOOK_SECRET}"
 api_base = "http://{telegram_api_addr}"
 "#,
         toml_path(&std::env::current_dir()?),
@@ -563,7 +565,7 @@ async fn post_update(
         .await
         .map_err(|err| err.to_string())?;
     let request = format!(
-        "POST {WEBHOOK_PATH} HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        "POST {WEBHOOK_PATH} HTTP/1.1\r\nHost: {addr}\r\nX-Telegram-Bot-Api-Secret-Token: {WEBHOOK_SECRET}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
         body.len()
     );
     stream

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -105,6 +105,18 @@ Common route keys:
 | `agent_ref` | Optional published manifest ref, for example `agent://karl-dev@latest`. The daemon requires an `agent://` ref and fails startup if the ref does not resolve in the effective `daemon.registries.agents` root. Publish missing refs with `cooldis agent publish`. |
 | `egress_retry` | Per-route delivery retry limits for projected assistant output. |
 
+Telegram route keys:
+
+| Key | Meaning |
+| --- | --- |
+| `listen` | Required webhook socket address. Use a reverse proxy for public TLS termination. |
+| `path` | Webhook request path. Defaults to `/telegram`. |
+| `secret_token` | Required when the route is enabled unless `secret_token_env` is set. Sent by Telegram in `X-Telegram-Bot-Api-Secret-Token`. |
+| `secret_token_env` | Environment variable containing the required webhook secret token. |
+| `bot_token` | Optional Bot API token for Telegram egress unless `bot_token_env` is set. |
+| `bot_token_env` | Environment variable containing the Bot API token. |
+| `api_base` | Optional Telegram-compatible Bot API base URL override. |
+
 `daemon.runtime.placement` is the default manifest-bind placement. It accepts
 `target = "local" | "remote" | "sandbox"`, optional `executor_ref`, and an
 optional executor-specific `config` table. An additive app-server bind override

--- a/docs/io.md
+++ b/docs/io.md
@@ -273,6 +273,12 @@ kind = "clock.tick"
 enabled = true
 ```
 
+Enabled Telegram routes must set either `secret_token` or
+`secret_token_env`; daemon config validation rejects a listener without one.
+The daemon authenticates `X-Telegram-Bot-Api-Secret-Token` before route or
+payload processing. `bot_token`/`bot_token_env` remains optional for
+ingress-only routes.
+
 Dynamic code plugins can come later as out-of-process adapters that speak the
 same envelope shape over JSON-RPC, websocket, or another small transport.
 


### PR DESCRIPTION
Enabled telegram.bot routes require a secret token at config validation (breaking, intended: enabled-and-secretless was silently open). The listener hashes the configured token once and compares SHA-256 digests with constant-time equality before any routing or parsing; every unauthenticated failure gets the same minimal 401; header contents never reach logs.

Review-gate hardening in the same diff: 16 KiB head budget inside a 10s deadline, 30s total request deadline, 128 concurrent requests owned by a JoinSet aborted on serve drop, and a constant-time presence+digest combination (no short-circuit between missing and wrong token).

Linear: EMO-472. Implementation + write-capable review gate (4 findings fixed) + gate-fix round, all architect-verified.