### PR TITLE
EMO-493: make the product-term guard merge-aware

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,6 +22,14 @@ jobs:
       - name: Verify remote sentinel
         run: scripts/check-remote-ci.sh
 
+  script-tests:
+    name: Script tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - name: Guard-rails test suite
+        run: scripts/guard-rails-test.sh
+
   tests:
     name: Workspace tests
     runs-on: ubuntu-latest

--- a/scripts/guard-rails-test.sh
+++ b/scripts/guard-rails-test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+
+# Pins staged product-term behavior for ordinary commits and in-progress merges:
+# exact legacy output off-merge, parent-carried lines ignored during merges,
+# resolution-authored lines rejected, and the intentional override preserved.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+GUARD_SCRIPT="$SCRIPT_DIR/guard-rails.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/guard-rails-test.XXXXXX")" || exit 1
+TMP_DIR="$(cd "$TMP_DIR" && pwd -P)"
+PII_TERMS_FILE="$TMP_DIR/pii-terms"
+FAILURES=0
+REPO=
+RUN_STATUS=0
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+assert_eq() {
+  local expected=$1
+  local actual=$2
+  local name=$3
+
+  if [[ "$actual" != "$expected" ]]; then
+    fail "$name (expected '$expected', got '$actual')"
+  fi
+}
+
+assert_files_equal() {
+  local expected=$1
+  local actual=$2
+  local name=$3
+
+  if ! cmp -s "$expected" "$actual"; then
+    fail "$name"
+    printf 'expected:\n%sactual:\n%s' "$(<"$expected")" "$(<"$actual")" >&2
+  fi
+}
+
+init_repo() {
+  local name=$1
+
+  REPO="$TMP_DIR/$name"
+  mkdir -p "$REPO/scripts" "$REPO/crates/cooldis-kernel/src"
+  cp "$GUARD_SCRIPT" "$REPO/scripts/guard-rails.sh"
+  printf 'pub const runtime_value: &str = "base";\n' >"$REPO/crates/cooldis-kernel/src/lib.rs"
+  git -C "$REPO" init -q -b current
+  git -C "$REPO" config user.name 'Guard Rails Test'
+  git -C "$REPO" config user.email 'guard-rails-test@example.invalid'
+  git -C "$REPO" add .
+  git -C "$REPO" commit -qm 'base'
+}
+
+run_guard() {
+  local name=$1
+  local allow_product_terms=${2:-0}
+
+  COOLDIS_PII_TERMS="$PII_TERMS_FILE" \
+    COOLDIS_ALLOW_PRODUCT_TERMS="$allow_product_terms" \
+    "$REPO/scripts/guard-rails.sh" staged \
+    >"$TMP_DIR/$name.out" 2>"$TMP_DIR/$name.err"
+  RUN_STATUS=$?
+}
+
+: >"$PII_TERMS_FILE"
+: >"$TMP_DIR/empty"
+printf 'Cooldis guard rails passed (staged).\n' >"$TMP_DIR/passed"
+
+# A plain staged product term preserves the legacy failure bytes.
+init_repo non-merge-hit
+printf '// telegram adapter: intentional\n' \
+  >>"$REPO/crates/cooldis-kernel/src/lib.rs"
+git -C "$REPO" add crates/cooldis-kernel/src/lib.rs
+run_guard non-merge-hit
+assert_eq 1 "$RUN_STATUS" 'non-merge product term failed'
+assert_files_equal "$TMP_DIR/empty" "$TMP_DIR/non-merge-hit.out" 'non-merge failure stdout stayed empty'
+{
+  printf 'Staged runtime code appears to add product-shaped terms.\n'
+  printf 'Keep product logic out of Cooldis, or set COOLDIS_ALLOW_PRODUCT_TERMS=1 for an intentional exception.\n'
+  printf '+// telegram adapter: intentional\n'
+} >"$TMP_DIR/non-merge-hit.expected.err"
+assert_files_equal "$TMP_DIR/non-merge-hit.expected.err" "$TMP_DIR/non-merge-hit.err" \
+  'non-merge product-term diagnostics stayed byte-identical'
+run_guard non-merge-override 1
+assert_eq 0 "$RUN_STATUS" 'non-merge override passed'
+assert_files_equal "$TMP_DIR/passed" "$TMP_DIR/non-merge-override.out" 'non-merge override output matched'
+assert_files_equal "$TMP_DIR/empty" "$TMP_DIR/non-merge-override.err" 'non-merge override stderr stayed empty'
+
+# A plain staged clean change preserves the legacy success bytes.
+init_repo non-merge-clean
+printf 'pub const kernel_adapter: &str = "clean";\n' \
+  >>"$REPO/crates/cooldis-kernel/src/lib.rs"
+git -C "$REPO" add crates/cooldis-kernel/src/lib.rs
+run_guard non-merge-clean
+assert_eq 0 "$RUN_STATUS" 'non-merge clean change passed'
+assert_files_equal "$TMP_DIR/passed" "$TMP_DIR/non-merge-clean.out" 'non-merge clean output stayed byte-identical'
+assert_files_equal "$TMP_DIR/empty" "$TMP_DIR/non-merge-clean.err" 'non-merge clean stderr stayed empty'
+
+# A product term copied verbatim from a merge parent is not newly authored.
+init_repo merge-parent-only
+git -C "$REPO" switch -qc product-parent
+printf '// telegram adapter: parent\n' \
+  >>"$REPO/crates/cooldis-kernel/src/lib.rs"
+git -C "$REPO" add crates/cooldis-kernel/src/lib.rs
+git -C "$REPO" commit -qm 'product parent'
+git -C "$REPO" switch -q current
+printf 'current branch\n' >"$REPO/current.txt"
+git -C "$REPO" add current.txt
+git -C "$REPO" commit -qm 'diverge current'
+git -C "$REPO" merge -q --no-commit product-parent >/dev/null 2>&1
+run_guard merge-parent-only
+assert_eq 0 "$RUN_STATUS" 'merge carrying parent-only product term passed'
+assert_files_equal "$TMP_DIR/passed" "$TMP_DIR/merge-parent-only.out" 'parent-only merge output matched'
+assert_files_equal "$TMP_DIR/empty" "$TMP_DIR/merge-parent-only.err" 'parent-only merge stderr stayed empty'
+
+# A product term absent from both parents remains new after conflict resolution.
+init_repo merge-resolution
+git -C "$REPO" switch -qc product-parent
+printf 'pub const runtime_value: &str = "parent";\n' >"$REPO/crates/cooldis-kernel/src/lib.rs"
+git -C "$REPO" add crates/cooldis-kernel/src/lib.rs
+git -C "$REPO" commit -qm 'parent edit'
+git -C "$REPO" switch -q current
+printf 'pub const runtime_value: &str = "current";\n' >"$REPO/crates/cooldis-kernel/src/lib.rs"
+git -C "$REPO" add crates/cooldis-kernel/src/lib.rs
+git -C "$REPO" commit -qm 'current edit'
+git -C "$REPO" merge -q --no-commit product-parent >/dev/null 2>&1
+assert_eq 1 "$?" 'merge fixture produced a conflict'
+printf '// telegram adapter: resolution\n' \
+  >"$REPO/crates/cooldis-kernel/src/lib.rs"
+git -C "$REPO" add crates/cooldis-kernel/src/lib.rs
+run_guard merge-resolution
+assert_eq 1 "$RUN_STATUS" 'resolution-authored product term failed'
+assert_files_equal "$TMP_DIR/empty" "$TMP_DIR/merge-resolution.out" 'merge failure stdout stayed empty'
+{
+  printf 'Staged runtime code appears to add product-shaped terms.\n'
+  printf 'Keep product logic out of Cooldis, or set COOLDIS_ALLOW_PRODUCT_TERMS=1 for an intentional exception.\n'
+  printf '+// telegram adapter: resolution\n'
+} >"$TMP_DIR/merge-resolution.expected.err"
+assert_files_equal "$TMP_DIR/merge-resolution.expected.err" "$TMP_DIR/merge-resolution.err" \
+  'resolution-authored product-term diagnostics matched'
+run_guard merge-resolution-override 1
+assert_eq 0 "$RUN_STATUS" 'merge override passed'
+assert_files_equal "$TMP_DIR/passed" "$TMP_DIR/merge-resolution-override.out" 'merge override output matched'
+assert_files_equal "$TMP_DIR/empty" "$TMP_DIR/merge-resolution-override.err" 'merge override stderr stayed empty'
+
+if ((FAILURES > 0)); then
+  printf 'guard-rails-test: %s failure(s)\n' "$FAILURES" >&2
+  exit 1
+fi
+
+printf 'guard-rails-test: ok\n'

