### PR TITLE
EMO-448: effect classes and fingerprints govern tool invocation recovery

### DIFF
--- a/crates/cooldis-agent/src/manifest_schema.rs
+++ b/crates/cooldis-agent/src/manifest_schema.rs
@@ -109,6 +109,7 @@ impl AgentManifestSchema {
         }
 
         reject_reserved_resource_kinds(value)?;
+        validate_raw_effect_classes(value)?;
         validate_raw_grant_shapes(value)?;
 
         let identity = required_section(value, "agent")?;
@@ -552,6 +553,21 @@ pub enum AgentManifestTool {
     ProtocolImport(AgentManifestProtocolToolImport),
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum EffectClass {
+    Pure,
+    Idempotent,
+    #[default]
+    AtMostOnce,
+}
+
+impl EffectClass {
+    pub fn is_at_most_once(&self) -> bool {
+        *self == Self::AtMostOnce
+    }
+}
+
 /// A command exposed inside virtual bash, backed by a published operation.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -560,6 +576,8 @@ pub struct AgentManifestBashTool {
     pub command: String,
     /// `op://...` operation artifact reference.
     pub operation_ref: String,
+    #[serde(default, skip_serializing_if = "EffectClass::is_at_most_once")]
+    pub effect_class: EffectClass,
     /// Effect grants ride on the binding that uses them (audit section 10);
     /// there is no manifest-global grant pool.
     #[serde(default)]
@@ -574,6 +592,8 @@ pub struct AgentManifestDirectTool {
     pub tool_name: String,
     /// `op://...` operation artifact reference.
     pub operation_ref: String,
+    #[serde(default, skip_serializing_if = "EffectClass::is_at_most_once")]
+    pub effect_class: EffectClass,
     #[serde(default)]
     pub grants: Vec<AgentManifestGrant>,
 }
@@ -592,6 +612,8 @@ pub struct AgentManifestProtocolToolImport {
     /// names placement; content-addressing belongs to per-tool contract pins
     /// (`mcptool://...@sha256:<hash>`), not the source record.
     pub server_ref: String,
+    #[serde(default, skip_serializing_if = "EffectClass::is_at_most_once")]
+    pub effect_class: EffectClass,
     /// Which surfaces imported tools may be exposed on. Empty means the
     /// search surface only (the default for live universes).
     #[serde(default)]
@@ -1200,6 +1222,37 @@ fn reject_reserved_resource_kinds(value: &toml::Value) -> CooldisResult<()> {
             return Err(CooldisError::RuntimeFactory(format!(
                 "resource kind {kind:?} is reserved for a deferred V1 resource scope"
             )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_raw_effect_classes(value: &toml::Value) -> CooldisResult<()> {
+    let Some(tools) = value.get("tools").and_then(toml::Value::as_array) else {
+        return Ok(());
+    };
+    for (tool_index, tool) in tools.iter().enumerate() {
+        let tool_id = tool
+            .get("id")
+            .and_then(toml::Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("<row {tool_index}>"));
+        let Some(effect_class) = tool.get("effect_class") else {
+            continue;
+        };
+        match effect_class.as_str() {
+            Some("pure" | "idempotent" | "at-most-once") => {}
+            Some(effect_class) => {
+                return Err(CooldisError::RuntimeFactory(format!(
+                    "tool {tool_id:?} effect_class {effect_class:?} is unknown; expected pure, idempotent, or at-most-once"
+                )));
+            }
+            None => {
+                return Err(CooldisError::RuntimeFactory(format!(
+                    "tool {tool_id:?} effect_class must be a string, got {}",
+                    toml_value_kind(effect_class)
+                )));
+            }
         }
     }
     Ok(())

--- a/crates/cooldis-agent/src/manifest_schema/tests.rs
+++ b/crates/cooldis-agent/src/manifest_schema/tests.rs
@@ -156,6 +156,57 @@ fn full_fixture_manifest_parses_and_validates() {
     assert!(manifest.workspace.is_none());
     assert!(manifest.couplings.is_empty());
     assert_eq!(manifest.effective_context_pipeline().sources.len(), 3);
+    assert!(manifest.tools.iter().all(|tool| match tool {
+        AgentManifestTool::Bash(tool) => tool.effect_class == EffectClass::AtMostOnce,
+        AgentManifestTool::Direct(tool) => tool.effect_class == EffectClass::AtMostOnce,
+        AgentManifestTool::ProtocolImport(tool) => {
+            tool.effect_class == EffectClass::AtMostOnce
+        }
+    }));
+    assert!(
+        !toml::to_string(&manifest).unwrap().contains("effect_class"),
+        "legacy manifests must not acquire defaulted effect_class fields when re-encoded"
+    );
+}
+
+#[test]
+fn tool_rows_accept_effect_classes_and_reject_unknown_values_by_row() {
+    let source = valid_manifest()
+        .replace(
+            "command = \"tailcat\"",
+            "command = \"tailcat\"\neffect_class = \"pure\"",
+        )
+        .replace(
+            "tool_name = \"risk_lookup\"",
+            "tool_name = \"risk_lookup\"\neffect_class = \"idempotent\"",
+        )
+        .replace(
+            "server_ref = \"mcp://docs\"",
+            "server_ref = \"mcp://docs\"\neffect_class = \"at-most-once\"",
+        );
+    let manifest = parse(&source).unwrap();
+    assert!(matches!(
+        &manifest.tools[0],
+        AgentManifestTool::Bash(tool) if tool.effect_class == EffectClass::Pure
+    ));
+    assert!(matches!(
+        &manifest.tools[1],
+        AgentManifestTool::Direct(tool) if tool.effect_class == EffectClass::Idempotent
+    ));
+    assert!(matches!(
+        &manifest.tools[2],
+        AgentManifestTool::ProtocolImport(tool) if tool.effect_class == EffectClass::AtMostOnce
+    ));
+
+    let err = parse(&valid_manifest().replace(
+        "tool_name = \"risk_lookup\"",
+        "tool_name = \"risk_lookup\"\neffect_class = \"retryable\"",
+    ))
+    .unwrap_err();
+    let text = err.to_string();
+    assert!(text.contains("tool \"risk_lookup\""), "{text}");
+    assert!(text.contains("effect_class"), "{text}");
+    assert!(text.contains("retryable"), "{text}");
 }
 
 #[test]

--- a/crates/cooldis-kernel/src/adapters/app_server/default_manifest.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/default_manifest.rs
@@ -282,6 +282,7 @@ fn default_manifest_tools(
                         "op://{COOLDIS_THREADS_PACKAGE}/{operation_name}@sha256:{}",
                         record.active_artifact_hash
                     ),
+                    effect_class: Default::default(),
                     grants,
                 }));
             }
@@ -333,6 +334,7 @@ fn default_manifest_tools(
                     "op://{}/{}@sha256:{}",
                     record.name, operation.operation_name, record.active_artifact_hash
                 ),
+                effect_class: Default::default(),
                 grants: grants.clone(),
             }));
         }

--- a/crates/cooldis-kernel/src/adapters/app_server/subscriptions.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/subscriptions.rs
@@ -1830,6 +1830,7 @@ mod tests {
                 snapshot_id: "snapshot".to_string(),
                 tool_name: "bash".to_string(),
                 success: false,
+                args_fingerprint: None,
                 duration_ms: Some(12),
                 finish_order: Some(0),
                 cancellation: Some(ToolCallCancellation::CancelledExceededGrace),

--- a/crates/cooldis-kernel/src/adapters/app_server/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/tests.rs
@@ -10,16 +10,16 @@ use super::threads::{
 use super::*;
 use crate::{
     CHANNEL_EMIT_OPERATION, COOLDIS_NOTIFY_PACKAGE, COOLDIS_PROCESS_PACKAGE,
-    COOLDIS_SCHEDULE_PACKAGE, COOLDIS_THREADS_PACKAGE, EventKind, EventOrigin, KERNEL_RUNTIME_KIND,
-    LocalOperationRegistry, LocalSkillRegistry, MANDATE_LIST_OPERATION, MANDATE_REVOKE_OPERATION,
-    MANDATE_START_OPERATION, NOTIFY_PREVIEW_OPERATION, OPERATION_METADATA_RUNTIME_KIND,
-    PROCESS_EXEC_OPERATION, PROCESS_POLL_OPERATION, PROCESS_TERMINATE_OPERATION,
-    PROCESS_WRITE_OPERATION, ProviderError, PublishSkillPackageRequest, PublishedOperationSource,
-    SCHEDULE_MANAGE_CAPABILITY, SCHEDULE_READ_CAPABILITY, THREAD_CANCEL_OPERATION,
-    THREAD_SPAWN_OPERATION, THREAD_STATUS_OPERATION, THREAD_SUBMIT_OPERATION,
-    THREAD_WAIT_OPERATION, THREADS_CONTROL_CAPABILITY, THREADS_READ_CAPABILITY,
-    THREADS_SPAWN_CAPABILITY, TOOL_CALL_TOOL, TOOL_DESCRIBE_TOOL, TOOL_SEARCH_TOOL, ThinkingConfig,
-    ThinkingEffort,
+    COOLDIS_SCHEDULE_PACKAGE, COOLDIS_THREADS_PACKAGE, EffectClass, EventKind, EventOrigin,
+    KERNEL_RUNTIME_KIND, LocalOperationRegistry, LocalSkillRegistry, MANDATE_LIST_OPERATION,
+    MANDATE_REVOKE_OPERATION, MANDATE_START_OPERATION, NOTIFY_PREVIEW_OPERATION,
+    OPERATION_METADATA_RUNTIME_KIND, PROCESS_EXEC_OPERATION, PROCESS_POLL_OPERATION,
+    PROCESS_TERMINATE_OPERATION, PROCESS_WRITE_OPERATION, ProviderError,
+    PublishSkillPackageRequest, PublishedOperationSource, SCHEDULE_MANAGE_CAPABILITY,
+    SCHEDULE_READ_CAPABILITY, THREAD_CANCEL_OPERATION, THREAD_SPAWN_OPERATION,
+    THREAD_STATUS_OPERATION, THREAD_SUBMIT_OPERATION, THREAD_WAIT_OPERATION,
+    THREADS_CONTROL_CAPABILITY, THREADS_READ_CAPABILITY, THREADS_SPAWN_CAPABILITY, TOOL_CALL_TOOL,
+    TOOL_DESCRIBE_TOOL, TOOL_SEARCH_TOOL, ThinkingConfig, ThinkingEffort,
 };
 
 #[test]
@@ -7091,6 +7091,7 @@ type = "bash_tool"
 id = "profile"
 command = "profile"
 operation_ref = "op://analytics/profile@sha256:{}"
+effect_class = "idempotent"
 
 [runtime]
 default_cwd = "."
@@ -7154,6 +7155,22 @@ streaming = false
         bind.payload["operation_bindings"][0]["operations"],
         json!(["profile"])
     );
+    let request = crate::ToolCallRequestedPayload {
+        subject: crate::ToolCallSubject {
+            turn_id: "turn-effect-class".to_string(),
+            call_id: "call-effect-class".to_string(),
+        },
+        snapshot_id: bind.payload["manifest_hash"].as_str().unwrap().to_string(),
+        tool_name: crate::BASH_TOOL.to_string(),
+        arguments: json!({"command":"profile customer-1"}),
+        args_fingerprint: None,
+        holds: Vec::new(),
+    };
+    assert_eq!(
+        crate::adapters::provider_runtime::effect_class_for_request(&events, &request).unwrap(),
+        EffectClass::Idempotent,
+        "the runtime lookup must read the class from the real top-level bind receipt shape"
+    );
 
     app.dispatch_request(
         &connection,
@@ -7197,6 +7214,7 @@ fn thread_manifest_operation_bindings_accept_legacy_metadata_without_operations(
             name: "analytics".to_string(),
             artifact_hash: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
                 .to_string(),
+            effect_class: EffectClass::AtMostOnce,
             grants: vec!["net:https://example.com".to_string()],
             grant_expiries: Vec::new(),
             operations: Vec::new(),

--- a/crates/cooldis-kernel/src/adapters/app_server/threads.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/threads.rs
@@ -2179,6 +2179,7 @@ impl CapsuleBindingRuntimeFactory {
             let AgentManifestOperationBinding {
                 name,
                 artifact_hash,
+                effect_class: _,
                 grants,
                 grant_expiries,
                 operations,

--- a/crates/cooldis-kernel/src/adapters/provider_runtime.rs
+++ b/crates/cooldis-kernel/src/adapters/provider_runtime.rs
@@ -18,30 +18,32 @@
 //! history.
 
 use crate::agent::contracts::sha256_hex;
+use crate::agent::tool_universe::args_fingerprint;
+use crate::kernel::control_decision::tool_invocation_fingerprint_matches;
 use crate::{
     AgentContextCompileInput, AgentContextCompilePolicy, AgentContextCompiler,
     AgentManifestStaticContextSegment, AgentRuntime, AgentRuntimeFactory, AgentToolRouter,
     AllowAllToolPermissionGate, BashToolProvider, COOLDIS_NOTIFY_PACKAGE, COOLDIS_PROCESS_PACKAGE,
     COOLDIS_SCHEDULE_PACKAGE, COOLDIS_THREADS_PACKAGE, CanonicalContent, CanonicalMessage,
     CompactionPolicy, CompactionTrigger, CompiledAgentContext, CooldisError, CooldisResult,
-    DEFAULT_TOOL_CANCELLATION_GRACE, EventKind, EventProvenance, EventRecord, EventRecordId,
-    EventSequence, EventStreamId, HistoryError, HookHandlerSpec, HookMutationWitness, HookPipeline,
-    HookRunRecord, KernelNotifyOperationProvider, KernelOperationDispatcher,
-    KernelProcessOperationProvider, KernelScheduleOperationProvider, KernelThreadOperationProvider,
-    KernelThreadSpawnAgentResolver, NewEventRecord, NewObservationRecord, ObservationProvenance,
-    OperationRegistry, PostCompactHookRequest, PreCompactHookRequest, ProviderApi, ProviderClient,
-    ProviderError, ProviderRequest, ProviderRequestMode, ProviderStreamEvent,
-    ReplayTransformCounts, RuntimeEventKind, RuntimeModelRequestErrorClass,
-    RuntimeModelRequestMode, RuntimeModelRequestPurpose, RuntimePermissionDecision,
-    RuntimeServices, RuntimeTerminalState, RuntimeToolLogLevel, RuntimeUsage, SessionEntry,
-    SessionEntryId, SessionEntryKind, SessionStartHookRequest, StopHookRequest, SystemBlock,
-    THREAD_AGENT_SKILL_CONTEXT_SEGMENTS_METADATA, THREAD_AGENT_STATIC_CONTEXT_SEGMENTS_METADATA,
-    ThinkingConfig, ThreadCommand, ThreadContext, ThreadEvent, ThreadSignal, ThreadStatus,
-    ThreadTerminalState, ToolCallCancellation, ToolCallCompletedPayload, ToolCallDecision,
-    ToolCallRequestedPayload, ToolCallSubject, ToolDecisionRequest, ToolDefinition,
-    ToolExecutionInterceptor, ToolExecutionOutcome, ToolExecutionRequest,
-    ToolInvocationCancellation, ToolPermissionDecision, ToolPermissionGate, TurnBudget,
-    TurnContext, TurnInput, TurnSubmissionMode, UserPromptSubmitHookRequest,
+    DEFAULT_TOOL_CANCELLATION_GRACE, EffectClass, EventKind, EventProvenance, EventRecord,
+    EventRecordId, EventSequence, EventStreamId, HistoryError, HookHandlerSpec,
+    HookMutationWitness, HookPipeline, HookRunRecord, KernelNotifyOperationProvider,
+    KernelOperationDispatcher, KernelProcessOperationProvider, KernelScheduleOperationProvider,
+    KernelThreadOperationProvider, KernelThreadSpawnAgentResolver, NewEventRecord,
+    NewObservationRecord, ObservationProvenance, OperationRegistry, PostCompactHookRequest,
+    PreCompactHookRequest, ProviderApi, ProviderClient, ProviderError, ProviderRequest,
+    ProviderRequestMode, ProviderStreamEvent, ReplayTransformCounts, RuntimeEventKind,
+    RuntimeModelRequestErrorClass, RuntimeModelRequestMode, RuntimeModelRequestPurpose,
+    RuntimePermissionDecision, RuntimeServices, RuntimeTerminalState, RuntimeToolLogLevel,
+    RuntimeUsage, SessionEntry, SessionEntryId, SessionEntryKind, SessionStartHookRequest,
+    StopHookRequest, SystemBlock, THREAD_AGENT_SKILL_CONTEXT_SEGMENTS_METADATA,
+    THREAD_AGENT_STATIC_CONTEXT_SEGMENTS_METADATA, ThinkingConfig, ThreadCommand, ThreadContext,
+    ThreadEvent, ThreadSignal, ThreadStatus, ThreadTerminalState, ToolCallCancellation,
+    ToolCallCompletedPayload, ToolCallDecision, ToolCallRequestedPayload, ToolCallSubject,
+    ToolDecisionRequest, ToolDefinition, ToolExecutionInterceptor, ToolExecutionOutcome,
+    ToolExecutionRequest, ToolInvocationCancellation, ToolPermissionDecision, ToolPermissionGate,
+    TurnBudget, TurnContext, TurnInput, TurnSubmissionMode, UserPromptSubmitHookRequest,
     VirtualBashRuntimeConfig, active_manifest_bind_receipt, active_tool_controller_for_request,
     compile_provider_request_context, decide_tool_call, deterministic_compaction_summary,
     emit_runtime_event, normalize_history_for_target,
@@ -954,10 +956,9 @@ async fn sweep_cancelled_turn_tool_calls(
         return Ok(());
     }
 
-    let mut completed = BTreeSet::new();
+    let mut completed = BTreeMap::<ToolCallSubject, Vec<ToolCallCompletedPayload>>::new();
     let mut next_finish_order = HashMap::<String, u64>::new();
-    let mut requests = Vec::new();
-    let mut requested = BTreeSet::new();
+    let mut requests = BTreeMap::new();
     for event in &thread_events {
         match event.kind {
             EventKind::ToolCallCompleted => {
@@ -987,7 +988,10 @@ async fn sweep_cancelled_turn_tool_calls(
                         *next = (*next).max(payload.finish_order.unwrap_or(0).saturating_add(1))
                     })
                     .or_insert_with(|| payload.finish_order.unwrap_or(0).saturating_add(1));
-                completed.insert(payload.subject);
+                completed
+                    .entry(payload.subject.clone())
+                    .or_default()
+                    .push(payload);
             }
             EventKind::ToolCallRequested => {
                 let Some(turn_id) = event
@@ -1010,16 +1014,19 @@ async fn sweep_cancelled_turn_tool_calls(
                         event.id
                     ))
                 })?;
-                if requested.insert(payload.subject.clone()) {
-                    requests.push((event.id, payload));
-                }
+                requests.insert(payload.subject.clone(), (event.id, payload));
             }
             _ => {}
         }
     }
 
-    for (request_event_id, request) in requests {
-        if completed.contains(&request.subject) {
+    for (request_event_id, request) in requests.into_values() {
+        if completed.get(&request.subject).is_some_and(|completions| {
+            completions.iter().any(|completion| {
+                completion.snapshot_id == request.snapshot_id
+                    && completion.args_fingerprint == request.args_fingerprint
+            })
+        }) {
             continue;
         }
         let finish_order = next_finish_order
@@ -1032,6 +1039,7 @@ async fn sweep_cancelled_turn_tool_calls(
                 arguments: request.arguments.clone(),
             },
             snapshot_id: request.snapshot_id.clone(),
+            args_fingerprint: request.args_fingerprint.clone(),
             request_event_id,
             holds: request
                 .holds
@@ -1044,6 +1052,9 @@ async fn sweep_cancelled_turn_tool_calls(
                         "tool hold payload is invalid during cancellation recovery: {err}"
                     ))
                 })?,
+            recovery_action: ToolRecoveryAction::ConservativeFailure,
+            recovery_source_event_id: None,
+            recovery_fingerprint_mismatch: false,
         };
         let turn_context = runtime.turn_context(
             thread_context,
@@ -1064,6 +1075,8 @@ async fn sweep_cancelled_turn_tool_calls(
             coordinates,
             request_event_id,
             &request.subject.call_id,
+            &request.snapshot_id,
+            request.args_fingerprint.as_deref(),
         )
         .await?
         {
@@ -1081,6 +1094,7 @@ async fn sweep_cancelled_turn_tool_calls(
                 request.subject.call_id.clone(),
                 request.snapshot_id.clone(),
                 request.tool_name.clone(),
+                request.args_fingerprint.clone(),
                 success,
                 Some(0),
                 Some(current_finish_order),
@@ -1097,7 +1111,6 @@ async fn sweep_cancelled_turn_tool_calls(
             )
             .await?;
         }
-        completed.insert(request.subject);
     }
     Ok(())
 }
@@ -2077,6 +2090,115 @@ async fn run_provider_turn(
             return true;
         }
     }
