### PR TITLE
EMO-450: immutable authored + resolved manifest version snapshots

### DIFF
--- a/crates/cooldis-kernel/src/adapters/app_server/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/tests.rs
@@ -1504,6 +1504,8 @@ async fn agent_query_methods_project_local_registry_records() {
     assert_eq!(local_agent["toolIds"].as_array().unwrap().len(), 0);
     assert_eq!(local_agent["aliases"][0]["alias"].as_str(), Some("latest"));
     assert_eq!(local_agent["aliases"][0]["version"].as_str(), Some("0.1.0"));
+    assert!(local_agent.get("authored_source").is_none());
+    assert!(local_agent.get("resolved_manifest").is_none());
 
     let read = app
         .dispatch_request(
@@ -1716,11 +1718,12 @@ async fn agent_publish_writes_new_version_and_rejects_stale_base() {
         Some("Publisher v2")
     );
     assert_eq!(publish["latestAlias"]["version"].as_str(), Some("0.1.1"));
-    assert!(
-        LocalAgentRegistry::new(&agent_registry_root)
-            .version_record_path("publisher", "0.1.1")
-            .unwrap()
-            .exists()
+    let published_record = LocalAgentRegistry::new(&agent_registry_root)
+        .load_version_record("publisher", "0.1.1")
+        .unwrap();
+    assert_eq!(
+        published_record.authored_source.as_deref(),
+        publish["source"].as_str()
     );
 
     let stale = app
@@ -2857,6 +2860,12 @@ async fn default_manifest_publish_is_idempotent_and_patch_bumps_on_model_change(
     let registry = LocalAgentRegistry::new(&agent_registry_root);
     let first = registry.load_ref("agent://cooldis/default@latest").unwrap();
     assert_eq!(first.version, "1.0.0");
+    assert!(
+        first
+            .authored_source
+            .as_deref()
+            .is_some_and(|source| source.contains("name = \"default\""))
+    );
     assert_eq!(default_agent_version_count(&agent_registry_root), 1);
 
     let _ = CooldisAppServer::new_local(config.clone()).await.unwrap();

--- a/crates/cooldis-kernel/src/agent/manifest.rs
+++ b/crates/cooldis-kernel/src/agent/manifest.rs
@@ -12,6 +12,7 @@ use cooldis_agent::{validate_namespace, validate_version};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -236,6 +237,45 @@ impl LocalAgentRegistry {
             .collect()
     }
 
+    pub fn list_version_records(&self, name: &str) -> CooldisResult<Vec<AgentVersionSummary>> {
+        let name = validate_record_name(name)?;
+        let versions_dir = self.root.join("versions").join(&name);
+        if !versions_dir.exists() {
+            return Ok(Vec::new());
+        }
+        let mut records = Vec::new();
+        for entry in fs::read_dir(&versions_dir).map_err(|err| {
+            CooldisError::RuntimeFactory(format!(
+                "failed to read agent versions directory {}: {err}",
+                versions_dir.display()
+            ))
+        })? {
+            let entry = entry.map_err(|err| {
+                CooldisError::RuntimeFactory(format!(
+                    "failed to read agent version entry in {}: {err}",
+                    versions_dir.display()
+                ))
+            })?;
+            let path = entry.path();
+            if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+                continue;
+            }
+            let Some(version) = path.file_stem().and_then(|stem| stem.to_str()) else {
+                continue;
+            };
+            let record = self.load_version_record(&name, version)?;
+            records.push(AgentVersionSummary {
+                version: record.version,
+                source_hash: record.source_hash,
+                manifest_hash: record.manifest_hash,
+                published_at_ms: record.published_at_ms,
+                authored_source_present: record.authored_source.is_some(),
+            });
+        }
+        records.sort_by_key(|record| record.published_at_ms);
+        Ok(records)
+    }
+
     /// Resolve a mutable alias (`latest`, `stable`, ...) to its immutable
     /// version record, producing a resolution receipt. Aliases live under
     /// `aliases/<name>/<alias>.json`; `latest` is maintained automatically on
@@ -409,6 +449,7 @@ pub struct AgentPublishPlan {
     pub version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    pub authored_source: String,
     pub source_hash: String,
     pub manifest_hash: String,
     pub model_profile_count: usize,
@@ -535,6 +576,7 @@ impl AgentPublishPlan {
             namespace,
             version,
             description: manifest.identity.description.clone(),
+            authored_source: source.to_string(),
             source_hash,
             manifest_hash,
             model_profile_count: manifest.model_profiles.len(),
@@ -645,6 +687,7 @@ impl AgentPublishPlan {
             namespace: self.namespace,
             version: self.version,
             description: self.description,
+            authored_source: Some(self.authored_source),
             source_hash: self.source_hash,
             manifest_hash: self.manifest_hash,
             model_profile_count: self.model_profile_count,
@@ -659,6 +702,8 @@ impl AgentPublishPlan {
     }
 }
 
+/// A manifest version snapshot pairs `authored_source` and `resolved_manifest`
+/// with their `source_hash` and `manifest_hash`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PublishedAgentRecord {
     pub schema_version: u32,
@@ -669,6 +714,8 @@ pub struct PublishedAgentRecord {
     pub version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authored_source: Option<String>,
     pub source_hash: String,
     pub manifest_hash: String,
     pub model_profile_count: usize,
@@ -682,6 +729,114 @@ pub struct PublishedAgentRecord {
     pub ref_uri: String,
     pub resolved_manifest: JsonValue,
     pub published_at_ms: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentVersionSummary {
+    pub version: String,
+    pub source_hash: String,
+    pub manifest_hash: String,
+    pub published_at_ms: u64,
+    pub authored_source_present: bool,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentManifestDiffKind {
+    Added,
+    Removed,
+    Changed,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentManifestDiffChange {
+    pub path: String,
+    pub kind: AgentManifestDiffKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after: Option<JsonValue>,
+}
+
+pub fn diff_canonical_json(before: &JsonValue, after: &JsonValue) -> Vec<AgentManifestDiffChange> {
+    let mut changes = Vec::new();
+    diff_canonical_json_at_path(before, after, "", &mut changes);
+    changes.sort_by(|left, right| left.path.cmp(&right.path));
+    changes
+}
+
+fn diff_canonical_json_at_path(
+    before: &JsonValue,
+    after: &JsonValue,
+    path: &str,
+    changes: &mut Vec<AgentManifestDiffChange>,
+) {
+    if before == after {
+        return;
+    }
+    match (before, after) {
+        (JsonValue::Object(before), JsonValue::Object(after)) => {
+            let keys = before
+                .keys()
+                .chain(after.keys())
+                .map(String::as_str)
+                .collect::<BTreeSet<_>>();
+            for key in keys {
+                let child_path = json_pointer_child(path, key);
+                match (before.get(key), after.get(key)) {
+                    (Some(before), Some(after)) => {
+                        diff_canonical_json_at_path(before, after, &child_path, changes)
+                    }
+                    (Some(before), None) => changes.push(AgentManifestDiffChange {
+                        path: child_path,
+                        kind: AgentManifestDiffKind::Removed,
+                        before: Some(before.clone()),
+                        after: None,
+                    }),
+                    (None, Some(after)) => changes.push(AgentManifestDiffChange {
+                        path: child_path,
+                        kind: AgentManifestDiffKind::Added,
+                        before: None,
+                        after: Some(after.clone()),
+                    }),
+                    (None, None) => {}
+                }
+            }
+        }
+        (JsonValue::Array(before), JsonValue::Array(after)) => {
+            for index in 0..before.len().max(after.len()) {
+                let child_path = json_pointer_child(path, &index.to_string());
+                match (before.get(index), after.get(index)) {
+                    (Some(before), Some(after)) => {
+                        diff_canonical_json_at_path(before, after, &child_path, changes)
+                    }
+                    (Some(before), None) => changes.push(AgentManifestDiffChange {
+                        path: child_path,
+                        kind: AgentManifestDiffKind::Removed,
+                        before: Some(before.clone()),
+                        after: None,
+                    }),
+                    (None, Some(after)) => changes.push(AgentManifestDiffChange {
+                        path: child_path,
+                        kind: AgentManifestDiffKind::Added,
+                        before: None,
+                        after: Some(after.clone()),
+                    }),
+                    (None, None) => {}
+                }
+            }
+        }
+        _ => changes.push(AgentManifestDiffChange {
+            path: path.to_string(),
+            kind: AgentManifestDiffKind::Changed,
+            before: Some(before.clone()),
+            after: Some(after.clone()),
+        }),
+    }
+}
+
+fn json_pointer_child(path: &str, segment: &str) -> String {
+    format!("{path}/{}", segment.replace('~', "~0").replace('/', "~1"))
 }
 
 impl PublishedAgentRecord {
@@ -1203,6 +1358,13 @@ fn canonical_json_from_schema(value: &AgentManifestSchema) -> CooldisResult<Json
         CooldisError::RuntimeFactory(format!("failed to canonicalize agent manifest: {err}"))
     })?;
     Ok(sort_json(json))
+}
+
+pub(crate) fn canonical_json_from_authored_source(source: &str) -> CooldisResult<JsonValue> {
+    let value: toml::Value = toml::from_str(source)
+        .map_err(|err| CooldisError::RuntimeFactory(format!("invalid agent manifest: {err}")))?;
+    let manifest = AgentManifestSchema::from_toml_value(&value)?;
+    canonical_json_from_schema(&manifest)
 }
 
 fn sort_json(value: JsonValue) -> JsonValue {

--- a/crates/cooldis-kernel/src/agent/manifest/tests.rs
+++ b/crates/cooldis-kernel/src/agent/manifest/tests.rs
@@ -933,3 +933,213 @@ fn legacy_records_without_resolved_refs_still_load() {
     let loaded = registry.load_record("release-verifier").unwrap();
     assert!(loaded.resolved_refs.is_empty());
 }
+
+#[test]
+fn published_records_round_trip_authored_source_and_legacy_absence() {
+    let registry = LocalAgentRegistry::new(temp_root("authored-source"));
+    let operation_root = seed_tailcat_operation_root("authored-source-operations");
+    let source = manifest_source("release-verifier", "1.0.0", false);
+    let record = registry
+        .publish_plan_with_operation_registry(
+            AgentPublishPlan::from_source(&source).unwrap(),
+            &operation_root,
+        )
+        .unwrap();
+
+    assert_eq!(record.authored_source.as_deref(), Some(source.as_str()));
+    assert_eq!(
+        registry
+            .load_record("release-verifier")
+            .unwrap()
+            .authored_source
+            .as_deref(),
+        Some(source.as_str())
+    );
+    assert_eq!(
+        registry
+            .load_version_record("release-verifier", "1.0.0")
+            .unwrap()
+            .authored_source
+            .as_deref(),
+        Some(source.as_str())
+    );
+
+    for path in [
+        registry.record_path("release-verifier").unwrap(),
+        registry
+            .version_record_path("release-verifier", "1.0.0")
+            .unwrap(),
+    ] {
+        let mut json: JsonValue = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        json.as_object_mut().unwrap().remove("authored_source");
+        fs::write(&path, serde_json::to_vec_pretty(&json).unwrap()).unwrap();
+    }
+
+    let legacy_head = registry.load_record("release-verifier").unwrap();
+    let legacy_version = registry
+        .load_version_record("release-verifier", "1.0.0")
+        .unwrap();
+    assert!(legacy_head.authored_source.is_none());
+    assert!(legacy_version.authored_source.is_none());
+    assert!(
+        serde_json::to_value(&legacy_head)
+            .unwrap()
+            .get("authored_source")
+            .is_none()
+    );
+    assert!(
+        serde_json::to_value(&legacy_version)
+            .unwrap()
+            .get("authored_source")
+            .is_none()
+    );
+}
+
+#[test]
+fn immutable_version_record_keeps_first_authored_snapshot() {
+    let registry = LocalAgentRegistry::new(temp_root("authored-source-immutable"));
+    let operation_root = seed_tailcat_operation_root("authored-source-immutable-operations");
+    let original = manifest_source("release-verifier", "1.0.0", false);
+    registry
+        .publish_plan_with_operation_registry(
+            AgentPublishPlan::from_source(&original).unwrap(),
+            &operation_root,
+        )
+        .unwrap();
+
+    let reformatted = format!("# republished with a comment\n{original}");
+    registry
+        .publish_plan_with_operation_registry(
+            AgentPublishPlan::from_source(&reformatted).unwrap(),
+            &operation_root,
+        )
+        .unwrap();
+
+    let version = registry
+        .load_version_record("release-verifier", "1.0.0")
+        .unwrap();
+    assert_eq!(version.authored_source.as_deref(), Some(original.as_str()));
+
+    let changed = original.replace("Checks a release branch.", "Checks every release branch.");
+    let error = registry
+        .publish_plan_with_operation_registry(
+            AgentPublishPlan::from_source(&changed).unwrap(),
+            &operation_root,
+        )
+        .unwrap_err();
+    assert!(error.to_string().contains("refusing to replace"));
+    assert_eq!(
+        registry
+            .load_version_record("release-verifier", "1.0.0")
+            .unwrap()
+            .authored_source
+            .as_deref(),
+        Some(original.as_str())
+    );
+}
+
+#[test]
+fn version_records_are_listed_by_publication_time_not_declared_version() {
+    let registry = LocalAgentRegistry::new(temp_root("version-history"));
+    for (version, published_at_ms) in [("9.0.0", 300), ("1.0.0", 100), ("2.0.0", 200)] {
+        let record =
+            AgentPublishPlan::from_source(&manifest_source("release-verifier", version, false))
+                .unwrap()
+                .into_record(published_at_ms);
+        registry.write_version_record_atomically(&record).unwrap();
+    }
+
+    let versions = registry.list_version_records("release-verifier").unwrap();
+    assert_eq!(
+        versions
+            .iter()
+            .map(|record| record.version.as_str())
+            .collect::<Vec<_>>(),
+        vec!["1.0.0", "2.0.0", "9.0.0"]
+    );
+    assert_eq!(
+        versions
+            .iter()
+            .map(|record| record.published_at_ms)
+            .collect::<Vec<_>>(),
+        vec![100, 200, 300]
+    );
+    assert!(versions.iter().all(|record| record.authored_source_present));
+    let listed = serde_json::to_value(&versions).unwrap();
+    assert!(listed[0].get("authored_source").is_none());
+    assert!(listed[0].get("resolved_manifest").is_none());
+}
+
+#[test]
+fn canonical_json_diff_is_structural_path_ordered_and_escapes_json_pointers() {
+    let before = serde_json::json!({
+        "array": [{"pin": "op://tailcat@sha256:old"}, "removed"],
+        "nested": {"changed": 1, "removed": true},
+        "ref": "agent://worker@latest",
+        "a/b": {"~pin": "old"},
+    });
+    let after = serde_json::json!({
+        "array": [{"pin": "op://tailcat@sha256:new"}],
+        "nested": {"added": null, "changed": 2},
+        "ref": "agent://worker@2.0.0",
+        "a/b": {"~pin": "new"},
+    });
+
+    let changes = diff_canonical_json(&before, &after);
+
+    assert_eq!(
+        changes
+            .iter()
+            .map(|change| (change.path.as_str(), change.kind))
+            .collect::<Vec<_>>(),
+        vec![
+            ("/array/0/pin", AgentManifestDiffKind::Changed),
+            ("/array/1", AgentManifestDiffKind::Removed),
+            ("/a~1b/~0pin", AgentManifestDiffKind::Changed),
+            ("/nested/added", AgentManifestDiffKind::Added),
+            ("/nested/changed", AgentManifestDiffKind::Changed),
+            ("/nested/removed", AgentManifestDiffKind::Removed),
+            ("/ref", AgentManifestDiffKind::Changed),
+        ]
+    );
+    assert_eq!(
+        changes[0].before,
+        Some(serde_json::json!("op://tailcat@sha256:old"))
+    );
+    assert_eq!(
+        changes[0].after,
+        Some(serde_json::json!("op://tailcat@sha256:new"))
+    );
+    assert_eq!(changes[1].before, Some(serde_json::json!("removed")));
+    assert_eq!(changes[1].after, None);
+    assert_eq!(changes[3].before, None);
+    assert_eq!(changes[3].after, Some(JsonValue::Null));
+    assert!(changes.iter().all(|change| match change.kind {
+        AgentManifestDiffKind::Added => change.before.is_none() && change.after.is_some(),
+        AgentManifestDiffKind::Removed => change.before.is_some() && change.after.is_none(),
+        AgentManifestDiffKind::Changed => change.before.is_some() && change.after.is_some(),
+    }));
+    let encoded = serde_json::to_value(&changes).unwrap();
+    assert!(encoded[0].get("before").is_some());
+    assert!(encoded[0].get("after").is_some());
+    assert!(encoded[1].get("before").is_some());
+    assert!(encoded[1].get("after").is_none());
+    assert!(encoded[3].get("before").is_none());
+    assert!(encoded[3].get("after").is_some_and(JsonValue::is_null));
+}
+
+#[test]
+fn canonical_json_diff_sorts_array_index_paths_lexicographically() {
+    let before = serde_json::json!([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    let after = serde_json::json!([0, 1, 20, 3, 4, 5, 6, 7, 8, 9, 100]);
+
+    let changes = diff_canonical_json(&before, &after);
+
+    assert_eq!(
+        changes
+            .iter()
+            .map(|change| change.path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["/10", "/2"]
+    );
+}

--- a/crates/cooldis-kernel/src/cli/agent.rs
+++ b/crates/cooldis-kernel/src/cli/agent.rs
@@ -1,6 +1,7 @@
 //! The `agent` subcommand family.
 
 use super::*;
+use chrono::{SecondsFormat, TimeZone, Utc};
 
 pub(super) async fn run_agent(mut args: Vec<OsString>) -> CooldisResult<()> {
     if args.is_empty()
@@ -17,6 +18,8 @@ pub(super) async fn run_agent(mut args: Vec<OsString>) -> CooldisResult<()> {
         "plan" => agent_plan(args).await,
         "publish" => agent_publish(args).await,
         "list" => agent_list(args).await,
+        "versions" => agent_versions(args).await,
+        "diff" => agent_diff(args).await,
         "show" => agent_show(args).await,
         "run" => agent_run(args).await,
         other => Err(usage_error(format!("unknown agent subcommand {other:?}"))),
@@ -498,6 +501,143 @@ pub(super) async fn agent_list(args: Vec<OsString>) -> CooldisResult<()> {
     Ok(())
 }
 
+pub(super) async fn agent_versions(args: Vec<OsString>) -> CooldisResult<()> {
+    let options = parse_agent_versions_args(args)?;
+    if options.help {
+        print_agent_versions_help();
+        return Ok(());
+    }
+    let name = options
+        .name
+        .ok_or_else(|| usage_error("agent versions requires <name>"))?;
+    let registry = LocalAgentRegistry::new(agent_registry_root(options.registry_root));
+    let records = registry.list_version_records(&name)?;
+    if options.json {
+        let rows = records
+            .iter()
+            .map(|record| {
+                json!({
+                    "version": record.version,
+                    "source_hash": record.source_hash,
+                    "manifest_hash": record.manifest_hash,
+                    "published_at_ms": record.published_at_ms,
+                    "authored_source_present": record.authored_source_present,
+                })
+            })
+            .collect::<Vec<_>>();
+        serde_json::to_writer_pretty(std::io::stdout(), &rows)
+            .map_err(|err| usage_error(format!("failed to encode agent versions JSON: {err}")))?;
+        println!();
+        return Ok(());
+    }
+    println!("{:<24}  {:<16}  MANIFEST HASH", "PUBLISHED AT", "VERSION");
+    for record in records {
+        let published_at = i64::try_from(record.published_at_ms)
+            .ok()
+            .and_then(|millis| Utc.timestamp_millis_opt(millis).single())
+            .ok_or_else(|| {
+                CooldisError::RuntimeFactory(format!(
+                    "agent record {}@{} has invalid published_at_ms {}",
+                    name, record.version, record.published_at_ms
+                ))
+            })?
+            .to_rfc3339_opts(SecondsFormat::Millis, true);
+        let authored = if !record.authored_source_present {
+            "  [no-authored-source]"
+        } else {
+            ""
+        };
+        println!(
+            "{published_at:<24}  {:<16}  {}{authored}",
+            record.version, record.manifest_hash
+        );
+    }
+    Ok(())
+}
+
+pub(super) async fn agent_diff(args: Vec<OsString>) -> CooldisResult<()> {
+    let options = parse_agent_diff_args(args)?;
+    if options.help {
+        print_agent_diff_help();
+        return Ok(());
+    }
+    let name = options
+        .name
+        .ok_or_else(|| usage_error("agent diff requires <name>"))?;
+    let from = options
+        .from
+        .ok_or_else(|| usage_error("agent diff requires --from <version>[:authored|:resolved]"))?;
+    let to = options
+        .to
+        .ok_or_else(|| usage_error("agent diff requires --to <version>[:authored|:resolved]"))?;
+    let registry = LocalAgentRegistry::new(agent_registry_root(options.registry_root));
+    let from_record = registry.load_version_record(&name, &from.version)?;
+    let to_record = registry.load_version_record(&name, &to.version)?;
+    let before = manifest_diff_snapshot(&from_record, from.form)?;
+    let after = manifest_diff_snapshot(&to_record, to.form)?;
+    let changes = crate::diff_canonical_json(&before, &after);
+    if options.json {
+        serde_json::to_writer_pretty(std::io::stdout(), &changes)
+            .map_err(|err| usage_error(format!("failed to encode agent diff JSON: {err}")))?;
+        println!();
+        return Ok(());
+    }
+    println!(
+        "manifest {name} {}:{} -> {}:{}",
+        from.version,
+        from.form.as_str(),
+        to.version,
+        to.form.as_str()
+    );
+    for change in changes {
+        match change.kind {
+            crate::AgentManifestDiffKind::Changed => println!(
+                "~ {}: {} -> {}",
+                change.path,
+                render_manifest_diff_value(change.before.as_ref().expect("changed before value")),
+                render_manifest_diff_value(change.after.as_ref().expect("changed after value"))
+            ),
+            crate::AgentManifestDiffKind::Added => println!(
+                "+ {}: {}",
+                change.path,
+                render_manifest_diff_value(change.after.as_ref().expect("added after value"))
+            ),
+            crate::AgentManifestDiffKind::Removed => println!(
+                "- {}: {}",
+                change.path,
+                render_manifest_diff_value(change.before.as_ref().expect("removed before value"))
+            ),
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn manifest_diff_snapshot(
+    record: &PublishedAgentRecord,
+    form: AgentManifestForm,
+) -> CooldisResult<Value> {
+    match form {
+        AgentManifestForm::Resolved => Ok(record.resolved_manifest.clone()),
+        AgentManifestForm::Authored => {
+            let source = record.authored_source.as_deref().ok_or_else(|| {
+                CooldisError::RuntimeFactory(format!(
+                    "agent record {}@{}: legacy record has no authored_source; authored-form diff is unavailable",
+                    record.name, record.version
+                ))
+            })?;
+            crate::agent::manifest::canonical_json_from_authored_source(source)
+        }
+    }
+}
+
+pub(super) fn render_manifest_diff_value(value: &Value) -> String {
+    let rendered = serde_json::to_string(value).unwrap_or_else(|_| "null".to_string());
+    if rendered.chars().count() <= 120 {
+        return rendered;
+    }
+    rendered.chars().take(117).collect::<String>() + "..."
+}
+
 pub(super) async fn agent_show(args: Vec<OsString>) -> CooldisResult<()> {
     let options = parse_agent_show_args(args)?;
     if options.help {
@@ -599,6 +739,45 @@ pub(super) struct AgentManifestArgs {
 #[derive(Debug)]
 pub(super) struct AgentRegistryArgs {
     registry_root: Option<PathBuf>,
+    help: bool,
+}
+
+#[derive(Debug)]
+pub(super) struct AgentVersionsArgs {
+    name: Option<String>,
+    registry_root: Option<PathBuf>,
+    json: bool,
+    help: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum AgentManifestForm {
+    Authored,
+    Resolved,
+}
+
+impl AgentManifestForm {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Authored => "authored",
+            Self::Resolved => "resolved",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct AgentDiffEndpoint {
+    version: String,
+    form: AgentManifestForm,
+}
+
+#[derive(Debug)]
+pub(super) struct AgentDiffArgs {
+    name: Option<String>,
+    from: Option<AgentDiffEndpoint>,
+    to: Option<AgentDiffEndpoint>,
+    registry_root: Option<PathBuf>,
+    json: bool,
     help: bool,
 }
 
@@ -716,6 +895,120 @@ pub(super) fn parse_agent_registry_args(
         registry_root,
         help,
     })
+}
+
+pub(super) fn parse_agent_versions_args(args: Vec<OsString>) -> CooldisResult<AgentVersionsArgs> {
+    let mut name = None;
+    let mut registry_root = None;
+    let mut json = false;
+    let mut help = false;
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        match arg.to_string_lossy().as_ref() {
+            "--help" | "-h" => help = true,
+            "--json" => json = true,
+            "--registry-root" => {
+                registry_root = Some(PathBuf::from(required_agent_history_value(
+                    &mut iter,
+                    "--registry-root",
+                )?))
+            }
+            other if other.starts_with('-') => {
+                return Err(usage_error(format!(
+                    "unknown agent versions argument {other:?}"
+                )));
+            }
+            _ => {
+                if name.is_some() {
+                    return Err(usage_error("agent versions accepts exactly one <name>"));
+                }
+                name = Some(arg.to_string_lossy().to_string());
+            }
+        }
+    }
+    Ok(AgentVersionsArgs {
+        name,
+        registry_root,
+        json,
+        help,
+    })
+}
+
+pub(super) fn parse_agent_diff_args(args: Vec<OsString>) -> CooldisResult<AgentDiffArgs> {
+    let mut name = None;
+    let mut from = None;
+    let mut to = None;
+    let mut registry_root = None;
+    let mut json = false;
+    let mut help = false;
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        match arg.to_string_lossy().as_ref() {
+            "--help" | "-h" => help = true,
+            "--json" => json = true,
+            "--from" => {
+                from = Some(parse_agent_diff_endpoint(
+                    &required_agent_history_value(&mut iter, "--from")?.to_string_lossy(),
+                )?)
+            }
+            "--to" => {
+                to = Some(parse_agent_diff_endpoint(
+                    &required_agent_history_value(&mut iter, "--to")?.to_string_lossy(),
+                )?)
+            }
+            "--registry-root" => {
+                registry_root = Some(PathBuf::from(required_agent_history_value(
+                    &mut iter,
+                    "--registry-root",
+                )?))
+            }
+            other if other.starts_with('-') => {
+                return Err(usage_error(format!(
+                    "unknown agent diff argument {other:?}"
+                )));
+            }
+            _ => {
+                if name.is_some() {
+                    return Err(usage_error("agent diff accepts exactly one <name>"));
+                }
+                name = Some(arg.to_string_lossy().to_string());
+            }
+        }
+    }
+    Ok(AgentDiffArgs {
+        name,
+        from,
+        to,
+        registry_root,
+        json,
+        help,
+    })
+}
+
+pub(super) fn parse_agent_diff_endpoint(value: &str) -> CooldisResult<AgentDiffEndpoint> {
+    let (version, form) = match value.rsplit_once(':') {
+        Some((version, "authored")) => (version, AgentManifestForm::Authored),
+        Some((version, "resolved")) => (version, AgentManifestForm::Resolved),
+        _ => (value, AgentManifestForm::Resolved),
+    };
+    cooldis_agent::validate_version(version)?;
+    Ok(AgentDiffEndpoint {
+        version: version.to_string(),
+        form,
+    })
+}
+
+fn required_agent_history_value(
+    iter: &mut impl Iterator<Item = OsString>,
+    flag: &'static str,
+) -> CooldisResult<OsString> {
+    let value = iter
+        .next()
+        .ok_or_else(|| usage_error(format!("{flag} requires a value")))?;
+    if value.to_string_lossy().starts_with('-') {
+        return Err(usage_error(format!("{flag} requires a value")));
+    }
+    Ok(value)
 }
 
 pub(super) fn parse_agent_show_args(args: Vec<OsString>) -> CooldisResult<AgentShowArgs> {
@@ -1038,6 +1331,8 @@ Usage:\n\
   cooldis agent plan <manifest> [--registry-root .cooldis/agents] [--operations-registry-root .cooldis/operations]\n\
   cooldis agent publish <manifest> [--registry-root .cooldis/agents] [--operations-registry-root .cooldis/operations]\n\
   cooldis agent list [--registry-root .cooldis/agents]\n\
+  cooldis agent versions <name> [--json] [--registry-root .cooldis/agents]\n\
+  cooldis agent diff <name> --from <version>[:authored|:resolved] --to <version>[:authored|:resolved] [--json] [--registry-root .cooldis/agents]\n\
   cooldis agent show <agent-ref-or-name> [--registry-root .cooldis/agents]\n\
   cooldis agent run <agent-ref> --input <text> [--registry-root .cooldis/agents]\n\
 \n\
@@ -1100,6 +1395,28 @@ Lists published agent records in the local registry.\n"
     );
 }
 
+pub(super) fn print_agent_versions_help() {
+    println!(
+        "cooldis agent versions\n\
+\n\
+Usage:\n\
+  cooldis agent versions <name> [--json] [--registry-root .cooldis/agents]\n\
+\n\
+Lists immutable agent versions in publication order.\n"
+    );
+}
+
+pub(super) fn print_agent_diff_help() {
+    println!(
+        "cooldis agent diff\n\
+\n\
+Usage:\n\
+  cooldis agent diff <name> --from <version>[:authored|:resolved] --to <version>[:authored|:resolved] [--json] [--registry-root .cooldis/agents]\n\
+\n\
+Prints a structural diff between immutable authored or resolved manifest snapshots.\n"
+    );
+}
+
 pub(super) fn print_agent_show_help() {
     println!(
         "cooldis agent show\n\
@@ -1121,4 +1438,79 @@ Usage:\n\
 Starts a manifest-backed app-server thread, runs one turn, prints the assistant\n\
 output, then prints the manifest compile and bind receipt event ids.\n"
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_diff_endpoint_preserves_colons_inside_versions() {
+        let endpoint = parse_agent_diff_endpoint("release:2026:07").unwrap();
+        assert_eq!(endpoint.version, "release:2026:07");
+        assert_eq!(endpoint.form, AgentManifestForm::Resolved);
+
+        let endpoint = parse_agent_diff_endpoint("release:2026:07:authored").unwrap();
+        assert_eq!(endpoint.version, "release:2026:07");
+        assert_eq!(endpoint.form, AgentManifestForm::Authored);
+    }
+
+    #[test]
+    fn agent_history_parsers_reject_missing_flag_values_and_duplicate_names() {
+        let error = parse_agent_diff_args(
+            ["auditor", "--from", "--to", "2.0.0"]
+                .into_iter()
+                .map(OsString::from)
+                .collect(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("--from requires a value"));
+
+        let error = parse_agent_versions_args(
+            ["auditor", "--registry-root", "--json"]
+                .into_iter()
+                .map(OsString::from)
+                .collect(),
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("--registry-root requires a value")
+        );
+
+        let error = parse_agent_diff_args(
+            ["auditor", "second", "--from", "1", "--to", "2"]
+                .into_iter()
+                .map(OsString::from)
+                .collect(),
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("agent diff accepts exactly one <name>")
+        );
+    }
+
+    #[test]
+    fn manifest_diff_values_are_compact_json_truncated_to_120_characters() {
+        let value = Value::String("x".repeat(200));
+        let rendered = render_manifest_diff_value(&value);
+
+        assert_eq!(rendered.chars().count(), 120);
+        assert!(rendered.ends_with("..."));
+        assert!(rendered.starts_with('"'));
+    }
+
+    #[test]
+    fn manifest_diff_value_truncation_counts_multibyte_characters_at_the_boundary() {
+        let exactly_120 = render_manifest_diff_value(&Value::String("é".repeat(118)));
+        assert_eq!(exactly_120.chars().count(), 120);
+        assert!(!exactly_120.ends_with("..."));
+
+        let over_boundary = render_manifest_diff_value(&Value::String("é".repeat(119)));
+        assert_eq!(over_boundary.chars().count(), 120);
+        assert!(over_boundary.ends_with("..."));
+    }
 }

--- a/crates/cooldis-kernel/src/cli/mod.rs
+++ b/crates/cooldis-kernel/src/cli/mod.rs
@@ -183,6 +183,12 @@ fn print_command_help(path: &[String]) -> CooldisResult<()> {
         [command, subcommand] if command == "agent" && subcommand == "list" => {
             print_agent_list_help()
         }
+        [command, subcommand] if command == "agent" && subcommand == "versions" => {
+            print_agent_versions_help()
+        }
+        [command, subcommand] if command == "agent" && subcommand == "diff" => {
+            print_agent_diff_help()
+        }
         [command, subcommand] if command == "agent" && subcommand == "show" => {
             print_agent_show_help()
         }
@@ -334,6 +340,8 @@ const CANONICAL_COMMANDS: &[&str] = &[
     "cooldis agent plan <manifest> [--registry-root .cooldis/agents] [--operations-registry-root .cooldis/operations]",
     "cooldis agent publish <manifest> [--registry-root .cooldis/agents] [--operations-registry-root .cooldis/operations]",
     "cooldis agent list [--registry-root .cooldis/agents]",
+    "cooldis agent versions <name> [--json] [--registry-root .cooldis/agents]",
+    "cooldis agent diff <name> --from <version>[:authored|:resolved] --to <version>[:authored|:resolved] [--json] [--registry-root .cooldis/agents]",
     "cooldis agent show <agent-ref-or-name> [--registry-root .cooldis/agents]",
     "cooldis agent run <agent-ref> --input <text> [--registry-root .cooldis/agents]",
     "cooldis blob publish <file> [--registry-root .cooldis/blobs] [--name <name>]",

--- a/crates/cooldis-kernel/src/lib.rs
+++ b/crates/cooldis-kernel/src/lib.rs
@@ -320,10 +320,11 @@ pub use agent::hooks::{
     UserPromptSubmitHookOutcome, UserPromptSubmitHookRequest,
 };
 pub use agent::manifest::{
-    AgentAliasRecord, AgentAliasResolutionReceipt, AgentManifestRefVerification,
-    AgentManifestRefVerificationStatus, AgentPublishPlan, AgentRecordRef, AgentToolRef,
-    LocalAgentRegistry, PublishedAgentRecord, agent_ref_uri, default_blob_registry_root,
-    default_blob_registry_root_for_agent_registry_root, default_operations_registry_root,
+    AgentAliasRecord, AgentAliasResolutionReceipt, AgentManifestDiffChange, AgentManifestDiffKind,
+    AgentManifestRefVerification, AgentManifestRefVerificationStatus, AgentPublishPlan,
+    AgentRecordRef, AgentToolRef, AgentVersionSummary, LocalAgentRegistry, PublishedAgentRecord,
+    agent_ref_uri, default_blob_registry_root, default_blob_registry_root_for_agent_registry_root,
+    default_operations_registry_root, diff_canonical_json,
 };
 pub use agent::manifest_bind::{
     AgentManifestBindOverrides, AgentManifestBindReceipt, AgentManifestBoundThread,

--- a/crates/cooldis-kernel/tests/cooldis_cli_publish.rs
+++ b/crates/cooldis-kernel/tests/cooldis_cli_publish.rs
@@ -278,6 +278,8 @@ fn cooldis_cli_uses_clean_public_entrypoints() {
     assert!(commands.contains("cooldis skill publish"));
     assert!(commands.contains("cooldis skill import"));
     assert!(commands.contains("cooldis auth set"));
+    assert!(commands.contains("cooldis agent versions <name> [--json]"));
+    assert!(commands.contains("cooldis agent diff <name> --from"));
     assert_no_command(&commands, &["dev"]);
     assert_no_command(&commands, &["operator"]);
 
@@ -287,6 +289,11 @@ fn cooldis_cli_uses_clean_public_entrypoints() {
 
     let help_chat = run_cooldis(["help", "chat"]);
     assert!(help_chat.contains("cooldis chat"));
+
+    let versions_help = run_cooldis(["help", "agent", "versions"]);
+    assert!(versions_help.contains("cooldis agent versions <name> [--json]"));
+    let diff_help = run_cooldis(["help", "agent", "diff"]);
+    assert!(diff_help.contains("--from <version>[:authored|:resolved]"));
 
     let help_auth = run_cooldis(["help", "auth"]);
     assert!(help_auth.contains("cooldis auth"));
@@ -1681,6 +1688,203 @@ operation_ref = "op://tailcat@sha256:{TEST_OPERATION_HASH}"
         registry_root.to_str().unwrap(),
     ]);
     assert!(show_by_ref.contains("\"version\": \"0.1.0\""));
+}
+
+#[test]
+fn cooldis_cli_lists_and_diffs_immutable_agent_version_snapshots() {
+    let workspace = temp_dir("agent-version-snapshots");
+    let project = workspace.join("auditor");
+    fs::create_dir_all(project.join("prompts")).unwrap();
+    let manifest_path = project.join("cooldis.agent.toml");
+    let source = |version: &str, description: &str| {
+        format!(
+            r#"[agent]
+name = "auditor"
+version = "{version}"
+description = "{description}"
+
+[[model_profiles]]
+id = "default"
+provider_ref = "provider://openai_compatible"
+model_ref = "model://example-chat-model"
+"#,
+        )
+    };
+    fs::write(project.join("prompts/system.md"), "Audit every release.\n").unwrap();
+    fs::write(&manifest_path, source("1.0.0", "First snapshot.")).unwrap();
+    let registry_root = workspace.join("agents");
+    let operation_registry_root = workspace.join("operations");
+
+    run_cooldis([
+        "agent",
+        "publish",
+        manifest_path.to_str().unwrap(),
+        "--registry-root",
+        registry_root.to_str().unwrap(),
+        "--operations-registry-root",
+        operation_registry_root.to_str().unwrap(),
+    ]);
+    fs::write(&manifest_path, source("2.0.0", "Second snapshot.")).unwrap();
+    run_cooldis([
+        "agent",
+        "publish",
+        manifest_path.to_str().unwrap(),
+        "--registry-root",
+        registry_root.to_str().unwrap(),
+        "--operations-registry-root",
+        operation_registry_root.to_str().unwrap(),
+    ]);
+
+    for (version, published_at_ms) in [("1.0.0", 0_u64), ("2.0.0", 1_000_u64)] {
+        let path = LocalAgentRegistry::new(&registry_root)
+            .version_record_path("auditor", version)
+            .unwrap();
+        let mut record: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        record["published_at_ms"] = Value::from(published_at_ms);
+        fs::write(&path, serde_json::to_vec_pretty(&record).unwrap()).unwrap();
+    }
+
+    let versions = run_cooldis([
+        "agent",
+        "versions",
+        "auditor",
+        "--registry-root",
+        registry_root.to_str().unwrap(),
+    ]);
+    assert!(versions.contains("PUBLISHED AT"));
+    assert!(versions.contains("VERSION"));
+    assert!(versions.contains("MANIFEST HASH"));
+    assert!(versions.contains("1970-01-01T00:00:00.000Z"));
+    assert!(versions.contains("1970-01-01T00:00:01.000Z"));
+    assert!(versions.find("1.0.0").unwrap() < versions.find("2.0.0").unwrap());
+    assert!(!versions.contains("[no-authored-source]"));
+
+    let versions_json = run_cooldis([
+        "agent",
+        "versions",
+        "auditor",
+        "--json",
+        "--registry-root",
+        registry_root.to_str().unwrap(),
+    ]);
+    let versions: Vec<Value> = serde_json::from_str(&versions_json).unwrap();
+    assert_eq!(versions.len(), 2);
+    assert_eq!(versions[0]["version"], "1.0.0");
+    assert_eq!(versions[1]["version"], "2.0.0");
+    assert!(
+        versions[0]["source_hash"]
+            .as_str()
+            .unwrap()
+            .starts_with("sha256:")
+    );
+    assert!(
+        versions[0]["manifest_hash"]
+            .as_str()
+            .unwrap()
+            .starts_with("sha256:")
+    );
+    assert_eq!(versions[0]["authored_source_present"], true);
+
+    let diff = run_cooldis([
+        "agent",
+        "diff",
+        "auditor",
+        "--from",
+        "1.0.0",
+        "--to",
+        "2.0.0",
+        "--registry-root",
+        registry_root.to_str().unwrap(),
+    ]);
+    assert!(diff.contains("manifest auditor 1.0.0:resolved -> 2.0.0:resolved"));
+    assert!(diff.contains("~ /identity/description: \"First snapshot.\" -> \"Second snapshot.\""));
+
+    let diff_json = run_cooldis([
+        "agent",
+        "diff",
+        "auditor",
+        "--from",
+        "1.0.0",
+        "--to",
+        "2.0.0",
+        "--json",
+        "--registry-root",
+        registry_root.to_str().unwrap(),
+    ]);
+    let changes: Vec<Value> = serde_json::from_str(&diff_json).unwrap();
+    assert!(changes.iter().any(|change| {
+        change["path"] == "/identity/description" && change["kind"] == "changed"
+    }));
+
+    let cross_form = run_cooldis([
+        "agent",
+        "diff",
+        "auditor",
+        "--from",
+        "1.0.0:authored",
+        "--to",
+        "1.0.0:resolved",
+        "--registry-root",
+        registry_root.to_str().unwrap(),
+    ]);
+    assert!(cross_form.contains("manifest auditor 1.0.0:authored -> 1.0.0:resolved"));
+    assert!(cross_form.contains("~ /context:"));
+    assert!(cross_form.contains("+ /resources/0:"));
+
+    let legacy_path = LocalAgentRegistry::new(&registry_root)
+        .version_record_path("auditor", "1.0.0")
+        .unwrap();
+    let mut legacy: Value = serde_json::from_slice(&fs::read(&legacy_path).unwrap()).unwrap();
+    legacy.as_object_mut().unwrap().remove("authored_source");
+    fs::write(&legacy_path, serde_json::to_vec_pretty(&legacy).unwrap()).unwrap();
+    let failed = run_cooldis_failed([
+        "agent",
+        "diff",
+        "auditor",
+        "--from",
+        "1.0.0:authored",
+        "--to",
+        "2.0.0:resolved",
+        "--registry-root",
+        registry_root.to_str().unwrap(),
+    ]);
+    let error = stderr(&failed);
+    assert!(error.contains("auditor@1.0.0"));
+    assert!(error.contains("legacy record has no authored_source"));
+
+    let missing_value = run_cooldis_failed([
+        "agent",
+        "diff",
+        "auditor",
+        "--from",
+        "--to",
+        "2.0.0",
+        "--registry-root",
+        registry_root.to_str().unwrap(),
+    ]);
+    assert!(stderr(&missing_value).contains("--from requires a value"));
+
+    let invalid_timestamp_path = LocalAgentRegistry::new(&registry_root)
+        .version_record_path("auditor", "2.0.0")
+        .unwrap();
+    let mut invalid_timestamp: Value =
+        serde_json::from_slice(&fs::read(&invalid_timestamp_path).unwrap()).unwrap();
+    invalid_timestamp["published_at_ms"] = Value::from(u64::MAX);
+    fs::write(
+        &invalid_timestamp_path,
+        serde_json::to_vec_pretty(&invalid_timestamp).unwrap(),
+    )
+    .unwrap();
+    let invalid_timestamp = run_cooldis_failed([
+        "agent",
+        "versions",
+        "auditor",
+        "--registry-root",
+        registry_root.to_str().unwrap(),
+    ]);
+    let error = stderr(&invalid_timestamp);
+    assert!(error.contains("auditor@2.0.0"));
+    assert!(error.contains("invalid published_at_ms"));
 }
 
 #[test]

--- a/crates/cooldis-kernel/tests/quality_contracts.rs
+++ b/crates/cooldis-kernel/tests/quality_contracts.rs
@@ -224,6 +224,8 @@ fn public_api_coverage_tracks_docs_and_man_page_gaps() {
         "cooldis agent plan",
         "cooldis agent publish",
         "cooldis agent list",
+        "cooldis agent versions",
+        "cooldis agent diff",
         "cooldis agent show",
         "cooldis agent run",
         "cooldis blob publish",

--- a/crates/cooldis-process/src/process/tests.rs
+++ b/crates/cooldis-process/src/process/tests.rs
@@ -302,8 +302,13 @@ async fn host_process_termination_kills_term_ignoring_process_group_members() {
 
     let child_pid = tokio::time::timeout(Duration::from_secs(2), async {
         loop {
-            if let Ok(pid) = std::fs::read_to_string(&pid_file) {
-                break pid.trim().parse::<libc::pid_t>().unwrap();
+            // The shell creates the pid file before the echo's content lands;
+            // keep polling until the content actually parses.
+            if let Some(pid) = std::fs::read_to_string(&pid_file)
+                .ok()
+                .and_then(|pid| pid.trim().parse::<libc::pid_t>().ok())
+            {
+                break pid;
             }
             tokio::task::yield_now().await;
         }

--- a/docs/agent-cli.md
+++ b/docs/agent-cli.md
@@ -20,6 +20,8 @@ cooldis blob publish release-verifier/prompts/system.md --name identity
 cooldis skill publish release-verifier/skills
 cooldis skill import ~/.agents/skills/release-checker --dry-run
 cooldis agent list
+cooldis agent versions release-verifier
+cooldis agent diff release-verifier --from 0.1.0:authored --to 0.1.0:resolved
 cooldis agent show agent://release-verifier@0.1.0
 cooldis agent run agent://release-verifier@latest --input "check the branch"
 ```
@@ -71,7 +73,10 @@ an operations registry, it still succeeds and reports those refs as
 version records live in `versions/<name>/<version>.json`. Republish of the same
 name and version is allowed only when the manifest hash is identical. When a
 folder-first prompt is lowered, the publish receipt pins the blob hash through
-the resolved blob resource and the `identity` context source.
+the resolved blob resource and the `identity` context source. Each new record
+retains the authored TOML verbatim beside the canonical resolved manifest; the
+source and manifest hashes identify those two forms. Legacy records remain
+readable but do not gain an authored form retroactively.
 
 `publish` is a registry oracle for `op://` refs. Every operation tool row must
 name a local operation record, pin a published version hash, select either the
@@ -136,8 +141,20 @@ workspace-relative `path` (default `.agents/skills`); this does not publish or
 mount the files. See [Agent Manifest Ontology — Skills](agent-manifest-ontology.md#skills)
 for the two-lane model, no-mount rule, and durable witness semantics.
 
-`list` and `show` inspect published records from the local registry. They are the
-minimum discovery surface required once publication exists.
+`list` and `show` inspect published records from the local registry. `versions
+<name>` lists immutable versions by `published_at_ms`, not by the author-declared
+version string. Its text output includes an RFC3339 publication time, declared
+version, manifest hash, and `[no-authored-source]` for legacy records; `--json`
+also exposes the source hash and authored-source availability.
+
+`diff <name> --from <version>[:authored|:resolved] --to
+<version>[:authored|:resolved]` compares two immutable snapshots structurally.
+The form defaults to `resolved`; `authored` parses the retained TOML through the
+manifest schema before comparison. Comparing authored and resolved forms of one
+version shows fields filled during resolution, including folder-first prompt
+lowering. Changes are JSON-pointer path ordered and reported as added, removed,
+or changed. `--json` emits the raw change list. Authored comparison fails
+explicitly when a legacy record has no retained source.
 
 `run` starts a manifest-backed app-server thread from a published `agent://...`
 ref, sends one input turn, prints the assistant output, then prints the manifest

--- a/docs/public-api-coverage.md
+++ b/docs/public-api-coverage.md
@@ -36,6 +36,8 @@ inputs, durable effects, or output semantics.
 | `cooldis agent plan` | [Cooldis Agent CLI](agent-cli.md) | `cooldis agent plan --help` | partial | Document JSON/text output shape and validation exit statuses. |
 | `cooldis agent publish` | [Cooldis Agent CLI](agent-cli.md) | `cooldis agent publish --help` | partial | Document registry writes, idempotency, and failure statuses in man form. |
 | `cooldis agent list` | [Cooldis Agent CLI](agent-cli.md) | `cooldis agent list --help` | partial | Document listing output and registry-root behavior in man form. |
+| `cooldis agent versions` | [Cooldis Agent CLI](agent-cli.md) | `cooldis agent versions --help` | partial | Lists immutable snapshots in publication order with text and JSON projections; generated manual output remains follow-up work. |
+| `cooldis agent diff` | [Cooldis Agent CLI](agent-cli.md) | `cooldis agent diff --help` | partial | Diffs authored and resolved snapshots structurally with text and JSON projections; generated manual output remains follow-up work. |
 | `cooldis agent show` | [Cooldis Agent CLI](agent-cli.md) | `cooldis agent show --help` | partial | Document JSON record schema pointer in man form. |
 | `cooldis agent run` | [Cooldis Agent CLI](agent-cli.md), [V1 Release Candidate Gate](v1-release-candidate.md) | `cooldis agent run --help` | partial | Runs one manifest-backed local app-server turn and prints manifest receipt event ids; generated manual output remains follow-up work. |
 | `cooldis blob publish` | [Cooldis Agent CLI](agent-cli.md) | `cooldis blob publish --help` | partial | Publishes immutable blob resources for folder-first prompts and explicit static context inputs; generated manual output remains follow-up work. |


### PR DESCRIPTION
Linear: EMO-450

Retains the authored TOML verbatim on published agent version records and adds history inspection over the recorded snapshots.

## What changed

- `PublishedAgentRecord` gains an optional `authored_source` field, populated at publish time from the exact text that produced `source_hash`. The field is additive: legacy records decode unchanged and never gain the field on re-encode.
- `cooldis agent versions <name>` lists the recorded version history as a bounded summary projection (version, source hash, manifest hash, published-at, authored-source presence). The verbatim source and resolved manifest never leak into list output.
- `cooldis agent diff <name> --from <ver>[:authored|:resolved] --to <ver>[:authored|:resolved]` compares two recorded snapshots structurally: JSON-pointer paths with proper escaping, deterministic path ordering, added/removed/changed kinds, and value rendering truncated at 120 characters. Authored form reparses the recorded TOML; resolved form uses the recorded canonical manifest.
- Both commands take `--json` for machine-readable output.

## Review

Write-capable review gate fixed four findings, all architect-read: bounded list projection instead of full records, absent-vs-null distinction on diff sides, colon-tolerant version parsing (only terminal `:authored`/`:resolved` selects a form), and rejection of flag-shaped values after options.

## Ride-along

One test-only deflake commit: the host process termination test polled for pid-file existence and unwrapped a parse of possibly-empty content (the shell redirect creates the file before echo writes it). It now polls until the content parses. This flake blocked the pre-push hook and predates this branch.

## Verification

`scripts/cargo-lane.sh test --workspace --all-targets --locked` green (full suite, 938 passed in the primary binary).