--- a/scripts/guard-rails-test.sh
+++ b/scripts/guard-rails-test.sh
@@ -1,19 +1,29 @@
 #!/usr/bin/env bash
 
 # Pins staged product-term behavior for ordinary commits and in-progress merges:
-# exact legacy output off-merge, parent-carried lines ignored during merges,
-# resolution-authored lines rejected, and the intentional override preserved.
+# exact legacy output off-merge, index-only reads, every merge parent considered,
+# malformed parent data failing closed, resolution-authored lines rejected, and
+# the intentional override preserved.
 
-set -u
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 GUARD_SCRIPT="$SCRIPT_DIR/guard-rails.sh"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/guard-rails-test.XXXXXX")" || exit 1
 TMP_DIR="$(cd "$TMP_DIR" && pwd -P)"
+GIT_TEMPLATE_DIR="$TMP_DIR/git-template"
 PII_TERMS_FILE="$TMP_DIR/pii-terms"
 FAILURES=0
 REPO=
 RUN_STATUS=0
+
+mkdir -p "$GIT_TEMPLATE_DIR"
+unset GIT_COMMON_DIR GIT_CONFIG_COUNT GIT_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY
+unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_WORK_TREE
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_TEMPLATE_DIR
+export LC_ALL=C
 
 cleanup() {
   rm -rf "$TMP_DIR"
@@ -57,18 +67,21 @@ init_repo() {
   git -C "$REPO" config user.name 'Guard Rails Test'
   git -C "$REPO" config user.email 'guard-rails-test@example.invalid'
   git -C "$REPO" add .
-  git -C "$REPO" commit -qm 'base'
+  git -C "$REPO" commit --no-gpg-sign -qm 'base'
 }
 
 run_guard() {
   local name=$1
   local allow_product_terms=${2:-0}
 
-  COOLDIS_PII_TERMS="$PII_TERMS_FILE" \
+  if COOLDIS_PII_TERMS="$PII_TERMS_FILE" \
     COOLDIS_ALLOW_PRODUCT_TERMS="$allow_product_terms" \
     "$REPO/scripts/guard-rails.sh" staged \
-    >"$TMP_DIR/$name.out" 2>"$TMP_DIR/$name.err"
-  RUN_STATUS=$?
+    >"$TMP_DIR/$name.out" 2>"$TMP_DIR/$name.err"; then
+    RUN_STATUS=0
+  else
+    RUN_STATUS=$?
+  fi
 }
 
 : >"$PII_TERMS_FILE"
@@ -90,6 +103,14 @@ assert_files_equal "$TMP_DIR/empty" "$TMP_DIR/non-merge-hit.out" 'non-merge fail
 } >"$TMP_DIR/non-merge-hit.expected.err"
 assert_files_equal "$TMP_DIR/non-merge-hit.expected.err" "$TMP_DIR/non-merge-hit.err" \
   'non-merge product-term diagnostics stayed byte-identical'
