### PR TITLE
EMO-478: admission-coverage ratchet over all turn-entry surfaces

### DIFF
--- a/crates/cooldis-kernel/src/adapters/app_server/connection.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/connection.rs
@@ -3266,6 +3266,7 @@ impl CooldisAppServer {
         handle: &RuntimeThreadHandle,
         method: &str,
         input: &[Value],
+        surface: &str,
     ) -> Result<crate::EventRecord, JsonRpcErrorError> {
         let coordinates = handle.context().coordinates.clone();
         let envelope_digest = crate::agent::manifest_bind::canonical_json_hash(&json!({
@@ -3274,10 +3275,7 @@ impl CooldisAppServer {
         }))
         .map_err(internal_error)?;
         let payload = crate::IoIngressReceivedPayload {
-            route_id: Some(format!(
-                "surface:{}",
-                crate::kernel::admission::APP_SERVER_RPC_SURFACE
-            )),
+            route_id: Some(format!("surface:{surface}")),
             dedupe_key: None,
             external_conversation_id: None,
             external_actor_id: None,
@@ -3447,11 +3445,12 @@ impl CooldisAppServer {
         } else {
             input
         };
+        let surface = connection.admission_surface().await;
         let ingress_event = self
-            .record_rpc_ingress_received(&handle, "turn/start", &params.input)
+            .record_rpc_ingress_received(&handle, "turn/start", &params.input, surface)
             .await?;
         let admission = crate::kernel::admission::AdmissionGateContext::surface_default(
-            crate::kernel::admission::APP_SERVER_RPC_SURFACE,
+            surface,
             vec![ingress_event.id],
         )
         .map_err(internal_error)?;
@@ -3477,7 +3476,7 @@ impl CooldisAppServer {
 
         self.inner
             .supervisor
-            .submit_turn_to_with_admission(
+            .submit_admitted_turn_to(
                 &coordinates,
                 turn_id.clone(),
                 input,
@@ -4184,6 +4183,11 @@ impl ConnectionState {
 
     pub(super) async fn initialize_seen(&self) -> bool {
         self.handshake.lock().await.initialize_seen
+    }
+
+    pub(super) async fn admission_surface(&self) -> &'static str {
+        let handshake = self.handshake.lock().await;
+        crate::kernel::admission::app_server_surface(handshake.client_name.as_deref())
     }
 
     pub(super) async fn mark_initialized(&self) {

--- a/crates/cooldis-kernel/src/adapters/mcp_server/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/mcp_server/tests.rs
@@ -5,9 +5,10 @@ use crate::adapters::app_server::{
 use crate::{
     APP_SERVER_OPENAI_COMPATIBLE_MODEL, APP_SERVER_OPENAI_COMPATIBLE_PROVIDER, AppServerListenAddr,
     CanonicalContent, CanonicalProviderRuntimeConfig, CanonicalStopReason, CanonicalUsage,
-    CapsuleBindingsConfig, CooldisAppServer, CooldisAppServerConfig, LocalOperationRegistry,
-    ProviderApi, ProviderClient, ProviderRequest, ProviderResponse, ProviderResult,
-    PublishOperationRequest, PublishedOperationSource, SecretSourceKind, SqliteSecretStore,
+    CapsuleBindingsConfig, CooldisAppServer, CooldisAppServerConfig, EventStore, EventStreamId,
+    LocalOperationRegistry, ProviderApi, ProviderClient, ProviderRequest, ProviderResponse,
+    ProviderResult, PublishOperationRequest, PublishedOperationSource, SecretSourceKind,
+    SqliteSecretStore, SqliteSessionStore,
 };
 use async_trait::async_trait;
 use std::path::Path;
@@ -74,6 +75,7 @@ async fn mcp_server_runs_prompt_and_command_through_daemon() {
     let listen = AppServerListenAddr::Unix(socket.clone());
     let config = isolated_app_config(listen.clone(), &root);
     let app = CooldisAppServer::new_local(config).await.unwrap();
+    let session_store_path = app.session_store_path().to_path_buf();
     let serve_task = tokio::spawn(async move { app.serve(listen).await });
     wait_for_socket(&socket).await;
 
@@ -109,6 +111,15 @@ async fn mcp_server_runs_prompt_and_command_through_daemon() {
         prompt["result"]["structuredContent"]["assistantText"],
         "local:hello mcp"
     );
+    let prompt_thread_id = prompt["result"]["structuredContent"]["threadId"]
+        .as_str()
+        .unwrap();
+    assert_admission_surface(
+        &session_store_path,
+        prompt_thread_id,
+        crate::kernel::admission::MCP_ADAPTER_SURFACE,
+    )
+    .await;
 
     send(
             &mut write,
@@ -629,6 +640,23 @@ fn isolated_app_config(listen: AppServerListenAddr, root: &Path) -> CooldisAppSe
     config.state_home = root.join("state");
     config.agent_registry_root = root.join("agents");
     config
+}
+
+async fn assert_admission_surface(store_path: &Path, thread_id: &str, surface: &str) {
+    let store = SqliteSessionStore::open(store_path).await.unwrap();
+    let control_events = store
+        .read_events(&EventStreamId::new(format!("control:{thread_id}")), None)
+        .await
+        .unwrap();
+    let thread_events = store
+        .read_events(&EventStreamId::new(format!("thread:{thread_id}")), None)
+        .await
+        .unwrap();
+    let admission = crate::kernel::admission::assert_admission_precedes_turn_records(
+        &control_events,
+        &thread_events,
+    );
+    assert_eq!(admission.payload["route_id"], format!("surface:{surface}"));
 }
 
 #[derive(Default)]

--- a/crates/cooldis-kernel/src/daemon/daemon_io.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_io.rs
@@ -3369,7 +3369,7 @@ impl CooldisDaemonIoBridge {
                 .insert(target.address.scope_key(), child_key.to_string());
             let reserved = match self
                 .supervisor
-                .reserve_turn_to_with_admission(
+                .reserve_admitted_turn_to(
                     &child_coordinates,
                     child_key.to_string(),
                     self.runtime_input(input),
@@ -3384,7 +3384,7 @@ impl CooldisDaemonIoBridge {
                     return Err(cooldis_bridge_error(err));
                 }
             };
-            reserved.submit().await;
+            crate::kernel::admission::submit_reserved(reserved).await;
         }
 
         let mut receipt_target = target.clone();
@@ -4320,7 +4320,7 @@ impl CooldisDaemonIoBridge {
         .await?;
         self.lock_active_turns()
             .insert(target.address.scope_key(), turn_id.to_string());
-        reserved.submit().await;
+        crate::kernel::admission::submit_reserved(reserved).await;
         let evidence = self
             .wait_for_turn_execution_evidence(coordinates, turn_id, submission_mode)
             .await?;
@@ -4478,7 +4478,7 @@ impl CooldisDaemonIoBridge {
                 }
                 let reserved = self
                     .supervisor
-                    .reserve_turn_to_with_admission(
+                    .reserve_admitted_turn_to(
                         &coordinates,
                         turn_id.clone(),
                         self.runtime_input(&input),
@@ -4557,7 +4557,7 @@ impl CooldisDaemonIoBridge {
                 }
                 let reserved = self
                     .supervisor
-                    .reserve_turn_to_with_admission(
+                    .reserve_admitted_turn_to(
                         &coordinates,
                         turn_id.clone(),
                         self.runtime_input(&input),
@@ -4638,7 +4638,7 @@ impl CooldisDaemonIoBridge {
                 let (coordinates, handle) = self.ensure_thread(target, envelope).await?;
                 let reserved = self
                     .supervisor
-                    .reserve_turn_to_with_admission(
+                    .reserve_admitted_turn_to(
                         &coordinates,
                         turn_id.clone(),
                         self.runtime_input(input),
@@ -4661,7 +4661,7 @@ impl CooldisDaemonIoBridge {
                     .await?;
                     self.lock_active_turns()
                         .insert(target.address.scope_key(), turn_id.clone());
-                    reserved.submit().await;
+                    crate::kernel::admission::submit_reserved(reserved).await;
                     let mut receipt = KernelIoReceipt::new(envelope, target.clone(), decision);
                     receipt.thread_id = Some(coordinates.thread_id.to_string());
                     return Ok((receipt, None));
@@ -4723,7 +4723,7 @@ impl CooldisDaemonIoBridge {
                 let (coordinates, handle) = self.ensure_thread(target, envelope).await?;
                 let reserved = self
                     .supervisor
-                    .reserve_turn_to_with_admission(
+                    .reserve_admitted_turn_to(
                         &coordinates,
                         turn_id.clone(),
                         self.runtime_input(input),
@@ -4746,7 +4746,7 @@ impl CooldisDaemonIoBridge {
                     .await?;
                     self.lock_active_turns()
                         .insert(target.address.scope_key(), turn_id.clone());
-                    reserved.submit().await;
+                    crate::kernel::admission::submit_reserved(reserved).await;
                     let mut receipt = KernelIoReceipt::new(envelope, target.clone(), decision);
                     receipt.thread_id = Some(coordinates.thread_id.to_string());
                     return Ok((receipt, None));
@@ -4814,7 +4814,7 @@ impl CooldisDaemonIoBridge {
                     if let (Some(turn_id), Some(input)) = (replacement_turn_id, replacement) {
                         Some(
                             self.supervisor
-                                .reserve_turn_to_with_admission(
+                                .reserve_admitted_turn_to(
                                     &coordinates,
                                     turn_id.clone(),
                                     self.runtime_input(input),
@@ -4846,7 +4846,7 @@ impl CooldisDaemonIoBridge {
                         .await?;
                         self.lock_active_turns()
                             .insert(target.address.scope_key(), turn_id.clone());
-                        reserved.submit().await;
+                        crate::kernel::admission::submit_reserved(reserved).await;
                     }
                     let mut receipt = KernelIoReceipt::new(envelope, target.clone(), decision);
                     receipt.thread_id = Some(coordinates.thread_id.to_string());

--- a/crates/cooldis-kernel/src/daemon/daemon_io/tests.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_io/tests.rs
@@ -608,6 +608,9 @@ async fn remote_queue_redelivery_enters_child_ingress_once() {
         .read_events(&control_stream_id(&child_coordinates), None)
         .await
         .unwrap();
+    let admission =
+        crate::kernel::admission::assert_admission_precedes_turn_records(&control, &events);
+    assert_eq!(admission.payload["route_id"], "cooldis.remote:ingress");
     assert_eq!(
         control
             .iter()
@@ -6433,6 +6436,10 @@ async fn queue_worker_processes_envelope_after_queue_and_bridge_restart() {
         Some("queue")
     );
     assert_eq!(
+        control_events[admission_pos].payload["route_id"].as_str(),
+        Some("main")
+    );
+    assert_eq!(
         control_events[admission_pos].payload["policy_hash"],
         policy_bound.payload["content_hash"]
     );
@@ -6449,6 +6456,10 @@ async fn queue_worker_processes_envelope_after_queue_and_bridge_restart() {
         .read_events(&thread_stream, None)
         .await
         .unwrap();
+    crate::kernel::admission::assert_admission_precedes_turn_records(
+        &control_events,
+        &thread_events,
+    );
     let turn_submitted_count = thread_events
         .iter()
         .filter(|event| event.kind == crate::EventKind::TurnSubmitted)
@@ -8212,6 +8223,28 @@ async fn telegram_webhook_accepts_update_and_uses_sink() {
     let captured = envelopes.lock().await;
     assert_eq!(captured.len(), 1);
     assert_eq!(captured[0].content.text_projection(), "hello webhook");
+    let envelope = captured[0].clone();
+    drop(captured);
+
+    let (bridge, _rx, session_store_path) = test_bridge().await;
+    let receipt = bridge.submit_envelope(envelope).await.unwrap();
+    let thread_id = receipt.thread_id.unwrap();
+    wait_for_assistant_text(&bridge, &thread_id, "local:hello webhook").await;
+    let store = SqliteSessionStore::open(session_store_path).await.unwrap();
+    let coordinates = only_thread_coordinates(&bridge).await;
+    let control_events = store
+        .read_events(&control_stream_id(&coordinates), None)
+        .await
+        .unwrap();
+    let thread_events = store
+        .read_events(&EventStreamId::for_thread(&coordinates), None)
+        .await
+        .unwrap();
+    let admission = crate::kernel::admission::assert_admission_precedes_turn_records(
+        &control_events,
+        &thread_events,
+    );
+    assert_eq!(admission.payload["route_id"], "telegram.bot:main");
 }
 
 #[tokio::test]

--- a/crates/cooldis-kernel/src/kernel/admission.rs
+++ b/crates/cooldis-kernel/src/kernel/admission.rs
@@ -3,11 +3,49 @@ use crate::kernel::history::{
     AdmissionDecidedPayload, AdmissionDecision, EventKind, EventProvenance, EventRecord,
     EventRecordId, EventStreamId, NewEventRecord,
 };
-use crate::{CooldisError, CooldisResult, RuntimeThreadHandle};
+use crate::kernel::runtime_host::ReservedTurnSubmission;
+use crate::{
+    CooldisError, CooldisResult, RuntimeHost, RuntimeThreadHandle, ThreadId, TurnInput,
+    TurnSubmissionMode,
+};
 use serde_json::{Value, json};
 
-pub(crate) const HOST_SUBMIT_SURFACE: &str = "host-submit";
-pub(crate) const APP_SERVER_RPC_SURFACE: &str = "app-server-rpc";
+macro_rules! turn_entry_surfaces {
+    ($($constant:ident => $name:literal),+ $(,)?) => {
+        $(pub(crate) const $constant: &str = $name;)+
+
+        /// The complete registry of turn-entry surfaces guarded by admission.
+        ///
+        /// Every continuation the kernel executes was admitted; there is no side
+        /// door around this boundary. Add a new surface to the declaration below,
+        /// then add its end-to-end fixture to the admission coverage manifest. The
+        /// coverage ratchet fails and names any registered surface without one.
+        pub(crate) const TURN_ENTRY_SURFACES: &[&str] = &[$($constant),+];
+    };
+}
+
+turn_entry_surfaces! {
+    HOST_SUBMIT_SURFACE => "host-submit",
+    APP_SERVER_RPC_SURFACE => "app-server-rpc",
+    MCP_ADAPTER_SURFACE => "mcp-adapter",
+    ACP_ADAPTER_SURFACE => "acp-adapter",
+    DEBUG_RPC_SURFACE => "debug-rpc",
+    TELEGRAM_WEBHOOK_SURFACE => "telegram-webhook-ingress",
+    PGQRS_QUEUE_SURFACE => "pgqrs-queue-ingress",
+    REMOTE_SYNC_INGRESS_SURFACE => "remote-sync-ingress",
+    KERNEL_THREAD_SUBMIT_SURFACE => "kernel-thread-submit",
+}
+
+pub(crate) fn app_server_surface(client_name: Option<&str>) -> &'static str {
+    let surface = match client_name {
+        Some("cooldis-mcp-server") => MCP_ADAPTER_SURFACE,
+        Some("cooldis-acp-agent") => ACP_ADAPTER_SURFACE,
+        Some("cooldis-debug-rpc") => DEBUG_RPC_SURFACE,
+        _ => APP_SERVER_RPC_SURFACE,
+    };
+    debug_assert!(TURN_ENTRY_SURFACES.contains(&surface));
+    surface
+}
 
 const SURFACE_ADMISSION_FUNCTION: &str = "surface_admission/v1";
 const ADMISSION_ROUTE_FUNCTION: &str = "admission_route/v1";
@@ -72,6 +110,35 @@ pub(crate) async fn append_admission_decided(
 ) -> CooldisResult<EventRecord> {
     let record = admission_decided_record(handle.context().coordinates.clone(), context)?;
     handle.append_control_event(record).await
+}
+
+pub(crate) async fn submit_turn(
+    host: &RuntimeHost,
+    thread_id: ThreadId,
+    turn_id: impl Into<String>,
+    input: TurnInput,
+    mode: TurnSubmissionMode,
+    admission: Option<AdmissionGateContext>,
+) -> CooldisResult<()> {
+    let reserved = reserve_turn(host, thread_id, turn_id, input, mode, admission).await?;
+    submit_reserved(reserved).await;
+    Ok(())
+}
+
+pub(crate) async fn reserve_turn(
+    host: &RuntimeHost,
+    thread_id: ThreadId,
+    turn_id: impl Into<String>,
+    input: TurnInput,
+    mode: TurnSubmissionMode,
+    admission: Option<AdmissionGateContext>,
+) -> CooldisResult<ReservedTurnSubmission> {
+    host.reserve_turn_submission_at_choke_point(thread_id, turn_id, input, mode, admission)
+        .await
+}
+
+pub(crate) async fn submit_reserved(reserved: ReservedTurnSubmission) -> bool {
+    reserved.submit_unchecked().await
 }
 
 pub(crate) fn admission_decided_record(
@@ -199,37 +266,386 @@ pub(crate) fn assert_admission_precedes_turn_values<'a>(
 }
 
 #[cfg(test)]
-fn event_order_key(event: &EventRecord) -> (i64, String) {
-    (event.created_at_ms, event.id.to_string())
+fn event_order_key(event: &EventRecord) -> (i64, String, i64, String) {
+    (
+        event.created_at_ms,
+        event.stream_id.to_string(),
+        event.sequence.get(),
+        event.id.to_string(),
+    )
 }
 
 #[cfg(test)]
-fn value_order_key(event: &Value) -> (i64, String) {
+fn value_order_key(event: &Value) -> (i64, String, i64, String) {
     let at_ms = event
         .get("atMs")
         .and_then(Value::as_i64)
         .expect("event missing atMs");
+    let stream_id = event
+        .get("stream_id")
+        .and_then(Value::as_str)
+        .expect("event missing stream_id")
+        .to_string();
+    let sequence = event
+        .get("sequence")
+        .and_then(Value::as_i64)
+        .expect("event missing sequence");
     let event_id = event
         .get("eventId")
         .and_then(Value::as_str)
         .expect("event missing eventId")
         .to_string();
-    (at_ms, event_id)
+    (at_ms, stream_id, sequence, event_id)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::{Path, PathBuf};
     use uuid::Uuid;
 
+    const COVERED_SURFACE_FIXTURES: &[(&str, &str)] = &[
+        (
+            HOST_SUBMIT_SURFACE,
+            "runtime_host_submit_records_surface_admission_before_turn_execution",
+        ),
+        (
+            APP_SERVER_RPC_SURFACE,
+            "app_server_turn_start_records_surface_admission_before_execution",
+        ),
+        (
+            MCP_ADAPTER_SURFACE,
+            "mcp_server_runs_prompt_and_command_through_daemon",
+        ),
+        (
+            ACP_ADAPTER_SURFACE,
+            "acp_agent_process_smoke_runs_binary_over_stdio",
+        ),
+        (
+            DEBUG_RPC_SURFACE,
+            "debug_rpc_cli_calls_and_streams_turns_over_websocket",
+        ),
+        (
+            TELEGRAM_WEBHOOK_SURFACE,
+            "telegram_webhook_accepts_update_and_uses_sink",
+        ),
+        (
+            PGQRS_QUEUE_SURFACE,
+            "queue_worker_processes_envelope_after_queue_and_bridge_restart",
+        ),
+        (
+            REMOTE_SYNC_INGRESS_SURFACE,
+            "remote_queue_redelivery_enters_child_ingress_once",
+        ),
+        (
+            KERNEL_THREAD_SUBMIT_SURFACE,
+            "cross_thread_prompt_and_result_events_do_not_rewrite_lineage",
+        ),
+    ];
+
     #[test]
-    fn admission_order_key_breaks_same_millisecond_ties_with_event_id() {
+    fn admission_order_key_matches_replay_merge_tie_breaks() {
         let first = EventRecordId::from_uuid(Uuid::now_v7());
         let second = EventRecordId::from_uuid(Uuid::now_v7());
 
+        // UUIDv7's canonical hyphenated representation preserves UUID byte
+        // order, and `Uuid::now_v7` is process-monotonic within a millisecond.
+        assert!(first.to_string() < second.to_string());
         assert!(
-            (1_772_650_000_000_i64, first.to_string())
-                < (1_772_650_000_000_i64, second.to_string())
+            (
+                1_772_650_000_000_i64,
+                "control:thread".to_string(),
+                1_i64,
+                first.to_string(),
+            ) < (
+                1_772_650_000_000_i64,
+                "thread:thread".to_string(),
+                1_i64,
+                second.to_string(),
+            )
         );
+    }
+
+    #[test]
+    fn raw_submit_guard_detects_non_call_symbol_references() {
+        let source = r#"
+let reserve = RuntimeHost::reserve_turn_submission_at_choke_point;
+pub(super) use ReservedTurnSubmission::submit_unchecked;
+reserved.submit_unchecked
+    ();
+"#;
+
+        assert_eq!(
+            identifier_occurrences(source, "reserve_turn_submission_at_choke_point")
+                .into_iter()
+                .map(|occurrence| occurrence.line)
+                .collect::<Vec<_>>(),
+            vec![2]
+        );
+        assert_eq!(
+            identifier_occurrences(source, "submit_unchecked")
+                .into_iter()
+                .map(|occurrence| occurrence.line)
+                .collect::<Vec<_>>(),
+            vec![3, 4]
+        );
+    }
+
+    #[test]
+    fn admission_fixture_contract_rejects_ignored_or_assertionless_tests() {
+        let ignored = r#"
+#[tokio::test]
+#[ignore = "not in the required lane"]
+async fn fixture() {
+    assert_admission_surface().await;
+}
+"#;
+        let assertionless = r#"
+#[test]
+fn fixture() {
+    // assert_admission_precedes_turn_records();
+    assert!(true);
+}
+"#;
+        let covered = r#"
+#[tokio::test]
+async fn fixture() {
+    assert_admission_precedes_turn_records();
+}
+"#;
+
+        assert!(admission_fixture_contract(ignored, "fixture").is_err());
+        assert!(admission_fixture_contract(assertionless, "fixture").is_err());
+        assert!(admission_fixture_contract(covered, "fixture").is_ok());
+    }
+
+    #[test]
+    fn every_registered_surface_has_an_admission_fixture() {
+        let covered = COVERED_SURFACE_FIXTURES
+            .iter()
+            .map(|(surface, _)| *surface)
+            .collect::<std::collections::BTreeSet<_>>();
+        let missing = TURN_ENTRY_SURFACES
+            .iter()
+            .copied()
+            .filter(|surface| !covered.contains(surface))
+            .collect::<Vec<_>>();
+
+        assert!(
+            missing.is_empty(),
+            "registered turn-entry surface(s) missing admission coverage fixture: {}",
+            missing.join(", ")
+        );
+        assert_eq!(
+            covered.len(),
+            COVERED_SURFACE_FIXTURES.len(),
+            "admission coverage manifest contains duplicate surface entries"
+        );
+
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let mut test_sources = Vec::new();
+        collect_rust_sources(&manifest_dir, &mut |path| {
+            let source = std::fs::read_to_string(path)
+                .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+            test_sources.push((path.to_path_buf(), source));
+        });
+        for (surface, fixture) in COVERED_SURFACE_FIXTURES {
+            let declarations = test_sources
+                .iter()
+                .filter(|(_, source)| source.contains(&format!("fn {fixture}")))
+                .collect::<Vec<_>>();
+            assert_eq!(
+                declarations.len(),
+                1,
+                "registered turn-entry surface {surface} must name exactly one admission fixture {fixture}, found {}",
+                declarations.len()
+            );
+            let (path, source) = declarations[0];
+            admission_fixture_contract(source, fixture).unwrap_or_else(|reason| {
+                let relative = path.strip_prefix(&manifest_dir).unwrap_or(path);
+                panic!(
+                    "registered turn-entry surface {surface} has invalid admission fixture {fixture} in {}: {reason}",
+                    relative.display()
+                )
+            });
+        }
+    }
+
+    #[test]
+    fn app_server_adapter_clients_resolve_to_registered_surfaces() {
+        assert_eq!(app_server_surface(None), APP_SERVER_RPC_SURFACE);
+        assert_eq!(
+            app_server_surface(Some("cooldis-mcp-server")),
+            MCP_ADAPTER_SURFACE
+        );
+        assert_eq!(
+            app_server_surface(Some("cooldis-acp-agent")),
+            ACP_ADAPTER_SURFACE
+        );
+        assert_eq!(
+            app_server_surface(Some("cooldis-debug-rpc")),
+            DEBUG_RPC_SURFACE
+        );
+    }
+
+    #[test]
+    fn raw_turn_submit_choke_point_has_no_callers_outside_admission() {
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let source_root = manifest_dir.join("src");
+        let admission_path = source_root.join("kernel/admission.rs");
+        let runtime_host_path = source_root.join("kernel/runtime_host.rs");
+        let raw_symbols = ["reserve_turn_submission_at_choke_point", "submit_unchecked"];
+        let mut definitions = std::collections::BTreeMap::new();
+        let mut offenders = Vec::new();
+        collect_rust_sources(&source_root, &mut |path| {
+            if path == admission_path {
+                return;
+            }
+            let source = std::fs::read_to_string(path)
+                .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+            let compact = source
+                .chars()
+                .filter(|character| !character.is_whitespace())
+                .collect::<String>();
+            if path.starts_with(source_root.join("kernel"))
+                && (compact.contains("#[path=") || compact.contains("include!("))
+            {
+                let relative = path.strip_prefix(&manifest_dir).unwrap_or(path);
+                offenders.push(format!(
+                    "{}: kernel module uses #[path] or include!, which can hide a raw choke-point reference from the source ratchet",
+                    relative.display()
+                ));
+            }
+            for symbol in raw_symbols {
+                for occurrence in identifier_occurrences(&source, symbol) {
+                    let line = source.lines().nth(occurrence.line - 1).unwrap_or_default();
+                    if path == runtime_host_path
+                        && previous_identifier(&source, occurrence.offset) == Some("fn")
+                    {
+                        *definitions.entry(symbol).or_insert(0_usize) += 1;
+                        continue;
+                    }
+                    let relative = path.strip_prefix(&manifest_dir).unwrap_or(path);
+                    offenders.push(format!(
+                        "{}:{}: {}",
+                        relative.display(),
+                        occurrence.line,
+                        line.trim()
+                    ));
+                }
+            }
+        });
+        for symbol in raw_symbols {
+            let count = definitions.get(symbol).copied().unwrap_or_default();
+            if count != 1 {
+                offenders.push(format!(
+                    "src/kernel/runtime_host.rs: expected exactly one private definition of {symbol}, found {count}"
+                ));
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "turn-submit choke point referenced outside kernel/admission.rs:\n{}",
+            offenders.join("\n")
+        );
+    }
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    struct IdentifierOccurrence {
+        offset: usize,
+        line: usize,
+    }
+
+    fn identifier_occurrences(source: &str, identifier: &str) -> Vec<IdentifierOccurrence> {
+        source
+            .match_indices(identifier)
+            .filter_map(|(offset, _)| {
+                let before = source[..offset].chars().next_back();
+                let after = source[offset + identifier.len()..].chars().next();
+                let is_boundary = |character: Option<char>| {
+                    character
+                        .is_none_or(|character| character != '_' && !character.is_alphanumeric())
+                };
+                (is_boundary(before) && is_boundary(after)).then(|| IdentifierOccurrence {
+                    offset,
+                    line: source[..offset]
+                        .bytes()
+                        .filter(|byte| *byte == b'\n')
+                        .count()
+                        + 1,
+                })
+            })
+            .collect()
+    }
+
+    fn previous_identifier(source: &str, offset: usize) -> Option<&str> {
+        source[..offset]
+            .rsplit(|character: char| character != '_' && !character.is_alphanumeric())
+            .find(|token| !token.is_empty())
+    }
+
+    fn admission_fixture_contract(source: &str, fixture: &str) -> Result<(), String> {
+        let declaration = format!("fn {fixture}");
+        let declaration_offset = source
+            .find(&declaration)
+            .ok_or_else(|| "function declaration is missing".to_string())?;
+        if source[declaration_offset + declaration.len()..].contains(&declaration) {
+            return Err("function declaration is duplicated".to_string());
+        }
+        let declaration_line_start = source[..declaration_offset]
+            .rfind('\n')
+            .map_or(0, |offset| offset + 1);
+        let attribute_start = source[..declaration_line_start]
+            .rfind("\n\n")
+            .map_or(0, |offset| offset + 2);
+        let attributes = &source[attribute_start..declaration_line_start];
+        if !(attributes.contains("#[test]") || attributes.contains("#[tokio::test")) {
+            return Err("fixture is not declared as a test".to_string());
+        }
+        if attributes.contains("ignore") {
+            return Err(
+                "fixture is ignored and does not run in the required full suite".to_string(),
+            );
+        }
+        let body_start = source[declaration_offset..]
+            .find('{')
+            .map(|offset| declaration_offset + offset + 1)
+            .ok_or_else(|| "fixture body is missing".to_string())?;
+        let declaration_prefix = &source[declaration_line_start..declaration_offset];
+        let indent_len = declaration_prefix
+            .find(|character: char| !character.is_whitespace())
+            .unwrap_or(declaration_prefix.len());
+        let indent = &declaration_prefix[..indent_len];
+        let body_end_marker = format!("\n{indent}}}");
+        let body_end = source[body_start..]
+            .find(&body_end_marker)
+            .map(|offset| body_start + offset)
+            .ok_or_else(|| "fixture body closing brace is missing".to_string())?;
+        let body = &source[body_start..body_end];
+        let calls_admission_assertion = body.lines().any(|line| {
+            line.split("//")
+                .next()
+                .unwrap_or_default()
+                .split(|character: char| character != '_' && !character.is_alphanumeric())
+                .any(|token| token.starts_with("assert_admission_"))
+        });
+        if !calls_admission_assertion {
+            return Err("fixture body no longer calls an admission assertion".to_string());
+        }
+        Ok(())
+    }
+
+    fn collect_rust_sources(root: &Path, visit: &mut impl FnMut(&Path)) {
+        let entries = std::fs::read_dir(root)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", root.display()));
+        for entry in entries {
+            let path = entry.expect("source directory entry").path();
+            if path.is_dir() {
+                collect_rust_sources(&path, visit);
+            } else if path.extension().and_then(|extension| extension.to_str()) == Some("rs") {
+                visit(&path);
+            }
+        }
     }
 }

--- a/crates/cooldis-kernel/src/kernel/runtime_host.rs
+++ b/crates/cooldis-kernel/src/kernel/runtime_host.rs
@@ -1,8 +1,6 @@
 use crate::CompactionTrigger;
 use crate::agent::manifest_bind::BoundCouplingSet;
-use crate::kernel::admission::{
-    AdmissionGateContext, HOST_SUBMIT_SURFACE, append_admission_decided,
-};
+use crate::kernel::admission::{AdmissionGateContext, HOST_SUBMIT_SURFACE};
 use crate::kernel::control_decision::{TurnContinuationDecision, TurnContinuationDecisionRequest};
 use crate::kernel::history::{
     EventKind, EventStreamId, InMemorySessionStore, RuntimeStore, SessionContext, SessionEntryKind,
@@ -362,7 +360,7 @@ impl Drop for PublishedThreadStartGuard {
 
 impl ReservedTurnSubmission {
     /// Publishes a submission after all fallible admission work has completed.
-    pub(crate) async fn submit(self) -> bool {
+    pub(super) async fn submit_unchecked(self) -> bool {
         let Self {
             host,
             thread,
@@ -923,7 +921,8 @@ impl RuntimeHost {
                     *accepted_event_id,
                 )
                 .await?;
-                self.submit_turn_with_admission(
+                crate::kernel::admission::submit_turn(
+                    self,
                     thread_id,
                     next_turn_id.clone(),
                     TurnInput::text(request_payload.next_turn_input),
@@ -976,7 +975,8 @@ impl RuntimeHost {
                     accepted.id,
                 )
                 .await?;
-                self.submit_turn_with_admission(
+                crate::kernel::admission::submit_turn(
+                    self,
                     thread_id,
                     next_turn_id.clone(),
                     TurnInput::text(next_turn_input),
@@ -1023,26 +1023,18 @@ impl RuntimeHost {
         mode: TurnSubmissionMode,
     ) -> CooldisResult<()> {
         let admission = AdmissionGateContext::surface_default(HOST_SUBMIT_SURFACE, Vec::new())?;
-        self.submit_turn_with_admission(thread_id, turn_id, input, mode, Some(admission))
-            .await
+        crate::kernel::admission::submit_turn(
+            self,
+            thread_id,
+            turn_id,
+            input,
+            mode,
+            Some(admission),
+        )
+        .await
     }
 
-    pub(crate) async fn submit_turn_with_admission(
-        &self,
-        thread_id: ThreadId,
-        turn_id: impl Into<String>,
-        input: TurnInput,
-        mode: TurnSubmissionMode,
-        admission: Option<AdmissionGateContext>,
-    ) -> CooldisResult<()> {
-        self.reserve_turn_submission_with_admission(thread_id, turn_id, input, mode, admission)
-            .await?
-            .submit()
-            .await;
-        Ok(())
-    }
-
-    pub(crate) async fn reserve_turn_submission_with_admission(
+    pub(super) async fn reserve_turn_submission_at_choke_point(
         &self,
         thread_id: ThreadId,
         turn_id: impl Into<String>,
@@ -1115,7 +1107,7 @@ impl RuntimeHost {
             .await
             .map_err(|_| CooldisError::ThreadClosed(thread_id))?;
         if let Some(admission) = admission {
-            append_admission_decided(&thread, admission).await?;
+            crate::kernel::admission::append_admission_decided(&thread, admission).await?;
         }
         let turn_watchdog = if self.inner.execution_policy.turn_timeout_ms.is_some() {
             Some(thread.thread.services.register_turn_watchdog(&mut input))

--- a/crates/cooldis-kernel/src/kernel/runtime_host/kernel_control.rs
+++ b/crates/cooldis-kernel/src/kernel/runtime_host/kernel_control.rs
@@ -15,6 +15,7 @@ use crate::agent::manifest_bind::{BoundCouplingSet, coupling_set_content_hash};
 use crate::daemon::remote_store::placement::{
     RemoteThreadExecutor, RemoteThreadSpawnRequest, RemoteThreadSubmitRequest,
 };
+use crate::kernel::admission::{AdmissionGateContext, KERNEL_THREAD_SUBMIT_SURFACE};
 use crate::kernel::history::{
     EventKind, EventProvenance, EventRecord, EventRecordId, EventSequence, EventStreamId,
     NewEventRecord, SessionContext, ThreadSpawnedPayload,
@@ -823,17 +824,18 @@ impl RuntimeKernelControl {
             });
         }
         let target = self.scoped_thread(caller, target_thread_id).await?;
-        let submitted = host
-            .reserve_turn_submission_with_admission(
-                target_thread_id,
-                turn_id.clone(),
-                input,
-                TurnSubmissionMode::Queue,
-                None,
-            )
-            .await?
-            .submit()
-            .await;
+        let admission =
+            AdmissionGateContext::surface_default(KERNEL_THREAD_SUBMIT_SURFACE, Vec::new())?;
+        let reserved = crate::kernel::admission::reserve_turn(
+            &host,
+            target_thread_id,
+            turn_id.clone(),
+            input,
+            TurnSubmissionMode::Queue,
+            Some(admission),
+        )
+        .await?;
+        let submitted = crate::kernel::admission::submit_reserved(reserved).await;
         let metadata = BTreeMap::from([
             (
                 "operation".to_string(),

--- a/crates/cooldis-kernel/src/kernel/runtime_host/tests.rs
+++ b/crates/cooldis-kernel/src/kernel/runtime_host/tests.rs
@@ -2364,6 +2364,16 @@ async fn cross_thread_prompt_and_result_events_do_not_rewrite_lineage() {
     .await;
     assert_eq!(received.coordinates.thread_id, child_id);
     assert_output(&mut child_output_events, "turn-cross:from root").await;
+    let control_events = child.read_control_events().await.unwrap();
+    let thread_events = child.read_thread_events(None).await.unwrap();
+    let admission = crate::kernel::admission::assert_admission_precedes_turn_records(
+        &control_events,
+        &thread_events,
+    );
+    assert_eq!(
+        admission.payload["route_id"],
+        "surface:kernel-thread-submit"
+    );
 
     let wait = control
         .wait_thread(root.context(), child_id, Some(1_000))

--- a/crates/cooldis-kernel/src/kernel/supervisor.rs
+++ b/crates/cooldis-kernel/src/kernel/supervisor.rs
@@ -528,7 +528,7 @@ impl CooldisSupervisor {
             .await
     }
 
-    pub(crate) async fn submit_turn_to_with_admission(
+    pub(crate) async fn submit_admitted_turn_to(
         &self,
         coordinates: &ThreadCoordinates,
         turn_id: impl Into<String>,
@@ -537,14 +537,19 @@ impl CooldisSupervisor {
         admission: Option<AdmissionGateContext>,
     ) -> CooldisResult<()> {
         self.get_thread_at(coordinates).await?;
-        self.tenant(&coordinates.tenant_id)
-            .await?
-            .host
-            .submit_turn_with_admission(coordinates.thread_id, turn_id, input, mode, admission)
-            .await
+        let tenant = self.tenant(&coordinates.tenant_id).await?;
+        crate::kernel::admission::submit_turn(
+            &tenant.host,
+            coordinates.thread_id,
+            turn_id,
+            input,
+            mode,
+            admission,
+        )
+        .await
     }
 
-    pub(crate) async fn reserve_turn_to_with_admission(
+    pub(crate) async fn reserve_admitted_turn_to(
         &self,
         coordinates: &ThreadCoordinates,
         turn_id: impl Into<String>,
@@ -553,17 +558,16 @@ impl CooldisSupervisor {
         admission: Option<AdmissionGateContext>,
     ) -> CooldisResult<ReservedTurnSubmission> {
         self.get_thread_at(coordinates).await?;
-        self.tenant(&coordinates.tenant_id)
-            .await?
-            .host
-            .reserve_turn_submission_with_admission(
-                coordinates.thread_id,
-                turn_id,
-                input,
-                mode,
-                admission,
-            )
-            .await
+        let tenant = self.tenant(&coordinates.tenant_id).await?;
+        crate::kernel::admission::reserve_turn(
+            &tenant.host,
+            coordinates.thread_id,
+            turn_id,
+            input,
+            mode,
+            admission,
+        )
+        .await
     }
 
     pub async fn compact_thread_at(

--- a/crates/cooldis-kernel/src/kernel/supervisor/tests.rs
+++ b/crates/cooldis-kernel/src/kernel/supervisor/tests.rs
@@ -234,7 +234,7 @@ async fn dropped_turn_reservation_releases_turn_id() {
 
     drop(
         supervisor
-            .reserve_turn_to_with_admission(
+            .reserve_admitted_turn_to(
                 coordinates,
                 "turn-retry",
                 TurnInput::text("first"),

--- a/crates/cooldis-kernel/tests/acp_agent_process_smoke.rs
+++ b/crates/cooldis-kernel/tests/acp_agent_process_smoke.rs
@@ -1,4 +1,7 @@
-use cooldis::{AppServerListenAddr, CooldisAppServer, CooldisAppServerConfig};
+use cooldis::{
+    AppServerListenAddr, CooldisAppServer, CooldisAppServerConfig, EventKind, EventStore,
+    EventStreamId, SqliteSessionStore,
+};
 use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -116,6 +119,18 @@ async fn acp_agent_process_smoke_runs_binary_over_stdio() {
         prompt["result"]["cooldis"]["assistantText"],
         "local:process smoke"
     );
+    let store = SqliteSessionStore::open(root.join("state/session_history.sqlite3"))
+        .await
+        .unwrap();
+    let control_events = store
+        .read_events(&EventStreamId::new(format!("control:{session_id}")), None)
+        .await
+        .unwrap();
+    let thread_events = store
+        .read_events(&EventStreamId::new(format!("thread:{session_id}")), None)
+        .await
+        .unwrap();
+    assert_admission_precedes_execution(&control_events, &thread_events, "surface:acp-adapter");
 
     send(
         &mut stdin,
@@ -135,6 +150,40 @@ async fn acp_agent_process_smoke_runs_binary_over_stdio() {
     serve_task.abort();
     let _ = serve_task.await;
     let _ = std::fs::remove_dir_all(root);
+}
+
+fn assert_admission_precedes_execution(
+    control_events: &[cooldis::EventRecord],
+    thread_events: &[cooldis::EventRecord],
+    route_id: &str,
+) {
+    let admission = control_events
+        .iter()
+        .find(|event| {
+            event.kind == EventKind::AdmissionDecided && event.payload["route_id"] == route_id
+        })
+        .expect("control stream missing expected admission.decided");
+    let executed = thread_events
+        .iter()
+        .find(|event| {
+            event.kind == EventKind::SessionEntryAppended
+                && event.payload["runtime_kind"] != "thread_started"
+        })
+        .expect("thread stream missing executed turn session entry");
+    assert!(
+        (
+            admission.created_at_ms,
+            admission.stream_id.to_string(),
+            admission.sequence.get(),
+            admission.id.to_string(),
+        ) < (
+            executed.created_at_ms,
+            executed.stream_id.to_string(),
+            executed.sequence.get(),
+            executed.id.to_string(),
+        ),
+        "admission.decided must precede executed turn session entry"
+    );
 }
 
 async fn send<W>(writer: &mut W, message: &str)

--- a/crates/cooldis-kernel/tests/cooldis_debug_rpc.rs
+++ b/crates/cooldis-kernel/tests/cooldis_debug_rpc.rs
@@ -1,6 +1,6 @@
 use cooldis::{
     AppServerListenAddr, CodexTuiConnectConfig, CodexTuiTestClient, CooldisAppServer,
-    CooldisAppServerConfig,
+    CooldisAppServerConfig, EventKind, EventStore, EventStreamId, SqliteSessionStore,
 };
 use serde_json::Value;
 use std::net::{SocketAddr, TcpListener};
@@ -75,9 +75,55 @@ async fn debug_rpc_cli_calls_and_streams_turns_over_websocket() {
         resumed_stdout.contains("second debug rpc turn"),
         "resumed turn output did not include prompt: {resumed_stdout:?}"
     );
+    let store = SqliteSessionStore::open(root.join("state/session_history.sqlite3"))
+        .await
+        .unwrap();
+    let control_events = store
+        .read_events(&EventStreamId::new(format!("control:{thread_id}")), None)
+        .await
+        .unwrap();
+    let thread_events = store
+        .read_events(&EventStreamId::new(format!("thread:{thread_id}")), None)
+        .await
+        .unwrap();
+    assert_admission_precedes_execution(&control_events, &thread_events, "surface:debug-rpc");
 
     server.stop().await;
     let _ = std::fs::remove_dir_all(root);
+}
+
+fn assert_admission_precedes_execution(
+    control_events: &[cooldis::EventRecord],
+    thread_events: &[cooldis::EventRecord],
+    route_id: &str,
+) {
+    let admission = control_events
+        .iter()
+        .find(|event| {
+            event.kind == EventKind::AdmissionDecided && event.payload["route_id"] == route_id
+        })
+        .expect("control stream missing expected admission.decided");
+    let executed = thread_events
+        .iter()
+        .find(|event| {
+            event.kind == EventKind::SessionEntryAppended
+                && event.payload["runtime_kind"] != "thread_started"
+        })
+        .expect("thread stream missing executed turn session entry");
+    assert!(
+        (
+            admission.created_at_ms,
+            admission.stream_id.to_string(),
+            admission.sequence.get(),
+            admission.id.to_string(),
+        ) < (
+            executed.created_at_ms,
+            executed.stream_id.to_string(),
+            executed.sequence.get(),
+            executed.id.to_string(),
+        ),
+        "admission.decided must precede executed turn session entry"
+    );
 }
 
 struct DebugRpcServer {

--- a/docs/agent-manifest-ontology.md
+++ b/docs/agent-manifest-ontology.md
@@ -369,17 +369,23 @@ runtime command is enqueued. Daemon ingress records its route policy context
 `io.ingress.received` event ids) and then schedules through the already-admitted
 runtime path so it cannot double emit.
 
-Non-daemon turn-starting surfaces use the `surface:<name>` route convention. The
-app-server RPC path records `surface:app-server-rpc`; direct
-`RuntimeHost::submit*` records `surface:host-submit`. Their policy hash is the
-canonical hash of the declared trivial surface policy, not an empty string. The
-current journal schema has queue/steer/interrupt/fork/observe/reject/coalesce
-decision values, so the trivial admitted surface policy lowers to
-`decision = "queue"` with `admissible = ["queue"]`. App-server RPC first
-witnesses the input as `io.ingress.received` and names that event in
-`source_ingress_event_ids`; direct host submit has no ingress event, so its
-source list is intentionally empty. CLI chat submits through the operator RPC
-path and inherits the app-server surface admission record.
+Non-daemon turn-starting surfaces use the `surface:<name>` route convention.
+The app-server RPC path records the surface of the initialized client:
+`surface:mcp-adapter`, `surface:acp-adapter`, and `surface:debug-rpc` for the
+bundled adapters, `surface:app-server-rpc` for any other client. The surface
+label is attribution and provenance only; admission authority is the same
+declared surface policy for all of them. Direct `RuntimeHost::submit*` records
+`surface:host-submit`; kernel thread-to-thread submission records
+`surface:kernel-thread-submit`. Their policy hash is the canonical hash of the
+declared trivial surface policy, not an empty string. The current journal
+schema has queue/steer/interrupt/fork/observe/reject/coalesce decision values,
+so the trivial admitted surface policy lowers to `decision = "queue"` with
+`admissible = ["queue"]`. App-server RPC first witnesses the input as
+`io.ingress.received` and names that event in `source_ingress_event_ids`;
+direct host submit has no ingress event, so its source list is intentionally
+empty. CLI chat submits through the operator RPC path and inherits the
+app-server surface admission record. The registry of turn-entry surfaces and
+the coverage ratchet over them live in `kernel/admission.rs`.
 
 In-loop continuations use the same admission law through the continuation gate:
 `turn.continuation.accepted` or `turn.continuation.rejected` records the


### PR DESCRIPTION
Mechanical ratchet for the admission law: every continuation the kernel executes was admitted; no side door.

- `turn_entry_surfaces!` registry in `kernel/admission.rs` now enumerates all nine turn-entry surfaces (including `remote-sync-ingress`, added by the review gate as a High finding) and is the single source of surface labels.
- Coverage test requires exactly one non-ignored admission fixture per registered surface.
- Source-scan guard rejects any caller of the raw submit choke point outside the admission module, plus `#[path=]`/`include!` smuggling in kernel modules.
- Admission order key pinned to the canonical replay-merge tie-break `(created_at_ms, stream_id, sequence, id)`.
- `runtime_host` raw submit demoted to `pub(super)`; kernel-thread cross-submission routed through the declared-surface gate.
- Doc: `docs/agent-manifest-ontology.md` now states the surface label is attribution/provenance only; admission authority is the same declared surface policy for all adapters (resolves the doc-vs-code direction call in code's favor).

Review trail: implementation + write-capable review gate (4 fixes) on Linear EMO-478.

Verification: full workspace suite green locally (pre-push hook), fmt/clippy/guard-rails clean.