### PR TITLE
EMO-451: bind explain projects the effective envelope from receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ stateful product harnesses are future direction. See
 - [Docs index](docs/README.md): documentation map.
 - [Overview](docs/index.md): product category and current status.
 - [Getting started](docs/getting-started.md): local run and inspection path.
-- [CLI](docs/cli.md): canonical commands and help model.
+- [CLI](docs/cli.md): canonical commands, help model, and receipt-backed bind
+  inspection.
 - [Runtime primitives](docs/developers/runtime-primitives.md): kernel-owned
   surfaces and boundaries.
 - [ABI](docs/abi.md): operation boundary and host/guest contract.

--- a/crates/cooldis-kernel/src/adapters/app_server/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/tests.rs
@@ -2649,6 +2649,10 @@ allow = ["default_cwd"]
         Some(record.ref_uri.as_str())
     );
     assert_eq!(bind.payload["model_profile_id"].as_str(), Some("small"));
+    assert_eq!(
+        bind.payload["model_profile_origin"].as_str(),
+        Some("selected-at-start")
+    );
     assert_eq!(bind.payload["model_id"].as_str(), Some("fixture-small"));
 
     let large_start = app

--- a/crates/cooldis-kernel/src/adapters/provider_runtime/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/provider_runtime/tests.rs
@@ -336,6 +336,7 @@ impl KernelThreadSpawnAgentResolver for StaticThreadSpawnAgentResolver {
                 ref_uri: CHILD_AGENT_REF.to_string(),
                 manifest_hash: CHILD_MANIFEST_HASH.to_string(),
                 model_profile_id: "default".to_string(),
+                model_profile_origin: None,
                 provider_id: "test".to_string(),
                 model_id: "model".to_string(),
                 tool_ids: Vec::new(),
@@ -350,7 +351,9 @@ impl KernelThreadSpawnAgentResolver for StaticThreadSpawnAgentResolver {
                 effective_runtime: AgentManifestRuntimeDefaults::default(),
                 overridden_keys: Vec::new(),
                 placement: None,
+                placement_origin: None,
                 workspace: None,
+                workspace_origin: None,
             })
             .unwrap(),
         })