+
+# Only the index is guarded; a clean worktree copy must not hide a staged hit.
+printf 'pub const runtime_value: &str = "worktree clean";\n' \
+  >"$REPO/crates/cooldis-kernel/src/lib.rs"
+run_guard non-merge-index-only
+assert_eq 1 "$RUN_STATUS" 'staged product term survived a differing worktree'
+assert_files_equal "$TMP_DIR/non-merge-hit.expected.err" "$TMP_DIR/non-merge-index-only.err" \
+  'staged product-term diagnostics came from the index'
 run_guard non-merge-override 1
 assert_eq 0 "$RUN_STATUS" 'non-merge override passed'
 assert_files_equal "$TMP_DIR/passed" "$TMP_DIR/non-merge-override.out" 'non-merge override output matched'
@@ -111,29 +132,95 @@ git -C "$REPO" switch -qc product-parent
 printf '// telegram adapter: parent\n' \
   >>"$REPO/crates/cooldis-kernel/src/lib.rs"
 git -C "$REPO" add crates/cooldis-kernel/src/lib.rs
-git -C "$REPO" commit -qm 'product parent'
+git -C "$REPO" commit --no-gpg-sign -qm 'product parent'
 git -C "$REPO" switch -q current
 printf 'current branch\n' >"$REPO/current.txt"
 git -C "$REPO" add current.txt