+    if tool_rounds > 0 {
+        let pending_suspensions = match crate::list_pending_tool_call_suspensions(
+            services.runtime_store().as_ref(),
+            coordinates,
+        )
+        .await
+        {
+            Ok(pending) => pending,
+            Err(err) => {
+                fail_provider_turn(
+                    coordinates,
+                    thread_id,
+                    events,
+                    status,
+                    "history",
+                    err.to_string(),
+                );
+                return true;
+            }
+        };
+        if pending_suspensions
+            .iter()
+            .any(|pending| pending.subject.turn_id == turn_id)
+        {
+            let _ = status.send(ThreadStatus::Idle);
+            return false;
+        }
+        let pending_batch =
+            match pending_witnessed_tool_batch_for_turn(services, coordinates, &turn_id).await {
+                Ok(batch) => batch,
+                Err(err) => {
+                    fail_provider_turn(
+                        coordinates,
+                        thread_id,
+                        events,
+                        status,
+                        "history",
+                        err.to_string(),
+                    );
+                    return true;
+                }
+            };
+        if let Some((tool_calls, assistant_entry_id)) = pending_batch {
+            match append_tool_results_while_handling_commands(
+                runtime,
+                &turn_context,
+                services,
+                thread_id,
+                events,
+                tool_calls,
+                assistant_entry_id,
+                &turn_input,
+                turn_source_event_id,
+                coordinates,
+                status,
+                commands,
+                runtime_cancellation,
+                pending_commands,
+                tool_cancellation_grace,
+            )
+            .await
+            {
+                ToolBatchAwaitOutcome::Completed(Ok(ToolAppendOutcome::Suspended)) => {
+                    let _ = status.send(ThreadStatus::Idle);
+                    return false;
+                }
+                ToolBatchAwaitOutcome::Completed(Ok(_)) => {}
+                ToolBatchAwaitOutcome::Completed(Err(err)) => {
+                    fail_provider_turn(
+                        coordinates,
+                        thread_id,
+                        events,
+                        status,
+                        "tool_router",
+                        err.to_string(),
+                    );
+                    return true;
+                }
+                ToolBatchAwaitOutcome::Cancelled { reason } => {
+                    emit_runtime_event(
+                        events,
+                        coordinates,
+                        RuntimeEventKind::Cancelled {
+                            reason: reason.clone(),
+                        },
+                    );
+                    emit_runtime_event(
+                        events,
+                        coordinates,
+                        RuntimeEventKind::Terminal {
+                            state: RuntimeTerminalState::Cancelled,
+                        },
+                    );
+                    let _ = events.send(ThreadEvent::Cancelled { thread_id, reason });
+                    let _ = status.send(ThreadStatus::Idle);
+                    return false;
+                }
+                ToolBatchAwaitOutcome::Shutdown => {
+                    let _ = status.send(ThreadStatus::Stopped);
+                    let _ = events.send(ThreadEvent::Stopped { thread_id });
+                    return true;
+                }
+                ToolBatchAwaitOutcome::Failed { code, reason } => {
+                    fail_provider_turn(coordinates, thread_id, events, status, code, reason);
+                    return true;
+                }
+            }
+        }
+    }
     loop {
         let mut cancelled_reason = None;
         let mut shutdown_after_turn = false;
@@ -2569,6 +2691,160 @@ async fn persisted_tool_rounds_for_turn(
     Ok(assistant_batches.len())
 }
 
+async fn pending_witnessed_tool_batch_for_turn(
+    services: &RuntimeServices,
+    coordinates: &crate::ThreadCoordinates,
+    turn_id: &str,
+) -> CooldisResult<Option<(Vec<ProviderToolCall>, SessionEntryId)>> {
+    let events = services
+        .runtime_store()
+        .read_events(&EventStreamId::for_thread(coordinates), None)
+        .await
+        .map_err(|err| CooldisError::History(err.to_string()))?;
+    let Some(latest_request) = events
+        .iter()
+        .filter(|event| {
+            event.kind == EventKind::ToolCallRequested
+                && event.payload["subject"]["turn_id"] == turn_id
+        })
+        .max_by_key(|event| event.sequence.get())
+    else {
+        return Ok(None);
+    };
+    let assistant_source_event_id = latest_request
+        .provenance
+        .source_event_ids
+        .first()
+        .copied()
+        .ok_or_else(|| {
+            CooldisError::History(format!(
+                "tool.call.requested {} for turn {turn_id} has no assistant source event",
+                latest_request.id
+            ))
+        })?;
+    let mut requests = BTreeMap::<String, (i64, EventRecordId, ToolCallRequestedPayload)>::new();
+    for event in events.iter().filter(|event| {
+        event.kind == EventKind::ToolCallRequested
+            && event.provenance.source_event_ids.first() == Some(&assistant_source_event_id)
+    }) {
+        let request = serde_json::from_value::<ToolCallRequestedPayload>(event.payload.clone())
+            .map_err(|err| {
+                CooldisError::History(format!(
+                    "tool.call.requested {} payload is invalid during turn replay: {err}",
+                    event.id
+                ))
+            })?;
+        if request.subject.turn_id == turn_id {
+            let replace = requests
+                .get(&request.subject.call_id)
+                .is_none_or(|(sequence, _, _)| *sequence < event.sequence.get());
+            if replace {
+                requests.insert(
+                    request.subject.call_id.clone(),
+                    (event.sequence.get(), event.id, request),
+                );
+            }
+        }
+    }
+    let mut completions = Vec::new();
+    for event in events.iter().filter(|event| {
+        event.kind == EventKind::ToolCallCompleted && event.payload["subject"]["turn_id"] == turn_id
+    }) {
+        completions.push(
+            serde_json::from_value::<ToolCallCompletedPayload>(event.payload.clone()).map_err(
+                |err| {
+                    CooldisError::History(format!(
+                        "tool.call.completed {} payload is invalid during turn replay: {err}",
+                        event.id
+                    ))
+                },
+            )?,
+        );
+    }
+    let mut incomplete = false;
+    for (_, request_event_id, request) in requests.values() {
+        let completed = completions.iter().any(|completion| {
+            completion.subject == request.subject
+                && completion.snapshot_id == request.snapshot_id
+                && completion.args_fingerprint == request.args_fingerprint
+        });
+        let result = existing_tool_result_message(
+            services,
+            coordinates,
+            *request_event_id,
+            &request.subject.call_id,
+            &request.snapshot_id,
+            request.args_fingerprint.as_deref(),
+        )
+        .await?;
+        incomplete |= !completed || result.is_none();
+    }
+    if !incomplete {
+        return Ok(None);
+    }
+
+    let assistant_event = events
+        .iter()
+        .find(|event| {
+            event.id == assistant_source_event_id && event.kind == EventKind::SessionEntryAppended
+        })
+        .ok_or_else(|| {
+            CooldisError::History(format!(
+                "tool request batch source {assistant_source_event_id} is not an assistant session entry"
+            ))
+        })?;
+    let assistant_entry_id = assistant_event
+        .payload
+        .get("entry_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            CooldisError::History(format!(
+                "assistant session event {assistant_source_event_id} has no entry_id"
+            ))
+        })?;
+    let context = services.build_session_context(coordinates).await?;
+    let assistant_entry = context
+        .entries
+        .iter()
+        .find(|entry| entry.entry_id.to_string() == assistant_entry_id)
+        .ok_or_else(|| {
+            CooldisError::History(format!(
+                "assistant session entry {assistant_entry_id} is missing during turn replay"
+            ))
+        })?;
+    let SessionEntryKind::Message { message } = &assistant_entry.kind else {
+        return Err(CooldisError::History(format!(
+            "tool request batch source {assistant_entry_id} is not a canonical message"
+        )));
+    };
+    let tool_calls = tool_calls_from_message(message);
+    for (_, _, request) in requests.values() {
+        let call = tool_calls
+            .iter()
+            .find(|call| call.id == request.subject.call_id)
+            .ok_or_else(|| {
+                CooldisError::History(format!(
+                    "witnessed assistant batch {assistant_entry_id} lost tool call {}",
+                    request.subject.call_id
+                ))
+            })?;
+        let replayed_fingerprint = args_fingerprint(&call.name, &call.arguments)?;
+        if call.name != request.tool_name
+            || call.arguments != request.arguments
+            || request
+                .args_fingerprint
+                .as_deref()
+                .is_some_and(|fingerprint| fingerprint != replayed_fingerprint)
+        {
+            return Err(CooldisError::History(format!(
+                "witnessed assistant batch {assistant_entry_id} disagrees with tool request {}",
+                request.subject.call_id
+            )));
+        }
+    }
+    Ok(Some((tool_calls, assistant_entry.entry_id)))
+}
+
 enum ActiveProviderCommandOutcome {
     Continue,
     Cancelled { reason: String },
@@ -2832,6 +3108,7 @@ struct PendingToolCallRequest {
     snapshot_id: String,
     tool_name: String,
     arguments: Value,
+    args_fingerprint: Option<String>,
     holds: Vec<tool_holds::ToolHold>,
 }
 
@@ -2844,8 +3121,220 @@ enum ResumedToolCallAction {
 struct WitnessedToolCall {
     tool_call: ProviderToolCall,
     snapshot_id: String,
+    args_fingerprint: Option<String>,
     request_event_id: EventRecordId,
     holds: Vec<tool_holds::ToolHold>,
+    recovery_action: ToolRecoveryAction,
+    recovery_source_event_id: Option<EventRecordId>,
+    recovery_fingerprint_mismatch: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ToolRecoveryAction {
+    Reuse,
+    Reexecute,
+    ConservativeFailure,
+}
+
+/// Recovery honors the effect class; a recorded outcome is reused only under
+/// a matching fingerprint within the same snapshot.
+fn tool_recovery_action(
+    effect_class: EffectClass,
+    outcome_exists: bool,
+    fingerprint_matches: bool,
+) -> ToolRecoveryAction {
+    if outcome_exists && fingerprint_matches {
+        ToolRecoveryAction::Reuse
+    } else if effect_class == EffectClass::AtMostOnce {
+        ToolRecoveryAction::ConservativeFailure
+    } else {
+        ToolRecoveryAction::Reexecute
+    }
+}
+
+fn effect_class_from_bind_receipt(
+    receipt: &crate::AgentManifestBindReceipt,
+    tool_name: &str,
+    arguments: &Value,
+) -> EffectClass {
+    if let Some(effect_class) = receipt
+        .operation_bindings
+        .iter()
+        .flat_map(|binding| &binding.direct_tools)
+        .find(|tool| tool.tool_name == tool_name)
+        .map(|tool| tool.effect_class)
+    {
+        return effect_class;
+    }
+    if let Some(effect_class) = receipt
+        .tool_universes
+        .iter()
+        .flat_map(|universe| &universe.tools)
+        .find(|tool| tool.tool_name == tool_name)
+        .map(|tool| tool.effect_class)
+    {
+        return effect_class;
+    }
+    let operation_name = if tool_name == crate::BASH_TOOL {
+        arguments
+            .get("command")
+            .and_then(Value::as_str)
+            .and_then(exact_single_bash_operation_name)
+    } else {
+        Some(tool_name)
+    };
+    operation_name
+        .into_iter()
+        .flat_map(|operation_name| {
+            receipt
+                .operation_bindings
+                .iter()
+                .filter(move |binding| {
+                    binding
+                        .operations
+                        .iter()
+                        .any(|operation| operation == operation_name)
+                })
+                .map(|binding| binding.effect_class)
+        })
+        .max()
+        .unwrap_or_default()
+}
+
+fn exact_single_bash_operation_name(command: &str) -> Option<&str> {
+    // Bashkit accepts full shell scripts, including pipelines, control lists,
+    // substitutions, redirections, assignments, and quoted command names.
+    // Recovery may inherit a declared class only for the deliberately smaller
+    // single-simple-command subset whose executable is unambiguous here.
+    if command.chars().any(|character| {
+        character.is_control()
+            || matches!(
+                character,
+                ';' | '&' | '|' | '<' | '>' | '$' | '`' | '\\' | '\'' | '"' | '(' | ')' | '{' | '}'
+            )
+    }) {
+        return None;
+    }
+    let operation_name = command.split_whitespace().next()?;
+    (!operation_name.contains('=')).then_some(operation_name)
+}
+
+pub(crate) fn effect_class_for_request(
+    events: &[EventRecord],
+    request: &ToolCallRequestedPayload,
+) -> CooldisResult<EffectClass> {
+    let Some(event) = events.iter().rev().find(|event| {
+        event.kind == EventKind::ManifestBindCompleted
+            && event.payload.get("manifest_hash").and_then(Value::as_str)
+                == Some(request.snapshot_id.as_str())
+    }) else {
+        return Ok(EffectClass::AtMostOnce);
+    };
+    let receipt = serde_json::from_value::<crate::AgentManifestBindReceipt>(event.payload.clone())
+        .map_err(|err| {
+            CooldisError::History(format!(
+                "manifest.bind.completed {} payload is invalid: {err}",
+                event.id
+            ))
+        })?;
+    Ok(effect_class_from_bind_receipt(
+        &receipt,
+        &request.tool_name,
+        &request.arguments,
+    ))
+}
+
+async fn apply_tool_recovery_actions(
+    services: &RuntimeServices,
+    coordinates: &crate::ThreadCoordinates,
+    turn_id: &str,
+    calls: &mut [WitnessedToolCall],
+) -> CooldisResult<()> {
+    let events = services
+        .runtime_store()
+        .read_events(&EventStreamId::for_thread(coordinates), None)
+        .await
+        .map_err(|err| CooldisError::History(err.to_string()))?;
+    let has_prior_request = calls.iter().any(|call| {
+        events.iter().any(|event| {
+            event.kind == EventKind::ToolCallRequested
+                && event.id != call.request_event_id
+                && event.payload["subject"]["turn_id"] == turn_id
+                && event.payload["subject"]["call_id"] == call.tool_call.id
+        })
+    });
+    if !has_prior_request {
+        return Ok(());
+    }
+    for call in calls {
+        let prior_request = events
+            .iter()
+            .filter(|event| {
+                event.kind == EventKind::ToolCallRequested
+                    && event.id != call.request_event_id
+                    && event.payload["subject"]["turn_id"] == turn_id
+                    && event.payload["subject"]["call_id"] == call.tool_call.id
+            })
+            .max_by_key(|event| event.sequence.get());
+        let Some(prior_request) = prior_request else {
+            continue;
+        };
+        let request =
+            serde_json::from_value::<ToolCallRequestedPayload>(prior_request.payload.clone())
+                .map_err(|err| {
+                    CooldisError::History(format!(
+                        "tool.call.requested {} payload is invalid during recovery: {err}",
+                        prior_request.id
+                    ))
+                })?;
+        let result = existing_tool_result_message(
+            services,
+            coordinates,
+            prior_request.id,
+            &call.tool_call.id,
+            &call.snapshot_id,
+            call.args_fingerprint.as_deref(),
+        )
+        .await?;
+        let fingerprint_matches = tool_invocation_fingerprint_matches(
+            &request.snapshot_id,
+            request.args_fingerprint.as_deref(),
+            &call.snapshot_id,
+            call.args_fingerprint.as_deref(),
+        );
+        let mut effect_class = effect_class_for_request(&events, &request)?;
+        if effect_class != EffectClass::AtMostOnce
+            && request.tool_name == crate::BASH_TOOL
+            && matches!(
+                decide_tool_call(
+                    services.runtime_store().as_ref(),
+                    ToolDecisionRequest {
+                        coordinates: coordinates.clone(),
+                        subject: request.subject.clone(),
+                        snapshot_id: request.snapshot_id.clone(),
+                        request_event_id: prior_request.id,
+                    },
+                )
+                .await?,
+                ToolCallDecision::Rewrite { .. }
+            )
+        {
+            // The request fingerprint and class describe the original bash
+            // script, not a controller-rewritten script. Without a witnessed
+            // class for the rewritten command, automatic replay must fail
+            // closed even when the original operation was retryable.
+            effect_class = EffectClass::AtMostOnce;
+        }
+        // The canonical result is the reusable durable outcome and is appended
+        // before tool.call.completed. A completion without that result is an
+        // anomalous/legacy partial record, so recovery degrades by effect class
+        // instead of entering Reuse and hard-erroring on a missing message.
+        call.recovery_action =
+            tool_recovery_action(effect_class, result.is_some(), fingerprint_matches);
+        call.recovery_source_event_id = result.map(|_| prior_request.id);
+        call.recovery_fingerprint_mismatch = !fingerprint_matches;
+    }
+    Ok(())
 }
 
 #[derive(Clone)]
@@ -2854,6 +3343,7 @@ enum PreparedToolCallOutcome {
         call_id: String,
         tool_name: String,
         snapshot_id: String,
+        args_fingerprint: Option<String>,
         source_event_id: EventRecordId,
         finish_order: u64,
         cancellation: Option<ToolCallCancellation>,
@@ -2863,6 +3353,7 @@ enum PreparedToolCallOutcome {
         call_id: String,
         tool_name: String,
         snapshot_id: String,
+        args_fingerprint: Option<String>,
         source_event_id: EventRecordId,
         finish_order: u64,
         reason: String,
@@ -3040,7 +3531,23 @@ async fn resume_pending_tool_call(
             "tool resume requires a tool router".to_string(),
         ));
     };
-    if tool_call_completed_exists(services, &thread_context.coordinates, turn_id, call_id).await? {
+    let Some(request) =
+        pending_tool_call_request(services, &thread_context.coordinates, turn_id, call_id).await?
+    else {
+        return Err(CooldisError::RuntimeExecution(format!(
+            "missing tool.call.requested for pending call {turn_id}/{call_id}"
+        )));
+    };
+    if matching_tool_call_completed_exists(
+        services,
+        &thread_context.coordinates,
+        turn_id,
+        call_id,
+        &request.snapshot_id,
+        request.args_fingerprint.as_deref(),
+    )
+    .await?
+    {
         return Ok(ToolResumeOutcome::AlreadyCompleted);
     }
     if !tool_call_suspension_exists(services, &thread_context.coordinates, turn_id, call_id).await?
@@ -3049,13 +3556,6 @@ async fn resume_pending_tool_call(
             "no pending suspended tool call {turn_id}/{call_id}"
         )));
     }
-    let Some(request) =
-        pending_tool_call_request(services, &thread_context.coordinates, turn_id, call_id).await?
-    else {
-        return Err(CooldisError::RuntimeExecution(format!(
-            "missing tool.call.requested for pending call {turn_id}/{call_id}"
-        )));
-    };
     let turn_submitted =
         existing_turn_submitted_event(services, &thread_context.coordinates, turn_id)
             .await?
@@ -3126,7 +3626,8 @@ async fn resume_pending_tool_call(
                 arguments,
                 request.holds,
                 request.snapshot_id,
-                resumed.id,
+                request.args_fingerprint,
+                request.request_event_id,
             )
             .await?;
         }