@@ -5713,6 +5716,7 @@ async fn append_tool_controller_bind_receipt(
         ref_uri: "agent://test/controller".to_string(),
         manifest_hash: "snapshot-controller".to_string(),
         model_profile_id: "default".to_string(),
+        model_profile_origin: None,
         provider_id: "test".to_string(),
         model_id: "model".to_string(),
         tool_ids: Vec::new(),
@@ -5743,7 +5747,9 @@ async fn append_tool_controller_bind_receipt(
         effective_runtime: AgentManifestRuntimeDefaults::default(),
         overridden_keys: Vec::new(),
         placement: None,
+        placement_origin: None,
         workspace: None,
+        workspace_origin: None,
     };
     store
         .append_events(
@@ -5773,6 +5779,7 @@ async fn append_manifest_runtime_grace(
         ref_uri: "agent://test/interruption".to_string(),
         manifest_hash: "snapshot-interruption".to_string(),
         model_profile_id: "default".to_string(),
+        model_profile_origin: None,
         provider_id: "test".to_string(),
         model_id: "model".to_string(),
         tool_ids: Vec::new(),
@@ -5790,7 +5797,9 @@ async fn append_manifest_runtime_grace(
         },
         overridden_keys: vec!["cancellation_grace_ms".to_string()],
         placement: None,
+        placement_origin: None,
         workspace: None,
+        workspace_origin: None,
     };
     store
         .append_events(

--- a/crates/cooldis-kernel/src/agent/manifest_bind.rs
+++ b/crates/cooldis-kernel/src/agent/manifest_bind.rs
@@ -397,17 +397,17 @@ pub(crate) async fn bind_published_agent_record_with_placement_and_skill_witness
     now_ms: i64,
 ) -> CooldisResult<AgentManifestBoundThread> {
     let (manifest, compile_receipt) = compile_published_agent_record(record, alias)?;
-    let placement = resolve_manifest_placement(
+    let placement = resolve_manifest_placement_with_origin(
         default_placement,
         placement_override,
         remote_event_store_served,
     )?;
-    let workspace = resolve_manifest_workspace(
+    let workspace = resolve_manifest_workspace_with_origin(
         manifest.workspace.as_ref(),
         default_workspace,
         workspace_override,
     )?;
-    if placement.target != PlacementTarget::Local && workspace.is_some() {
+    if placement.binding.target != PlacementTarget::Local && workspace.is_some() {
         return Err(CooldisError::RuntimeFactory(
             "workspace bindings currently require local placement; remote and sandbox workspace transfer belongs to the sandbox executor boundary"
                 .to_string(),
@@ -461,7 +461,7 @@ pub(crate) async fn bind_published_agent_record_with_placement_and_skill_witness
     };
     let (skill_discovery, discovery_context_segment) = bind_workspace_skill_discovery(
         &manifest,
-        workspace.as_ref(),
+        workspace.as_ref().map(|workspace| &workspace.mount),
         skill_discovery_witness,
         rehydrating_from_witness,
         &bound_skills.skill_names,
@@ -501,6 +501,7 @@ pub(crate) async fn bind_published_agent_record_with_placement_and_skill_witness
         ref_uri: record.ref_uri.clone(),
         manifest_hash: record.manifest_hash.clone(),
         model_profile_id: profile.id.clone(),
+        model_profile_origin: Some(selected.origin),
         provider_id,
         model_id,
         tool_ids: bound_tools.tool_ids,
@@ -522,8 +523,10 @@ pub(crate) async fn bind_published_agent_record_with_placement_and_skill_witness
             .collect(),
         effective_runtime,
         overridden_keys,
-        placement: Some(placement),
-        workspace,
+        placement: Some(placement.binding),
+        placement_origin: Some(placement.origin),
+        workspace_origin: workspace.as_ref().map(|workspace| workspace.origin),
+        workspace: workspace.map(|workspace| workspace.mount),
     };
     Ok(AgentManifestBoundThread {
         manifest,
@@ -2281,6 +2284,7 @@ struct SelectedManifestModelProfile<'a> {
     profile: &'a AgentManifestModelProfile,
     provider_id: String,
     model_id: String,
+    origin: AgentManifestModelProfileOrigin,
 }
 
 fn select_manifest_model_profile<'a>(
@@ -2314,6 +2318,11 @@ fn select_manifest_model_profile<'a>(
                 profile,
                 provider_id,
                 model_id,
+                origin: if selection.is_empty() {
+                    AgentManifestModelProfileOrigin::ManifestDefault
+                } else {
+                    AgentManifestModelProfileOrigin::SelectedAtStart
+                },
             });
             if selection.is_empty() {
                 break;
@@ -2834,6 +2843,8 @@ pub struct AgentManifestBindReceipt {
     pub manifest_hash: String,
     /// The selected declared profile for this bind.
     pub model_profile_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_profile_origin: Option<AgentManifestModelProfileOrigin>,
     pub provider_id: String,
     pub model_id: String,
     pub tool_ids: Vec<String>,
@@ -2874,10 +2885,29 @@ pub struct AgentManifestBindReceipt {
     /// witnessed before the field existed keep decoding and folding.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub placement: Option<AgentManifestPlacementBinding>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement_origin: Option<AgentManifestBindingOrigin>,
     /// Effective host workspace mount fixed for this bind. Optional so bind
     /// receipts written before workspace binding existed keep decoding.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace: Option<AgentManifestResolvedWorkspaceMount>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_origin: Option<AgentManifestBindingOrigin>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentManifestModelProfileOrigin {
+    ManifestDefault,
+    SelectedAtStart,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentManifestBindingOrigin {
+    DaemonDefault,
+    BindOverride,
+    Manifest,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -2938,12 +2968,36 @@ pub fn resolve_manifest_placement(
     placement_override: Option<&AgentManifestPlacementBinding>,
     remote_event_store_served: bool,
 ) -> CooldisResult<AgentManifestPlacementBinding> {
-    let resolved = placement_override
-        .or(default_placement)
-        .cloned()
-        .unwrap_or_default();
+    Ok(resolve_manifest_placement_with_origin(
+        default_placement,
+        placement_override,
+        remote_event_store_served,
+    )?
+    .binding)
+}
+
+struct ResolvedManifestPlacement {
+    binding: AgentManifestPlacementBinding,
+    origin: AgentManifestBindingOrigin,
+}
+
+fn resolve_manifest_placement_with_origin(
+    default_placement: Option<&AgentManifestPlacementBinding>,
+    placement_override: Option<&AgentManifestPlacementBinding>,
+    remote_event_store_served: bool,
+) -> CooldisResult<ResolvedManifestPlacement> {
+    let (resolved, origin) = match placement_override {
+        Some(placement) => (placement.clone(), AgentManifestBindingOrigin::BindOverride),
+        None => (
+            default_placement.cloned().unwrap_or_default(),
+            AgentManifestBindingOrigin::DaemonDefault,
+        ),
+    };
     if resolved.target == PlacementTarget::Remote && remote_event_store_served {
-        return Ok(resolved);
+        return Ok(ResolvedManifestPlacement {
+            binding: resolved,
+            origin,
+        });
     }
     if resolved.target != PlacementTarget::Local {
         let target = match resolved.target {
@@ -2955,7 +3009,10 @@ pub fn resolve_manifest_placement(
             "placement target {target} requires the remote EventStore backend capability, which is not available"
         )));
     }
-    Ok(resolved)
+    Ok(ResolvedManifestPlacement {
+        binding: resolved,
+        origin,
+    })
 }
 
 /// Machine-local workspace authority supplied by daemon config or an
@@ -2999,7 +3056,26 @@ pub fn resolve_manifest_workspace(
     default_workspace: Option<&AgentManifestWorkspaceBinding>,
     workspace_override: Option<&AgentManifestWorkspaceBinding>,
 ) -> CooldisResult<Option<AgentManifestResolvedWorkspaceMount>> {
-    let binding = workspace_override.or(default_workspace);
+    Ok(
+        resolve_manifest_workspace_with_origin(requirement, default_workspace, workspace_override)?
+            .map(|workspace| workspace.mount),
+    )
+}
+
+struct ResolvedManifestWorkspace {
+    mount: AgentManifestResolvedWorkspaceMount,
+    origin: AgentManifestBindingOrigin,
+}
+
+fn resolve_manifest_workspace_with_origin(
+    requirement: Option<&AgentManifestWorkspaceRequirement>,
+    default_workspace: Option<&AgentManifestWorkspaceBinding>,
+    workspace_override: Option<&AgentManifestWorkspaceBinding>,
+) -> CooldisResult<Option<ResolvedManifestWorkspace>> {
+    let (binding, origin) = match workspace_override {
+        Some(binding) => (Some(binding), AgentManifestBindingOrigin::BindOverride),
+        None => (default_workspace, AgentManifestBindingOrigin::DaemonDefault),
+    };
     let (requirement, binding) = match (requirement, binding) {
         (None, None) => return Ok(None),
         (Some(_), None) => {
@@ -3036,10 +3112,13 @@ pub fn resolve_manifest_workspace(
             host_path.display()
         )));
     }
-    Ok(Some(AgentManifestResolvedWorkspaceMount {
-        guest_path: PathBuf::from(&requirement.guest_path),
-        host_path,
-        mode: binding.mode,
+    Ok(Some(ResolvedManifestWorkspace {
+        mount: AgentManifestResolvedWorkspaceMount {
+            guest_path: PathBuf::from(&requirement.guest_path),
+            host_path,
+            mode: binding.mode,
+        },
+        origin,
     }))
 }
 

--- a/crates/cooldis-kernel/src/agent/manifest_bind/tests.rs
+++ b/crates/cooldis-kernel/src/agent/manifest_bind/tests.rs
@@ -178,6 +178,25 @@ fn workspace_binding_resolution_is_declared_fail_closed_and_override_first() {
         fs::canonicalize(&override_host).unwrap()
     );
     assert_eq!(resolved.mode, AgentManifestWorkspaceMode::ReadWrite);
+    let default_origin =
+        resolve_manifest_workspace_with_origin(Some(&requirement), Some(&default_binding), None)
+            .unwrap()
+            .unwrap();
+    assert_eq!(
+        default_origin.origin,
+        AgentManifestBindingOrigin::DaemonDefault
+    );
+    let override_origin = resolve_manifest_workspace_with_origin(
+        Some(&requirement),
+        Some(&default_binding),
+        Some(&override_binding),
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(
+        override_origin.origin,
+        AgentManifestBindingOrigin::BindOverride
+    );
 
     let _ = fs::remove_dir_all(root);
 }
@@ -381,6 +400,9 @@ pinned = true
         bound.bind_receipt.static_context_segments[0].content_sha256,
         blob.content_sha256
     );
+    let receipt = serde_json::to_value(&bound.bind_receipt).unwrap();
+    assert_eq!(receipt["model_profile_origin"], "manifest-default");
+    assert_eq!(receipt["placement_origin"], "daemon-default");
     let _ = fs::remove_dir_all(root);
 }
 
@@ -624,6 +646,182 @@ async fn protocol_tool_import_direct_pins_must_not_duplicate_tool_rows() {
             .contains("duplicate direct tool_name surface")
     );
     assert!(err.to_string().contains("cooldis_mcp_echo"));
+}
+
+#[tokio::test]
+async fn bind_receipt_keeps_each_pinned_universe_import_correspondence() {
+    let root = temp_dir("manifest-bind-multiple-pinned-universes");
+    let first_tool = witnessed_tool("first.echo", "string");
+    let second_tool = witnessed_tool("second.echo", "string");
+    let first_pin = format!(
+        "mcptool://arcade/{}@{}",
+        first_tool.tool_name, first_tool.schema_hash
+    );
+    let second_pin = format!(
+        "mcptool://arcade/{}@{}",
+        second_tool.tool_name, second_tool.schema_hash
+    );
+    let discovery =
+        ToolUniverseDiscovery::witness("mcp://arcade", vec![first_tool, second_tool], 1).unwrap();
+    let discoverer = StaticToolUniverseDiscoverer { discovery };
+    let record = publish_agent_manifest(
+        &root,
+        &format!(
+            r#"
+[agent]
+name = "multiple-pinned-universes"
+version = "0.1.0"
+kind = "cooldis.agent-manifest"
+schema_version = 1
+
+[[model_profiles]]
+id = "default"
+provider_ref = "provider://local_offline"
+model_ref = "model://local_offline/echo"
+
+[[tools]]
+type = "protocol_tool_import"
+id = "first-import"
+protocol = "mcp"
+server_ref = "mcp://arcade"
+expose = ["direct_tool"]
+pin = "{first_pin}"
+
+[[tools]]
+type = "protocol_tool_import"
+id = "second-import"
+protocol = "mcp"
+server_ref = "mcp://arcade"
+expose = ["direct_tool"]
+pin = "{second_pin}"
+
+[runtime]
+default_cwd = "."
+streaming = false
+"#
+        ),
+    );
+    let surface = AgentManifestProviderSurface::single("local_offline", "echo")
+        .with_supports_streaming(false);
+
+    let bound = bind_published_agent_record(
+        &record,
+        None,
+        &surface,
+        None,
+        None,
+        None,
+        &BTreeSet::from(["mcp://arcade".to_string()]),
+        Some(&discoverer),
+        &AgentManifestModelProfileSelection::default(),
+        &AgentManifestBindOverrides::default(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        bound.bind_receipt.tool_ids,
+        vec!["first-import".to_string(), "second-import".to_string()]
+    );
+    assert_eq!(bound.bind_receipt.tool_universes.len(), 2);
+    assert_eq!(
+        bound.bind_receipt.tool_universes[0].import_id,
+        "first-import"
+    );
+    assert_eq!(bound.bind_receipt.tool_universes[0].pinned, vec![first_pin]);
+    assert_eq!(
+        bound.bind_receipt.tool_universes[1].import_id,
+        "second-import"
+    );
+    assert_eq!(
+        bound.bind_receipt.tool_universes[1].pinned,
+        vec![second_pin]
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn bind_receipt_does_not_record_operation_rows_by_manifest_tool_id() {
+    let root = temp_dir("manifest-bind-operation-tool-correspondence");
+    let operation_root = root.join("operations");
+    let operation = publish_multi_operation_record(
+        &operation_root,
+        "operation-record",
+        &[("operation-name", Vec::new())],
+    )
+    .await;
+    let manifest_path = root.join("operation-tool.cooldis.agent.toml");
+    fs::write(
+        &manifest_path,
+        format!(
+            r#"
+[agent]
+name = "operation-tool-correspondence"
+version = "0.1.0"
+kind = "cooldis.agent-manifest"
+schema_version = 1
+
+[[model_profiles]]
+id = "default"
+provider_ref = "provider://local_offline"
+model_ref = "model://local_offline/echo"
+
+[[tools]]
+type = "bash_tool"
+id = "manifest-tool-id"
+command = "run-operation"
+operation_ref = "op://operation-record/operation-name@sha256:{}"
+
+[runtime]
+default_cwd = "."
+streaming = false
+"#,
+            operation.active_artifact_hash
+        ),
+    )
+    .unwrap();
+    let record = crate::LocalAgentRegistry::new(root.join("agents"))
+        .publish_manifest_path_with_operation_registry(&manifest_path, &operation_root)
+        .unwrap();
+    let surface = AgentManifestProviderSurface::single("local_offline", "echo")
+        .with_supports_streaming(false);
+
+    let bound = bind_published_agent_record(
+        &record,
+        None,
+        &surface,
+        Some(&operation_root),
+        None,
+        None,
+        &BTreeSet::new(),
+        None,
+        &AgentManifestModelProfileSelection::default(),
+        &AgentManifestBindOverrides::default(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        bound.bind_receipt.tool_ids,
+        vec!["manifest-tool-id".to_string()]
+    );
+    assert_eq!(bound.bind_receipt.operation_bindings.len(), 1);
+    assert_eq!(
+        bound.bind_receipt.operation_bindings[0].name,
+        "operation-record"
+    );
+    assert_eq!(
+        bound.bind_receipt.operation_bindings[0].operations,
+        vec!["operation-name".to_string()]
+    );
+    assert!(
+        bound.bind_receipt.operation_bindings[0]
+            .direct_tools
+            .is_empty()
+    );
+
+    let _ = fs::remove_dir_all(root);
 }
 
 #[tokio::test]
@@ -1808,6 +2006,10 @@ discover = true
     .await
     .unwrap();
 
+    assert_eq!(
+        bound.bind_receipt.workspace_origin,
+        Some(AgentManifestBindingOrigin::BindOverride)
+    );
     let discovery = bound
         .bind_receipt
         .skill_discovery
@@ -3267,10 +3469,17 @@ fn raw_legacy_bind_receipt_decodes_without_optional_witnesses() {
     );
     let legacy_receipt: AgentManifestBindReceipt = serde_json::from_str(&legacy_wire).unwrap();
     assert_eq!(legacy_receipt.placement, None);
+    assert_eq!(legacy_receipt.model_profile_origin, None);
+    assert_eq!(legacy_receipt.placement_origin, None);
     assert_eq!(legacy_receipt.workspace, None);
+    assert_eq!(legacy_receipt.workspace_origin, None);
     assert_eq!(legacy_receipt.skill_discovery, None);
     assert_eq!(legacy_receipt.ref_uri, "cooldis://agents/karl");
     assert_eq!(legacy_receipt.tool_ids, vec!["threads/spawn"]);
+    let legacy_value = serde_json::to_value(&legacy_receipt).unwrap();
+    assert!(legacy_value.get("model_profile_origin").is_none());
+    assert!(legacy_value.get("placement_origin").is_none());
+    assert!(legacy_value.get("workspace_origin").is_none());
     assert!(
         serde_json::to_value(&legacy_receipt)
             .unwrap()
@@ -3359,6 +3568,18 @@ fn placement_resolution_defaults_local_and_rpc_override_wins() {
     assert_eq!(
         resolve_manifest_placement(Some(&default), Some(&rpc_override), false).unwrap(),
         rpc_override
+    );
+    assert_eq!(
+        resolve_manifest_placement_with_origin(None, None, false)
+            .unwrap()
+            .origin,
+        AgentManifestBindingOrigin::DaemonDefault
+    );
+    assert_eq!(
+        resolve_manifest_placement_with_origin(Some(&default), Some(&rpc_override), false)
+            .unwrap()
+            .origin,
+        AgentManifestBindingOrigin::BindOverride
     );
 }
 

--- a/crates/cooldis-kernel/src/cli/debug_bind.rs
+++ b/crates/cooldis-kernel/src/cli/debug_bind.rs
@@ -1,0 +1,811 @@
+//! Receipt-backed effective bind inspection.
+
+use super::*;
+use crate::{
+    AgentManifestBindReceipt, AgentManifestBindingOrigin, AgentManifestCompileReceipt,
+    AgentManifestModelProfileOrigin,
+};
+use chrono::{SecondsFormat, TimeZone, Utc};
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Debug)]
+pub(super) struct DebugBindArgs {
+    thread_id: String,
+    json: bool,
+    journal: Option<PathBuf>,
+    endpoint: DebugRpcEndpointArgs,
+}
+
+/// A projection of recorded compile and bind receipts. Under the receipt law
+/// in `formalism/lexicon.md`, this explanation never recomputes resolution or
+/// fills gaps from current configuration; absent receipt facts remain
+/// unrecorded.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BindExplanation {
+    pub thread_id: String,
+    pub manifest: BindManifestExplanation,
+    pub model: BindModelExplanation,
+    pub placement: Option<BindPlacementExplanation>,
+    pub workspace: Option<BindWorkspaceExplanation>,
+    pub runtime: Vec<BindRuntimeExplanation>,
+    pub tools: Vec<BindToolExplanation>,
+    pub universes: Vec<BindUniverseExplanation>,
+    pub couplings: Vec<BindCouplingExplanation>,
+    pub grants: Vec<BindGrantExplanation>,
+    pub skills: Vec<BindSkillExplanation>,
+    pub context: Vec<BindContextExplanation>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BindManifestExplanation {
+    pub ref_uri: String,
+    pub manifest_hash: String,
+    pub source_hash: String,
+    pub alias: Option<BindAliasExplanation>,
+    pub compile_event_id: String,
+    pub bind_event_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BindAliasExplanation {
+    pub alias: String,
+    pub version: String,
+    pub resolved_at: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BindModelExplanation {
+    pub profile_id: String,
+    pub provider_id: String,
+    pub model_id: String,
+    pub origin: Option<AgentManifestModelProfileOrigin>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BindPlacementExplanation {
+    pub target: String,
+    pub executor_ref: Option<String>,
+    pub origin: Option<AgentManifestBindingOrigin>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BindWorkspaceExplanation {
+    pub guest_path: PathBuf,
+    pub host_path: PathBuf,
+    pub mode: String,
+    pub origin: Option<AgentManifestBindingOrigin>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BindRuntimeExplanation {
+    pub key: String,
+    pub value: Value,
+    pub overridden: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BindToolExplanation {
+    pub tool_id: String,
+    pub origin: Option<String>,
+    pub row_id: Option<String>,
+    pub pinned: bool,
+    pub operation_name: Option<String>,
+    pub artifact_hash: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BindUniverseExplanation {
+    pub import_id: String,
+    pub server_ref: String,
+    pub discovery_hash: String,
+    pub tool_count: usize,
+    pub pinned_count: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BindCouplingExplanation {
+    pub id: String,
+    pub role: String,
+    pub function_ref: String,
+    pub artifact_hash: String,
+    pub config_hash: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BindGrantExplanation {
+    pub capability: String,
+    pub subject_kind: String,
+    pub subject_id: String,
+    pub expires_at: Option<String>,
+    pub lapsed_at_bind: bool,
+    pub excluded: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BindSkillExplanation {
+    pub package: String,
+    pub artifact_hash: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BindContextExplanation {
+    pub ref_uri: String,
+    pub content_sha256: String,
+}
+
+#[derive(Clone, Debug)]
+struct RecordedReceiptEvent {
+    event_id: String,
+    sequence: i64,
+    kind: String,
+    source_event_ids: Vec<String>,
+    payload: Value,
+}
+
+pub(super) async fn run_debug_bind(args: Vec<OsString>) -> CooldisResult<()> {
+    if args
+        .first()
+        .is_some_and(|arg| arg == "--help" || arg == "-h")
+    {
+        print_debug_bind_help();
+        return Ok(());
+    }
+    let options = parse_debug_bind_args(args)?;
+    let events = match &options.journal {
+        Some(journal) => load_debug_bind_journal_events(journal, &options.thread_id).await?,
+        None => load_debug_bind_daemon_events(&options.endpoint, &options.thread_id).await?,
+    };
+    let (compile_event, bind_event) = active_receipt_events(&events)?;
+    let compile: AgentManifestCompileReceipt =
+        serde_json::from_value(compile_event.payload.clone()).map_err(|err| {
+            usage_error(format!(
+                "manifest.compile.completed payload is invalid: {err}"
+            ))
+        })?;
+    let bind: AgentManifestBindReceipt = serde_json::from_value(bind_event.payload.clone())
+        .map_err(|err| usage_error(format!("manifest.bind.completed payload is invalid: {err}")))?;
+    let explanation = assemble_bind_explanation(
+        &options.thread_id,
+        &compile_event.event_id,
+        &bind_event.event_id,
+        &compile,
+        &bind,
+    )?;
+    if options.json {
+        serde_json::to_writer_pretty(std::io::stdout(), &explanation)
+            .map_err(|err| usage_error(format!("failed to encode bind explanation: {err}")))?;
+        println!();
+    } else {
+        print!("{}", render_bind_explanation(&explanation));
+    }
+    Ok(())
+}
+
+pub(super) fn parse_debug_bind_args(args: Vec<OsString>) -> CooldisResult<DebugBindArgs> {
+    let mut endpoint = DebugRpcEndpointArgs {
+        url: None,
+        config: None,
+    };
+    let mut journal = None;
+    let mut json = false;
+    let mut positionals = Vec::new();
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        match arg.to_string_lossy().as_ref() {
+            "--json" => json = true,
+            "--url" => endpoint.url = Some(required_debug_bind_string(&mut iter, "--url")?),
+            "--config" => endpoint.config = Some(required_debug_bind_path(&mut iter, "--config")?),
+            "--journal" => journal = Some(required_debug_bind_path(&mut iter, "--journal")?),
+            other if other.starts_with('-') => {
+                return Err(debug_bind_usage_error(format!(
+                    "unknown debug bind argument {other:?}"
+                )));
+            }
+            _ => positionals.push(arg.to_string_lossy().to_string()),
+        }
+    }
+    if positionals.len() != 1 {
+        return Err(debug_bind_usage_error(
+            "cooldis debug bind requires exactly one <thread-id>",
+        ));
+    }
+    let endpoint_count = usize::from(endpoint.url.is_some())
+        + usize::from(endpoint.config.is_some())
+        + usize::from(journal.is_some());
+    if endpoint_count > 1 {
+        return Err(debug_bind_usage_error(
+            "cooldis debug bind accepts --url, --config, or --journal, not more than one",
+        ));
+    }
+    Ok(DebugBindArgs {
+        thread_id: positionals.remove(0),
+        json,
+        journal,
+        endpoint,
+    })
+}
+
+fn required_debug_bind_string(
+    iter: &mut impl Iterator<Item = OsString>,
+    flag: &'static str,
+) -> CooldisResult<String> {
+    required_debug_bind_value(iter, flag).map(|value| value.to_string_lossy().to_string())
+}
+
+fn required_debug_bind_path(
+    iter: &mut impl Iterator<Item = OsString>,
+    flag: &'static str,
+) -> CooldisResult<PathBuf> {
+    required_debug_bind_value(iter, flag).map(PathBuf::from)
+}
+
+fn required_debug_bind_value(
+    iter: &mut impl Iterator<Item = OsString>,
+    flag: &'static str,
+) -> CooldisResult<OsString> {
+    let value = iter
+        .next()
+        .ok_or_else(|| usage_error(format!("{flag} requires a value")))?;
+    if value.to_string_lossy().starts_with('-') {
+        return Err(usage_error(format!("{flag} requires a value")));
+    }
+    Ok(value)
+}
+
+async fn load_debug_bind_daemon_events(
+    endpoint: &DebugRpcEndpointArgs,
+    thread_id: &str,
+) -> CooldisResult<Vec<RecordedReceiptEvent>> {
+    let url = resolve_debug_rpc_endpoint(endpoint)?;
+    let mut client = connect_debug_rpc_client(&url).await?;
+    let mut cursor: Option<String> = None;
+    let mut events = Vec::new();
+    loop {
+        let mut params = json!({
+            "threadId": thread_id,
+            "limit": 500,
+            "kinds": [
+                EventKind::ManifestCompileCompleted.as_str(),
+                EventKind::ManifestBindCompleted.as_str(),
+            ],
+        });
+        if let Some(cursor) = cursor.as_ref() {
+            params["cursor"] = Value::String(cursor.clone());
+        }
+        let result = client.request("thread/events/list", params).await?;
+        let page = result["data"]
+            .as_array()
+            .ok_or_else(|| usage_error("thread/events/list response missing data array"))?;
+        events.extend(
+            page.iter()
+                .map(recorded_receipt_event_from_rpc)
+                .collect::<CooldisResult<Vec<_>>>()?,
+        );
+        cursor = result["cursor"].as_str().map(str::to_string);
+        if cursor.is_none() {
+            break;
+        }
+    }
+    client.close().await?;
+    Ok(events)
+}
+
+async fn load_debug_bind_journal_events(
+    journal: &Path,
+    thread_id: &str,
+) -> CooldisResult<Vec<RecordedReceiptEvent>> {
+    let thread_id = ThreadId::parse_str(thread_id)
+        .map_err(|err| debug_bind_usage_error(format!("invalid thread id {thread_id:?}: {err}")))?;
+    let store = SqliteSessionStore::open_read_only(journal)
+        .await
+        .map_err(|err| usage_error(format!("failed to open journal read-only: {err}")))?;
+    let events = store.list_thread_events(thread_id).await.map_err(|err| {
+        usage_error(format!(
+            "failed to read recorded events for thread {thread_id}: {err}"
+        ))
+    })?;
+    Ok(events
+        .into_iter()
+        .filter(|event| {
+            matches!(
+                event.kind,
+                EventKind::ManifestCompileCompleted | EventKind::ManifestBindCompleted
+            )
+        })
+        .map(|event| RecordedReceiptEvent {
+            event_id: event.id.to_string(),
+            sequence: event.sequence.get(),
+            kind: event.kind.to_string(),
+            source_event_ids: event
+                .provenance
+                .source_event_ids
+                .iter()
+                .map(ToString::to_string)
+                .collect(),
+            payload: event.payload,
+        })
+        .collect())
+}
+
+fn recorded_receipt_event_from_rpc(value: &Value) -> CooldisResult<RecordedReceiptEvent> {
+    let event_id = value["eventId"]
+        .as_str()
+        .ok_or_else(|| usage_error("thread/events/list event missing eventId"))?;
+    let sequence = value["sequence"]
+        .as_i64()
+        .ok_or_else(|| usage_error("thread/events/list event missing sequence"))?;
+    let kind = value["kind"]
+        .as_str()
+        .ok_or_else(|| usage_error("thread/events/list event missing kind"))?;
+    let source_event_ids = value["provenance"]["source_event_ids"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::to_string)
+        .collect();
+    Ok(RecordedReceiptEvent {
+        event_id: event_id.to_string(),
+        sequence,
+        kind: kind.to_string(),
+        source_event_ids,
+        payload: value["payload"].clone(),
+    })
+}
+
+fn active_receipt_events(
+    events: &[RecordedReceiptEvent],
+) -> CooldisResult<(&RecordedReceiptEvent, &RecordedReceiptEvent)> {
+    let bind = events
+        .iter()
+        .filter(|event| event.kind == EventKind::ManifestBindCompleted.as_str())
+        .max_by_key(|event| event.sequence)
+        .ok_or_else(|| usage_error("manifest.bind.completed receipt event was not found"))?;
+    let compile_id = bind.source_event_ids.first().ok_or_else(|| {
+        usage_error("active manifest bind receipt does not witness a compile receipt")
+    })?;
+    let compile = events
+        .iter()
+        .find(|event| {
+            event.event_id == *compile_id
+                && event.kind == EventKind::ManifestCompileCompleted.as_str()
+        })
+        .ok_or_else(|| {
+            usage_error("active manifest bind receipt references an unavailable compile receipt")
+        })?;
+    Ok((compile, bind))
+}
+
+pub fn assemble_bind_explanation(
+    thread_id: &str,
+    compile_event_id: &str,
+    bind_event_id: &str,
+    compile: &AgentManifestCompileReceipt,
+    bind: &AgentManifestBindReceipt,
+) -> CooldisResult<BindExplanation> {
+    let alias = compile
+        .alias
+        .as_ref()
+        .map(|alias| -> CooldisResult<BindAliasExplanation> {
+            let resolved_at_ms = i64::try_from(alias.resolved_at_ms)
+                .map_err(|_| usage_error("alias receipt resolved_at_ms is out of range"))?;
+            let resolved_at = Utc
+                .timestamp_millis_opt(resolved_at_ms)
+                .single()
+                .ok_or_else(|| usage_error("alias receipt resolved_at_ms is out of range"))?
+                .to_rfc3339_opts(SecondsFormat::Millis, true);
+            Ok(BindAliasExplanation {
+                alias: alias.alias.clone(),
+                version: alias.version.clone(),
+                resolved_at,
+            })
+        })
+        .transpose()?;
+    let overridden = bind.overridden_keys.iter().collect::<BTreeSet<_>>();
+    let runtime_values = [
+        ("default_cwd", json!(bind.effective_runtime.default_cwd)),
+        ("streaming", json!(bind.effective_runtime.streaming)),
+        (
+            "turn_timeout_ms",
+            json!(bind.effective_runtime.turn_timeout_ms),
+        ),
+        (
+            "cancellation_grace_ms",
+            json!(bind.effective_runtime.cancellation_grace_ms),
+        ),
+        (
+            "max_tool_rounds",
+            json!(bind.effective_runtime.max_tool_rounds),
+        ),
+        (
+            "compaction.auto_at_text_bytes",
+            json!(bind.effective_runtime.compaction.auto_at_text_bytes),
+        ),
+    ];
+    let runtime = runtime_values
+        .into_iter()
+        .map(|(key, value)| BindRuntimeExplanation {
+            key: key.to_string(),
+            value,
+            overridden: overridden.contains(&key.to_string()),
+        })
+        .collect();
+    let tools = assemble_tools(bind);
+    Ok(BindExplanation {
+        thread_id: thread_id.to_string(),
+        manifest: BindManifestExplanation {
+            ref_uri: compile.ref_uri.clone(),
+            manifest_hash: compile.manifest_hash.clone(),
+            source_hash: compile.source_hash.clone(),
+            alias,
+            compile_event_id: compile_event_id.to_string(),
+            bind_event_id: bind_event_id.to_string(),
+        },
+        model: BindModelExplanation {
+            profile_id: bind.model_profile_id.clone(),
+            provider_id: bind.provider_id.clone(),
+            model_id: bind.model_id.clone(),
+            origin: bind.model_profile_origin,
+        },
+        placement: Some(BindPlacementExplanation {
+            target: bind
+                .placement
+                .as_ref()
+                .map(|placement| &placement.target)
+                .map(|target| serde_json::to_value(target).expect("placement target serializes"))
+                .unwrap_or_else(|| json!("local"))
+                .as_str()
+                .expect("placement target is a string")
+                .to_string(),
+            executor_ref: bind
+                .placement
+                .as_ref()
+                .and_then(|placement| placement.executor_ref.clone()),
+            origin: bind.placement_origin,
+        }),
+        workspace: bind
+            .workspace
+            .as_ref()
+            .map(|workspace| BindWorkspaceExplanation {
+                guest_path: workspace.guest_path.clone(),
+                host_path: workspace.host_path.clone(),
+                mode: serde_json::to_value(workspace.mode)
+                    .expect("workspace mode serializes")
+                    .as_str()
+                    .expect("workspace mode is a string")
+                    .to_string(),
+                origin: bind.workspace_origin,
+            }),
+        runtime,
+        tools,
+        universes: bind
+            .tool_universes
+            .iter()
+            .map(|universe| BindUniverseExplanation {
+                import_id: universe.import_id.clone(),
+                server_ref: universe.server_ref.clone(),
+                discovery_hash: universe.discovery_hash.clone(),
+                tool_count: universe.tools.len(),
+                pinned_count: universe.pinned.len(),
+            })
+            .collect(),
+        couplings: bind
+            .couplings
+            .iter()
+            .map(|coupling| BindCouplingExplanation {
+                id: coupling.id.clone(),
+                role: serde_json::to_value(coupling.role)
+                    .expect("coupling role serializes")
+                    .as_str()
+                    .expect("coupling role is a string")
+                    .to_string(),
+                function_ref: coupling.function_ref.clone(),
+                artifact_hash: coupling.artifact_hash.clone(),
+                config_hash: coupling.config_hash.clone(),
+            })
+            .collect(),
+        grants: bind
+            .grant_bindings
+            .iter()
+            .map(|grant| BindGrantExplanation {
+                capability: grant.capability.clone(),
+                subject_kind: grant.subject_kind.clone(),
+                subject_id: grant.subject_id.clone(),
+                expires_at: grant.expires_at.clone(),
+                lapsed_at_bind: grant.lapsed_at_bind,
+                excluded: grant.surface_excluded,
+            })
+            .collect(),
+        skills: bind
+            .skill_packages
+            .iter()
+            .map(|skill| BindSkillExplanation {
+                package: skill.package_name.clone(),
+                artifact_hash: skill.artifact_hash.clone(),
+            })
+            .collect(),
+        context: bind
+            .static_context_segments
+            .iter()
+            .map(|segment| BindContextExplanation {
+                ref_uri: segment.ref_uri.clone(),
+                content_sha256: segment.content_sha256.clone(),
+            })
+            .collect(),
+    })
+}
+
+fn assemble_tools(bind: &AgentManifestBindReceipt) -> Vec<BindToolExplanation> {
+    let mut tools = Vec::new();
+    for tool_id in &bind.tool_ids {
+        if let Some(universe) = bind
+            .tool_universes
+            .iter()
+            .find(|universe| universe.import_id == *tool_id)
+        {
+            if let [pin] = universe.pinned.as_slice()
+                && let Some((operation_name, artifact_hash)) = pinned_operation(pin)
+            {
+                tools.push(BindToolExplanation {
+                    tool_id: tool_id.clone(),
+                    origin: Some("universe".to_string()),
+                    row_id: Some(universe.import_id.clone()),
+                    pinned: true,
+                    operation_name: Some(operation_name),
+                    artifact_hash: Some(artifact_hash),
+                });
+            } else if !universe.pinned.is_empty() {
+                tools.push(unrecorded_tool(tool_id));
+            }
+            continue;
+        }
+        tools.push(unrecorded_tool(tool_id));
+    }
+    tools
+}
+
+fn unrecorded_tool(tool_id: &str) -> BindToolExplanation {
+    BindToolExplanation {
+        tool_id: tool_id.to_string(),
+        origin: None,
+        row_id: None,
+        pinned: false,
+        operation_name: None,
+        artifact_hash: None,
+    }
+}
+
+fn pinned_operation(pin: &str) -> Option<(String, String)> {
+    let body = pin.strip_prefix("mcptool://")?;
+    let (path, hash) = body.rsplit_once("@sha256:")?;
+    let name = path.rsplit('/').next()?.to_string();
+    Some((name, format!("sha256:{hash}")))
+}
+
+pub fn render_bind_explanation(explanation: &BindExplanation) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("thread {}\n", explanation.thread_id));
+    out.push_str(&format!(
+        "manifest {} (manifest {}, source {})\n",
+        explanation.manifest.ref_uri,
+        short_hash(&explanation.manifest.manifest_hash),
+        short_hash(&explanation.manifest.source_hash),
+    ));
+    if let Some(alias) = &explanation.manifest.alias {
+        out.push_str(&format!(
+            "  alias {} -> {} (resolved {})\n",
+            alias.alias, alias.version, alias.resolved_at
+        ));
+    }
+    out.push_str(&format!(
+        "  receipts compile {} bind {}\n",
+        explanation.manifest.compile_event_id, explanation.manifest.bind_event_id
+    ));
+    out.push_str("\nmodel\n");
+    out.push_str(&format!(
+        "  {}: {} / {}   [{}]\n",
+        explanation.model.profile_id,
+        explanation.model.provider_id,
+        explanation.model.model_id,
+        model_origin_text(explanation.model.origin),
+    ));
+    if let Some(placement) = &explanation.placement {
+        out.push_str("\nplacement\n");
+        out.push_str(&format!(
+            "  {} (executor {})   [{}]\n",
+            placement.target,
+            placement.executor_ref.as_deref().unwrap_or("-"),
+            binding_origin_text(placement.origin),
+        ));
+    }
+    if let Some(workspace) = &explanation.workspace {
+        out.push_str("\nworkspace\n");
+        out.push_str(&format!(
+            "  {} -> {} ({})   [{}]\n",
+            workspace.guest_path.display(),
+            workspace.host_path.display(),
+            workspace.mode,
+            binding_origin_text(workspace.origin),
+        ));
+    }
+    if !explanation.runtime.is_empty() {
+        out.push_str("\nruntime\n");
+        for runtime in &explanation.runtime {
+            out.push_str(&format!(
+                "  {} = {}   [{}]\n",
+                runtime.key,
+                runtime_value_text(&runtime.value),
+                if runtime.overridden {
+                    "override"
+                } else {
+                    "manifest"
+                },
+            ));
+        }
+    }
+    if !explanation.tools.is_empty() {
+        out.push_str("\ntools\n");
+        for tool in &explanation.tools {
+            match (
+                tool.origin.as_deref(),
+                tool.row_id.as_deref(),
+                tool.operation_name.as_deref(),
+                tool.artifact_hash.as_deref(),
+            ) {
+                (Some(origin), Some(row_id), Some(operation_name), Some(artifact_hash)) => {
+                    let pinned = if tool.pinned { " pinned" } else { "" };
+                    out.push_str(&format!(
+                        "  {}   [{} {}{}]  operation {}@{}\n",
+                        tool.tool_id,
+                        origin,
+                        row_id,
+                        pinned,
+                        operation_name,
+                        short_hash(artifact_hash),
+                    ));
+                }
+                _ => out.push_str(&format!("  {}   [unrecorded]\n", tool.tool_id)),
+            }
+        }
+    }
+    if !explanation.universes.is_empty() {
+        out.push_str("\nuniverses\n");
+        for universe in &explanation.universes {
+            out.push_str(&format!(
+                "  {} {} (discovery {})  tools {}  pinned {}\n",
+                universe.import_id,
+                universe.server_ref,
+                short_hash(&universe.discovery_hash),
+                universe.tool_count,
+                universe.pinned_count,
+            ));
+        }
+    }
+    if !explanation.couplings.is_empty() {
+        out.push_str("\ncouplings\n");
+        for coupling in &explanation.couplings {
+            let function_ref =
+                coupling_function_ref_base(&coupling.function_ref, &coupling.artifact_hash);
+            out.push_str(&format!(
+                "  {} ({})  fn {}@{}  config {}\n",
+                coupling.id,
+                coupling.role,
+                function_ref,
+                short_hash(&coupling.artifact_hash),
+                short_hash(&coupling.config_hash),
+            ));
+        }
+    }
+    if !explanation.grants.is_empty() {
+        out.push_str("\ngrants\n");
+        for grant in &explanation.grants {
+            out.push_str(&format!(
+                "  {}  <- {} {}  [{}]",
+                grant.capability,
+                grant.subject_kind,
+                grant.subject_id,
+                grant
+                    .expires_at
+                    .as_ref()
+                    .map(|expiry| format!("expires {expiry}"))
+                    .unwrap_or_else(|| "no expiry".to_string()),
+            ));
+            if grant.lapsed_at_bind {
+                out.push_str("  [lapsed-at-bind]");
+            } else if grant.excluded {
+                out.push_str("  [excluded]");
+            }
+            out.push('\n');
+        }
+    }
+    if !explanation.skills.is_empty() {
+        out.push_str("\nskills\n");
+        for skill in &explanation.skills {
+            out.push_str(&format!(
+                "  {}  {}\n",
+                skill.package,
+                short_hash(&skill.artifact_hash),
+            ));
+        }
+    }
+    if !explanation.context.is_empty() {
+        out.push_str("\ncontext\n");
+        for context in &explanation.context {
+            out.push_str(&format!(
+                "  {}  {}\n",
+                context.ref_uri,
+                short_hash(&context.content_sha256),
+            ));
+        }
+    }
+    out
+}
+
+fn runtime_value_text(value: &Value) -> String {
+    value
+        .as_str()
+        .map(str::to_string)
+        .unwrap_or_else(|| value.to_string())
+}
+
+fn coupling_function_ref_base<'a>(function_ref: &'a str, artifact_hash: &str) -> &'a str {
+    let hash = artifact_hash
+        .strip_prefix("sha256:")
+        .unwrap_or(artifact_hash);
+    function_ref
+        .strip_suffix(&format!("@sha256:{hash}"))
+        .unwrap_or(function_ref)
+}
+
+fn short_hash(value: &str) -> String {
+    let prefixed = value.strip_prefix("sha256:");
+    let hash = prefixed.unwrap_or(value);
+    let is_hex = !hash.is_empty() && hash.bytes().all(|byte| byte.is_ascii_hexdigit());
+    if hash.len() > 12 && is_hex {
+        format!("sha256:{}…", &hash[..12])
+    } else if prefixed.is_some() {
+        value.to_string()
+    } else if is_hex {
+        format!("sha256:{value}")
+    } else {
+        value.to_string()
+    }
+}
+
+fn model_origin_text(origin: Option<AgentManifestModelProfileOrigin>) -> &'static str {
+    match origin {
+        Some(AgentManifestModelProfileOrigin::ManifestDefault) => "manifest-default",
+        Some(AgentManifestModelProfileOrigin::SelectedAtStart) => "selected-at-start",
+        None => "unrecorded",
+    }
+}
+
+fn binding_origin_text(origin: Option<AgentManifestBindingOrigin>) -> &'static str {
+    match origin {
+        Some(AgentManifestBindingOrigin::DaemonDefault) => "daemon-default",
+        Some(AgentManifestBindingOrigin::BindOverride) => "bind-override",
+        Some(AgentManifestBindingOrigin::Manifest) => "manifest",
+        None => "unrecorded",
+    }
+}
+
+pub(super) fn print_debug_bind_help() {
+    println!(
+        "cooldis debug bind\n\
+\n\
+Usage:\n\
+  cooldis debug bind <thread-id> [--json] [--url <ws-url> | --config <cooldis.toml> | --journal <db>]\n\
+\n\
+Explain the effective runtime envelope from recorded manifest compile and bind\n\
+receipts. Daemon mode uses thread/events/list; --journal reads SQLite offline.\n"
+    );
+}
+
+fn debug_bind_usage_error(message: impl Into<String>) -> CooldisError {
+    usage_error(format!(
+        "{}\nUsage: cooldis debug bind --help",
+        message.into()
+    ))
+}

--- a/crates/cooldis-kernel/src/cli/debug_bind/tests.rs
+++ b/crates/cooldis-kernel/src/cli/debug_bind/tests.rs
@@ -1,0 +1,399 @@
+use super::*;
+
+#[test]
+fn parse_debug_bind_requires_thread_id_and_rejects_conflicting_endpoints() {
+    let missing = parse_debug_bind_args(Vec::new()).unwrap_err().to_string();
+    assert!(missing.contains("requires exactly one <thread-id>"));
+
+    let conflicting = vec![
+        "thread-1",
+        "--url",
+        "ws://127.0.0.1:49200/rpc",
+        "--journal",
+        "/tmp/history.sqlite3",
+    ]
+    .into_iter()
+    .map(OsString::from)
+    .collect();
+    let err = parse_debug_bind_args(conflicting).unwrap_err().to_string();
+    assert!(err.contains("--url, --config, or --journal"));
+
+    for flag in ["--url", "--config", "--journal"] {
+        let missing_value = vec!["thread-1", flag]
+            .into_iter()
+            .map(OsString::from)
+            .collect();
+        let err = parse_debug_bind_args(missing_value)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains(&format!("{flag} requires a value")));
+
+        let next_flag_is_not_a_value = vec!["thread-1", flag, "--json"]
+            .into_iter()
+            .map(OsString::from)
+            .collect();
+        let err = parse_debug_bind_args(next_flag_is_not_a_value)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains(&format!("{flag} requires a value")));
+    }
+}
+
+#[test]
+fn legacy_receipts_assemble_with_unrecorded_origins() {
+    let compile: AgentManifestCompileReceipt = serde_json::from_value(json!({
+        "ref_uri": "agent://legacy@1.0.0",
+        "manifest_hash": format!("sha256:{}", "1".repeat(64)),
+        "source_hash": format!("sha256:{}", "2".repeat(64)),
+    }))
+    .unwrap();
+    let bind: AgentManifestBindReceipt = serde_json::from_value(json!({
+        "ref_uri": "agent://legacy@1.0.0",
+        "manifest_hash": format!("sha256:{}", "1".repeat(64)),
+        "model_profile_id": "default",
+        "provider_id": "local_offline",
+        "model_id": "echo",
+        "tool_ids": [],
+        "operation_bindings": [],
+        "granted": [],
+        "effective_runtime": {},
+        "overridden_keys": [],
+    }))
+    .unwrap();
+
+    let explanation =
+        assemble_bind_explanation("thread-1", "compile-1", "bind-1", &compile, &bind).unwrap();
+    let rendered = render_bind_explanation(&explanation);
+
+    assert_eq!(explanation.model.origin, None);
+    let placement = explanation.placement.unwrap();
+    assert_eq!(placement.target, "local");
+    assert_eq!(placement.origin, None);
+    assert!(rendered.contains("[unrecorded]"));
+}
+
+#[test]
+fn grant_explanations_preserve_subject_expiry_and_lapse_witnesses() {
+    let compile: AgentManifestCompileReceipt = serde_json::from_value(json!({
+        "ref_uri": "agent://grants@1.0.0",
+        "manifest_hash": "sha256:manifest",
+        "source_hash": "sha256:source",
+    }))
+    .unwrap();
+    let bind: AgentManifestBindReceipt = serde_json::from_value(json!({
+        "ref_uri": "agent://grants@1.0.0",
+        "manifest_hash": "sha256:manifest",
+        "model_profile_id": "default",
+        "provider_id": "local_offline",
+        "model_id": "echo",
+        "tool_ids": [],
+        "operation_bindings": [],
+        "granted": [],
+        "grant_bindings": [{
+            "subject_kind": "tool",
+            "subject_id": "search",
+            "capability": "net:https://example.test",
+            "expires_at": "2026-07-16T20:00:00Z",
+            "lapsed_at_bind": true,
+            "surface_excluded": true
+        }],
+        "effective_runtime": {},
+        "overridden_keys": [],
+    }))
+    .unwrap();
+
+    let explanation =
+        assemble_bind_explanation("thread-1", "compile-1", "bind-1", &compile, &bind).unwrap();
+
+    assert_eq!(
+        explanation.grants,
+        vec![BindGrantExplanation {
+            capability: "net:https://example.test".to_string(),
+            subject_kind: "tool".to_string(),
+            subject_id: "search".to_string(),
+            expires_at: Some("2026-07-16T20:00:00Z".to_string()),
+            lapsed_at_bind: true,
+            excluded: true,
+        }]
+    );
+    assert!(render_bind_explanation(&explanation).contains(
+        "net:https://example.test  <- tool search  [expires 2026-07-16T20:00:00Z]  [lapsed-at-bind]"
+    ));
+}
+
+#[test]
+fn active_receipts_follow_the_highest_bind_sequence_and_its_provenance() {
+    let events = vec![
+        RecordedReceiptEvent {
+            event_id: "compile-1".to_string(),
+            sequence: 1,
+            kind: EventKind::ManifestCompileCompleted.to_string(),
+            source_event_ids: Vec::new(),
+            payload: json!({"generation": 1}),
+        },
+        RecordedReceiptEvent {
+            event_id: "bind-1".to_string(),
+            sequence: 2,
+            kind: EventKind::ManifestBindCompleted.to_string(),
+            source_event_ids: vec!["compile-1".to_string()],
+            payload: json!({"generation": 1}),
+        },
+        RecordedReceiptEvent {
+            event_id: "compile-2".to_string(),
+            sequence: 3,
+            kind: EventKind::ManifestCompileCompleted.to_string(),
+            source_event_ids: Vec::new(),
+            payload: json!({"generation": 2}),
+        },
+        RecordedReceiptEvent {
+            event_id: "bind-2".to_string(),
+            sequence: 4,
+            kind: EventKind::ManifestBindCompleted.to_string(),
+            source_event_ids: vec!["compile-2".to_string()],
+            payload: json!({"generation": 2}),
+        },
+    ];
+
+    let (compile, bind) = active_receipt_events(&events).unwrap();
+
+    assert_eq!(compile.event_id, "compile-2");
+    assert_eq!(bind.event_id, "bind-2");
+}
+
+#[test]
+fn operation_tool_origins_are_not_guessed_from_receipt_order() {
+    let bind: AgentManifestBindReceipt = serde_json::from_value(json!({
+        "ref_uri": "agent://tools@1.0.0",
+        "manifest_hash": format!("sha256:{}", "1".repeat(64)),
+        "model_profile_id": "default",
+        "provider_id": "local_offline",
+        "model_id": "echo",
+        "tool_ids": ["manifest-tool-id"],
+        "operation_bindings": [{
+            "name": "operation-record",
+            "artifact_hash": "a".repeat(64),
+            "operations": ["operation-name"]
+        }],
+        "granted": [],
+        "effective_runtime": {},
+        "overridden_keys": []
+    }))
+    .unwrap();
+
+    let tools = assemble_tools(&bind);
+
+    assert_eq!(
+        tools,
+        vec![BindToolExplanation {
+            tool_id: "manifest-tool-id".to_string(),
+            origin: None,
+            row_id: None,
+            pinned: false,
+            operation_name: None,
+            artifact_hash: None,
+        }]
+    );
+    let explanation = BindExplanation {
+        thread_id: "thread-1".to_string(),
+        manifest: BindManifestExplanation {
+            ref_uri: "agent://tools@1.0.0".to_string(),
+            manifest_hash: format!("sha256:{}", "1".repeat(64)),
+            source_hash: format!("sha256:{}", "2".repeat(64)),
+            alias: None,
+            compile_event_id: "compile-1".to_string(),
+            bind_event_id: "bind-1".to_string(),
+        },
+        model: BindModelExplanation {
+            profile_id: "default".to_string(),
+            provider_id: "local_offline".to_string(),
+            model_id: "echo".to_string(),
+            origin: None,
+        },
+        placement: None,
+        workspace: None,
+        runtime: Vec::new(),
+        tools,
+        universes: Vec::new(),
+        couplings: Vec::new(),
+        grants: Vec::new(),
+        skills: Vec::new(),
+        context: Vec::new(),
+    };
+    assert!(
+        render_bind_explanation(&explanation)
+            .contains("tools\n  manifest-tool-id   [unrecorded]\n")
+    );
+}
+
+#[test]
+fn alias_timestamp_overflow_is_rejected() {
+    let compile: AgentManifestCompileReceipt = serde_json::from_value(json!({
+        "ref_uri": "agent://alias@1.0.0",
+        "manifest_hash": format!("sha256:{}", "1".repeat(64)),
+        "source_hash": format!("sha256:{}", "2".repeat(64)),
+        "alias": {
+            "ref_uri": "agent://alias@latest",
+            "alias": "latest",
+            "version": "1.0.0",
+            "manifest_hash": format!("sha256:{}", "1".repeat(64)),
+            "resolved_at_ms": u64::MAX
+        }
+    }))
+    .unwrap();
+    let bind: AgentManifestBindReceipt = serde_json::from_value(json!({
+        "ref_uri": "agent://alias@1.0.0",
+        "manifest_hash": format!("sha256:{}", "1".repeat(64)),
+        "model_profile_id": "default",
+        "provider_id": "local_offline",
+        "model_id": "echo",
+        "tool_ids": [],
+        "operation_bindings": [],
+        "granted": [],
+        "effective_runtime": {},
+        "overridden_keys": []
+    }))
+    .unwrap();
+
+    let err = assemble_bind_explanation("thread-1", "compile-1", "bind-1", &compile, &bind)
+        .unwrap_err()
+        .to_string();
+
+    assert!(err.contains("resolved_at_ms is out of range"));
+}
+
+#[test]
+fn short_hash_preserves_non_hash_values() {
+    assert_eq!(short_hash("not-a-hash"), "not-a-hash");
+    assert_eq!(short_hash("sha256:not-a-hash"), "sha256:not-a-hash");
+    assert_eq!(short_hash(&"a".repeat(64)), "sha256:aaaaaaaaaaaa…");
+}
+
+#[test]
+fn render_bind_explanation_matches_pinned_format() {
+    let hash_a = format!("sha256:{}", "a".repeat(64));
+    let hash_b = format!("sha256:{}", "b".repeat(64));
+    let hash_c = format!("sha256:{}", "c".repeat(64));
+    let explanation = BindExplanation {
+        thread_id: "0190-thread".to_string(),
+        manifest: BindManifestExplanation {
+            ref_uri: "agent://analyst@1.2.3".to_string(),
+            manifest_hash: hash_a.clone(),
+            source_hash: hash_b.clone(),
+            alias: Some(BindAliasExplanation {
+                alias: "latest".to_string(),
+                version: "1.2.3".to_string(),
+                resolved_at: "2026-07-16T20:00:00.000Z".to_string(),
+            }),
+            compile_event_id: "compile-event".to_string(),
+            bind_event_id: "bind-event".to_string(),
+        },
+        model: BindModelExplanation {
+            profile_id: "fast".to_string(),
+            provider_id: "openai".to_string(),
+            model_id: "gpt-5".to_string(),
+            origin: Some(AgentManifestModelProfileOrigin::SelectedAtStart),
+        },
+        placement: Some(BindPlacementExplanation {
+            target: "remote".to_string(),
+            executor_ref: Some("executor://pool/main".to_string()),
+            origin: Some(AgentManifestBindingOrigin::BindOverride),
+        }),
+        workspace: Some(BindWorkspaceExplanation {
+            guest_path: PathBuf::from("/workspace"),
+            host_path: PathBuf::from("/srv/repo"),
+            mode: "rw".to_string(),
+            origin: Some(AgentManifestBindingOrigin::DaemonDefault),
+        }),
+        runtime: vec![
+            BindRuntimeExplanation {
+                key: "streaming".to_string(),
+                value: json!(true),
+                overridden: false,
+            },
+            BindRuntimeExplanation {
+                key: "turn_timeout_ms".to_string(),
+                value: json!(30000),
+                overridden: true,
+            },
+        ],
+        tools: vec![BindToolExplanation {
+            tool_id: "search".to_string(),
+            origin: Some("direct".to_string()),
+            row_id: Some("search".to_string()),
+            pinned: false,
+            operation_name: Some("search-op".to_string()),
+            artifact_hash: Some(hash_c.clone()),
+        }],
+        universes: vec![BindUniverseExplanation {
+            import_id: "docs".to_string(),
+            server_ref: "mcp://docs".to_string(),
+            discovery_hash: hash_b.clone(),
+            tool_count: 8,
+            pinned_count: 1,
+        }],
+        couplings: vec![BindCouplingExplanation {
+            id: "audit".to_string(),
+            role: "projection".to_string(),
+            function_ref: format!("op://audit/project@{hash_c}"),
+            artifact_hash: hash_c.clone(),
+            config_hash: hash_a.clone(),
+        }],
+        grants: vec![BindGrantExplanation {
+            capability: "fs.read:/workspace".to_string(),
+            subject_kind: "tool".to_string(),
+            subject_id: "search".to_string(),
+            expires_at: None,
+            lapsed_at_bind: false,
+            excluded: false,
+        }],
+        skills: vec![BindSkillExplanation {
+            package: "release-checks".to_string(),
+            artifact_hash: hash_b.clone(),
+        }],
+        context: vec![BindContextExplanation {
+            ref_uri: "resource://system".to_string(),
+            content_sha256: hash_c,
+        }],
+    };
+
+    assert_eq!(
+        render_bind_explanation(&explanation),
+        concat!(
+            "thread 0190-thread\n",
+            "manifest agent://analyst@1.2.3 (manifest sha256:aaaaaaaaaaaa…, source sha256:bbbbbbbbbbbb…)\n",
+            "  alias latest -> 1.2.3 (resolved 2026-07-16T20:00:00.000Z)\n",
+            "  receipts compile compile-event bind bind-event\n",
+            "\n",
+            "model\n",
+            "  fast: openai / gpt-5   [selected-at-start]\n",
+            "\n",
+            "placement\n",
+            "  remote (executor executor://pool/main)   [bind-override]\n",
+            "\n",
+            "workspace\n",
+            "  /workspace -> /srv/repo (rw)   [daemon-default]\n",
+            "\n",
+            "runtime\n",
+            "  streaming = true   [manifest]\n",
+            "  turn_timeout_ms = 30000   [override]\n",
+            "\n",
+            "tools\n",
+            "  search   [direct search]  operation search-op@sha256:cccccccccccc…\n",
+            "\n",
+            "universes\n",
+            "  docs mcp://docs (discovery sha256:bbbbbbbbbbbb…)  tools 8  pinned 1\n",
+            "\n",
+            "couplings\n",
+            "  audit (projection)  fn op://audit/project@sha256:cccccccccccc…  config sha256:aaaaaaaaaaaa…\n",
+            "\n",
+            "grants\n",
+            "  fs.read:/workspace  <- tool search  [no expiry]\n",
+            "\n",
+            "skills\n",
+            "  release-checks  sha256:bbbbbbbbbbbb…\n",
+            "\n",
+            "context\n",
+            "  resource://system  sha256:cccccccccccc…\n",
+        )
+    );
+}

--- a/crates/cooldis-kernel/src/cli/debug_rpc.rs
+++ b/crates/cooldis-kernel/src/cli/debug_rpc.rs
@@ -16,6 +16,7 @@ pub(super) async fn run_debug(mut args: Vec<OsString>) -> CooldisResult<()> {
     }
     let subcommand = args.remove(0);
     match subcommand.to_string_lossy().as_ref() {
+        "bind" => run_debug_bind(args).await,
         "rpc" => run_debug_rpc(args).await,
         other => Err(usage_error(format!(
             "unknown debug subcommand {other:?}; use `cooldis debug --help`"
@@ -52,8 +53,8 @@ pub(super) async fn run_debug_rpc(mut args: Vec<OsString>) -> CooldisResult<()> 
 /// `--url` and `--config` together is a usage error.
 #[derive(Debug)]
 pub(super) struct DebugRpcEndpointArgs {
-    url: Option<String>,
-    config: Option<PathBuf>,
+    pub(super) url: Option<String>,
+    pub(super) config: Option<PathBuf>,
 }
 
 #[derive(Debug)]
@@ -511,6 +512,7 @@ pub(super) fn print_debug_help() {
         "cooldis debug\n\
 \n\
 Usage:\n\
+  cooldis debug bind <thread-id> [--json] [--url <ws-url> | --config <cooldis.toml> | --journal <db>]\n\
   cooldis debug rpc (call|turn|tail) ...   debug client for a running daemon (see `cooldis debug rpc --help`)\n\
 \n\
 Maintainer and protocol inspection tools. These commands are not the public\n\

--- a/crates/cooldis-kernel/src/cli/mod.rs
+++ b/crates/cooldis-kernel/src/cli/mod.rs
@@ -65,6 +65,7 @@ mod chat;
 mod console;
 mod coupling;
 mod daemon;
+mod debug_bind;
 mod debug_rpc;
 mod import;
 mod rpc;
@@ -78,6 +79,7 @@ use blob::*;
 use console::*;
 use coupling::*;
 use daemon::*;
+use debug_bind::*;
 use debug_rpc::*;
 use import::*;
 use rpc::*;
@@ -260,6 +262,9 @@ fn print_command_help(path: &[String]) -> CooldisResult<()> {
         }
         [command] if command == "rpc" => print_rpc_help(),
         [command] if command == "debug" => print_debug_help(),
+        [command, subcommand] if command == "debug" && subcommand == "bind" => {
+            print_debug_bind_help()
+        }
         [command, subcommand] if command == "debug" && subcommand == "rpc" => {
             print_debug_rpc_help()
         }
@@ -356,6 +361,7 @@ const CANONICAL_COMMANDS: &[&str] = &[
     "cooldis tool source show <name> [--json] [--state-home .cooldis/state]",
     "cooldis tool source remove <name> [--state-home .cooldis/state]",
     "cooldis rpc --listen <unix://PATH|ws://HOST:PORT[/rpc]> [--cwd <path>]",
+    "cooldis debug bind <thread-id> [--json] [--url <ws-url> | --config <cooldis.toml> | --journal <db>]",
     "cooldis debug rpc call <method> [PARAMS_JSON] [--url <ws-url> | --config <cooldis.toml>]",
     "cooldis debug rpc turn (--thread <id> | --new) [--json] <text> [--url <ws-url> | --config <cooldis.toml>]",
     "cooldis debug rpc tail --thread <id> [--url <ws-url> | --config <cooldis.toml>]",

--- a/crates/cooldis-kernel/src/daemon/daemon_io/tests.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_io/tests.rs
@@ -7199,6 +7199,7 @@ async fn daemon_fork_copies_the_parent_workspace_bind_witness() {
         ref_uri: "agent://workspace@0.1.0".to_string(),
         manifest_hash: "sha256:workspace".to_string(),
         model_profile_id: "default".to_string(),
+        model_profile_origin: None,
         provider_id: APP_SERVER_LOCAL_PROVIDER.to_string(),
         model_id: APP_SERVER_LOCAL_MODEL.to_string(),
         tool_ids: Vec::new(),
@@ -7213,7 +7214,9 @@ async fn daemon_fork_copies_the_parent_workspace_bind_witness() {
         effective_runtime: crate::AgentManifestRuntimeDefaults::default(),
         overridden_keys: Vec::new(),
         placement: Some(crate::AgentManifestPlacementBinding::default()),
+        placement_origin: None,
         workspace: Some(resolved_workspace),
+        workspace_origin: None,
     })
     .unwrap();
     parent

--- a/crates/cooldis-kernel/src/kernel/control_decision.rs
+++ b/crates/cooldis-kernel/src/kernel/control_decision.rs
@@ -1495,6 +1495,7 @@ mod tests {
                 ref_uri: "agent://test/bash".to_string(),
                 manifest_hash: self.snapshot_id.clone(),
                 model_profile_id: "default".to_string(),
+                model_profile_origin: None,
                 provider_id: "test".to_string(),
                 model_id: "model".to_string(),
                 tool_ids: Vec::new(),
@@ -1509,7 +1510,9 @@ mod tests {
                 effective_runtime: AgentManifestRuntimeDefaults::default(),
                 overridden_keys: Vec::new(),
                 placement: None,
+                placement_origin: None,
                 workspace: None,
+                workspace_origin: None,
             };
             self.store
                 .append_events(

--- a/crates/cooldis-kernel/src/kernel/thread_spawn_projector.rs
+++ b/crates/cooldis-kernel/src/kernel/thread_spawn_projector.rs
@@ -1435,6 +1435,7 @@ mod tests {
                     ref_uri: agent_ref.to_string(),
                     manifest_hash: "sha256:forged-remote-workspace".to_string(),
                     model_profile_id: "default".to_string(),
+                    model_profile_origin: None,
                     provider_id: "test".to_string(),
                     model_id: "model".to_string(),
                     tool_ids: Vec::new(),
@@ -1453,11 +1454,13 @@ mod tests {
                         executor_ref: Some("executor://cluster/default".to_string()),
                         config: BTreeMap::new(),
                     }),
+                    placement_origin: None,
                     workspace: Some(AgentManifestResolvedWorkspaceMount {
                         guest_path: PathBuf::from("/work"),
                         host_path: PathBuf::from("/tmp/forged-remote-workspace"),
                         mode: AgentManifestWorkspaceMode::ReadWrite,
                     }),
+                    workspace_origin: None,
                 })
                 .unwrap(),
             })

--- a/crates/cooldis-kernel/src/lib.rs
+++ b/crates/cooldis-kernel/src/lib.rs
@@ -326,11 +326,11 @@ pub use agent::manifest::{
     default_blob_registry_root_for_agent_registry_root, default_operations_registry_root,
 };
 pub use agent::manifest_bind::{
-    AgentManifestBindOverrides, AgentManifestBindReceipt, AgentManifestBoundThread,
-    AgentManifestCompileReceipt, AgentManifestCouplingBinding, AgentManifestDirectToolBinding,
-    AgentManifestDiscoveredSkill, AgentManifestGrantBindingReceipt,
-    AgentManifestModelProfileSelection, AgentManifestOperationBinding,
-    AgentManifestPlacementBinding, AgentManifestProviderSurface,
+    AgentManifestBindOverrides, AgentManifestBindReceipt, AgentManifestBindingOrigin,
+    AgentManifestBoundThread, AgentManifestCompileReceipt, AgentManifestCouplingBinding,
+    AgentManifestDirectToolBinding, AgentManifestDiscoveredSkill, AgentManifestGrantBindingReceipt,
+    AgentManifestModelProfileOrigin, AgentManifestModelProfileSelection,
+    AgentManifestOperationBinding, AgentManifestPlacementBinding, AgentManifestProviderSurface,
     AgentManifestResolvedWorkspaceMount, AgentManifestSkillDiscovery,
     AgentManifestSkillPackageBinding, AgentManifestStaticContextSegment,
     AgentManifestWorkspaceBinding, BoundCoupling, BoundCouplingFunction, BoundCouplingSelector,

--- a/crates/cooldis-kernel/tests/cooldis_cli_publish.rs
+++ b/crates/cooldis-kernel/tests/cooldis_cli_publish.rs
@@ -274,6 +274,7 @@ fn cooldis_cli_uses_clean_public_entrypoints() {
     assert!(commands.contains("cooldis console"));
     assert!(commands.contains("cooldis chat [PROMPT]"));
     assert!(commands.contains("cooldis debug rpc call"));
+    assert!(commands.contains("cooldis debug bind"));
     assert!(commands.contains("cooldis tool manual"));
     assert!(commands.contains("cooldis skill publish"));
     assert!(commands.contains("cooldis skill import"));
@@ -312,6 +313,9 @@ fn cooldis_cli_uses_clean_public_entrypoints() {
     let help_debug_rpc = run_cooldis(["help", "debug", "rpc"]);
     assert!(help_debug_rpc.contains("cooldis debug rpc"));
 
+    let help_debug_bind = run_cooldis(["help", "debug", "bind"]);
+    assert!(help_debug_bind.contains("cooldis debug bind"));
+
     let rpc = run_cooldis(["rpc", "--help"]);
     assert!(rpc.contains("cooldis rpc"));
     assert!(rpc.contains("--listen"));
@@ -327,6 +331,9 @@ fn cooldis_cli_uses_clean_public_entrypoints() {
 
     let debug_rpc = run_cooldis(["debug", "rpc", "--help"]);
     assert!(debug_rpc.contains("Protocol-level debug client"));
+
+    let debug_bind = run_cooldis(["debug", "bind", "--help"]);
+    assert!(debug_bind.contains("recorded manifest compile and bind"));
 
     let old_tool_plan = run_cooldis_failed(["tool", "plan", "--help"]);
     assert!(stderr(&old_tool_plan).contains("unknown tool subcommand"));

--- a/crates/cooldis-kernel/tests/cooldis_debug_rpc.rs
+++ b/crates/cooldis-kernel/tests/cooldis_debug_rpc.rs
@@ -58,6 +58,36 @@ async fn debug_rpc_cli_calls_and_streams_turns_over_websocket() {
         "completed text did not include prompt: {completed_text:?}"
     );
 
+    let live_bind = run_cooldis([
+        "debug",
+        "bind",
+        thread_id.as_str(),
+        "--json",
+        "--url",
+        url.as_str(),
+    ])
+    .await;
+    assert_success(&live_bind);
+    let live_explanation: Value = serde_json::from_slice(&live_bind.stdout).unwrap();
+    assert_eq!(live_explanation["thread_id"], thread_id);
+    assert_eq!(live_explanation["model"]["origin"], "manifest-default");
+
+    let missing_thread_id = Uuid::now_v7().to_string();
+    let missing_bind = run_cooldis([
+        "debug",
+        "bind",
+        missing_thread_id.as_str(),
+        "--url",
+        url.as_str(),
+    ])
+    .await;
+    assert!(!missing_bind.status.success());
+    assert!(
+        String::from_utf8_lossy(&missing_bind.stderr).contains("thread not found"),
+        "missing-thread error was not preserved: {}",
+        String::from_utf8_lossy(&missing_bind.stderr)
+    );
+
     let resumed = run_cooldis([
         "debug",
         "rpc",
@@ -87,8 +117,22 @@ async fn debug_rpc_cli_calls_and_streams_turns_over_websocket() {
         .await
         .unwrap();
     assert_admission_precedes_execution(&control_events, &thread_events, "surface:debug-rpc");
+    drop(store);
 
     server.stop().await;
+    let journal = root.join("state/session_history.sqlite3");
+    let offline_bind = run_cooldis([
+        "debug",
+        "bind",
+        thread_id.as_str(),
+        "--json",
+        "--journal",
+        journal.to_str().unwrap(),
+    ])
+    .await;
+    assert_success(&offline_bind);
+    let offline_explanation: Value = serde_json::from_slice(&offline_bind.stdout).unwrap();
+    assert_eq!(offline_explanation, live_explanation);
     let _ = std::fs::remove_dir_all(root);
 }
 

--- a/crates/cooldis-process/src/process/tests.rs
+++ b/crates/cooldis-process/src/process/tests.rs
@@ -302,8 +302,13 @@ async fn host_process_termination_kills_term_ignoring_process_group_members() {
 
     let child_pid = tokio::time::timeout(Duration::from_secs(2), async {
         loop {
-            if let Ok(pid) = std::fs::read_to_string(&pid_file) {
-                break pid.trim().parse::<libc::pid_t>().unwrap();
+            // The shell creates the pid file before the echo's content lands;
+            // keep polling until the content actually parses.
+            if let Some(pid) = std::fs::read_to_string(&pid_file)
+                .ok()
+                .and_then(|pid| pid.trim().parse::<libc::pid_t>().ok())
+            {
+                break pid;
             }
             tokio::task::yield_now().await;
         }

--- a/docs/app-server.md
+++ b/docs/app-server.md
@@ -80,6 +80,22 @@ cargo run --bin cooldis -- debug rpc turn --thread <thread-id> --json "resume he
 cargo run --bin cooldis -- debug rpc tail --thread <thread-id> --url ws://127.0.0.1:49200/rpc
 ```
 
+`cooldis debug bind` answers why a thread has its effective configuration by
+projecting its recorded `manifest.compile.completed` and
+`manifest.bind.completed` receipts. It uses the same WebSocket endpoint
+selection as `debug rpc`, and it can inspect the same thread offline from the
+SQLite journal without a daemon:
+
+```sh
+cargo run --bin cooldis -- debug bind <thread-id>
+cargo run --bin cooldis -- debug bind <thread-id> --json --url ws://127.0.0.1:49200/rpc
+cargo run --bin cooldis -- debug bind <thread-id> --journal .cooldis/state/session_history.sqlite3
+```
+
+The command never resolves the manifest again or consults current daemon
+defaults to fill old receipt gaps. Legacy origins that were not recorded print
+as `[unrecorded]`.
+
 ## Provider Config
 
 The chat command can point its private app-server runtime at a live

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -55,6 +55,7 @@ Both redact stored values in status and list output.
 
 ```sh
 cooldis rpc --listen <unix://PATH|ws://HOST:PORT[/rpc]> [--cwd <path>]
+cooldis debug bind <thread-id> [--json] [--url <ws-url> | --config <path> | --journal <db>]
 cooldis debug rpc call <method> [PARAMS_JSON]
 cooldis debug rpc turn (--thread <id> | --new) <text>
 cooldis debug rpc tail --thread <id>
@@ -62,8 +63,13 @@ cooldis daemon run|config|service
 ```
 
 `cooldis rpc` is the app-server control plane for scripts, local hosts, MCP,
-ACP, and other clients. `cooldis debug rpc` is protocol tooling for maintainers
-and smoke tests; it is not the default user console.
+ACP, and other clients. `cooldis debug bind` explains the effective model,
+placement, workspace, runtime, tool, coupling, grant, skill, and context
+envelope strictly from recorded compile and bind receipts. It reads a running
+daemon through `thread/events/list`, or a stopped daemon's SQLite journal with
+`--journal`; `--json` emits the full receipt projection. `cooldis debug rpc` is
+protocol tooling for maintainers and smoke tests; it is not the default user
+console.
 
 ## Release Contract
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,8 @@ allowed to exercise.
 - Opt into conventional workspace skill discovery and retain the exact bind
   witness across resume/fork while later workspace reads remain live.
 - Run the agent through a governed runtime instead of a one-off app server.
-- Inspect events, tool calls, receipts, and artifacts.
+- Inspect events, tool calls, receipts, artifacts, and the effective bind
+  envelope recorded for a thread.
 - Resume work from durable records.
 - Start idempotent process handles whose terminal outcomes re-enter the owning
   thread through durable ingress.

--- a/docs/public-api-coverage.md
+++ b/docs/public-api-coverage.md
@@ -54,6 +54,7 @@ inputs, durable effects, or output semantics.
 | `cooldis rpc` | [RPC Control Plane](app-server.md) | `cooldis rpc --help` | partial | Add generated endpoint/method manual and wire examples. |
 | `cooldis chat` | [Chat Console](chat.md), [RPC Control Plane](app-server.md), [Provider Adapter Surface](provider-adapters.md) | `cooldis chat --help` | partial | Bundled local terminal console over app-server RPC; richer generated manual remains follow-up work. |
 | `cooldis debug rpc` | [RPC Control Plane](app-server.md) | `cooldis debug rpc --help` | partial | Protocol debug client for running daemon WebSocket endpoints; formal man page remains follow-up work. |
+| `cooldis debug bind` | [RPC Control Plane](app-server.md), [CLI](cli.md) | `cooldis debug bind --help` | partial | Receipt-only effective bind explanation over live `thread/events/list` or an offline SQLite journal; formal man page remains follow-up work. |
 | `cooldis daemon run` | [Cooldis Daemon](daemon.md), [Cooldis IO](io.md) | `cooldis daemon --help` | partial | Add generated daemon run/config/service man pages. |
 | `cooldis daemon config validate` | [Cooldis Daemon](daemon.md) | `cooldis daemon --help` | partial | Document config schema and validation errors in man form. |
 | `cooldis daemon service print` | [Cooldis Daemon](daemon.md) | `cooldis daemon --help` | partial | Document generated launchd/systemd output and side-effect boundary. |


### PR DESCRIPTION
Linear: EMO-451

Adds `cooldis debug bind <thread-id>`: a receipt-only explanation of the effective runtime envelope a thread is bound to.

## What changed

- The bind receipt now records where three resolutions came from: model profile (manifest-default or selected-at-start), placement (daemon-default, bind-override, or manifest), and workspace. The fields are additive and optional; legacy receipts decode unchanged, never gain the fields on re-encode, and render their origins as `[unrecorded]`.
- `cooldis debug bind` projects the recorded manifest compile and bind receipts into a sectioned text explanation (thread, manifest, model, placement, workspace, runtime, tools, universes, couplings, grants, skills, context) with bracketed origin annotations, or a JSON form with `--json`. It works against a live daemon over the existing `thread/events/list` RPC or offline against a read-only SQLite journal via `--journal`.
- The explanation is a pure projection: it never recomputes resolution, never consults current config, registries, or resolvers. What was not recorded renders as `[unrecorded]` rather than being re-derived.

## Review

Write-capable review gate fixed five findings, all architect-read. The High one matters for trust in the output: the tool section guessed a positional tool-to-operation correspondence the receipt does not record; the projection now only annotates exact recorded correspondences and otherwise shows `[unrecorded]`. Also fixed: fabricated `sha256:` labels on non-hash values, silent wrap of out-of-range alias timestamps, duplicate rendering of pinned coupling hashes, and flags consuming flag-shaped values.

## Ride-along

The same test-only deflake commit as PR #22 (host process termination pid read), cherry-picked so the pre-push hook passes on this branch. It disappears from this diff once #22 merges.

## Verification

`scripts/cargo-lane.sh test --workspace --all-targets --locked` green (938 passed in the primary binary); live-daemon and offline-journal explanations verified equal in an integration test.