-git -C "$REPO" commit -qm 'diverge current'
+git -C "$REPO" commit --no-gpg-sign -qm 'diverge current'
 git -C "$REPO" merge -q --no-commit product-parent >/dev/null 2>&1
 run_guard merge-parent-only
 assert_eq 0 "$RUN_STATUS" 'merge carrying parent-only product term passed'
 assert_files_equal "$TMP_DIR/passed" "$TMP_DIR/merge-parent-only.out" 'parent-only merge output matched'
 assert_files_equal "$TMP_DIR/empty" "$TMP_DIR/merge-parent-only.err" 'parent-only merge stderr stayed empty'
 
+# MERGE_HEAD is line-oriented; a missing final newline must not skip a parent.
+merge_head_path="$(git -C "$REPO" rev-parse --git-path MERGE_HEAD)"
+printf '%s' "$(git -C "$REPO" rev-parse product-parent)" >"$REPO/$merge_head_path"
+run_guard merge-parent-no-final-newline
+assert_eq 0 "$RUN_STATUS" 'merge parent without final newline was still considered'
+assert_files_equal "$TMP_DIR/passed" "$TMP_DIR/merge-parent-no-final-newline.out" \
+  'merge parent without final newline output matched'
+
+# An octopus merge must intersect against later MERGE_HEAD parents too.
+init_repo merge-octopus
+git -C "$REPO" switch -qc clean-parent
+printf 'clean parent\n' >"$REPO/clean-parent.txt"
+git -C "$REPO" add clean-parent.txt
+git -C "$REPO" commit --no-gpg-sign -qm 'clean parent'
+git -C "$REPO" switch -q current
+git -C "$REPO" switch -qc product-parent
+printf '// telegram adapter: later parent\n' \
+  >>"$REPO/crates/cooldis-kernel/src/lib.rs"
+git -C "$REPO" add crates/cooldis-kernel/src/lib.rs
+git -C "$REPO" commit --no-gpg-sign -qm 'product parent'
+git -C "$REPO" switch -q current
+printf 'current branch\n' >"$REPO/current.txt"
+git -C "$REPO" add current.txt
+git -C "$REPO" commit --no-gpg-sign -qm 'diverge current'
+git -C "$REPO" merge -q --no-commit clean-parent product-parent >/dev/null 2>&1
+run_guard merge-octopus
+assert_eq 0 "$RUN_STATUS" 'octopus merge considered every parent'
+assert_files_equal "$TMP_DIR/passed" "$TMP_DIR/merge-octopus.out" 'octopus merge output matched'
+assert_files_equal "$TMP_DIR/empty" "$TMP_DIR/merge-octopus.err" 'octopus merge stderr stayed empty'
+
+# Identical normalized content in a carried file cannot hide a newly added
+# occurrence in another guarded file.
+init_repo merge-identical-lines
+printf 'pub const second_value: &str = "base";\n' \
+  >"$REPO/crates/cooldis-kernel/src/second.rs"
+git -C "$REPO" add crates/cooldis-kernel/src/second.rs
+git -C "$REPO" commit --no-gpg-sign -qm 'second base file'
+git -C "$REPO" switch -qc product-parent
+printf '// telegram adapter: collision\n' \
+  >>"$REPO/crates/cooldis-kernel/src/lib.rs"
+git -C "$REPO" add crates/cooldis-kernel/src/lib.rs
+git -C "$REPO" commit --no-gpg-sign -qm 'product parent'
+git -C "$REPO" switch -q current
+printf 'current branch\n' >"$REPO/current.txt"
+git -C "$REPO" add current.txt
+git -C "$REPO" commit --no-gpg-sign -qm 'diverge current'
+git -C "$REPO" merge -q --no-commit product-parent >/dev/null 2>&1
+printf '// telegram adapter: collision\n' \
+  >>"$REPO/crates/cooldis-kernel/src/second.rs"
+git -C "$REPO" add crates/cooldis-kernel/src/second.rs
+run_guard merge-identical-lines
+assert_eq 1 "$RUN_STATUS" 'identical carried content did not hide a new line'
+{
+  printf 'Staged runtime code appears to add product-shaped terms.\n'
+  printf 'Keep product logic out of Cooldis, or set COOLDIS_ALLOW_PRODUCT_TERMS=1 for an intentional exception.\n'
+  printf '+// telegram adapter: collision\n'
+  printf '+// telegram adapter: collision\n'
+} >"$TMP_DIR/merge-identical-lines.expected.err"
+assert_files_equal "$TMP_DIR/merge-identical-lines.expected.err" \
+  "$TMP_DIR/merge-identical-lines.err" \
+  'identical carried content retained the merge diagnostic'
+
 # A product term absent from both parents remains new after conflict resolution.
 init_repo merge-resolution
 git -C "$REPO" switch -qc product-parent
 printf 'pub const runtime_value: &str = "parent";\n' >"$REPO/crates/cooldis-kernel/src/lib.rs"
 git -C "$REPO" add crates/cooldis-kernel/src/lib.rs