@@ -3139,10 +3640,11 @@ async fn resume_pending_tool_call(
                 call_id.to_string(),
                 request.tool_name,
                 request.snapshot_id,
+                request.args_fingerprint,
                 reason,
                 Some(0),
                 None,
-                resumed.id,
+                request.request_event_id,
             )
             .await?;
         }
@@ -3492,13 +3994,29 @@ async fn prepare_tool_results(
         calls_with_snapshots.into_iter().zip(request_events)
     {
         let holds = decode_witnessed_tool_holds(&request_event)?;
+        let request_payload =
+            serde_json::from_value::<ToolCallRequestedPayload>(request_event.payload.clone())
+                .map_err(|err| {
+                    CooldisError::History(format!("tool.call.requested payload is invalid: {err}"))
+                })?;
         witnessed_calls.push(WitnessedToolCall {
             tool_call,
             snapshot_id: active_snapshot_id,
+            args_fingerprint: request_payload.args_fingerprint,
             request_event_id: request_event.id,
             holds,
+            recovery_action: ToolRecoveryAction::Reexecute,
+            recovery_source_event_id: None,
+            recovery_fingerprint_mismatch: false,
         });
     }
+    apply_tool_recovery_actions(
+        services,
+        turn_context.coordinates(),
+        &turn_context.turn_id,
+        &mut witnessed_calls,
+    )
+    .await?;
     let witnessed_wait_edges = tool_holds::batch_wait_edges(
         &witnessed_calls
             .iter()
@@ -3552,6 +4070,7 @@ async fn append_tool_results(
                 call_id,
                 tool_name,
                 snapshot_id,
+                args_fingerprint,
                 source_event_id,
                 finish_order,
                 cancellation,
@@ -3565,6 +4084,7 @@ async fn append_tool_results(
                     call_id,
                     tool_name,
                     snapshot_id,
+                    args_fingerprint,
                     source_event_id,
                     Some(finish_order),
                     cancellation,
@@ -3577,6 +4097,7 @@ async fn append_tool_results(
                 call_id,
                 tool_name,
                 snapshot_id,
+                args_fingerprint,
                 source_event_id,
                 finish_order,
                 reason,
@@ -3589,6 +4110,7 @@ async fn append_tool_results(
                     call_id,
                     tool_name,
                     snapshot_id,
+                    args_fingerprint,
                     reason,
                     Some(finish_order),
                     None,
@@ -4048,9 +4570,65 @@ async fn prepare_tool_call(
     finish_counter: Arc<AtomicU64>,
     cancellation: ToolInvocationCancellation,
 ) -> CooldisResult<PreparedToolCallOutcome> {
+    match call.recovery_action {
+        ToolRecoveryAction::Reuse => {
+            let source_event_id = call.recovery_source_event_id.ok_or_else(|| {
+                CooldisError::History(format!(
+                    "recorded tool outcome for {}/{} has no reusable canonical result",
+                    turn_context.turn_id, call.tool_call.id
+                ))
+            })?;
+            let result = existing_tool_result_message(
+                services,
+                turn_context.coordinates(),
+                source_event_id,
+                &call.tool_call.id,
+                &call.snapshot_id,
+                call.args_fingerprint.as_deref(),
+            )
+            .await?
+            .ok_or_else(|| {
+                CooldisError::History(format!(
+                    "recorded tool outcome for {}/{} lost its canonical result",
+                    turn_context.turn_id, call.tool_call.id
+                ))
+            })?;
+            return Ok(PreparedToolCallOutcome::Completed {
+                call_id: call.tool_call.id,
+                tool_name: call.tool_call.name,
+                snapshot_id: call.snapshot_id,
+                args_fingerprint: call.args_fingerprint,
+                source_event_id: call.request_event_id,
+                finish_order: finish_counter.fetch_add(1, Ordering::SeqCst),
+                cancellation: None,
+                outcome: Box::new(ToolExecutionOutcome {
+                    result,
+                    hook_records: Vec::new(),
+                    pre_model_contexts: Vec::new(),
+                    post_model_contexts: Vec::new(),
+                    permission_decision: None,
+                    duration_ms: 0,
+                }),
+            });
+        }
+        ToolRecoveryAction::ConservativeFailure => {
+            let reason = if call.recovery_fingerprint_mismatch {
+                "tool invocation recovery found a fingerprint mismatch; effect class at-most-once forbids automatic re-execution"
+            } else {
+                "tool invocation was interrupted before a witnessed outcome; effect class at-most-once forbids automatic re-execution"
+            };
+            return Ok(failed_tool_call_outcome(
+                &call,
+                finish_counter.fetch_add(1, Ordering::SeqCst),
+                reason,
+            ));
+        }
+        ToolRecoveryAction::Reexecute => {}
+    }
     let call_id = call.tool_call.id;
     let tool_name = call.tool_call.name;
     let mut arguments = call.tool_call.arguments;
+    let args_fingerprint = call.args_fingerprint;
     let controller = active_tool_controller_for_request(
         services.runtime_store().as_ref(),
         turn_context.coordinates(),
@@ -4077,6 +4655,7 @@ async fn prepare_tool_call(
                     call_id,
                     tool_name,
                     snapshot_id: call.snapshot_id,
+                    args_fingerprint,
                     source_event_id: call.request_event_id,
                     finish_order: finish_counter.fetch_add(1, Ordering::SeqCst),
                     reason: "tool controller did not emit a terminal decision".to_string(),
@@ -4092,6 +4671,7 @@ async fn prepare_tool_call(
                     call_id,
                     tool_name,
                     snapshot_id: call.snapshot_id,
+                    args_fingerprint,
                     source_event_id: call.request_event_id,
                     finish_order: finish_counter.fetch_add(1, Ordering::SeqCst),
                     reason,
@@ -4128,6 +4708,7 @@ async fn prepare_tool_call(
         call_id,
         tool_name,
         snapshot_id: call.snapshot_id,
+        args_fingerprint,
         source_event_id: call.request_event_id,
         finish_order: finish_counter.fetch_add(1, Ordering::SeqCst),
         cancellation: None,
@@ -4146,6 +4727,7 @@ fn settle_prepared_for_cancellation(
             call_id,
             tool_name,
             snapshot_id,
+            args_fingerprint,
             source_event_id,
             finish_order,
             outcome,
@@ -4154,6 +4736,7 @@ fn settle_prepared_for_cancellation(
             call_id,
             tool_name,
             snapshot_id,
+            args_fingerprint,
             source_event_id,
             finish_order,
             cancellation: Some(cancellation),
@@ -4197,6 +4780,7 @@ fn cancelled_tool_call_outcome(
         call_id: witness.tool_call.id.clone(),
         tool_name: witness.tool_call.name.clone(),
         snapshot_id: witness.snapshot_id.clone(),
+        args_fingerprint: witness.args_fingerprint.clone(),
         source_event_id: witness.request_event_id,
         finish_order,
         cancellation: Some(cancellation),
@@ -4256,6 +4840,7 @@ async fn append_detached_tool_call_outcome(
         call_id,
         tool_name,
         snapshot_id,
+        args_fingerprint,
         source_event_id,
         finish_order,
         cancellation,
@@ -4272,6 +4857,7 @@ async fn append_detached_tool_call_outcome(
         call_id,
         tool_name,
         snapshot_id,
+        args_fingerprint,
         source_event_id,
         Some(finish_order),
         cancellation,
@@ -4299,17 +4885,21 @@ async fn append_detached_tool_call_outcome_until_recorded(
     let PreparedToolCallOutcome::Completed {
         ref call_id,
         ref tool_name,
+        ref snapshot_id,
+        ref args_fingerprint,
         ..
     } = prepared
     else {
         return;
     };
     loop {
-        match tool_call_completed_exists(
+        match matching_tool_call_completed_exists(
             services,
             turn_context.coordinates(),
             &turn_context.turn_id,
             call_id,
+            snapshot_id,
+            args_fingerprint.as_deref(),
         )
         .await
         {
@@ -4381,6 +4971,7 @@ async fn execute_resumed_tool_call_with_interceptor(
     arguments: Value,
     holds: Vec<tool_holds::ToolHold>,
     snapshot_id: String,
+    args_fingerprint: Option<String>,
     source_event_id: EventRecordId,
 ) -> CooldisResult<()> {
     let wait_edges = tool_holds::batch_wait_edges(&[holds]);
@@ -4408,6 +4999,7 @@ async fn execute_resumed_tool_call_with_interceptor(
         call_id,
         tool_name,
         snapshot_id,
+        args_fingerprint,
         source_event_id,
         Some(0),
         None,
@@ -4458,6 +5050,7 @@ async fn append_tool_execution_outcome(
     call_id: String,
     tool_name: String,
     snapshot_id: String,
+    args_fingerprint: Option<String>,
     source_event_id: EventRecordId,
     finish_order: Option<u64>,
     cancellation: Option<ToolCallCancellation>,
@@ -4529,6 +5122,7 @@ async fn append_tool_execution_outcome(
         tool_name,
         turn_context.turn_id.clone(),
         snapshot_id,
+        args_fingerprint,
         outcome.result,
         Some(outcome.duration_ms),
         finish_order,
@@ -4678,6 +5272,7 @@ async fn append_tool_call_requested_events(
             })?;
     let mut records = Vec::with_capacity(calls.len());
     for (tool_call, snapshot_id) in calls {
+        let args_fingerprint = args_fingerprint(&tool_call.name, &tool_call.arguments)?;
         let mut payload = serde_json::to_value(ToolCallRequestedPayload {
             subject: ToolCallSubject {
                 turn_id: turn_context.turn_id.clone(),
@@ -4686,6 +5281,7 @@ async fn append_tool_call_requested_events(
             snapshot_id: snapshot_id.clone(),
             tool_name: tool_call.name.clone(),
             arguments: tool_call.arguments.clone(),
+            args_fingerprint: Some(args_fingerprint),
             holds: tool_holds::derive_tool_holds(&tool_call.name, &tool_call.arguments)
                 .into_iter()
                 .map(serde_json::to_value)
@@ -4726,6 +5322,7 @@ async fn append_denied_tool_result(
     call_id: String,
     tool_name: String,
     snapshot_id: String,
+    args_fingerprint: Option<String>,
     reason: String,
     finish_order: Option<u64>,
     cancellation: Option<ToolCallCancellation>,
@@ -4755,6 +5352,7 @@ async fn append_denied_tool_result(
         tool_name.clone(),
         turn_context.turn_id.clone(),
         snapshot_id,
+        args_fingerprint,
         result,
         Some(0),
         finish_order,
@@ -4882,6 +5480,7 @@ async fn pending_tool_call_request(
                 snapshot_id: payload.snapshot_id,
                 tool_name: payload.tool_name,
                 arguments: payload.arguments,
+                args_fingerprint: payload.args_fingerprint,
                 holds: payload
                     .holds
                     .into_iter()
@@ -4913,8 +5512,8 @@ async fn tool_call_batch_completed(
         .read_events(&EventStreamId::for_thread(coordinates), None)
         .await
         .map_err(|err| CooldisError::History(err.to_string()))?;
-    let mut batch_subjects = BTreeSet::new();
-    let mut completed_subjects = BTreeSet::new();
+    let mut batch_subjects = BTreeMap::new();
+    let mut completed_subjects = BTreeMap::<ToolCallSubject, Vec<ToolCallCompletedPayload>>::new();
     for event in events {
         match event.kind {
             EventKind::ToolCallRequested
@@ -4927,7 +5526,14 @@ async fn tool_call_batch_completed(
                             "tool.call.requested payload is invalid: {err}"
                         ))
                     })?;
-                if payload.subject.turn_id == turn_id && !batch_subjects.insert(payload.subject) {
+                if payload.subject.turn_id == turn_id
+                    && batch_subjects
+                        .insert(
+                            payload.subject,
+                            (payload.snapshot_id, payload.args_fingerprint),
+                        )
+                        .is_some()
+                {
                     return Err(CooldisError::History(format!(
                         "assistant source event {assistant_source_event_id} contains duplicate tool call subjects"
                     )));
@@ -4947,7 +5553,10 @@ async fn tool_call_batch_completed(
                             "tool.call.completed payload is invalid: {err}"
                         ))
                     })?;
-                completed_subjects.insert(payload.subject);
+                completed_subjects
+                    .entry(payload.subject.clone())
+                    .or_default()
+                    .push(payload);
             }
             _ => {}
         }
@@ -4957,42 +5566,48 @@ async fn tool_call_batch_completed(
             "assistant source event {assistant_source_event_id} has no tool request batch for turn {turn_id}"
         )));
     }
-    Ok(batch_subjects.is_subset(&completed_subjects))
+    Ok(batch_subjects
+        .iter()
+        .all(|(subject, (snapshot_id, fingerprint))| {
+            completed_subjects.get(subject).is_some_and(|completions| {
+                completions.iter().any(|completion| {
+                    completion.snapshot_id.as_str() == snapshot_id.as_str()
+                        && completion.args_fingerprint.as_deref() == fingerprint.as_deref()
+                })
+            })
+        }))
 }
 
-async fn tool_call_completed_exists(
+async fn matching_tool_call_completed_exists(
     services: &RuntimeServices,
     coordinates: &crate::ThreadCoordinates,
     turn_id: &str,
     call_id: &str,
+    snapshot_id: &str,
+    args_fingerprint: Option<&str>,
 ) -> CooldisResult<bool> {
     let events = services
         .runtime_store()
         .read_events(&EventStreamId::for_thread(coordinates), None)
         .await
         .map_err(|err| CooldisError::History(err.to_string()))?;
-    if let Some(event) = events.into_iter().find(|event| {
+    for event in events.into_iter().filter(|event| {
         event.kind == EventKind::ToolCallCompleted
-            && event
-                .payload
-                .get("subject")
-                .and_then(|subject| subject.get("turn_id"))
-                .and_then(Value::as_str)
-                == Some(turn_id)
-            && event
-                .payload
-                .get("subject")
-                .and_then(|subject| subject.get("call_id"))
-                .and_then(Value::as_str)
-                == Some(call_id)
+            && event.payload["subject"]["turn_id"] == turn_id
+            && event.payload["subject"]["call_id"] == call_id
     }) {
-        let payload = serde_json::from_value::<ToolCallCompletedPayload>(event.payload.clone())
-            .map_err(|err| {
-                CooldisError::History(format!("tool.call.completed payload is invalid: {err}"))
+        let payload =
+            serde_json::from_value::<ToolCallCompletedPayload>(event.payload).map_err(|err| {
+                CooldisError::History(format!(
+                    "tool.call.completed {} payload is invalid: {err}",
+                    event.id
+                ))
             })?;
-        debug_assert_eq!(payload.subject.turn_id, turn_id);
-        debug_assert_eq!(payload.subject.call_id, call_id);
-        return Ok(true);
+        if payload.snapshot_id == snapshot_id
+            && payload.args_fingerprint.as_deref() == args_fingerprint
+        {
+            return Ok(true);
+        }
     }
     Ok(false)
 }
@@ -5002,12 +5617,36 @@ async fn existing_tool_result_message(
     coordinates: &crate::ThreadCoordinates,
     source_event_id: EventRecordId,
     call_id: &str,
+    expected_snapshot_id: &str,
+    expected_fingerprint: Option<&str>,
 ) -> CooldisResult<Option<CanonicalMessage>> {
-    let result_entry_ids = services
+    let events = services
         .runtime_store()
         .read_events(&EventStreamId::for_thread(coordinates), None)
         .await
-        .map_err(|err| CooldisError::History(err.to_string()))?
+        .map_err(|err| CooldisError::History(err.to_string()))?;
+    let Some(request_event) = events
+        .iter()
+        .find(|event| event.id == source_event_id && event.kind == EventKind::ToolCallRequested)
+    else {
+        return Ok(None);
+    };
+    let request = serde_json::from_value::<ToolCallRequestedPayload>(request_event.payload.clone())
+        .map_err(|err| {
+            CooldisError::History(format!(
+                "tool.call.requested {} payload is invalid while reusing a result: {err}",
+                request_event.id
+            ))
+        })?;
+    if !tool_invocation_fingerprint_matches(
+        &request.snapshot_id,
+        request.args_fingerprint.as_deref(),
+        expected_snapshot_id,
+        expected_fingerprint,
+    ) {
+        return Ok(None);
+    }
+    let result_entry_ids = events
         .into_iter()
         .filter(|event| {
             event.kind == EventKind::SessionEntryAppended
@@ -5080,6 +5719,7 @@ async fn append_tool_result_message(
     tool_name: String,
     turn_id: String,
     snapshot_id: String,
+    args_fingerprint: Option<String>,
     result: CanonicalMessage,
     duration_ms: Option<u64>,
     finish_order: Option<u64>,
@@ -5088,7 +5728,15 @@ async fn append_tool_result_message(
     idempotent_result_append: bool,
 ) -> CooldisResult<()> {
     let existing_result = if idempotent_result_append {
-        existing_tool_result_message(services, coordinates, source_event_id, &call_id).await?
+        existing_tool_result_message(
+            services,
+            coordinates,
+            source_event_id,
+            &call_id,
+            &snapshot_id,
+            args_fingerprint.as_deref(),
+        )
+        .await?
     } else {
         None
     };
@@ -5127,6 +5775,7 @@ async fn append_tool_result_message(
         call_id,
         snapshot_id,
         tool_name,
+        args_fingerprint,
         success,
         duration_ms,
         finish_order,
@@ -5143,12 +5792,15 @@ async fn append_tool_completion_event(
     call_id: String,
     snapshot_id: String,
     tool_name: String,
+    args_fingerprint: Option<String>,
     success: bool,
     duration_ms: Option<u64>,
     finish_order: Option<u64>,
     cancellation: Option<ToolCallCancellation>,
 ) -> CooldisResult<()> {
     let subject = ToolCallSubject { turn_id, call_id };
+    let completion_snapshot_id = snapshot_id.clone();
+    let completion_fingerprint = args_fingerprint.clone();
     let record = NewEventRecord::witnessed(
         coordinates.clone(),
         EventKind::ToolCallCompleted,
@@ -5157,6 +5809,7 @@ async fn append_tool_completion_event(
             snapshot_id,
             tool_name,
             success,
+            args_fingerprint,
             duration_ms,
             finish_order,
             cancellation,
@@ -5172,20 +5825,23 @@ async fn append_tool_completion_event(
             .read_events(&stream_id, None)
             .await
             .map_err(|err| CooldisError::History(err.to_string()))?;
-        if let Some(event) = existing.iter().find(|event| {
+        for event in existing.iter().filter(|event| {
             event.kind == EventKind::ToolCallCompleted
                 && event.payload["subject"]["turn_id"] == subject.turn_id
                 && event.payload["subject"]["call_id"] == subject.call_id
         }) {
-            serde_json::from_value::<ToolCallCompletedPayload>(event.payload.clone()).map_err(
-                |err| {
+            let payload = serde_json::from_value::<ToolCallCompletedPayload>(event.payload.clone())
+                .map_err(|err| {
                     CooldisError::History(format!(
                         "tool.call.completed {} payload is invalid: {err}",
                         event.id
                     ))
-                },
-            )?;
-            return Ok(());
+                })?;
+            if payload.snapshot_id == completion_snapshot_id
+                && payload.args_fingerprint == completion_fingerprint
+            {
+                return Ok(());
+            }
         }
         let expected_next_sequence = existing
             .last()

--- a/crates/cooldis-kernel/src/adapters/provider_runtime/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/provider_runtime/tests.rs
@@ -176,6 +176,9 @@ fn recovery_bind_receipt(effect_class: EffectClass) -> AgentManifestBindReceipt 
     AgentManifestBindReceipt {
         ref_uri: "agent://test/recovery".to_string(),
         manifest_hash: "snapshot-recovery".to_string(),
+        model_profile_origin: None,
+        placement_origin: None,
+        workspace_origin: None,
         model_profile_id: "default".to_string(),
         provider_id: "test".to_string(),
         model_id: "model".to_string(),

--- a/crates/cooldis-kernel/src/adapters/provider_runtime/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/provider_runtime/tests.rs
@@ -3,16 +3,17 @@ use crate::EventKind;
 use crate::test_support::{FaultingProviderClient, FaultingRuntimeStore};
 use crate::{
     AgentKernelToolCall, AgentKernelToolProvider, AgentManifestBindReceipt,
-    AgentManifestCouplingBinding, AgentManifestCouplingBudget, AgentManifestRuntimeDefaults,
-    AgentToolRouter, CanonicalStopReason, CanonicalUsage, CommandHookHandler, CouplingRole,
-    EventProvenance, EventRecord, EventSequence, EventStore, EventStreamId, HistoryResult,
-    HookEventName, HookHandler, HookHandlerOutput, HookHandlerSpec, HookRequest, HookRunStatus,
+    AgentManifestCouplingBinding, AgentManifestCouplingBudget, AgentManifestDirectToolBinding,
+    AgentManifestOperationBinding, AgentManifestRuntimeDefaults, AgentToolRouter,
+    CanonicalStopReason, CanonicalUsage, CommandHookHandler, CouplingRole, EventProvenance,
+    EventRecord, EventSequence, EventStore, EventStreamId, HistoryResult, HookEventName,
+    HookHandler, HookHandlerOutput, HookHandlerSpec, HookRequest, HookRunStatus,
     InMemorySessionStore, KernelOperationRegistration, KernelThreadSpawnAgentBinding,
     KernelThreadSpawnAgentResolver, NewEventRecord, NewObservationRecord, ObservationRecord,
     ObservationStore, OperationRegistration, OperationRegistry, OperationToolAlias,
     ProviderCapabilityRecord, ProviderContextPolicy, RuntimeEvent, RuntimeExecutionPolicy,
-    RuntimeHost, SessionContext, SessionEntry, SessionEntryId, SessionEntryKind, SessionStore,
-    SqliteSessionStore, THREAD_SPAWN_OPERATION, ThreadBaseRef, ThreadCoordinates,
+    RuntimeHost, RuntimeStore, SessionContext, SessionEntry, SessionEntryId, SessionEntryKind,
+    SessionStore, SqliteSessionStore, THREAD_SPAWN_OPERATION, ThreadBaseRef, ThreadCoordinates,
     ThreadJoinedPayload, ThreadSpawnedPayload, ThreadTerminalState, ThreadTopology,
     ToolCallDecisionOutcomePayload, ToolCallDecisionPayload, ToolCallSubject,
     ToolCallSuspendedPayload, ToolInvocationCancellation, TurnContextSnapshot, WasmRuntimeArtifact,
@@ -115,6 +116,811 @@ impl NonObservingThreadToolProvider {
 struct ImmediateThreadToolProvider;
 
 struct IsolatedFailureToolProvider;
+
+#[derive(Default)]
+struct RecoveryCountingToolProvider {
+    invocations: AtomicU64,
+}
+
+#[async_trait]
+impl AgentKernelToolProvider for RecoveryCountingToolProvider {
+    async fn tool_definitions(&self) -> Vec<ToolDefinition> {
+        vec![ToolDefinition::new(
+            "recovery_tool",
+            "Recovery contract test tool.",
+            serde_json::json!({"type":"object"}),
+        )]
+    }
+
+    async fn invoke_tool_call(
+        &self,
+        call: AgentKernelToolCall,
+    ) -> CooldisResult<Option<CanonicalMessage>> {
+        self.invocations.fetch_add(1, Ordering::SeqCst);
+        Ok(Some(CanonicalMessage::tool_result(
+            call.call_id,
+            call.tool_name,
+            format!("executed:{}", call.arguments["input"].as_str().unwrap()),
+            false,
+        )))
+    }
+}
+
+#[test]
+fn recovery_action_truth_table_honors_effect_class_and_fingerprint() {
+    for effect_class in [
+        EffectClass::Pure,
+        EffectClass::Idempotent,
+        EffectClass::AtMostOnce,
+    ] {
+        for outcome_exists in [false, true] {
+            for fingerprint_matches in [false, true] {
+                let expected = if outcome_exists && fingerprint_matches {
+                    ToolRecoveryAction::Reuse
+                } else if effect_class == EffectClass::AtMostOnce {
+                    ToolRecoveryAction::ConservativeFailure
+                } else {
+                    ToolRecoveryAction::Reexecute
+                };
+                assert_eq!(
+                    tool_recovery_action(effect_class, outcome_exists, fingerprint_matches),
+                    expected,
+                    "{effect_class:?} outcome_exists={outcome_exists} fingerprint_matches={fingerprint_matches}"
+                );
+            }
+        }
+    }
+}
+
+fn recovery_bind_receipt(effect_class: EffectClass) -> AgentManifestBindReceipt {
+    AgentManifestBindReceipt {
+        ref_uri: "agent://test/recovery".to_string(),
+        manifest_hash: "snapshot-recovery".to_string(),
+        model_profile_id: "default".to_string(),
+        provider_id: "test".to_string(),
+        model_id: "model".to_string(),
+        tool_ids: vec!["recovery".to_string()],
+        operation_bindings: vec![AgentManifestOperationBinding {
+            name: "recovery".to_string(),
+            artifact_hash: "test".to_string(),
+            effect_class,
+            grants: Vec::new(),
+            grant_expiries: Vec::new(),
+            operations: vec!["recovery_tool".to_string()],
+            direct_tools: vec![AgentManifestDirectToolBinding {
+                tool_name: "recovery_tool".to_string(),
+                operation: "recovery_tool".to_string(),
+                effect_class,
+                grant_expiries: Vec::new(),
+            }],
+        }],
+        skill_packages: Vec::new(),
+        skill_discovery: None,
+        static_context_segments: Vec::new(),
+        tool_universes: Vec::new(),
+        couplings: Vec::new(),
+        granted: Vec::new(),
+        grant_bindings: Vec::new(),
+        effective_runtime: AgentManifestRuntimeDefaults::default(),
+        overridden_keys: Vec::new(),
+        placement: None,
+        workspace: None,
+    }
+}
+
+async fn append_recovery_bind_receipt(
+    store: &dyn RuntimeStore,
+    coordinates: &ThreadCoordinates,
+    effect_class: EffectClass,
+) {
+    store
+        .append_events(
+            &EventStreamId::for_thread(coordinates),
+            vec![NewEventRecord::witnessed(
+                coordinates.clone(),
+                EventKind::ManifestBindCompleted,
+                serde_json::to_value(recovery_bind_receipt(effect_class)).unwrap(),
+            )],
+        )
+        .await
+        .unwrap();
+}
+
+#[test]
+fn bash_effect_class_requires_one_exactly_attributable_operation() {
+    let mut receipt = recovery_bind_receipt(EffectClass::Idempotent);
+    receipt.operation_bindings[0].operations = vec!["safe".to_string()];
+    receipt.operation_bindings[0].direct_tools.clear();
+
+    assert_eq!(
+        effect_class_from_bind_receipt(
+            &receipt,
+            crate::BASH_TOOL,
+            &serde_json::json!({"command": "safe argument"}),
+        ),
+        EffectClass::Idempotent
+    );
+    for command in [
+        "FOO=1 safe",
+        "safe; destructive",
+        "safe ; destructive",
+        "safe && destructive",
+        "safe || destructive",
+        "safe | destructive",
+        "safe\ndestructive",
+        "safe > /tmp/output",
+        "safe $(destructive)",
+        "safe `destructive`",
+        "\"safe\" argument",
+    ] {
+        assert_eq!(
+            effect_class_from_bind_receipt(
+                &receipt,
+                crate::BASH_TOOL,
+                &serde_json::json!({"command": command}),
+            ),
+            EffectClass::AtMostOnce,
+            "compound or shell-evaluated command {command:?} must fail closed"
+        );
+    }
+}
+
+async fn append_recovery_request(
+    store: &dyn RuntimeStore,
+    coordinates: &ThreadCoordinates,
+    arguments: Value,
+) -> EventRecord {
+    let fingerprint = args_fingerprint("recovery_tool", &arguments).unwrap();
+    store
+        .append_events(
+            &EventStreamId::for_thread(coordinates),
+            vec![NewEventRecord::witnessed(
+                coordinates.clone(),
+                EventKind::ToolCallRequested,
+                serde_json::to_value(ToolCallRequestedPayload {
+                    subject: ToolCallSubject {
+                        turn_id: "turn-recovery".to_string(),
+                        call_id: "call-recovery".to_string(),
+                    },
+                    snapshot_id: "snapshot-recovery".to_string(),
+                    tool_name: "recovery_tool".to_string(),
+                    arguments,
+                    args_fingerprint: Some(fingerprint),
+                    holds: Vec::new(),
+                })
+                .unwrap(),
+            )],
+        )
+        .await
+        .unwrap()
+        .pop()
+        .unwrap()
+}
+
+async fn recovery_after_store_reopen(
+    effect_class: EffectClass,
+    prior_arguments: Value,
+    recorded_result: Option<&str>,
+    current_arguments: Value,
+) -> (u64, CanonicalMessage) {
+    let path = temp_db_path("cooldis-tool-recovery");
+    let coordinates = ThreadCoordinates::new("tenant_a", "user_1", "recovery");
+    {
+        let store = Arc::new(SqliteSessionStore::open(&path).await.unwrap());
+        append_recovery_bind_receipt(store.as_ref(), &coordinates, effect_class).await;
+        let request = append_recovery_request(store.as_ref(), &coordinates, prior_arguments).await;
+        if let Some(recorded_result) = recorded_result {
+            let services = RuntimeServices::new(store, RuntimeExecutionPolicy::default());
+            services
+                .append_agent_loop_session_entry(
+                    &coordinates,
+                    None,
+                    SessionEntryKind::Message {
+                        message: CanonicalMessage::tool_result(
+                            "call-recovery",
+                            "recovery_tool",
+                            recorded_result,
+                            false,
+                        ),
+                    },
+                    vec![request.id],
+                )
+                .await
+                .unwrap();
+            let request_payload =
+                serde_json::from_value::<ToolCallRequestedPayload>(request.payload).unwrap();
+            append_tool_completion_event(
+                &services,
+                &coordinates,
+                "turn-recovery".to_string(),
+                "call-recovery".to_string(),
+                "snapshot-recovery".to_string(),
+                "recovery_tool".to_string(),
+                request_payload.args_fingerprint,
+                true,
+                Some(1),
+                Some(0),
+                None,
+            )
+            .await
+            .unwrap();
+        }
+    }
+
+    let store = Arc::new(SqliteSessionStore::open(&path).await.unwrap());
+    let services = RuntimeServices::new(store, RuntimeExecutionPolicy::default());
+    let current_request = append_recovery_request(
+        services.runtime_store().as_ref(),
+        &coordinates,
+        current_arguments.clone(),
+    )
+    .await;
+    let current_payload =
+        serde_json::from_value::<ToolCallRequestedPayload>(current_request.payload).unwrap();
+    let mut calls = vec![WitnessedToolCall {
+        tool_call: ProviderToolCall {
+            id: "call-recovery".to_string(),
+            name: "recovery_tool".to_string(),
+            arguments: current_arguments,
+        },
+        snapshot_id: "snapshot-recovery".to_string(),
+        args_fingerprint: current_payload.args_fingerprint.clone(),
+        request_event_id: current_request.id,
+        holds: Vec::new(),
+        recovery_action: ToolRecoveryAction::Reexecute,
+        recovery_source_event_id: None,
+        recovery_fingerprint_mismatch: false,
+    }];
+    apply_tool_recovery_actions(&services, &coordinates, "turn-recovery", &mut calls)
+        .await
+        .unwrap();
+
+    let provider = Arc::new(RecoveryCountingToolProvider::default());
+    let kernel_provider: Arc<dyn AgentKernelToolProvider> = provider.clone();
+    let router = Arc::new(
+        AgentToolRouter::new(Arc::new(OperationRegistry::new()))
+            .with_kernel_tool_provider(kernel_provider),
+    );
+    let interceptor = ToolExecutionInterceptor::new(router);
+    let turn_context = TurnContext::new(
+        ThreadContext::root(coordinates),
+        "turn-recovery",
+        &TurnInput::text(""),
+        CancellationToken::new(),
+    );
+    let (events, _) = broadcast::channel(8);
+    let prepared = prepare_tool_call(
+        &interceptor,
+        &services,
+        &turn_context,
+        &events,
+        calls.pop().unwrap(),
+        Arc::new(AtomicU64::new(0)),
+        ToolInvocationCancellation::never(),
+    )
+    .await
+    .unwrap();
+    let PreparedToolCallOutcome::Completed { ref outcome, .. } = prepared else {
+        panic!("recovery should produce a completed outcome");
+    };
+    let result = outcome.result.clone();
+    append_detached_tool_call_outcome(
+        &services,
+        &turn_context,
+        turn_context.coordinates().thread_id,
+        &events,
+        Ok(prepared),
+    )
+    .await
+    .unwrap();
+    assert!(
+        matching_tool_call_completed_exists(
+            &services,
+            turn_context.coordinates(),
+            "turn-recovery",
+            "call-recovery",
+            "snapshot-recovery",
+            current_payload.args_fingerprint.as_deref(),
+        )
+        .await
+        .unwrap(),
+        "recovery completion must echo the current fingerprint"
+    );
+    assert!(
+        existing_tool_result_message(
+            &services,
+            turn_context.coordinates(),
+            current_request.id,
+            "call-recovery",
+            "snapshot-recovery",
+            current_payload.args_fingerprint.as_deref(),
+        )
+        .await
+        .unwrap()
+        .is_some(),
+        "recovery outcome must be witnessed from the current request"
+    );
+    let invocations = provider.invocations.load(Ordering::SeqCst);
+    drop(services);
+    let _ = std::fs::remove_file(path);
+    (invocations, result)
+}
+
+#[tokio::test]
+async fn crash_cut_idempotent_dangling_request_reexecutes_after_store_reopen() {
+    let (invocations, result) = recovery_after_store_reopen(
+        EffectClass::Idempotent,
+        serde_json::json!({"input":"same"}),
+        None,
+        serde_json::json!({"input":"same"}),
+    )
+    .await;
+    assert_eq!(invocations, 1);
+    assert_eq!(text_from_message(&result), "executed:same");
+}
+
+#[tokio::test]
+async fn crash_cut_at_most_once_dangling_request_records_conservative_failure() {
+    let (invocations, result) = recovery_after_store_reopen(
+        EffectClass::AtMostOnce,
+        serde_json::json!({"input":"same"}),
+        None,
+        serde_json::json!({"input":"same"}),
+    )
+    .await;
+    assert_eq!(invocations, 0);
+    assert!(matches!(
+        result,
+        CanonicalMessage::ToolResult { is_error: true, .. }
+    ));
+    let text = text_from_message(&result);
+    assert!(text.contains("interrupted"), "{text}");
+    assert!(text.contains("effect class at-most-once"), "{text}");
+}
+
+#[tokio::test]
+async fn completed_matching_fingerprint_reuses_and_mismatch_never_reuses() {
+    let (matching_invocations, matching_result) = recovery_after_store_reopen(
+        EffectClass::Idempotent,
+        serde_json::json!({"input":"same"}),
+        Some("recorded:same"),
+        serde_json::json!({"input":"same"}),
+    )
+    .await;
+    assert_eq!(matching_invocations, 0);
+    assert_eq!(text_from_message(&matching_result), "recorded:same");
+
+    let (mismatch_invocations, mismatch_result) = recovery_after_store_reopen(
+        EffectClass::Idempotent,
+        serde_json::json!({"input":"old"}),
+        Some("recorded:old"),
+        serde_json::json!({"input":"new"}),
+    )
+    .await;
+    assert_eq!(mismatch_invocations, 1);
+    assert_eq!(text_from_message(&mismatch_result), "executed:new");
+
+    let (at_most_once_invocations, at_most_once_result) = recovery_after_store_reopen(
+        EffectClass::AtMostOnce,
+        serde_json::json!({"input":"old"}),
+        Some("recorded:old"),
+        serde_json::json!({"input":"new"}),
+    )
+    .await;
+    assert_eq!(at_most_once_invocations, 0);
+    let text = text_from_message(&at_most_once_result);
+    assert!(text.contains("fingerprint mismatch"), "{text}");
+    assert!(text.contains("effect class at-most-once"), "{text}");
+}
+
+#[tokio::test]
+async fn completion_without_canonical_result_degrades_by_effect_class() {
+    for (label, effect_class, expected) in [
+        (
+            "idempotent",
+            EffectClass::Idempotent,
+            ToolRecoveryAction::Reexecute,
+        ),
+        (
+            "at-most-once",
+            EffectClass::AtMostOnce,
+            ToolRecoveryAction::ConservativeFailure,
+        ),
+    ] {
+        let store = Arc::new(InMemorySessionStore::new());
+        let services = RuntimeServices::new(store.clone(), RuntimeExecutionPolicy::default());
+        let coordinates =
+            ThreadCoordinates::new("tenant_a", "user_1", format!("completion-only-{label}"));
+        append_recovery_bind_receipt(store.as_ref(), &coordinates, effect_class).await;
+        let arguments = serde_json::json!({"input":"same"});
+        let prior = append_recovery_request(store.as_ref(), &coordinates, arguments.clone()).await;
+        let prior_payload =
+            serde_json::from_value::<ToolCallRequestedPayload>(prior.payload).unwrap();
+        append_tool_completion_event(
+            &services,
+            &coordinates,
+            "turn-recovery".to_string(),
+            "call-recovery".to_string(),
+            "snapshot-recovery".to_string(),
+            "recovery_tool".to_string(),
+            prior_payload.args_fingerprint,
+            true,
+            Some(1),
+            Some(0),
+            None,
+        )
+        .await
+        .unwrap();
+        let current =
+            append_recovery_request(store.as_ref(), &coordinates, arguments.clone()).await;
+        let current_payload =
+            serde_json::from_value::<ToolCallRequestedPayload>(current.payload).unwrap();
+        let mut calls = vec![WitnessedToolCall {
+            tool_call: ProviderToolCall {
+                id: "call-recovery".to_string(),
+                name: "recovery_tool".to_string(),
+                arguments,
+            },
+            snapshot_id: "snapshot-recovery".to_string(),
+            args_fingerprint: current_payload.args_fingerprint,
+            request_event_id: current.id,
+            holds: Vec::new(),
+            recovery_action: ToolRecoveryAction::Reexecute,
+            recovery_source_event_id: None,
+            recovery_fingerprint_mismatch: false,
+        }];
+
+        apply_tool_recovery_actions(&services, &coordinates, "turn-recovery", &mut calls)
+            .await
+            .unwrap();
+
+        assert_eq!(calls[0].recovery_action, expected, "{label}");
+        assert_eq!(calls[0].recovery_source_event_id, None, "{label}");
+    }
+}
+
+#[tokio::test]
+async fn legacy_request_and_completion_reuse_by_request_event_and_call_id() {
+    let store = Arc::new(InMemorySessionStore::new());
+    let services = RuntimeServices::new(store.clone(), RuntimeExecutionPolicy::default());
+    let coordinates = ThreadCoordinates::new("tenant_a", "user_1", "legacy-tool-recovery");
+    append_recovery_bind_receipt(store.as_ref(), &coordinates, EffectClass::Idempotent).await;
+    let prior = store
+        .append_events(
+            &EventStreamId::for_thread(&coordinates),
+            vec![NewEventRecord::witnessed(
+                coordinates.clone(),
+                EventKind::ToolCallRequested,
+                serde_json::json!({
+                    "subject": {"turn_id":"turn-recovery", "call_id":"call-recovery"},
+                    "snapshot_id": "snapshot-recovery",
+                    "tool_name": "recovery_tool",
+                    "arguments": {"input":"same"}
+                }),
+            )],
+        )
+        .await
+        .unwrap()
+        .pop()
+        .unwrap();
+    services
+        .append_agent_loop_session_entry(
+            &coordinates,
+            None,
+            SessionEntryKind::Message {
+                message: CanonicalMessage::tool_result(
+                    "call-recovery",
+                    "recovery_tool",
+                    "legacy result",
+                    false,
+                ),
+            },
+            vec![prior.id],
+        )
+        .await
+        .unwrap();
+    store
+        .append_events(
+            &EventStreamId::for_thread(&coordinates),
+            vec![NewEventRecord::witnessed(
+                coordinates.clone(),
+                EventKind::ToolCallCompleted,
+                serde_json::json!({
+                    "subject": {"turn_id":"turn-recovery", "call_id":"call-recovery"},
+                    "snapshot_id": "snapshot-recovery",
+                    "tool_name": "recovery_tool",
+                    "success": true
+                }),
+            )],
+        )
+        .await
+        .unwrap();
+    let current = append_recovery_request(
+        store.as_ref(),
+        &coordinates,
+        serde_json::json!({"input":"same"}),
+    )
+    .await;
+    let current_payload =
+        serde_json::from_value::<ToolCallRequestedPayload>(current.payload).unwrap();
+    let mut calls = vec![WitnessedToolCall {
+        tool_call: ProviderToolCall {
+            id: "call-recovery".to_string(),
+            name: "recovery_tool".to_string(),
+            arguments: serde_json::json!({"input":"same"}),
+        },
+        snapshot_id: "snapshot-recovery".to_string(),
+        args_fingerprint: current_payload.args_fingerprint,
+        request_event_id: current.id,
+        holds: Vec::new(),
+        recovery_action: ToolRecoveryAction::Reexecute,
+        recovery_source_event_id: None,
+        recovery_fingerprint_mismatch: false,
+    }];
+
+    apply_tool_recovery_actions(&services, &coordinates, "turn-recovery", &mut calls)
+        .await
+        .unwrap();
+
+    assert_eq!(calls[0].recovery_action, ToolRecoveryAction::Reuse);
+    assert_eq!(calls[0].recovery_source_event_id, Some(prior.id));
+    assert!(!calls[0].recovery_fingerprint_mismatch);
+}
+
+#[tokio::test]
+async fn recovered_bash_rewrite_does_not_inherit_the_original_commands_lax_class() {
+    let store = Arc::new(InMemorySessionStore::new());
+    let services = RuntimeServices::new(store.clone(), RuntimeExecutionPolicy::default());
+    let coordinates = ThreadCoordinates::new("tenant_a", "user_1", "rewritten-bash-recovery");
+    let mut receipt = recovery_bind_receipt(EffectClass::Idempotent);
+    receipt.operation_bindings[0].operations = vec!["safe".to_string()];
+    receipt.operation_bindings[0].direct_tools.clear();
+    store
+        .append_events(
+            &EventStreamId::for_thread(&coordinates),
+            vec![NewEventRecord::witnessed(
+                coordinates.clone(),
+                EventKind::ManifestBindCompleted,
+                serde_json::to_value(receipt).unwrap(),
+            )],
+        )
+        .await
+        .unwrap();
+    let arguments = serde_json::json!({"command":"safe input"});
+    let request = |arguments: Value| {
+        let fingerprint = args_fingerprint(crate::BASH_TOOL, &arguments).unwrap();
+        NewEventRecord::witnessed(
+            coordinates.clone(),
+            EventKind::ToolCallRequested,
+            serde_json::to_value(ToolCallRequestedPayload {
+                subject: ToolCallSubject {
+                    turn_id: "turn-recovery".to_string(),
+                    call_id: "call-recovery".to_string(),
+                },
+                snapshot_id: "snapshot-recovery".to_string(),
+                tool_name: crate::BASH_TOOL.to_string(),
+                arguments,
+                args_fingerprint: Some(fingerprint),
+                holds: Vec::new(),
+            })
+            .unwrap(),
+        )
+    };
+    let prior = store
+        .append_events(
+            &EventStreamId::for_thread(&coordinates),
+            vec![request(arguments.clone())],
+        )
+        .await
+        .unwrap()
+        .pop()
+        .unwrap();
+    store
+        .append_events(
+            &crate::control_stream_id(&coordinates),
+            vec![NewEventRecord::discharged(
+                coordinates.clone(),
+                EventKind::ToolCallDecision,
+                serde_json::to_value(ToolCallDecisionPayload {
+                    subject: ToolCallSubject {
+                        turn_id: "turn-recovery".to_string(),
+                        call_id: "call-recovery".to_string(),
+                    },
+                    snapshot_id: "snapshot-recovery".to_string(),
+                    outcome: ToolCallDecisionOutcomePayload::Rewrite {
+                        arguments: serde_json::json!({"command":"destructive input"}),
+                    },
+                    admissible: None,
+                })
+                .unwrap(),
+                EventProvenance {
+                    source_streams: vec![EventStreamId::for_thread(&coordinates)],
+                    source_event_ids: vec![prior.id],
+                    discharged_by: Some("test:rewrite".to_string()),
+                    function: Some("rewrite/v1".to_string()),
+                    ..EventProvenance::default()
+                },
+            )],
+        )
+        .await
+        .unwrap();
+    let current = store
+        .append_events(
+            &EventStreamId::for_thread(&coordinates),
+            vec![request(arguments.clone())],
+        )
+        .await
+        .unwrap()
+        .pop()
+        .unwrap();
+    let current_payload =
+        serde_json::from_value::<ToolCallRequestedPayload>(current.payload).unwrap();
+    let mut calls = vec![WitnessedToolCall {
+        tool_call: ProviderToolCall {
+            id: "call-recovery".to_string(),
+            name: crate::BASH_TOOL.to_string(),
+            arguments,
+        },
+        snapshot_id: "snapshot-recovery".to_string(),
+        args_fingerprint: current_payload.args_fingerprint,
+        request_event_id: current.id,
+        holds: Vec::new(),
+        recovery_action: ToolRecoveryAction::Reexecute,
+        recovery_source_event_id: None,
+        recovery_fingerprint_mismatch: false,
+    }];
+
+    apply_tool_recovery_actions(&services, &coordinates, "turn-recovery", &mut calls)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        calls[0].recovery_action,
+        ToolRecoveryAction::ConservativeFailure
+    );
+}
+
+#[tokio::test]
+async fn turn_rerun_replays_witnessed_assistant_batch_without_redecode_mismatch() {
+    let store = Arc::new(InMemorySessionStore::new());
+    let services = RuntimeServices::new(store.clone(), RuntimeExecutionPolicy::default());
+    let coordinates = ThreadCoordinates::new("tenant_a", "user_1", "witnessed-turn-rerun");
+    append_recovery_bind_receipt(store.as_ref(), &coordinates, EffectClass::Idempotent).await;
+    let input = TurnInput::text("recover the witnessed batch");
+    let user_entry = services
+        .append_user_turn_input(&coordinates, "turn-recovery", &input)
+        .await
+        .unwrap();
+    let submitted =
+        append_turn_submitted_event(&services, &coordinates, "turn-recovery", &user_entry)
+            .await
+            .unwrap();
+    let arguments = serde_json::json!({"input":"same"});
+    let assistant = CanonicalMessage::assistant(
+        "openai",
+        ProviderApi::OpenAIResponses,
+        "gpt-test",
+        vec![CanonicalContent::tool_call(
+            "call-recovery",
+            "recovery_tool",
+            arguments.clone(),
+        )],
+        CanonicalStopReason::ToolUse,
+    );
+    let assistant_entry = services
+        .append_agent_loop_session_entry(
+            &coordinates,
+            None,
+            SessionEntryKind::Message { message: assistant },
+            vec![submitted.id],
+        )
+        .await
+        .unwrap();
+    let turn_context = TurnContext::new(
+        ThreadContext::root(coordinates.clone()),
+        "turn-recovery",
+        &input,
+        CancellationToken::new(),
+    );
+    append_tool_call_requested_events(
+        &services,
+        &turn_context,
+        &[(
+            ProviderToolCall {
+                id: "call-recovery".to_string(),
+                name: "recovery_tool".to_string(),
+                arguments: arguments.clone(),
+            },
+            "snapshot-recovery".to_string(),
+        )],
+        assistant_entry.entry_id,
+    )
+    .await
+    .unwrap();
+    drop(services);
+
+    let provider = Arc::new(RecoveryCountingToolProvider::default());
+    let kernel_provider: Arc<dyn AgentKernelToolProvider> = provider.clone();
+    let router = Arc::new(
+        AgentToolRouter::new(Arc::new(OperationRegistry::new()))
+            .with_kernel_tool_provider(kernel_provider),
+    );
+    let client = Arc::new(RecordingClient::with_responses(vec![response_text(
+        "recovered final reply",
+    )]));
+    let host = RuntimeHost::with_session_store(
+        Arc::new(
+            CanonicalProviderRuntimeFactory::new(
+                CanonicalProviderRuntimeConfig::new(
+                    ProviderApi::OpenAIResponses,
+                    "openai",
+                    "gpt-test",
+                ),
+                client.clone(),
+            )
+            .with_tool_router(router),
+        ),
+        store.clone(),
+    );
+    let thread = host
+        .load_thread_with_topology_and_metadata(
+            coordinates.clone(),
+            ThreadTopology::root(),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap();
+    let mut events = thread.subscribe_events();
+
+    host.submit(
+        coordinates.thread_id,
+        "turn-recovery",
+        "recover the witnessed batch",
+    )
+    .await
+    .unwrap();
+    assert_output(&mut events, "recovered final reply").await;
+
+    assert_eq!(provider.invocations.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        client.requests().len(),
+        1,
+        "the model is called only after replay"
+    );
+    let requests = store
+        .read_events(&EventStreamId::for_thread(&coordinates), None)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|event| {
+            event.kind == EventKind::ToolCallRequested
+                && event.payload["subject"]["call_id"] == "call-recovery"
+        })
+        .map(|event| serde_json::from_value::<ToolCallRequestedPayload>(event.payload).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].arguments, requests[1].arguments);
+    assert_eq!(requests[0].args_fingerprint, requests[1].args_fingerprint);
+    assert!(
+        thread
+            .session_context()
+            .await
+            .unwrap()
+            .messages
+            .iter()
+            .any(|message| {
+                matches!(
+                    message,
+                    CanonicalMessage::ToolResult {
+                        tool_call_id,
+                        is_error: false,
+                        ..
+                    } if tool_call_id == "call-recovery"
+                )
+            })
+    );
+    host.shutdown_all().await.unwrap();
+}
 
 #[derive(Default)]
 struct AppendPause {
@@ -2456,6 +3262,7 @@ async fn persisted_round_accounting_rejects_a_request_without_an_assistant_sourc
                 snapshot_id: "unbound".to_string(),
                 tool_name: "thread_status".to_string(),
                 arguments: serde_json::json!({"task_name": "worker-a"}),
+                args_fingerprint: None,
                 holds: Vec::new(),
             })
             .unwrap(),
@@ -2558,6 +3365,7 @@ async fn persisted_round_accounting_rejects_a_cross_turn_assistant_source() {
                     snapshot_id: "unbound".to_string(),
                     tool_name: "thread_status".to_string(),
                     arguments: serde_json::json!({"task_name": "worker-a"}),
+                    args_fingerprint: None,
                     holds: Vec::new(),
                 })
                 .unwrap(),
@@ -3954,6 +4762,7 @@ async fn detached_completion_retry_is_idempotent_before_and_after_a_store_failur
                         snapshot_id: "snapshot-1".to_string(),
                         tool_name: "thread_status".to_string(),
                         arguments: serde_json::json!({}),
+                        args_fingerprint: None,
                         holds: Vec::new(),
                     })
                     .unwrap(),
@@ -4018,6 +4827,7 @@ async fn detached_completion_retry_is_idempotent_before_and_after_a_store_failur
                         call_id: "call-1".to_string(),
                         tool_name: "thread_status".to_string(),
                         snapshot_id: "snapshot-1".to_string(),
+                        args_fingerprint: None,
                         source_event_id: request.id,
                         finish_order: 0,
                         cancellation: Some(ToolCallCancellation::CancelledExceededGrace),
@@ -4088,6 +4898,206 @@ async fn detached_completion_retry_is_idempotent_before_and_after_a_store_failur
 }
 
 #[tokio::test]
+async fn result_append_commits_before_its_completion_event() {
+    let inner = Arc::new(InMemorySessionStore::new());
+    let coordinates = ThreadCoordinates::new("tenant_a", "user_1", "result-before-completion");
+    let request = append_recovery_request(
+        inner.as_ref(),
+        &coordinates,
+        serde_json::json!({"input":"same"}),
+    )
+    .await;
+    let payload =
+        serde_json::from_value::<ToolCallRequestedPayload>(request.payload.clone()).unwrap();
+    let faulting = Arc::new(FaultingRuntimeStore::new(inner.clone()).fail_nth(
+        "append_events_fenced",
+        1,
+        "completion append failed before commit",
+    ));
+    let services = RuntimeServices::new(faulting, RuntimeExecutionPolicy::default());
+    let (events, _) = broadcast::channel(8);
+
+    let err = append_tool_result_message(
+        &services,
+        &coordinates,
+        coordinates.thread_id,
+        &events,
+        "call-recovery".to_string(),
+        "recovery_tool".to_string(),
+        "turn-recovery".to_string(),
+        "snapshot-recovery".to_string(),
+        payload.args_fingerprint,
+        CanonicalMessage::tool_result("call-recovery", "recovery_tool", "persisted first", false),
+        Some(1),
+        Some(0),
+        None,
+        request.id,
+        false,
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("completion append failed"),
+        "{err}"
+    );
+
+    let records = inner
+        .read_events(&EventStreamId::for_thread(&coordinates), None)
+        .await
+        .unwrap();
+    assert!(
+        records
+            .iter()
+            .all(|event| event.kind != EventKind::ToolCallCompleted)
+    );
+    assert!(
+        inner
+            .build_context(&coordinates)
+            .await
+            .unwrap()
+            .messages
+            .iter()
+            .any(|message| matches!(
+                message,
+                CanonicalMessage::ToolResult { tool_call_id, .. }
+                    if tool_call_id == "call-recovery"
+            ))
+    );
+}
+
+#[tokio::test]
+async fn legacy_completion_does_not_swallow_a_new_fingerprinted_completion() {
+    let store = Arc::new(InMemorySessionStore::new());
+    let services = RuntimeServices::new(store.clone(), RuntimeExecutionPolicy::default());
+    let coordinates = ThreadCoordinates::new("tenant_a", "user_1", "legacy-completion-collision");
+    let legacy_request = store
+        .append_events(
+            &EventStreamId::for_thread(&coordinates),
+            vec![NewEventRecord::witnessed(
+                coordinates.clone(),
+                EventKind::ToolCallRequested,
+                serde_json::to_value(ToolCallRequestedPayload {
+                    subject: ToolCallSubject {
+                        turn_id: "turn-recovery".to_string(),
+                        call_id: "call-recovery".to_string(),
+                    },
+                    snapshot_id: "snapshot-recovery".to_string(),
+                    tool_name: "recovery_tool".to_string(),
+                    arguments: serde_json::json!({"input":"legacy"}),
+                    args_fingerprint: None,
+                    holds: Vec::new(),
+                })
+                .unwrap(),
+            )],
+        )
+        .await
+        .unwrap()
+        .pop()
+        .unwrap();
+    append_tool_completion_event(
+        &services,
+        &coordinates,
+        "turn-recovery".to_string(),
+        "call-recovery".to_string(),
+        "snapshot-recovery".to_string(),
+        "recovery_tool".to_string(),
+        None,
+        true,
+        Some(1),
+        Some(0),
+        None,
+    )
+    .await
+    .unwrap();
+    let current = append_recovery_request(
+        store.as_ref(),
+        &coordinates,
+        serde_json::json!({"input":"current"}),
+    )
+    .await;
+    let current_payload =
+        serde_json::from_value::<ToolCallRequestedPayload>(current.payload.clone()).unwrap();
+    let current_fingerprint = current_payload.args_fingerprint.clone().unwrap();
+    let (events, _) = broadcast::channel(8);
+
+    assert!(
+        !matching_tool_call_completed_exists(
+            &services,
+            &coordinates,
+            "turn-recovery",
+            "call-recovery",
+            "snapshot-recovery",
+            Some(&current_fingerprint),
+        )
+        .await
+        .unwrap(),
+        "a legacy completion must not terminate a new fingerprinted generation"
+    );
+
+    append_tool_result_message(
+        &services,
+        &coordinates,
+        coordinates.thread_id,
+        &events,
+        "call-recovery".to_string(),
+        "recovery_tool".to_string(),
+        "turn-recovery".to_string(),
+        "snapshot-recovery".to_string(),
+        current_payload.args_fingerprint,
+        CanonicalMessage::tool_result("call-recovery", "recovery_tool", "current result", false),
+        Some(1),
+        Some(1),
+        None,
+        current.id,
+        false,
+    )
+    .await
+    .unwrap();
+
+    let completions = store
+        .read_events(&EventStreamId::for_thread(&coordinates), None)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|event| event.kind == EventKind::ToolCallCompleted)
+        .map(|event| serde_json::from_value::<ToolCallCompletedPayload>(event.payload).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(completions.len(), 2);
+    assert!(
+        completions
+            .iter()
+            .any(|completion| completion.args_fingerprint.as_deref() == Some(&current_fingerprint))
+    );
+    assert!(
+        matching_tool_call_completed_exists(
+            &services,
+            &coordinates,
+            "turn-recovery",
+            "call-recovery",
+            "snapshot-recovery",
+            Some(&current_fingerprint),
+        )
+        .await
+        .unwrap(),
+        "the exact completion must terminate the current generation"
+    );
+    assert!(
+        existing_tool_result_message(
+            &services,
+            &coordinates,
+            current.id,
+            "call-recovery",
+            "snapshot-recovery",
+            Some(&current_fingerprint),
+        )
+        .await
+        .unwrap()
+        .is_some()
+    );
+    let _ = legacy_request;
+}
+
+#[tokio::test]
 async fn completion_append_is_subject_idempotent_under_concurrency() {
     let store = Arc::new(InMemorySessionStore::new());
     let services = RuntimeServices::new(store.clone(), RuntimeExecutionPolicy::default());
@@ -4100,6 +5110,7 @@ async fn completion_append_is_subject_idempotent_under_concurrency() {
             "call-1".to_string(),
             "snapshot-1".to_string(),
             "thread_status".to_string(),
+            Some(format!("sha256:{}", "a".repeat(64))),
             false,
             Some(0),
             Some(0),
@@ -4139,7 +5150,8 @@ async fn resume_sweep_settles_only_dangling_calls_from_the_full_cancelled_turn_w
         .unwrap()
         .pop()
         .unwrap();
-    let request = |call_id: &str| {
+    let request = |call_id: &str, arguments: Value| {
+        let fingerprint = args_fingerprint("thread_status", &arguments).unwrap();
         NewEventRecord::discharged(
             child_coordinates.clone(),
             EventKind::ToolCallRequested,
@@ -4150,7 +5162,8 @@ async fn resume_sweep_settles_only_dangling_calls_from_the_full_cancelled_turn_w
                 },
                 snapshot_id: "snapshot-cancelled".to_string(),
                 tool_name: "thread_status".to_string(),
-                arguments: serde_json::json!({"task_name": "worker"}),
+                arguments,
+                args_fingerprint: Some(fingerprint),
                 holds: Vec::new(),
             })
             .unwrap(),
@@ -4167,9 +5180,12 @@ async fn resume_sweep_settles_only_dangling_calls_from_the_full_cancelled_turn_w
         .append_events(
             &EventStreamId::for_thread(&child_coordinates),
             vec![
-                request("call-dangling"),
-                request("call-dangling"),
-                request("call-already-completed"),
+                request("call-dangling", serde_json::json!({"task_name": "old"})),
+                request("call-dangling", serde_json::json!({"task_name": "new"})),
+                request(
+                    "call-already-completed",
+                    serde_json::json!({"task_name": "completed"}),
+                ),
             ],
         )
         .await
@@ -4238,6 +5254,11 @@ async fn resume_sweep_settles_only_dangling_calls_from_the_full_cancelled_turn_w
                     snapshot_id: "snapshot-cancelled".to_string(),
                     tool_name: "thread_status".to_string(),
                     success: true,
+                    args_fingerprint: serde_json::from_value::<ToolCallRequestedPayload>(
+                        requests[2].payload.clone(),
+                    )
+                    .unwrap()
+                    .args_fingerprint,
                     duration_ms: Some(7),
                     finish_order: Some(4),
                     cancellation: Some(ToolCallCancellation::CancelledExceededGrace),
@@ -4314,10 +5335,10 @@ async fn resume_sweep_settles_only_dangling_calls_from_the_full_cancelled_turn_w
         .iter()
         .find(|payload| payload.subject.call_id == "call-dangling")
         .unwrap();
-    assert!(
-        recovered.success,
-        "recovery must preserve the persisted natural tool outcome"
-    );
+    assert!(!recovered.success);
+    let latest_request =
+        serde_json::from_value::<ToolCallRequestedPayload>(requests[1].payload.clone()).unwrap();
+    assert_eq!(recovered.args_fingerprint, latest_request.args_fingerprint);
     assert_eq!(
         recovered.cancellation,
         Some(ToolCallCancellation::CancelledExceededGrace)
@@ -4336,8 +5357,8 @@ async fn resume_sweep_settles_only_dangling_calls_from_the_full_cancelled_turn_w
                     if tool_call_id == "call-dangling"
             ))
             .count(),
-        1,
-        "recovery must reuse a canonical result persisted before its completion fact"
+        2,
+        "the stale result remains, while recovery settles the latest unfinished generation"
     );
     let _ = child;
     host.shutdown_all().await.unwrap();
@@ -4402,6 +5423,12 @@ async fn runtime_persists_tool_request_and_completion_facts() {
     assert_eq!(request.payload["tool_name"].as_str(), Some("echo_search"));
     assert_eq!(request.payload["tool"].as_str(), Some("echo_search"));
     assert_eq!(
+        request.payload["args_fingerprint"],
+        serde_json::json!(
+            args_fingerprint("echo_search", &serde_json::json!({"input": "cooldis"})).unwrap()
+        )
+    );
+    assert_eq!(
         request.payload["subject"]["turn_id"].as_str(),
         Some("turn-1")
     );
@@ -4425,6 +5452,10 @@ async fn runtime_persists_tool_request_and_completion_facts() {
     assert_eq!(completed.origin, crate::EventOrigin::Witnessed);
     assert_eq!(completed.payload["tool_name"].as_str(), Some("echo_search"));
     assert_eq!(completed.payload["success"].as_bool(), Some(true));
+    assert_eq!(
+        completed.payload["args_fingerprint"],
+        request.payload["args_fingerprint"]
+    );
     assert!(records.iter().any(|event| {
         event.kind == EventKind::TurnCompleted
             && event.origin == crate::EventOrigin::Discharged
@@ -4671,6 +5702,23 @@ async fn resume_tool_call_consumes_decision_and_invokes_once() {
         .find(|event| event.kind == EventKind::ToolCallCompleted)
         .expect("resumed call completion");
     assert_eq!(completion.payload["finish_order"], 0);
+    let request_payload =
+        serde_json::from_value::<ToolCallRequestedPayload>(request.payload.clone()).unwrap();
+    let services = RuntimeServices::new(store.clone(), RuntimeExecutionPolicy::default());
+    assert!(
+        existing_tool_result_message(
+            &services,
+            &thread.context().coordinates,
+            request.id,
+            "call_1|fc_1",
+            &request_payload.snapshot_id,
+            request_payload.args_fingerprint.as_deref(),
+        )
+        .await
+        .unwrap()
+        .is_some(),
+        "a resumed result remains reusable through its original request witness"
+    );
     assert!(
         records
             .iter()

--- a/crates/cooldis-kernel/src/agent/manifest_bind.rs
+++ b/crates/cooldis-kernel/src/agent/manifest_bind.rs
@@ -18,7 +18,7 @@ use crate::agent::manifest_schema::{
     AgentManifestProtocolToolImport, AgentManifestResource, AgentManifestResourceKind,
     AgentManifestRuntimeDefaults, AgentManifestRuntimeOverrideKey, AgentManifestSchema,
     AgentManifestTool, AgentManifestToolSurface, AgentManifestWorkspaceMode,
-    AgentManifestWorkspaceRequirement, KERNEL_ASSEMBLER_STATIC,
+    AgentManifestWorkspaceRequirement, EffectClass, KERNEL_ASSEMBLER_STATIC,
 };
 use crate::agent::tool_universe::{
     PinnedToolRef, ToolUniverseBindReceipt, ToolUniverseBinding, ToolUniverseDiscoverer,
@@ -746,6 +746,7 @@ struct OperationBindingAccumulator {
     grant_expiries: BTreeSet<AgentManifestGrantExpiry>,
     operations: BTreeSet<String>,
     direct_tools: BTreeSet<AgentManifestDirectToolBinding>,
+    effect_class: Option<EffectClass>,
     whole_record: bool,
 }
 
@@ -757,7 +758,13 @@ impl OperationBindingAccumulator {
         operation: Option<String>,
         direct_tool: Option<AgentManifestDirectToolBinding>,
     ) {
-        self.merge_with_expiries(grants, BTreeSet::new(), operation, direct_tool);
+        self.merge_with_expiries(
+            grants,
+            BTreeSet::new(),
+            operation,
+            direct_tool,
+            EffectClass::AtMostOnce,
+        );
     }
 
     fn merge_with_expiries(
@@ -766,12 +773,18 @@ impl OperationBindingAccumulator {
         grant_expiries: BTreeSet<AgentManifestGrantExpiry>,
         operation: Option<String>,
         direct_tool: Option<AgentManifestDirectToolBinding>,
+        effect_class: EffectClass,
     ) {
         self.grants.extend(grants);
         self.grant_expiries.extend(grant_expiries);
         if let Some(direct_tool) = direct_tool {
             self.direct_tools.insert(direct_tool);
         }
+        self.effect_class = Some(
+            self.effect_class
+                .map(|bound| bound.max(effect_class))
+                .unwrap_or(effect_class),
+        );
         match operation {
             Some(operation) if !self.whole_record => {
                 self.operations.insert(operation);
@@ -2162,6 +2175,7 @@ async fn bind_tools(
                     &tool.operation_ref,
                     &grants,
                     &grant_expiries,
+                    tool.effect_class,
                     None,
                     operation_registry_root,
                     &mut granted,
@@ -2193,6 +2207,7 @@ async fn bind_tools(
                     &tool.operation_ref,
                     &grants,
                     &grant_expiries,
+                    tool.effect_class,
                     Some(&tool.tool_name),
                     operation_registry_root,
                     &mut granted,
@@ -2392,6 +2407,7 @@ fn operation_bindings_from_map(
             AgentManifestOperationBinding {
                 name,
                 artifact_hash,
+                effect_class: binding.effect_class.unwrap_or_default(),
                 grants: binding.grants.into_iter().collect(),
                 grant_expiries: binding.grant_expiries.into_iter().collect(),
                 operations,
@@ -2468,6 +2484,7 @@ async fn bind_protocol_tool_import(
     let binding = ToolUniverseBinding {
         import_id: tool.id.clone(),
         server_ref: tool.server_ref.clone(),
+        effect_class: tool.effect_class,
         include_tools,
         pin,
         grant_expiries: grant_expiries(&tool.grants),
@@ -2492,6 +2509,7 @@ async fn bind_operation_ref(
         operation_ref,
         grants,
         &[],
+        EffectClass::AtMostOnce,
         direct_tool_name,
         operation_registry_root,
         granted,
@@ -2505,6 +2523,7 @@ async fn bind_operation_ref_with_expiries(
     operation_ref: &str,
     grants: &[String],
     grant_expiries: &[AgentManifestGrantExpiry],
+    effect_class: EffectClass,
     direct_tool_name: Option<&str>,
     operation_registry_root: Option<&Path>,
     granted: &mut BTreeSet<String>,
@@ -2527,6 +2546,7 @@ async fn bind_operation_ref_with_expiries(
             Ok::<AgentManifestDirectToolBinding, CooldisError>(AgentManifestDirectToolBinding {
                 tool_name: tool_name.to_string(),
                 operation,
+                effect_class,
                 grant_expiries: grant_expiries.to_vec(),
             })
         })
@@ -2540,6 +2560,7 @@ async fn bind_operation_ref_with_expiries(
             grant_expiries.iter().cloned().collect(),
             verification.operation,
             direct_tool_binding,
+            effect_class,
         );
     Ok(())
 }
@@ -3166,6 +3187,8 @@ impl AgentManifestCouplingBinding {
 pub struct AgentManifestOperationBinding {
     pub name: String,
     pub artifact_hash: String,
+    #[serde(default, skip_serializing_if = "EffectClass::is_at_most_once")]
+    pub effect_class: EffectClass,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub grants: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -3183,6 +3206,8 @@ pub struct AgentManifestOperationBinding {
 pub struct AgentManifestDirectToolBinding {
     pub tool_name: String,
     pub operation: String,
+    #[serde(default, skip_serializing_if = "EffectClass::is_at_most_once")]
+    pub effect_class: EffectClass,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub grant_expiries: Vec<AgentManifestGrantExpiry>,
 }

--- a/crates/cooldis-kernel/src/agent/manifest_bind/tests.rs
+++ b/crates/cooldis-kernel/src/agent/manifest_bind/tests.rs
@@ -3,10 +3,11 @@ use crate::agent::manifest_schema::{
     AgentManifestCouplingSource, AgentManifestCouplingTrigger, KERNEL_ASSEMBLER_STATIC,
 };
 use crate::{
-    AgentManifestCompactionDefaults, AgentManifestRuntimeOverridePolicy, AgentManifestToolProtocol,
-    LocalBlobRegistry, LocalSkillRegistry, PublishSkillPackageRequest,
-    STD_SUPERVISOR_SPAWN_TEMPLATE_ID, SkillImportPlan, THREADS_SPAWN_CAPABILITY, ToolDefinition,
-    ToolUniverseDiscovery, WitnessedToolContract,
+    AgentManifestBashTool, AgentManifestCompactionDefaults, AgentManifestDirectTool,
+    AgentManifestRuntimeOverridePolicy, AgentManifestToolProtocol, LocalBlobRegistry,
+    LocalSkillRegistry, PublishSkillPackageRequest, STD_SUPERVISOR_SPAWN_TEMPLATE_ID,
+    SkillImportPlan, THREADS_SPAWN_CAPABILITY, ToolDefinition, ToolUniverseDiscovery,
+    WitnessedToolContract,
 };
 use async_trait::async_trait;
 use std::fs;
@@ -492,6 +493,73 @@ async fn protocol_tool_import_binds_filtered_discovery() {
         binding.include_tools,
         Some(BTreeSet::from(["cooldis_mcp_echo".to_string()]))
     );
+}
+
+#[tokio::test]
+async fn effect_classes_land_in_operation_direct_and_pinned_universe_receipts() {
+    let root = temp_dir("manifest-bind-effect-classes");
+    let bash_record =
+        publish_multi_operation_record(&root, "bash-ops", &[("inspect", vec![])]).await;
+    let direct_record =
+        publish_multi_operation_record(&root, "direct-ops", &[("lookup", vec![])]).await;
+    let witnessed = witnessed_tool("remote.lookup", "string");
+    let pin = format!("mcptool://arcade/remote.lookup@{}", witnessed.schema_hash);
+    let discovery = ToolUniverseDiscovery::witness("mcp://arcade", vec![witnessed], 1).unwrap();
+    let discoverer = StaticToolUniverseDiscoverer { discovery };
+    let tools = vec![
+        AgentManifestTool::Bash(AgentManifestBashTool {
+            id: "inspect".to_string(),
+            command: "inspect".to_string(),
+            operation_ref: format!(
+                "op://bash-ops/inspect@sha256:{}",
+                bash_record.active_artifact_hash
+            ),
+            effect_class: EffectClass::Pure,
+            grants: Vec::new(),
+        }),
+        AgentManifestTool::Direct(AgentManifestDirectTool {
+            id: "lookup".to_string(),
+            tool_name: "lookup".to_string(),
+            operation_ref: format!(
+                "op://direct-ops/lookup@sha256:{}",
+                direct_record.active_artifact_hash
+            ),
+            effect_class: EffectClass::Idempotent,
+            grants: Vec::new(),
+        }),
+        AgentManifestTool::ProtocolImport(AgentManifestProtocolToolImport {
+            effect_class: EffectClass::Pure,
+            ..protocol_import("mcp://arcade", None, Some(pin))
+        }),
+    ];
+
+    let bound = bind_tools(
+        &tools,
+        Some(&root),
+        &BTreeSet::from(["mcp://arcade".to_string()]),
+        Some(&discoverer),
+        0,
+    )
+    .await
+    .unwrap();
+
+    let bash = bound
+        .operation_bindings
+        .iter()
+        .find(|binding| binding.name == "bash-ops")
+        .unwrap();
+    assert_eq!(bash.effect_class, EffectClass::Pure);
+    let direct = bound
+        .operation_bindings
+        .iter()
+        .find(|binding| binding.name == "direct-ops")
+        .unwrap();
+    assert_eq!(direct.effect_class, EffectClass::Idempotent);
+    assert_eq!(direct.direct_tools[0].effect_class, EffectClass::Idempotent);
+    let universe = ToolUniverseBindReceipt::from_binding(&bound.tool_universes[0]);
+    assert_eq!(universe.tools[0].effect_class, EffectClass::Pure);
+
+    let _ = fs::remove_dir_all(root);
 }
 
 #[tokio::test]
@@ -2458,6 +2526,7 @@ async fn operation_bind_requires_declared_grants() {
         vec![AgentManifestOperationBinding {
             name: "search".to_string(),
             artifact_hash: record.active_artifact_hash,
+            effect_class: EffectClass::AtMostOnce,
             grants: vec!["net:https://example.com".to_string()],
             grant_expiries: Vec::new(),
             operations: Vec::new(),
@@ -2612,6 +2681,7 @@ async fn two_segment_operation_ref_validates_only_named_operation() {
         vec![AgentManifestOperationBinding {
             name: "analytics".to_string(),
             artifact_hash: record.active_artifact_hash,
+            effect_class: EffectClass::AtMostOnce,
             grants: vec!["net:https://profile.example".to_string()],
             grant_expiries: Vec::new(),
             operations: vec!["profile".to_string()],
@@ -2741,6 +2811,7 @@ async fn operation_bindings_merge_grants_for_shared_artifact() {
         vec![AgentManifestOperationBinding {
             name: "search".to_string(),
             artifact_hash: record.active_artifact_hash,
+            effect_class: EffectClass::AtMostOnce,
             grants: vec![
                 "fs.read:/workspace".to_string(),
                 "net:https://example.com".to_string(),
@@ -2802,6 +2873,7 @@ async fn operation_binding_merge_whole_record_absorbs_operation_subset() {
         vec![AgentManifestOperationBinding {
             name: "analytics".to_string(),
             artifact_hash: record.active_artifact_hash,
+            effect_class: EffectClass::AtMostOnce,
             grants: vec![
                 "net:https://profile.example".to_string(),
                 "net:https://summary.example".to_string(),
@@ -2881,6 +2953,7 @@ fn operation_binding_accepts_legacy_metadata_without_grants_or_operations() {
             name: "search".to_string(),
             artifact_hash: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
                 .to_string(),
+            effect_class: EffectClass::AtMostOnce,
             grants: Vec::new(),
             grant_expiries: Vec::new(),
             operations: Vec::new(),
@@ -3049,6 +3122,7 @@ fn protocol_import(
         id: "mcp_echo".to_string(),
         protocol: AgentManifestToolProtocol::Mcp,
         server_ref: server_ref.to_string(),
+        effect_class: EffectClass::AtMostOnce,
         expose,
         pin,
         include_tools,

--- a/crates/cooldis-kernel/src/agent/tool_universe.rs
+++ b/crates/cooldis-kernel/src/agent/tool_universe.rs
@@ -28,8 +28,9 @@ use crate::agent::agent_tool_router::{
 };
 use crate::agent::contracts::sha256_hex;
 use crate::{
-    AgentManifestGrantExpiry, CanonicalMessage, CooldisError, CooldisResult, EventKind,
-    EventStreamId, NewEventRecord, RuntimeStore, ToolDefinition, ToolInvocationCancellation,
+    AgentManifestGrantExpiry, CanonicalMessage, CooldisError, CooldisResult, EffectClass,
+    EventKind, EventStreamId, NewEventRecord, RuntimeStore, ToolDefinition,
+    ToolInvocationCancellation,
 };
 use async_trait::async_trait;
 pub use cooldis_agent::PinnedToolRef;
@@ -40,7 +41,7 @@ use cooldis_runtime_contracts::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 /// Model-facing surface names for the reserved meta-operations. These are
@@ -98,6 +99,19 @@ impl WitnessedToolContract {
 pub fn schema_hash_of(schema: &Value) -> CooldisResult<String> {
     let bytes = serde_json::to_vec(schema).map_err(|err| {
         CooldisError::RuntimeFactory(format!("failed to encode tool schema for hashing: {err}"))
+    })?;
+    Ok(sha256_hex(&bytes))
+}
+
+pub(crate) fn args_fingerprint(tool_name: &str, arguments: &Value) -> CooldisResult<String> {
+    let invocation = BTreeMap::from([
+        ("arguments", arguments.clone()),
+        ("tool_name", Value::String(tool_name.to_string())),
+    ]);
+    let bytes = serde_json::to_vec(&invocation).map_err(|err| {
+        CooldisError::RuntimeFactory(format!(
+            "failed to encode tool invocation arguments for hashing: {err}"
+        ))
     })?;
     Ok(sha256_hex(&bytes))
 }
@@ -166,6 +180,8 @@ pub struct ToolUniverseBinding {
     /// Manifest tool id of the `protocol_tool_import`.
     pub import_id: String,
     pub server_ref: String,
+    #[serde(default, skip_serializing_if = "EffectClass::is_at_most_once")]
+    pub effect_class: EffectClass,
     /// Manifest-level filter, already applied to `discovery`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub include_tools: Option<BTreeSet<String>>,
@@ -223,6 +239,8 @@ pub struct ToolUniverseBindReceipt {
 pub struct ToolUniverseToolReceipt {
     pub tool_name: String,
     pub schema_hash: String,
+    #[serde(default, skip_serializing_if = "EffectClass::is_at_most_once")]
+    pub effect_class: EffectClass,
 }
 
 impl ToolUniverseBindReceipt {
@@ -238,6 +256,12 @@ impl ToolUniverseBindReceipt {
                 .map(|tool| ToolUniverseToolReceipt {
                     tool_name: tool.tool_name.clone(),
                     schema_hash: tool.schema_hash.clone(),
+                    effect_class: binding
+                        .pin
+                        .as_ref()
+                        .filter(|pin| pin.tool_name == tool.tool_name)
+                        .map(|_| binding.effect_class)
+                        .unwrap_or_default(),
                 })
                 .collect(),
             pinned: binding
@@ -278,6 +302,7 @@ impl ToolUniverseDiscoveryReceipt {
                 .map(|tool| ToolUniverseToolReceipt {
                     tool_name: tool.tool_name.clone(),
                     schema_hash: tool.schema_hash.clone(),
+                    effect_class: EffectClass::AtMostOnce,
                 })
                 .collect(),
         }

--- a/crates/cooldis-kernel/src/agent/tool_universe/tests.rs
+++ b/crates/cooldis-kernel/src/agent/tool_universe/tests.rs
@@ -98,6 +98,35 @@ fn witnessed_contracts_are_schema_hash_addressed() {
 }
 
 #[test]
+fn argument_fingerprint_is_stable_across_object_key_order() {
+    let first = serde_json::from_str::<Value>(
+        r#"{"outer":{"b":2.50,"a":"\u96ea"},"z":-0.0,"text":"caf\u00e9"}"#,
+    )
+    .unwrap();
+    let second =
+        serde_json::from_str::<Value>(r#"{"text":"café","z":-0.0,"outer":{"a":"雪","b":2.5}}"#)
+            .unwrap();
+
+    let first = args_fingerprint("search", &first).unwrap();
+    let second = args_fingerprint("search", &second).unwrap();
+
+    assert_eq!(first, second);
+    assert!(first.starts_with("sha256:"));
+    assert_ne!(
+        first,
+        args_fingerprint(
+            "different-search",
+            &serde_json::json!({
+                "outer": {"a": "雪", "b": 2.5},
+                "z": -0.0,
+                "text": "café"
+            })
+        )
+        .unwrap()
+    );
+}
+
+#[test]
 fn discovery_filter_restamps_the_hash() {
     let tools = vec![
         WitnessedToolContract::witness(&ToolDefinition::new(
@@ -799,6 +828,7 @@ fn mounted_universe(
         binding: ToolUniverseBinding {
             import_id: server_ref.trim_start_matches("mcp://").to_string(),
             server_ref: server_ref.to_string(),
+            effect_class: EffectClass::AtMostOnce,
             include_tools: None,
             pin,
             grant_expiries: Vec::new(),

--- a/crates/cooldis-kernel/src/kernel/control_decision.rs
+++ b/crates/cooldis-kernel/src/kernel/control_decision.rs
@@ -20,6 +20,8 @@ pub struct ToolCallRequestedPayload {
     pub snapshot_id: String,
     pub tool_name: String,
     pub arguments: JsonValue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub args_fingerprint: Option<String>,
     /// Kernel-derived resource holds for this invocation. Empty when decoding
     /// events written before hold scheduling existed.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -60,6 +62,8 @@ pub struct ToolCallCompletedPayload {
     pub tool_name: String,
     pub success: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub args_fingerprint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub duration_ms: Option<u64>,
     /// Zero-based completion order observed by the batch executor. Event and
     /// history append order remains model call order.
@@ -69,6 +73,19 @@ pub struct ToolCallCompletedPayload {
     /// call ran to completion without an interrupt reaching it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cancellation: Option<ToolCallCancellation>,
+}
+
+/// Recovery honors the effect class; a recorded outcome is reused only under
+/// a matching fingerprint within the same snapshot. A missing recorded
+/// fingerprint retains legacy request-event and call-id reuse.
+pub(crate) fn tool_invocation_fingerprint_matches(
+    recorded_snapshot_id: &str,
+    recorded_fingerprint: Option<&str>,
+    current_snapshot_id: &str,
+    current_fingerprint: Option<&str>,
+) -> bool {
+    recorded_snapshot_id == current_snapshot_id
+        && recorded_fingerprint.is_none_or(|recorded| Some(recorded) == current_fingerprint)
 }
 
 /// Witnessed cancellation outcome for a tool call reached by an interrupt.
@@ -473,6 +490,7 @@ pub async fn list_pending_tool_call_suspensions<S: EventStore + ?Sized>(
             })?;
         terminal_subjects.insert((payload.subject, payload.snapshot_id));
     }
+    let mut completions = Vec::new();
     for event in thread_events
         .iter()
         .filter(|event| event.kind == EventKind::ToolCallCompleted)
@@ -481,7 +499,7 @@ pub async fn list_pending_tool_call_suspensions<S: EventStore + ?Sized>(
             .map_err(|err| {
                 CooldisError::History(format!("tool.call.completed payload is invalid: {err}"))
             })?;
-        terminal_subjects.insert((payload.subject, payload.snapshot_id));
+        completions.push(payload);
     }
 
     let mut pending = Vec::new();
@@ -493,14 +511,48 @@ pub async fn list_pending_tool_call_suspensions<S: EventStore + ?Sized>(
             .map_err(|err| {
                 CooldisError::History(format!("tool.call.suspended payload is invalid: {err}"))
             })?;
-        if terminal_subjects.contains(&(payload.subject.clone(), payload.snapshot_id.clone())) {
+        let request_event_id = event.provenance.source_event_ids.first().copied();
+        let request = request_event_id
+            .and_then(|request_event_id| {
+                thread_events.iter().find(|event| {
+                    event.id == request_event_id && event.kind == EventKind::ToolCallRequested
+                })
+            })
+            .map(|request_event| {
+                serde_json::from_value::<ToolCallRequestedPayload>(request_event.payload.clone())
+                    .map_err(|err| {
+                        CooldisError::History(format!(
+                            "tool.call.requested payload is invalid: {err}"
+                        ))
+                    })
+            })
+            .transpose()?;
+        let completed = if let Some(request) = request {
+            completions.iter().any(|completion| {
+                completion.subject == request.subject
+                    && completion.snapshot_id == request.snapshot_id
+                    && completion.args_fingerprint == request.args_fingerprint
+            })
+        } else {
+            // Legacy/manual suspension facts may not identify their request in
+            // provenance. Preserve the former subject+snapshot terminal check
+            // only for that unresolved case; fingerprinted requests use the
+            // generation-aware path above.
+            completions.iter().any(|completion| {
+                completion.subject == payload.subject
+                    && completion.snapshot_id == payload.snapshot_id
+            })
+        };
+        if completed
+            || terminal_subjects.contains(&(payload.subject.clone(), payload.snapshot_id.clone()))
+        {
             continue;
         }
         pending.push(PendingToolCallSuspension {
             suspended_event_id: event.id,
             subject: payload.subject,
             snapshot_id: payload.snapshot_id,
-            request_event_id: event.provenance.source_event_ids.first().copied(),
+            request_event_id,
             approval_id: payload.approval_id,
             reason: payload.reason,
         });
@@ -871,6 +923,25 @@ mod tests {
         }))
         .unwrap();
         assert!(legacy_request.holds.is_empty());
+        assert_eq!(legacy_request.args_fingerprint, None);
+        assert!(tool_invocation_fingerprint_matches(
+            "snapshot-a",
+            None,
+            "snapshot-a",
+            Some("sha256:new"),
+        ));
+        assert!(!tool_invocation_fingerprint_matches(
+            "snapshot-a",
+            Some("sha256:old"),
+            "snapshot-a",
+            Some("sha256:new"),
+        ));
+        assert!(!tool_invocation_fingerprint_matches(
+            "snapshot-a",
+            None,
+            "snapshot-b",
+            None,
+        ));
 
         #[derive(Deserialize)]
         struct LegacyToolCallRequestedPayload {
@@ -885,6 +956,7 @@ mod tests {
             snapshot_id: legacy_request.snapshot_id.clone(),
             tool_name: legacy_request.tool_name.clone(),
             arguments: legacy_request.arguments.clone(),
+            args_fingerprint: Some(format!("sha256:{}", "a".repeat(64))),
             holds: vec![json!({
                 "key": {"kind": "kernel_thread", "task_name": "worker-a"},
                 "access": "exclusive"
@@ -911,8 +983,10 @@ mod tests {
         .unwrap();
         assert_eq!(legacy_completion.finish_order, None);
         assert_eq!(legacy_completion.cancellation, None);
+        assert_eq!(legacy_completion.args_fingerprint, None);
 
         let cancelled = serde_json::to_value(ToolCallCompletedPayload {
+            args_fingerprint: Some(format!("sha256:{}", "a".repeat(64))),
             cancellation: Some(ToolCallCancellation::CancelledExceededGrace),
             ..legacy_completion.clone()
         })
@@ -931,6 +1005,9 @@ mod tests {
 
         let completed_normally = serde_json::to_value(legacy_completion).unwrap();
         assert!(completed_normally.get("cancellation").is_none());
+        assert!(completed_normally.get("args_fingerprint").is_none());
+        let requested_normally = serde_json::to_value(legacy_request).unwrap();
+        assert!(requested_normally.get("args_fingerprint").is_none());
     }
 
     #[tokio::test]
@@ -1359,6 +1436,51 @@ mod tests {
         assert!(pending.is_empty());
     }
 
+    #[tokio::test]
+    async fn legacy_suspension_without_request_provenance_closes_on_subject_completion() {
+        let fixture = ToolDecisionFixture::new().await;
+        fixture
+            .append_control_witnessed(
+                EventKind::ToolCallSuspended,
+                serde_json::to_value(ToolCallSuspendedPayload {
+                    subject: fixture.subject.clone(),
+                    snapshot_id: fixture.snapshot_id.clone(),
+                    approval_id: Some("approval-legacy".to_string()),
+                    reason: Some("legacy suspension".to_string()),
+                })
+                .unwrap(),
+            )
+            .await;
+        fixture
+            .store
+            .append_events(
+                &EventStreamId::for_thread(&fixture.coordinates),
+                vec![NewEventRecord::witnessed(
+                    fixture.coordinates.clone(),
+                    EventKind::ToolCallCompleted,
+                    serde_json::to_value(ToolCallCompletedPayload {
+                        subject: fixture.subject.clone(),
+                        snapshot_id: fixture.snapshot_id.clone(),
+                        tool_name: "bash".to_string(),
+                        success: true,
+                        args_fingerprint: None,
+                        duration_ms: Some(1),
+                        finish_order: None,
+                        cancellation: None,
+                    })
+                    .unwrap(),
+                )],
+            )
+            .await
+            .unwrap();
+
+        let pending = list_pending_tool_call_suspensions(&fixture.store, &fixture.coordinates)
+            .await
+            .unwrap();
+
+        assert!(pending.is_empty());
+    }
+
     struct ToolDecisionFixture {
         store: InMemorySessionStore,
         coordinates: ThreadCoordinates,
@@ -1388,6 +1510,7 @@ mod tests {
                             snapshot_id: snapshot_id.clone(),
                             tool_name: "bash".to_string(),
                             arguments: json!({"cmd": "rm -rf /"}),
+                            args_fingerprint: None,
                             holds: Vec::new(),
                         })
                         .unwrap(),

--- a/crates/cooldis-kernel/src/lib.rs
+++ b/crates/cooldis-kernel/src/lib.rs
@@ -358,7 +358,8 @@ pub use agent::manifest_schema::{
     AgentManifestRuntimeDefaults, AgentManifestRuntimeOverrideKey,
     AgentManifestRuntimeOverridePolicy, AgentManifestSchema, AgentManifestSkills,
     AgentManifestTool, AgentManifestToolProtocol, AgentManifestToolSurface,
-    AgentManifestWorkspaceMode, AgentManifestWorkspaceRequirement, default_context_pipeline,
+    AgentManifestWorkspaceMode, AgentManifestWorkspaceRequirement, EffectClass,
+    default_context_pipeline,
 };
 pub use agent::tool_interceptor::{
     AllowAllToolPermissionGate, ToolExecutionInterceptor, ToolExecutionOutcome,

--- a/crates/cooldis-process/src/process/tests.rs
+++ b/crates/cooldis-process/src/process/tests.rs
@@ -302,8 +302,13 @@ async fn host_process_termination_kills_term_ignoring_process_group_members() {
 
     let child_pid = tokio::time::timeout(Duration::from_secs(2), async {
         loop {
-            if let Ok(pid) = std::fs::read_to_string(&pid_file) {
-                break pid.trim().parse::<libc::pid_t>().unwrap();
+            // The shell creates the pid file before the echo's content lands;
+            // keep polling until the content actually parses.
+            if let Some(pid) = std::fs::read_to_string(&pid_file)
+                .ok()
+                .and_then(|pid| pid.trim().parse::<libc::pid_t>().ok())
+            {
+                break pid;
             }
             tokio::task::yield_now().await;
         }

--- a/docs/agent-manifest-ontology.md
+++ b/docs/agent-manifest-ontology.md
@@ -158,6 +158,23 @@ First-party kernel tools are still operation artifacts. For example,
 `threads.spawn` grant. The manifest binds published operation records by
 artifact hash rather than copying tool implementations into itself.
 
+Every `bash_tool`, `direct_tool`, and `protocol_tool_import` row may declare an
+effect class:
+
+```toml
+effect_class = "idempotent" # pure | idempotent | at-most-once
+```
+
+The field defaults to `at-most-once`. `pure` and `idempotent` authorize a
+re-execution after an interrupted invocation; `at-most-once` instead produces
+a witnessed conservative failure. A recorded outcome is reused for every
+class only when its argument fingerprint and bound manifest snapshot match.
+Fingerprints are SHA-256 hashes of the canonical JSON tool name and arguments.
+Journal events written before fingerprints existed retain their legacy request
+event and call-id reuse behavior. Pinned protocol imports copy their declared
+class into the bind receipt; dynamic tool-universe calls remain
+`at-most-once`.
+
 Every `grants` array on `bash_tool`, `direct_tool`,
 `protocol_tool_import`, and coupling rows accepts either the existing bare
 capability string or an expiring object:


### PR DESCRIPTION
Linear: EMO-448

Tool invocations now carry a declared retry contract and a witnessed argument identity, and recovery honors both.

## What changed

- Every `bash_tool`, `direct_tool`, and `protocol_tool_import` row may declare `effect_class = "pure" | "idempotent" | "at-most-once"` (undeclared is at-most-once). The class rides the bind receipt; operation rows sharing one artifact merge to the most conservative class.
- Every tool call request witnesses a canonical SHA-256 fingerprint of (tool name, arguments), echoed on completion. Both payload fields are additive; pre-fingerprint journal events decode and keep their legacy reuse semantics.
- Recovery honors the effect class: a recorded outcome is reused only under a matching fingerprint within the same snapshot; pure and idempotent invocations interrupted before a witnessed outcome may re-execute as a new witnessed attempt; an interrupted at-most-once invocation reaches a witnessed conservative failure naming the interruption, never a silent re-execution.
- Turn reruns replay the latest witnessed assistant tool batch from the journal instead of re-decoding provider output, and fail closed if the canonical message disagrees with the witnessed request facts.

## Review

Write-capable review gate (xhigh) fixed eight findings, all architect-read. The Highs: bash effect-class attribution is now a fail-closed exact subset (any shell metacharacter, quoting, substitution, or assignment prefix defaults the command to at-most-once); controller-rewritten bash commands never inherit the original command's lax class; reruns replay witnessed batches; the cancellation sweep judges the latest request generation per subject; terminal guards are generation-exact so a legacy fingerprint-less completion cannot swallow a new witnessed outcome. One reported architecture conflict (forward tolerance of `deny_unknown_fields` for already-shipped binaries) was dispositioned as intended fail-closed behavior on the issue.

## Ride-along

The same test-only deflake commit as PR #22 (host process termination pid read); it disappears from this diff since #22 merged.

## Verification

`scripts/cargo-lane.sh test --workspace --all-targets --locked` green (942 passed in the core target); fingerprint determinism, decode-compat, and every recovery path (rerun, resume, sweep, detached retry) pinned by tests.