-git -C "$REPO" commit -qm 'parent edit'
+git -C "$REPO" commit --no-gpg-sign -qm 'parent edit'
 git -C "$REPO" switch -q current
 printf 'pub const runtime_value: &str = "current";\n' >"$REPO/crates/cooldis-kernel/src/lib.rs"
 git -C "$REPO" add crates/cooldis-kernel/src/lib.rs
-git -C "$REPO" commit -qm 'current edit'
-git -C "$REPO" merge -q --no-commit product-parent >/dev/null 2>&1
-assert_eq 1 "$?" 'merge fixture produced a conflict'
+git -C "$REPO" commit --no-gpg-sign -qm 'current edit'
+if git -C "$REPO" merge -q --no-commit product-parent >/dev/null 2>&1; then
+  merge_status=0
+else
+  merge_status=$?
+fi
+assert_eq 1 "$merge_status" 'merge fixture produced a conflict'
 printf '// telegram adapter: resolution\n' \
   >"$REPO/crates/cooldis-kernel/src/lib.rs"
 git -C "$REPO" add crates/cooldis-kernel/src/lib.rs
@@ -147,6 +234,25 @@ assert_files_equal "$TMP_DIR/empty" "$TMP_DIR/merge-resolution.out" 'merge failu
 } >"$TMP_DIR/merge-resolution.expected.err"
 assert_files_equal "$TMP_DIR/merge-resolution.expected.err" "$TMP_DIR/merge-resolution.err" \
   'resolution-authored product-term diagnostics matched'
+
+# Whitespace around a MERGE_HEAD object name must not turn a diff error into
+# an empty hit set and bypass a genuinely new resolution line.
+merge_head_path="$(git -C "$REPO" rev-parse --git-path MERGE_HEAD)"
+printf '%s   \n' "$(git -C "$REPO" rev-parse product-parent)" >"$REPO/$merge_head_path"
+run_guard merge-resolution-parent-whitespace
+assert_eq 1 "$RUN_STATUS" 'whitespace-suffixed merge parent did not bypass the guard'
+assert_files_equal "$TMP_DIR/merge-resolution.expected.err" \
+  "$TMP_DIR/merge-resolution-parent-whitespace.err" \
+  'whitespace-suffixed merge parent diagnostics matched'
+
+printf 'not-a-parent\n' >"$REPO/$merge_head_path"
+run_guard merge-resolution-invalid-parent
+assert_eq 1 "$RUN_STATUS" 'invalid merge parent failed closed'
+printf 'error: invalid merge parent in MERGE_HEAD\n' \
+  >"$TMP_DIR/merge-resolution-invalid-parent.expected.err"
+assert_files_equal "$TMP_DIR/merge-resolution-invalid-parent.expected.err" \
+  "$TMP_DIR/merge-resolution-invalid-parent.err" \
+  'invalid merge parent diagnostic matched'
 run_guard merge-resolution-override 1
 assert_eq 0 "$RUN_STATUS" 'merge override passed'
 assert_files_equal "$TMP_DIR/passed" "$TMP_DIR/merge-resolution-override.out" 'merge override output matched'

--- a/scripts/guard-rails.sh
+++ b/scripts/guard-rails.sh
@@ -52,12 +52,66 @@ if ((${#bad_runtime_paths[@]} > 0)); then
   exit 1
 fi
 
-if [[ "$MODE" == "staged" && "${COOLDIS_ALLOW_PRODUCT_TERMS:-0}" != "1" ]]; then
-  product_hits="$(
+product_term_hits() {
+  local base_rev="${1:-}"
+
+  if [[ -n "$base_rev" ]]; then
+    git diff --cached "$base_rev" --unified=0 -- crates/cooldis-kernel/src crates/cooldis-guest-sdk 2>/dev/null \
+      | grep -E '^\+[^+].*([^[:alnum:]_]|^)(billing|dashboard|dashboards|invite|invites|telegram|railway)([^[:alnum:]_]|$)' \
+      || true
+  else
     git diff --cached --unified=0 -- crates/cooldis-kernel/src crates/cooldis-guest-sdk 2>/dev/null \
       | grep -E '^\+[^+].*([^[:alnum:]_]|^)(billing|dashboard|dashboards|invite|invites|telegram|railway)([^[:alnum:]_]|$)' \
       || true
-  )"
+  fi
+}
+
+if [[ "$MODE" == "staged" && "${COOLDIS_ALLOW_PRODUCT_TERMS:-0}" != "1" ]]; then
+  product_hits="$(product_term_hits)"
+
+  # During a merge, only lines added relative to HEAD and every MERGE_HEAD
+  # parent are new; lines carried verbatim by any parent are already landed.
+  merge_head_path="$(git rev-parse --git-path MERGE_HEAD)"
+  if [[ -f "$merge_head_path" && -n "$product_hits" ]]; then
+    product_hit_lines=()
+    while IFS= read -r hit; do
+      [[ -n "$hit" ]] && product_hit_lines+=("$hit")
+    done <<<"$product_hits"
+
+    while IFS= read -r merge_parent; do
+      [[ -z "$merge_parent" ]] && continue
+      ((${#product_hit_lines[@]} == 0)) && break
+      parent_hits="$(product_term_hits "$merge_parent")"
+      common_product_hit_lines=()
+
+      for hit in "${product_hit_lines[@]}"; do
+        normalized_hit="${hit#+}"
+        parent_has_hit=0
+        while IFS= read -r parent_hit; do
+          if [[ -n "$parent_hit" && "${parent_hit#+}" == "$normalized_hit" ]]; then
+            parent_has_hit=1
+            break
+          fi
+        done <<<"$parent_hits"
+
+        if ((parent_has_hit)); then
+          common_product_hit_lines+=("$hit")
+        fi
+      done
+
+      if ((${#common_product_hit_lines[@]} > 0)); then
+        product_hit_lines=("${common_product_hit_lines[@]}")
+      else
+        product_hit_lines=()
+      fi
+    done <"$merge_head_path"
+
+    if ((${#product_hit_lines[@]} > 0)); then
+      product_hits="$(printf '%s\n' "${product_hit_lines[@]}")"
+    else
+      product_hits=""
+    fi
+  fi
 
   if [[ -n "$product_hits" ]]; then
     printf 'Staged runtime code appears to add product-shaped terms.\n' >&2

--- a/scripts/guard-rails.sh
+++ b/scripts/guard-rails.sh
@@ -78,9 +78,14 @@ if [[ "$MODE" == "staged" && "${COOLDIS_ALLOW_PRODUCT_TERMS:-0}" != "1" ]]; then
       [[ -n "$hit" ]] && product_hit_lines+=("$hit")
     done <<<"$product_hits"
 
-    while IFS= read -r merge_parent; do
+    while IFS= read -r merge_parent || [[ -n "$merge_parent" ]]; do
+      merge_parent="${merge_parent#"${merge_parent%%[![:space:]]*}"}"
+      merge_parent="${merge_parent%"${merge_parent##*[![:space:]]}"}"
       [[ -z "$merge_parent" ]] && continue
       ((${#product_hit_lines[@]} == 0)) && break
+      if ! git rev-parse --verify --quiet "${merge_parent}^{commit}" >/dev/null; then
+        die "invalid merge parent in MERGE_HEAD"
+      fi
       parent_hits="$(product_term_hits "$merge_parent")"
       common_product_hit_lines=()
 


### PR DESCRIPTION
The staged product-terms check in scripts/guard-rails.sh flagged every forward merge of main, because the staged diff against pre-merge HEAD re-presents all of main's own already-landed code (seen on EMO-467 with main's telegram surfaces from EMO-472). That trains reflexive use of the override flag and defeats the guard.

Semantics now: during a merge, a product-term line is flagged only if it is new relative to HEAD and every MERGE_HEAD parent. Lines carried verbatim by any parent pass; lines authored during conflict resolution are still caught. Non-merge commits are byte-identical to before. Malformed MERGE_HEAD entries fail closed.

Also adds scripts/guard-rails-test.sh (hermetic temp-repo fixtures, mutation-checked, byte-pins the legacy output) and a script-tests job in Verify so the suite runs on every PR.

Linear: EMO-493.
Verification: guard-rails-test.sh green, shellcheck clean, bash 3.2 syntax check clean, off-merge differential probes byte-identical against the previous script.