### PR TITLE
EMO-471: adapter envelope contract v0

### DIFF
--- a/crates/cooldis-io-core/src/lib.rs
+++ b/crates/cooldis-io-core/src/lib.rs
@@ -176,6 +176,65 @@ impl IoDedupeKey {
     }
 }
 
+/// The external system's own identity for one delivery of an ingress event
+/// (ADR 0007). The envelope's internal id names our receipt of the event;
+/// this names the event as the external system knows it, which is what
+/// redelivery dedupes on.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct IoDelivery {
+    /// A Telegram update id, a webhook delivery id, a queue message id, or a
+    /// scheduler occurrence ("{mandate_event_id}:{occurrence_index}").
+    pub delivery_id: String,
+    /// Redelivery attempt ordinal when the external system reports one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attempt: Option<u32>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: BTreeMap<String, String>,
+}
+
+impl IoDelivery {
+    pub fn new(delivery_id: impl Into<String>) -> Self {
+        Self {
+            delivery_id: delivery_id.into(),
+            attempt: None,
+            metadata: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_attempt(mut self, attempt: u32) -> Self {
+        self.attempt = Some(attempt);
+        self
+    }
+}
+
+/// The principal an ingress envelope acts for, stamped before admission
+/// (ADR 0007). Self-attributing sources (the clock route) stamp it at
+/// construction; protocol adapters leave it unset and the daemon stamps it
+/// during resolution from the route binding. `envelope.actor` remains
+/// external provenance and is never itself the principal.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct IoPrincipal {
+    pub tenant_id: String,
+    pub principal_id: String,
+    /// How attribution happened: "mandate:{event_id}", "route:{route_id}",
+    /// or a caller-auth scheme once boundary authentication lands.
+    pub via: String,
+}
+
+impl IoPrincipal {
+    pub fn new(
+        tenant_id: impl Into<String>,
+        principal_id: impl Into<String>,
+        via: impl Into<String>,
+    ) -> Self {
+        Self {
+            tenant_id: tenant_id.into(),
+            principal_id: principal_id.into(),
+            via: via.into(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum IngressContent {
@@ -266,6 +325,16 @@ pub struct IngressEnvelope {
     pub attachments: Vec<IoAttachment>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dedupe_key: Option<IoDedupeKey>,
+    /// External delivery identity (ADR 0007). `Option` only for wire
+    /// compatibility with pre-contract queued envelopes; the submit boundary
+    /// enforces presence via [`IngressEnvelope::require_witnessed`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delivery: Option<IoDelivery>,
+    /// Principal attribution (ADR 0007). `Option` because protocol adapters
+    /// cannot attribute; the admission boundary enforces presence via
+    /// [`IngressEnvelope::require_attributed`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub principal: Option<IoPrincipal>,
     pub received_at_ms: u64,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub metadata: BTreeMap<String, String>,
@@ -286,6 +355,8 @@ impl IngressEnvelope {
             content,
             attachments: Vec::new(),
             dedupe_key: None,
+            delivery: None,
+            principal: None,
             received_at_ms,
             metadata: BTreeMap::new(),
         }
@@ -299,6 +370,70 @@ impl IngressEnvelope {
     pub fn with_dedupe_key(mut self, dedupe_key: IoDedupeKey) -> Self {
         self.dedupe_key = Some(dedupe_key);
         self
+    }
+
+    pub fn with_delivery(mut self, delivery: IoDelivery) -> Self {
+        self.delivery = Some(delivery);
+        self
+    }
+
+    pub fn with_principal(mut self, principal: IoPrincipal) -> Self {
+        self.principal = Some(principal);
+        self
+    }
+
+    /// The dedupe identity redelivery is judged by (ADR 0007 D1): an
+    /// explicitly set `dedupe_key` wins; otherwise the key derives from
+    /// `delivery` as `IoDedupeKey::for_source(&source, &delivery.delivery_id)`.
+    /// `None` only when the envelope carries neither, which no boundary
+    /// accepts.
+    pub fn effective_dedupe_key(&self) -> Option<IoDedupeKey> {
+        self.dedupe_key.clone().or_else(|| {
+            self.delivery
+                .as_ref()
+                .map(|delivery| IoDedupeKey::for_source(&self.source, delivery.delivery_id.clone()))
+        })
+    }
+
+    /// Submit-boundary check (ADR 0007 D3): `delivery` present with a
+    /// non-empty `delivery_id`, and an effective dedupe key exists. Rejection
+    /// is `IoError::InvalidEnvelope` naming the missing attribute.
+    pub fn require_witnessed(&self) -> IoResult<()> {
+        let delivery = self
+            .delivery
+            .as_ref()
+            .ok_or_else(|| IoError::InvalidEnvelope("delivery is required".to_string()))?;
+        if delivery.delivery_id.is_empty() {
+            return Err(IoError::InvalidEnvelope(
+                "delivery.delivery_id cannot be empty".to_string(),
+            ));
+        }
+        if self.effective_dedupe_key().is_none() {
+            return Err(IoError::InvalidEnvelope(
+                "effective dedupe key is required".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Admission-boundary check (ADR 0007 D3): [`Self::require_witnessed`],
+    /// `principal` present, and `principal.tenant_id` equal to the resolved
+    /// target's `tenant_id` (cross-tenant injection guard). Called after
+    /// resolution and before the admission decision; this is the guarantee,
+    /// independent of any sink's early check.
+    pub fn require_attributed(&self, target: &ResolvedIoTarget) -> IoResult<()> {
+        self.require_witnessed()?;
+        let principal = self
+            .principal
+            .as_ref()
+            .ok_or_else(|| IoError::InvalidEnvelope("principal is required".to_string()))?;
+        if principal.tenant_id != target.address.tenant_id {
+            return Err(IoError::InvalidEnvelope(format!(
+                "principal tenant {:?} does not match resolved target tenant {:?}",
+                principal.tenant_id, target.address.tenant_id
+            )));
+        }
+        Ok(())
     }
 
     pub fn with_attachment(mut self, attachment: IoAttachment) -> Self {
@@ -534,7 +669,7 @@ impl IngressAck {
     pub fn accepted(envelope: &IngressEnvelope) -> Self {
         Self {
             envelope_id: envelope.id.clone(),
-            dedupe_key: envelope.dedupe_key.clone(),
+            dedupe_key: envelope.effective_dedupe_key(),
             accepted: true,
             reason: None,
         }
@@ -543,7 +678,7 @@ impl IngressAck {
     pub fn rejected(envelope: &IngressEnvelope, reason: impl Into<String>) -> Self {
         Self {
             envelope_id: envelope.id.clone(),
-            dedupe_key: envelope.dedupe_key.clone(),
+            dedupe_key: envelope.effective_dedupe_key(),
             accepted: false,
             reason: Some(reason.into()),
         }
@@ -870,6 +1005,10 @@ pub struct KernelIoReceipt {
     pub thread_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub turn_id: Option<String>,
+    /// Attribution of the admitted outcome (ADR 0007 D5), copied from the
+    /// validated envelope.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub principal: Option<IoPrincipal>,
 }
 
 impl KernelIoReceipt {
@@ -895,6 +1034,7 @@ impl KernelIoReceipt {
             target,
             mode: decision.mode(),
             turn_id,
+            principal: envelope.principal.clone(),
         }
     }
 }
@@ -923,6 +1063,89 @@ mod tests {
         .with_dedupe_key(IoDedupeKey::for_source(&source, "update:999"))
     }
 
+    fn attributed_envelope() -> IngressEnvelope {
+        telegram_like_envelope()
+            .with_delivery(IoDelivery::new("update:999").with_attempt(2))
+            .with_principal(IoPrincipal::new("tenant-a", "user-a", "route:main"))
+    }
+
+    fn attributed_target(tenant_id: &str) -> ResolvedIoTarget {
+        ResolvedIoTarget::new(ThreadAddress::new(tenant_id, "user-a", "session-a"))
+    }
+
+    #[test]
+    fn effective_dedupe_prefers_explicit_key_and_derives_when_absent() {
+        let explicit = attributed_envelope();
+        assert_eq!(
+            explicit
+                .effective_dedupe_key()
+                .as_ref()
+                .map(IoDedupeKey::stable_key),
+            Some("telegram.bot:main:update:999".to_string())
+        );
+
+        let mut derived = explicit;
+        derived.dedupe_key = None;
+        assert_eq!(
+            derived
+                .effective_dedupe_key()
+                .as_ref()
+                .map(IoDedupeKey::stable_key),
+            Some("telegram.bot:main:update:999".to_string())
+        );
+    }
+
+    #[test]
+    fn witnessed_validation_pins_missing_and_empty_delivery_errors() {
+        let legacy = telegram_like_envelope();
+        assert!(matches!(
+            legacy.require_witnessed(),
+            Err(IoError::InvalidEnvelope(message)) if message == "delivery is required"
+        ));
+
+        let empty = legacy.with_delivery(IoDelivery::new(""));
+        assert!(matches!(
+            empty.require_witnessed(),
+            Err(IoError::InvalidEnvelope(message))
+                if message == "delivery.delivery_id cannot be empty"
+        ));
+
+        let source = IoSource::new("external.test", "main");
+        let witnessed = IngressEnvelope::new(
+            source,
+            IoConversation::new("conversation", ConversationKind::Direct),
+            IngressContent::text("hello"),
+            1,
+        )
+        .with_delivery(IoDelivery::new("delivery-1"));
+        assert!(witnessed.require_witnessed().is_ok());
+    }
+
+    #[test]
+    fn attributed_validation_pins_absence_and_tenant_mismatch_errors() {
+        let target = attributed_target("tenant-a");
+        let unattributed = telegram_like_envelope().with_delivery(IoDelivery::new("update:999"));
+        assert!(matches!(
+            unattributed.require_attributed(&target),
+            Err(IoError::InvalidEnvelope(message)) if message == "principal is required"
+        ));
+
+        let mismatched = attributed_envelope();
+        let target = attributed_target("tenant-b");
+        assert!(matches!(
+            mismatched.require_attributed(&target),
+            Err(IoError::InvalidEnvelope(message))
+                if message
+                    == "principal tenant \"tenant-a\" does not match resolved target tenant \"tenant-b\""
+        ));
+
+        assert!(
+            attributed_envelope()
+                .require_attributed(&attributed_target("tenant-a"))
+                .is_ok()
+        );
+    }
+
     #[test]
     fn telegram_like_envelope_has_stable_dedupe_and_text_projection() {
         let envelope = telegram_like_envelope();
@@ -947,6 +1170,26 @@ mod tests {
 
         let roundtrip: IngressEnvelope = serde_json::from_value(value).unwrap();
         assert_eq!(roundtrip, envelope);
+    }
+
+    #[test]
+    fn pre_contract_and_attributed_envelope_shapes_both_round_trip() {
+        let legacy_value = serde_json::to_value(telegram_like_envelope()).unwrap();
+        assert!(legacy_value.get("delivery").is_none());
+        assert!(legacy_value.get("principal").is_none());
+        let legacy: IngressEnvelope = serde_json::from_value(legacy_value).unwrap();
+        assert_eq!(legacy.delivery, None);
+        assert_eq!(legacy.principal, None);
+
+        let attributed = attributed_envelope();
+        let value = serde_json::to_value(&attributed).unwrap();
+        assert_eq!(value["delivery"]["delivery_id"], "update:999");
+        assert_eq!(value["delivery"]["attempt"], 2);
+        assert_eq!(value["principal"]["tenant_id"], "tenant-a");
+        assert_eq!(value["principal"]["principal_id"], "user-a");
+        assert_eq!(value["principal"]["via"], "route:main");
+        let roundtrip: IngressEnvelope = serde_json::from_value(value).unwrap();
+        assert_eq!(roundtrip, attributed);
     }
 
     #[test]
@@ -1070,9 +1313,9 @@ mod tests {
 
     #[test]
     fn kernel_receipt_extracts_submission_identity_from_decision() {
-        let envelope = telegram_like_envelope();
+        let envelope = attributed_envelope();
         let target = ResolvedIoTarget::new(
-            ThreadAddress::new("local", "user", "session").with_thread_id("thread-1"),
+            ThreadAddress::new("tenant-a", "user-a", "session").with_thread_id("thread-1"),
         );
         let decision = AdmissionDecision::queue("turn-1", IoTurnInput::text("hello"));
 
@@ -1082,5 +1325,36 @@ mod tests {
         assert_eq!(receipt.mode, AdmissionMode::Queue);
         assert_eq!(receipt.thread_id.as_deref(), Some("thread-1"));
         assert_eq!(receipt.turn_id.as_deref(), Some("turn-1"));
+        assert_eq!(receipt.principal, envelope.principal);
+    }
+
+    #[test]
+    fn kernel_receipts_copy_principal_for_every_admitted_runtime_mode() {
+        let envelope = attributed_envelope();
+        let target = attributed_target("tenant-a");
+        let input = IoTurnInput::text("hello");
+        let decisions = [
+            AdmissionDecision::queue("turn-queue", input.clone()),
+            AdmissionDecision::steer("turn-steer", Some("active".to_string()), input.clone()),
+            AdmissionDecision::Interrupt {
+                reason: "replace".to_string(),
+                replacement_turn_id: Some("turn-interrupt".to_string()),
+                replacement: Some(input.clone()),
+            },
+            AdmissionDecision::Fork {
+                child_key: "child-fork".to_string(),
+                input,
+            },
+        ];
+
+        for decision in decisions {
+            let receipt = KernelIoReceipt::new(&envelope, target.clone(), &decision);
+            assert_eq!(
+                receipt.principal,
+                envelope.principal,
+                "{:?}",
+                decision.mode()
+            );
+        }
     }
 }

--- a/crates/cooldis-io-pgqrs/src/lib.rs
+++ b/crates/cooldis-io-pgqrs/src/lib.rs
@@ -137,6 +137,7 @@ fn pgqrs_store_config(dsn: &str) -> pgqrs::Config {
 #[async_trait]
 impl IngressSink for PgqrsIngressQueue {
     async fn submit(&self, envelope: IngressEnvelope) -> IoResult<IngressAck> {
+        envelope.require_witnessed()?;
         let claimed = self.try_claim_dedupe_key(&envelope)?;
         if !claimed {
             return Ok(IngressAck::rejected(&envelope, "duplicate dedupe key"));
@@ -159,9 +160,9 @@ impl PgqrsIngressQueue {
         let Some(path) = &self.sqlite_dedupe_path else {
             return Ok(true);
         };
-        let Some(dedupe_key) = &envelope.dedupe_key else {
-            return Ok(true);
-        };
+        let dedupe_key = envelope.effective_dedupe_key().ok_or_else(|| {
+            IoError::InvalidEnvelope("effective dedupe key is required".to_string())
+        })?;
         let connection = rusqlite::Connection::open(path)
             .map_err(|err| IoError::Queue(format!("open sqlite dedupe store: {err}")))?;
         connection
@@ -392,7 +393,8 @@ fn queue_error(err: PgqrsError) -> IoError {
 mod tests {
     use super::*;
     use cooldis_io_core::{
-        ConversationKind, IngressContent, IoActor, IoConversation, IoDedupeKey, IoSource,
+        ConversationKind, IngressContent, IoActor, IoConversation, IoDedupeKey, IoDelivery,
+        IoPrincipal, IoSource,
     };
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -416,6 +418,39 @@ mod tests {
         )
         .with_actor(IoActor::new("telegram:user:42"))
         .with_dedupe_key(IoDedupeKey::for_source(&source, format!("update:{text}")))
+        .with_delivery(IoDelivery::new(format!("update:{text}")))
+        .with_principal(IoPrincipal::new("tenant", "user", "route:main"))
+    }
+
+    #[tokio::test]
+    async fn sqlite_queue_rejects_unwitnessed_submit_before_mutation() {
+        let path = test_db_path("unwitnessed");
+        let queue =
+            PgqrsIngressQueue::connect(PgqrsQueueConfig::local_sqlite(&path, "cooldis-ingress"))
+                .await
+                .unwrap();
+        let source = IoSource::new("telegram.bot", "main");
+        let unwitnessed = IngressEnvelope::new(
+            source.clone(),
+            IoConversation::new("telegram:chat:123", ConversationKind::Direct),
+            IngressContent::text("missing delivery"),
+            1_777_000_000_000,
+        )
+        .with_dedupe_key(IoDedupeKey::for_source(&source, "update:missing"));
+
+        let err = queue.submit(unwitnessed).await.unwrap_err();
+        assert!(matches!(
+            err,
+            IoError::InvalidEnvelope(message) if message == "delivery is required"
+        ));
+        assert!(
+            queue
+                .lease_default("worker-1", 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        let _ = std::fs::remove_file(path);
     }
 
     #[tokio::test]
@@ -433,6 +468,14 @@ mod tests {
         assert_eq!(leased.len(), 1);
         assert_eq!(leased[0].envelope.content.text_projection(), "hello");
         assert_eq!(leased[0].attempt, 1);
+        assert_eq!(
+            leased[0].envelope.delivery,
+            Some(IoDelivery::new("update:hello"))
+        );
+        assert_eq!(
+            leased[0].envelope.principal,
+            Some(IoPrincipal::new("tenant", "user", "route:main"))
+        );
 
         queue.complete_ingress(&leased[0].message_id).await.unwrap();
         assert!(
@@ -488,7 +531,8 @@ mod tests {
             },
             1_777_000_000_000,
         )
-        .with_dedupe_key(IoDedupeKey::for_source(&source, "mandate:0"));
+        .with_dedupe_key(IoDedupeKey::for_source(&source, "mandate:0"))
+        .with_delivery(IoDelivery::new("mandate:0"));
         let duplicate = IngressEnvelope::new(
             source.clone(),
             IoConversation::new("thread:one", ConversationKind::System),
@@ -498,7 +542,8 @@ mod tests {
             },
             1_777_000_000_001,
         )
-        .with_dedupe_key(IoDedupeKey::for_source(&source, "mandate:0"));
+        .with_dedupe_key(IoDedupeKey::for_source(&source, "mandate:0"))
+        .with_delivery(IoDelivery::new("mandate:0"));
 
         assert!(queue.submit(first).await.unwrap().accepted);
         let duplicate_ack = queue.submit(duplicate).await.unwrap();

--- a/crates/cooldis-io-telegram/src/lib.rs
+++ b/crates/cooldis-io-telegram/src/lib.rs
@@ -10,7 +10,8 @@ use async_trait::async_trait;
 use cooldis_io_core::{
     ConversationKind, DeliveryReceipt, EgressAdapter, EgressEnvelope, EgressKind, IngressAck,
     IngressContent, IngressEnvelope, IngressSink, IoActor, IoAttachment, IoConversation,
-    IoDedupeKey, IoError, IoProtocolAdapter, IoProtocolCapabilities, IoResult, IoSource, IoTarget,
+    IoDedupeKey, IoDelivery, IoError, IoProtocolAdapter, IoProtocolCapabilities, IoResult,
+    IoSource, IoTarget,
 };
 use serde::{
     Deserialize, Deserializer, Serialize, Serializer, de::DeserializeOwned, ser::SerializeStruct,
@@ -190,6 +191,7 @@ impl TelegramNormalizer {
             &source,
             format!("update:{update_id}"),
         ))
+        .with_delivery(IoDelivery::new(format!("update:{update_id}")))
         .with_metadata("telegram_update_id", update_id.to_string())
         .with_metadata("telegram_update_kind", update_kind)
         .with_metadata("telegram_message_id", message.message_id.to_string())
@@ -224,6 +226,7 @@ impl TelegramNormalizer {
             &source,
             format!("update:{update_id}"),
         ))
+        .with_delivery(IoDelivery::new(format!("update:{update_id}")))
         .with_metadata("telegram_update_id", update_id.to_string())
         .with_metadata("telegram_update_kind", "message_reaction")
         .with_metadata("telegram_message_id", reaction.message_id.to_string())
@@ -1163,6 +1166,22 @@ mod tests {
             envelope.dedupe_key.as_ref().map(IoDedupeKey::stable_key),
             Some("telegram.bot:main:update:999".to_string())
         );
+        assert_eq!(
+            envelope
+                .effective_dedupe_key()
+                .as_ref()
+                .map(IoDedupeKey::stable_key),
+            Some("telegram.bot:main:update:999".to_string()),
+            "the adapter-envelope migration must preserve the literal pre-contract key"
+        );
+        assert_eq!(
+            envelope
+                .delivery
+                .as_ref()
+                .map(|delivery| delivery.delivery_id.as_str()),
+            Some("update:999")
+        );
+        assert_eq!(envelope.principal, None);
         assert_eq!(envelope.content.text_projection(), "hello telegram");
         assert_eq!(
             envelope

--- a/crates/cooldis-kernel/src/adapters/app_server/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/tests.rs
@@ -10769,7 +10769,8 @@ async fn command_exec_streaming_start_returns_running_process_id_then_poll_compl
 #[tokio::test]
 async fn process_dispatch_retry_and_duplicate_terminal_deliver_once() {
     use cooldis_io_core::{
-        ConversationKind, IngressContent, IngressEnvelope, IoConversation, IoDedupeKey, IoSource,
+        ConversationKind, IngressContent, IngressEnvelope, IoConversation, IoDedupeKey, IoDelivery,
+        IoPrincipal, IoSource,
     };
     use cooldis_runtime_contracts::{
         DispatchId, HANDLE_DISPATCH_CONTENT_KIND, HANDLE_OUTCOME_CONTENT_KIND, HandleId,
@@ -10888,7 +10889,16 @@ async fn process_dispatch_retry_and_duplicate_terminal_deliver_once() {
         },
         1,
     )
-    .with_dedupe_key(IoDedupeKey::new(HANDLE_OUTCOME_CONTENT_KIND, dispatch_id))
+    .with_dedupe_key(IoDedupeKey::new(
+        HANDLE_OUTCOME_CONTENT_KIND,
+        dispatch_id.clone(),
+    ))
+    .with_delivery(IoDelivery::new(dispatch_id.clone()))
+    .with_principal(IoPrincipal::new(
+        app.tenant_id(),
+        app.user_id(),
+        format!("handle:{dispatch_id}"),
+    ))
     .with_metadata("cooldis_route_id", HANDLE_OUTCOME_CONTENT_KIND)
     .with_metadata("cooldis_route_policy", "queue_per_conversation");
     duplicate.id = events

--- a/crates/cooldis-kernel/src/cli/daemon.rs
+++ b/crates/cooldis-kernel/src/cli/daemon.rs
@@ -296,7 +296,13 @@ pub(super) async fn route_sink_for_ingress(
             queue
         }
     };
-    Ok(Arc::new(RouteIngressSink::new(inner, route)))
+    let (tenant_id, principal_id) = bridge.route_identity();
+    Ok(Arc::new(RouteIngressSink::with_route_identity(
+        inner,
+        route,
+        tenant_id,
+        principal_id,
+    )))
 }
 
 pub(super) async fn start_clock_route(

--- a/crates/cooldis-kernel/src/daemon/clock_route.rs
+++ b/crates/cooldis-kernel/src/daemon/clock_route.rs
@@ -6,7 +6,7 @@ use crate::{
 use chrono::{DateTime, SecondsFormat, TimeZone, Utc};
 use cooldis_io_core::{
     ConversationKind, IngressContent, IngressEnvelope, IngressSink, IoConversation, IoDedupeKey,
-    IoSource,
+    IoDelivery, IoPrincipal, IoSource,
 };
 use croner::Cron;
 use std::cmp::{Ordering, Reverse};
@@ -145,10 +145,8 @@ impl ScheduledTick {
             catch_up: self.catch_up,
         };
         let source = IoSource::new(CLOCK_TICK_ROUTE_KIND, route_id);
-        let dedupe_key = IoDedupeKey::for_source(
-            &source,
-            format!("{}:{}", self.mandate_event_id, self.occurrence_index),
-        );
+        let delivery_id = format!("{}:{}", self.mandate_event_id, self.occurrence_index);
+        let dedupe_key = IoDedupeKey::for_source(&source, delivery_id.clone());
         Ok(IngressEnvelope::new(
             source,
             IoConversation::new(
@@ -162,9 +160,13 @@ impl ScheduledTick {
             now.timestamp_millis().max(0) as u64,
         )
         .with_dedupe_key(dedupe_key)
+        .with_delivery(IoDelivery::new(delivery_id))
+        .with_principal(IoPrincipal::new(
+            self.coordinates.tenant_id.clone(),
+            self.coordinates.user_id.clone(),
+            format!("mandate:{}", self.mandate_event_id),
+        ))
         .with_metadata("cooldis_route_id", route_id.to_string())
-        .with_metadata("cooldis_tenant_id", self.coordinates.tenant_id.clone())
-        .with_metadata("cooldis_user_id", self.coordinates.user_id.clone())
         .with_metadata("cooldis_session_id", self.coordinates.session_id.clone())
         .with_metadata("cooldis_thread_id", self.coordinates.thread_id.to_string())
         .with_metadata(
@@ -668,8 +670,9 @@ mod tests {
             .await
             .unwrap();
         let coordinates = coordinates();
+        let mandate_event_id = EventRecordId::from_uuid(uuid::Uuid::from_u128(1));
         let mandate = crate::NewEventRecord {
-            id: EventRecordId::new(),
+            id: mandate_event_id,
             coordinates: coordinates.clone(),
             created_at_ms: dt("2026-01-01T00:00:00Z").timestamp_millis(),
             kind: EventKind::MandateStarted,
@@ -710,6 +713,32 @@ mod tests {
         let captured = envelopes.lock().unwrap();
         assert_eq!(captured.len(), 1);
         assert_eq!(captured[0].source.protocol, CLOCK_TICK_ROUTE_KIND);
+        let delivery_id = "00000000-0000-0000-0000-000000000001:0";
+        assert_eq!(
+            captured[0]
+                .effective_dedupe_key()
+                .as_ref()
+                .map(IoDedupeKey::stable_key),
+            Some("clock.tick:clock-main:00000000-0000-0000-0000-000000000001:0".to_string()),
+            "the adapter-envelope migration must preserve the literal pre-contract key"
+        );
+        assert_eq!(
+            captured[0]
+                .delivery
+                .as_ref()
+                .map(|delivery| delivery.delivery_id.as_str()),
+            Some(delivery_id)
+        );
+        assert_eq!(
+            captured[0].principal,
+            Some(cooldis_io_core::IoPrincipal::new(
+                coordinates.tenant_id.clone(),
+                coordinates.user_id.clone(),
+                format!("mandate:{mandate_event_id}"),
+            ))
+        );
+        assert!(!captured[0].metadata.contains_key("cooldis_tenant_id"));
+        assert!(!captured[0].metadata.contains_key("cooldis_user_id"));
         assert_eq!(
             captured[0]
                 .metadata

--- a/crates/cooldis-kernel/src/daemon/daemon_io.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_io.rs
@@ -24,9 +24,9 @@ use crate::{
 use async_trait::async_trait;
 use cooldis_io_core::{
     AdmissionDecision, DeliveryReceipt, EgressAdapter, EgressEnvelope, EgressKind, IngressAck,
-    IngressContent, IngressEnvelope, IngressQueueStore, IngressSink, IngressState, IoError,
-    IoResult, IoTarget, IoTurnInput, KernelIoBridge, KernelIoReceipt, LeasedIngressEnvelope,
-    ProviderPolicy, ResolvedIoTarget, ThreadAddress,
+    IngressContent, IngressEnvelope, IngressQueueStore, IngressSink, IngressState, IoDelivery,
+    IoError, IoPrincipal, IoResult, IoTarget, IoTurnInput, KernelIoBridge, KernelIoReceipt,
+    LeasedIngressEnvelope, ProviderPolicy, ResolvedIoTarget, ThreadAddress,
 };
 use cooldis_io_telegram::{TelegramUpdate, TelegramWebhookAdapter};
 use cooldis_runtime_contracts::{
@@ -1063,6 +1063,10 @@ impl CooldisDaemonIoBridge {
         Arc::new(DirectRuntimeIngressSink::new(self.clone()))
     }
 
+    pub(crate) fn route_identity(&self) -> (&str, &str) {
+        (&self.tenant_id, &self.user_id)
+    }
+
     pub async fn register_egress_adapter(
         &self,
         protocol: impl Into<String>,
@@ -1658,6 +1662,11 @@ impl CooldisDaemonIoBridge {
             Some(target) => target,
             None => self.resolve_target(&envelope).await?,
         };
+        let attribution_error = envelope.require_attributed(&target).err().or_else(|| {
+            source_envelopes
+                .iter()
+                .find_map(|source_envelope| source_envelope.require_attributed(&target).err())
+        });
         if !ingress_message_ids.is_empty() {
             match self
                 .ingress_outcome(&target, source_envelopes, ingress_message_ids)
@@ -1694,9 +1703,12 @@ impl CooldisDaemonIoBridge {
                 .await?;
             ingress_event_ids.push(ingress_event.id);
         }
-        let decision = match decision_override {
-            Some(decision) => decision,
-            None => self.decide(&envelope, &target, &state).await?,
+        let decision = match attribution_error {
+            Some(err) => AdmissionDecision::reject(err.to_string()),
+            None => match decision_override {
+                Some(decision) => decision,
+                None => self.decide(&envelope, &target, &state).await?,
+            },
         };
         let ingress_source_stream = control_stream_id(&coordinates);
         let admission_event = self
@@ -1761,6 +1773,7 @@ impl CooldisDaemonIoBridge {
             )
             .with_thread_id(coordinates.thread_id.to_string()),
         );
+        envelope.require_attributed(&target)?;
         let decision = AdmissionDecision::ObserveOnly {
             reason: "clock tick admitted as timer.fired".to_string(),
         };
@@ -3701,7 +3714,10 @@ impl CooldisDaemonIoBridge {
         let route_id = route_id_for_ingress(envelope);
         let mut payload = serde_json::to_value(IoIngressReceivedPayload {
             route_id: Some(route_id.clone()),
-            dedupe_key: envelope.dedupe_key.as_ref().map(|key| key.stable_key()),
+            dedupe_key: envelope
+                .effective_dedupe_key()
+                .as_ref()
+                .map(|key| key.stable_key()),
             external_conversation_id: Some(envelope.conversation.external_conversation_id.clone()),
             external_actor_id: envelope
                 .actor
@@ -4995,10 +5011,17 @@ impl KernelIoBridge for CooldisDaemonIoBridge {
         target: &ResolvedIoTarget,
         decision: &AdmissionDecision,
     ) -> IoResult<KernelIoReceipt> {
-        let (receipt, _) = self
-            .apply_with_ingress_outcomes(envelope, target, decision, &[], None, &[], None, None)
-            .await?;
-        Ok(receipt)
+        let source_envelopes = [envelope.clone()];
+        self.submit_envelope_with_sources_at_target(
+            envelope.clone(),
+            &source_envelopes,
+            &[],
+            false,
+            None,
+            Some(target.clone()),
+            Some(decision.clone()),
+        )
+        .await
     }
 }
 
@@ -5016,6 +5039,7 @@ impl DirectRuntimeIngressSink {
 #[async_trait]
 impl IngressSink for DirectRuntimeIngressSink {
     async fn submit(&self, envelope: IngressEnvelope) -> IoResult<IngressAck> {
+        envelope.require_witnessed()?;
         let ack = IngressAck::accepted(&envelope);
         self.bridge.submit_envelope(envelope).await?;
         Ok(ack)
@@ -5030,6 +5054,7 @@ pub struct RouteIngressSink {
     threading: Option<String>,
     agent_ref: Option<String>,
     coalesce_bursts: Option<CooldisCoalesceBurstsConfig>,
+    principal: Option<IoPrincipal>,
 }
 
 impl RouteIngressSink {
@@ -5042,13 +5067,32 @@ impl RouteIngressSink {
             threading: route.threading.clone(),
             agent_ref: route.agent_ref.clone(),
             coalesce_bursts: route.coalesce_bursts,
+            principal: None,
         }
+    }
+
+    pub fn with_route_identity(
+        inner: Arc<dyn IngressSink>,
+        route: &CooldisIoRouteConfig,
+        tenant_id: impl Into<String>,
+        principal_id: impl Into<String>,
+    ) -> Self {
+        let mut sink = Self::new(inner, route);
+        sink.principal = Some(IoPrincipal::new(
+            tenant_id,
+            principal_id,
+            format!("route:{}", route.id),
+        ));
+        sink
     }
 }
 
 #[async_trait]
 impl IngressSink for RouteIngressSink {
     async fn submit(&self, mut envelope: IngressEnvelope) -> IoResult<IngressAck> {
+        if envelope.principal.is_none() {
+            envelope.principal = self.principal.clone();
+        }
         envelope
             .metadata
             .insert("cooldis_route_id".to_string(), self.route_id.clone());
@@ -5090,6 +5134,13 @@ impl IngressSink for RouteIngressSink {
                 "cooldis_coalesce_max_batch".to_string(),
                 coalesce.max_batch.to_string(),
             );
+        }
+        envelope.require_witnessed()?;
+        if envelope.principal.is_none() {
+            return Err(IoError::InvalidEnvelope(format!(
+                "principal is required: route {:?} has no identity binding",
+                self.route_id
+            )));
         }
         self.inner.submit(envelope).await
     }
@@ -5158,7 +5209,12 @@ impl CooldisDaemonQueueWorker {
         let mut held_until_ms: Option<u64> = None;
         let mut coalesce_groups: BTreeMap<CoalesceGroupKey, Vec<LeasedIngressEnvelope>> =
             BTreeMap::new();
-        for message in leased {
+        for mut message in leased {
+            self.prepare_leased_envelope(&mut message.envelope);
+            if message.envelope.require_witnessed().is_err() {
+                self.submit_leased_message(message).await?;
+                continue;
+            }
             match coalesce_policy_for_envelope(&message.envelope) {
                 Ok(Some(_)) => {
                     coalesce_groups
@@ -5189,6 +5245,25 @@ impl CooldisDaemonQueueWorker {
             count,
             held_until_ms,
         })
+    }
+
+    fn prepare_leased_envelope(&self, envelope: &mut IngressEnvelope) {
+        let legacy = envelope.delivery.is_none();
+        if legacy && let Some(dedupe_key) = envelope.dedupe_key.as_ref() {
+            envelope.delivery = Some(IoDelivery::new(dedupe_key.key.clone()));
+        }
+        if envelope.principal.is_none()
+            && let Some(route_id) = envelope
+                .metadata
+                .get("cooldis_route_id")
+                .filter(|route_id| !route_id.is_empty())
+        {
+            envelope.principal = Some(IoPrincipal::new(
+                self.bridge.tenant_id.clone(),
+                self.bridge.user_id.clone(),
+                format!("route:{route_id}"),
+            ));
+        }
     }
 
     async fn submit_leased_message(&self, message: LeasedIngressEnvelope) -> IoResult<()> {
@@ -6348,8 +6423,8 @@ fn ingress_ownership_keys(
 ) -> IoResult<Vec<IngressOwnershipKey>> {
     let mut keys = BTreeMap::<String, String>::new();
     for envelope in source_envelopes {
-        let Some(dedupe_key) = envelope.dedupe_key.as_ref() else {
-            // Queue envelopes without a protocol dedupe key retain the ADR
+        let Some(dedupe_key) = envelope.effective_dedupe_key() else {
+            // Queue envelopes without an effective dedupe key retain the ADR
             // 0003 envelope-id fold. There is no dedupe row to own or age.
             return Ok(Vec::new());
         };
@@ -6644,7 +6719,10 @@ fn ingress_received_control_record(
         .map_err(|err| IoError::Bridge(format!("ingress envelope codec failed: {err}")))?;
     let payload = IoIngressReceivedPayload {
         route_id: Some(route_id_for_envelope(envelope)),
-        dedupe_key: envelope.dedupe_key.as_ref().map(|key| key.stable_key()),
+        dedupe_key: envelope
+            .effective_dedupe_key()
+            .as_ref()
+            .map(|key| key.stable_key()),
         external_conversation_id: Some(envelope.conversation.external_conversation_id.clone()),
         external_actor_id: envelope
             .actor
@@ -6753,9 +6831,13 @@ fn is_clock_tick_envelope(envelope: &IngressEnvelope) -> bool {
 }
 
 fn clock_tick_coordinates(envelope: &IngressEnvelope) -> IoResult<ThreadCoordinates> {
+    let principal = envelope
+        .principal
+        .as_ref()
+        .ok_or_else(|| IoError::InvalidEnvelope("principal is required".to_string()))?;
     Ok(ThreadCoordinates {
-        tenant_id: required_metadata(envelope, "cooldis_tenant_id")?.to_string(),
-        user_id: required_metadata(envelope, "cooldis_user_id")?.to_string(),
+        tenant_id: principal.tenant_id.clone(),
+        user_id: principal.principal_id.clone(),
         session_id: required_metadata(envelope, "cooldis_session_id")?.to_string(),
         thread_id: ThreadId::parse_str(required_metadata(envelope, "cooldis_thread_id")?)
             .map_err(|err| IoError::Bridge(format!("invalid clock.tick thread id: {err}")))?,

--- a/crates/cooldis-kernel/src/daemon/daemon_io/tests.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_io/tests.rs
@@ -50,12 +50,12 @@ use crate::{
 use chrono::{DateTime, TimeZone, Utc};
 use cooldis_io_core::{
     ConversationKind, DeliveryReceipt, IngressContent, IoActor, IoConversation, IoDedupeKey,
-    IoProtocolAdapter, IoProtocolCapabilities, IoSource, IoTarget,
+    IoDelivery, IoPrincipal, IoProtocolAdapter, IoProtocolCapabilities, IoSource, IoTarget,
 };
 use cooldis_io_pgqrs::{PgqrsIngressQueue, PgqrsQueueConfig, sqlite_dsn};
 use cooldis_runtime_contracts::{
-    DispatchId, HANDLE_OUTCOME_CONTENT_KIND, HandleTerminalEnvelope, HandleTerminalOutcome,
-    RuntimeUsage,
+    DispatchId, HANDLE_OUTCOME_CONTENT_KIND, HandleId, HandleTerminalEnvelope,
+    HandleTerminalOutcome, RuntimeUsage,
 };
 use serde_json::json;
 use std::collections::{BTreeMap, HashSet, VecDeque};
@@ -335,12 +335,14 @@ impl IngressQueueStore for ScriptedIngressQueue {
 }
 
 fn test_envelope(text: &str) -> IngressEnvelope {
-    IngressEnvelope::new(
+    let mut envelope = IngressEnvelope::new(
         IoSource::new("telegram.bot", "main"),
         IoConversation::new("telegram:chat:123", ConversationKind::Direct),
         IngressContent::text(text),
         now_ms(),
-    )
+    );
+    envelope.delivery = Some(IoDelivery::new(envelope.id.clone()));
+    envelope
 }
 
 fn telegram_queue_envelope(text: &str) -> IngressEnvelope {
@@ -360,6 +362,7 @@ fn telegram_queue_envelope_with_update(text: &str, update_id: &str) -> IngressEn
         &source,
         format!("update:{update_id}"),
     ))
+    .with_delivery(IoDelivery::new(format!("update:{update_id}")))
     .with_metadata("cooldis_route_id", "main")
     .with_metadata("cooldis_route_policy", "queue_per_conversation")
     .with_metadata("telegram_message_id", "555")
@@ -381,7 +384,39 @@ fn event_envelope(kind: &str) -> IngressEnvelope {
     )
     .with_actor(IoActor::new("external:user:42"))
     .with_dedupe_key(IoDedupeKey::for_source(&source, format!("event:{kind}")))
+    .with_delivery(IoDelivery::new(format!("event:{kind}")))
     .with_metadata("external_message_id", "556")
+}
+
+fn with_bridge_principal(
+    bridge: &CooldisDaemonIoBridge,
+    envelope: IngressEnvelope,
+) -> IngressEnvelope {
+    envelope.with_principal(IoPrincipal::new(
+        bridge.tenant_id.clone(),
+        bridge.user_id.clone(),
+        "test:daemon-io",
+    ))
+}
+
+fn route_sink_for_bridge(
+    inner: Arc<dyn IngressSink>,
+    route: &CooldisIoRouteConfig,
+    bridge: &CooldisDaemonIoBridge,
+) -> RouteIngressSink {
+    RouteIngressSink::with_route_identity(
+        inner,
+        route,
+        bridge.tenant_id.clone(),
+        bridge.user_id.clone(),
+    )
+}
+
+fn capture_route_sink(
+    inner: Arc<dyn IngressSink>,
+    route: &CooldisIoRouteConfig,
+) -> RouteIngressSink {
+    RouteIngressSink::with_route_identity(inner, route, "test-tenant", "test-user")
 }
 
 fn coalesce_envelope(
@@ -574,7 +609,13 @@ async fn remote_queue_redelivery_enters_child_ingress_once() {
         IngressContent::text("deliver once"),
         now_ms(),
     )
-    .with_dedupe_key(IoDedupeKey::for_source(&source, "dispatch-redelivery"));
+    .with_dedupe_key(IoDedupeKey::for_source(&source, "dispatch-redelivery"))
+    .with_delivery(IoDelivery::new("dispatch-redelivery"))
+    .with_principal(IoPrincipal::new(
+        child_coordinates.tenant_id.clone(),
+        child_coordinates.user_id.clone(),
+        "remote:dispatch-redelivery",
+    ));
     envelope.id = "remote-ingress-redelivery".to_string();
     let mut target = ResolvedIoTarget::new(
         ThreadAddress::new(
@@ -1614,7 +1655,10 @@ async fn submit_and_wait_for_assistant_event(
     bridge: &CooldisDaemonIoBridge,
     text: &str,
 ) -> (String, String) {
-    let receipt = bridge.submit_envelope(test_envelope(text)).await.unwrap();
+    let receipt = bridge
+        .submit_envelope(with_bridge_principal(bridge, test_envelope(text)))
+        .await
+        .unwrap();
     let thread_id = receipt.thread_id.expect("receipt should include thread id");
     let expected = format!("local:{text}");
     wait_for_assistant_text(bridge, &thread_id, &expected).await;
@@ -2665,7 +2709,10 @@ async fn direct_sink_submits_ingress_to_runtime_and_emits_egress() {
 
     let ack = bridge
         .direct_sink()
-        .submit(test_envelope("hello direct"))
+        .submit(with_bridge_principal(
+            &bridge,
+            test_envelope("hello direct"),
+        ))
         .await
         .unwrap();
 
@@ -2708,7 +2755,7 @@ async fn route_agent_ref_binds_manifest_prompt_metadata_and_receipts() {
     let bridge = CooldisDaemonIoBridge::from_app_server(&server);
     let mut route = route_with_egress(Vec::new(), None);
     route.agent_ref = Some("agent://daemon-route-runner@latest".to_string());
-    let sink = RouteIngressSink::new(bridge.direct_sink(), &route);
+    let sink = route_sink_for_bridge(bridge.direct_sink(), &route, &bridge);
 
     sink.submit(test_envelope("hello route")).await.unwrap();
 
@@ -2788,7 +2835,7 @@ async fn route_agent_identity_survives_true_runtime_restart() {
     .await;
     let first_bridge = CooldisDaemonIoBridge::from_app_server(&first_server);
     register_route_state(&first_bridge, &route, &db).await;
-    RouteIngressSink::new(first_bridge.direct_sink(), &route)
+    route_sink_for_bridge(first_bridge.direct_sink(), &route, &first_bridge)
         .submit(test_envelope("before restart"))
         .await
         .unwrap();
@@ -2813,7 +2860,7 @@ async fn route_agent_identity_survives_true_runtime_restart() {
         Err(CooldisError::ThreadNotFound(_))
     ));
 
-    RouteIngressSink::new(restarted.direct_sink(), &route)
+    route_sink_for_bridge(restarted.direct_sink(), &route, &restarted)
         .submit(test_envelope("after restart"))
         .await
         .unwrap();
@@ -2869,7 +2916,7 @@ async fn fork_child_identity_survives_true_runtime_restart() {
     .await;
     let first_bridge = CooldisDaemonIoBridge::from_app_server(&first_server);
     register_route_state(&first_bridge, &route, &db).await;
-    RouteIngressSink::new(first_bridge.direct_sink(), &route)
+    route_sink_for_bridge(first_bridge.direct_sink(), &route, &first_bridge)
         .submit(test_envelope("before fork restart"))
         .await
         .unwrap();
@@ -2896,7 +2943,7 @@ async fn fork_child_identity_survives_true_runtime_restart() {
     .await;
     let restarted = CooldisDaemonIoBridge::from_app_server(&restarted_server);
     register_route_state(&restarted, &route, &db).await;
-    RouteIngressSink::new(restarted.direct_sink(), &route)
+    route_sink_for_bridge(restarted.direct_sink(), &route, &restarted)
         .submit(test_envelope("after fork restart"))
         .await
         .unwrap();
@@ -2976,7 +3023,7 @@ async fn route_without_agent_ref_stays_unbound() {
     .await;
     let bridge = CooldisDaemonIoBridge::from_app_server(&server);
     let route = route_with_egress(Vec::new(), None);
-    let sink = RouteIngressSink::new(bridge.direct_sink(), &route);
+    let sink = route_sink_for_bridge(bridge.direct_sink(), &route, &bridge);
 
     sink.submit(test_envelope("hello unbound")).await.unwrap();
 
@@ -3082,7 +3129,7 @@ async fn fork_on_new_dm_child_inherits_route_agent_binding() {
     let mut route = route_with_egress(Vec::new(), None);
     route.policy = Some("fork_on_new_dm".to_string());
     route.agent_ref = Some("agent://daemon-route-runner@latest".to_string());
-    let sink = RouteIngressSink::new(bridge.direct_sink(), &route);
+    let sink = route_sink_for_bridge(bridge.direct_sink(), &route, &bridge);
 
     sink.submit(test_envelope("fork route")).await.unwrap();
 
@@ -3165,7 +3212,10 @@ async fn racing_fork_applies_create_one_child_behind_one_parent_claim() {
     let egress_db = fixture_root.join("io.sqlite");
     register_route_state(&bridge, &route_with_egress(Vec::new(), None), &egress_db).await;
     bridge
-        .submit_envelope(test_envelope("seed the shared fork parent"))
+        .submit_envelope(with_bridge_principal(
+            &bridge,
+            test_envelope("seed the shared fork parent"),
+        ))
         .await
         .unwrap();
     let parent_coordinates = only_thread_coordinates(&bridge).await;
@@ -3177,8 +3227,11 @@ async fn racing_fork_applies_create_one_child_behind_one_parent_claim() {
         &egress_db,
     )
     .await;
-    let envelope = telegram_queue_envelope("fork once under contention")
-        .with_metadata("cooldis_route_policy", "fork_on_new_dm");
+    let envelope = with_bridge_principal(
+        &bridge,
+        telegram_queue_envelope("fork once under contention")
+            .with_metadata("cooldis_route_policy", "fork_on_new_dm"),
+    );
 
     let (first, second) = tokio::join!(
         bridge.submit_queued_envelope(envelope.clone(), 1),
@@ -3387,7 +3440,10 @@ async fn coalesced_fork_first_attempt_loser_runs_no_recovery_effects() {
     let egress_db = fixture_root.join("io.sqlite");
     register_route_state(&bridge, &route_with_egress(Vec::new(), None), &egress_db).await;
     bridge
-        .submit_envelope(test_envelope("seed the coalesced fork parent"))
+        .submit_envelope(with_bridge_principal(
+            &bridge,
+            test_envelope("seed the coalesced fork parent"),
+        ))
         .await
         .unwrap();
     let parent_coordinates = only_thread_coordinates(&bridge).await;
@@ -3398,8 +3454,11 @@ async fn coalesced_fork_first_attempt_loser_runs_no_recovery_effects() {
         &egress_db,
     )
     .await;
-    let envelope = telegram_queue_envelope("coalesced fork contention")
-        .with_metadata("cooldis_route_policy", "fork_on_new_dm");
+    let envelope = with_bridge_principal(
+        &bridge,
+        telegram_queue_envelope("coalesced fork contention")
+            .with_metadata("cooldis_route_policy", "fork_on_new_dm"),
+    );
     bridge
         .pause_after_ingress_claim
         .store(true, Ordering::SeqCst);
@@ -3688,9 +3747,9 @@ async fn settled_legacy_fork_claim_does_not_poison_new_scope_envelopes() {
     let session_store_path = server.session_store_path().to_path_buf();
     register_route_state(&bridge, &route_with_egress(Vec::new(), None), &egress_db).await;
     bridge
-        .submit_envelope(telegram_queue_envelope_with_update(
-            "seed legacy claim scope",
-            "6100",
+        .submit_envelope(with_bridge_principal(
+            &bridge,
+            telegram_queue_envelope_with_update("seed legacy claim scope", "6100"),
         ))
         .await
         .unwrap();
@@ -3744,9 +3803,9 @@ async fn unsettled_legacy_fork_claim_errors_only_its_own_envelope() {
     let session_store_path = server.session_store_path().to_path_buf();
     register_route_state(&bridge, &route_with_egress(Vec::new(), None), &egress_db).await;
     bridge
-        .submit_envelope(telegram_queue_envelope_with_update(
-            "seed unsettled legacy scope",
-            "6200",
+        .submit_envelope(with_bridge_principal(
+            &bridge,
+            telegram_queue_envelope_with_update("seed unsettled legacy scope", "6200"),
         ))
         .await
         .unwrap();
@@ -4267,7 +4326,7 @@ async fn interrupt_cancel_wait_does_not_hold_active_turn_state_lock() {
     let fixture_root = test_root("interrupt-active-turn-lock");
     let (bridge, runtime) = bridge_with_unresponsive_runtime(&fixture_root).await;
     bridge
-        .submit_envelope(test_envelope("active turn"))
+        .submit_envelope(with_bridge_principal(&bridge, test_envelope("active turn")))
         .await
         .unwrap();
     runtime.running.notified().await;
@@ -4278,10 +4337,11 @@ async fn interrupt_cancel_wait_does_not_hold_active_turn_state_lock() {
     let interrupt_bridge = bridge.clone();
     let interrupt = tokio::spawn(async move {
         interrupt_bridge
-            .submit_envelope(
+            .submit_envelope(with_bridge_principal(
+                &interrupt_bridge,
                 test_envelope("replacement")
                     .with_metadata("cooldis_route_policy", "interrupt_on_new_dm"),
-            )
+            ))
             .await
     });
 
@@ -4357,7 +4417,10 @@ fn ingress_outcome_fold_rejects_conflicting_claims() {
 async fn lone_effect_free_claims_fail_closed_during_recovery() {
     let root = test_root("effect-free-claim-corruption");
     let (server, bridge, _rx) = test_bridge_at_root(&root).await;
-    let envelope = observe_only_envelope("seed effect-free recovery target");
+    let envelope = with_bridge_principal(
+        &bridge,
+        observe_only_envelope("seed effect-free recovery target"),
+    );
     bridge.submit_envelope(envelope.clone()).await.unwrap();
     let target = bridge.resolve_target(&envelope).await.unwrap();
     let coordinates = only_thread_coordinates(&bridge).await;
@@ -4415,7 +4478,10 @@ async fn non_fork_claim_owner_survives_fork_rebind_before_redelivery() {
     let session_store_path = server.session_store_path().to_path_buf();
     register_route_state(&bridge, &route_with_egress(Vec::new(), None), &egress_db).await;
     bridge
-        .submit_envelope(test_envelope("seed the owning parent"))
+        .submit_envelope(with_bridge_principal(
+            &bridge,
+            test_envelope("seed the owning parent"),
+        ))
         .await
         .unwrap();
     let parent = only_thread_coordinates(&bridge).await;
@@ -4467,8 +4533,11 @@ async fn non_fork_claim_owner_survives_fork_rebind_before_redelivery() {
 
     let (_server, restarted, _rx) = restarted_bridge_at_root(&fixture_root).await;
     register_route_state(&restarted, &route_with_egress(Vec::new(), None), &egress_db).await;
-    let fork = telegram_queue_envelope_with_update("rebind to a child", "40102")
-        .with_metadata("cooldis_route_policy", "fork_on_new_dm");
+    let fork = with_bridge_principal(
+        &restarted,
+        telegram_queue_envelope_with_update("rebind to a child", "40102")
+            .with_metadata("cooldis_route_policy", "fork_on_new_dm"),
+    );
     restarted.submit_queued_envelope(fork, 1).await.unwrap();
     let child = only_thread_coordinates(&restarted).await;
     assert_ne!(child.thread_id, parent.thread_id);
@@ -4518,7 +4587,10 @@ async fn ownership_tombstone_is_superseded_after_rebind_before_any_claim() {
     let session_store_path = server.session_store_path().to_path_buf();
     register_route_state(&bridge, &route_with_egress(Vec::new(), None), &egress_db).await;
     bridge
-        .submit_envelope(test_envelope("seed the tombstone parent"))
+        .submit_envelope(with_bridge_principal(
+            &bridge,
+            test_envelope("seed the tombstone parent"),
+        ))
         .await
         .unwrap();
     let parent = only_thread_coordinates(&bridge).await;
@@ -4577,8 +4649,11 @@ async fn ownership_tombstone_is_superseded_after_rebind_before_any_claim() {
 
     let (_server, restarted, _rx) = restarted_bridge_at_root(&fixture_root).await;
     register_route_state(&restarted, &route_with_egress(Vec::new(), None), &egress_db).await;
-    let fork = telegram_queue_envelope_with_update("move past the tombstone", "40104")
-        .with_metadata("cooldis_route_policy", "fork_on_new_dm");
+    let fork = with_bridge_principal(
+        &restarted,
+        telegram_queue_envelope_with_update("move past the tombstone", "40104")
+            .with_metadata("cooldis_route_policy", "fork_on_new_dm"),
+    );
     restarted.submit_queued_envelope(fork, 1).await.unwrap();
     let child = only_thread_coordinates(&restarted).await;
     assert_ne!(child.thread_id, parent.thread_id);
@@ -5218,6 +5293,268 @@ async fn observe_settled_before_complete_redelivery_appends_nothing() {
     let _ = std::fs::remove_dir_all(fixture_root);
 }
 
+#[tokio::test]
+async fn direct_and_route_sinks_reject_unwitnessed_envelopes_synchronously() {
+    let (bridge, _rx, _) = test_bridge().await;
+
+    let direct = DirectRuntimeIngressSink::new(bridge.clone());
+    let err = direct
+        .submit(IngressEnvelope::new(
+            IoSource::new("external.test", "direct"),
+            IoConversation::new("conversation", ConversationKind::Direct),
+            IngressContent::text("missing delivery"),
+            now_ms(),
+        ))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        IoError::InvalidEnvelope(message) if message == "delivery is required"
+    ));
+
+    let route = route_with_egress(Vec::new(), None);
+    let routed = RouteIngressSink::with_route_identity(
+        Arc::new(CaptureSink {
+            envelopes: Arc::new(TokioMutex::new(Vec::new())),
+        }),
+        &route,
+        bridge.tenant_id.clone(),
+        bridge.user_id.clone(),
+    );
+    let err = routed
+        .submit(IngressEnvelope::new(
+            IoSource::new("external.test", "main"),
+            IoConversation::new("conversation", ConversationKind::Direct),
+            IngressContent::text("missing delivery"),
+            now_ms(),
+        ))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        IoError::InvalidEnvelope(message) if message == "delivery is required"
+    ));
+}
+
+#[tokio::test]
+async fn route_sink_without_identity_binding_fails_closed() {
+    let captured = Arc::new(TokioMutex::new(Vec::new()));
+    let route = route_with_egress(Vec::new(), None);
+    let sink = RouteIngressSink::new(
+        Arc::new(CaptureSink {
+            envelopes: captured.clone(),
+        }),
+        &route,
+    );
+
+    let err = sink
+        .submit(telegram_queue_envelope("unbound route"))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        IoError::InvalidEnvelope(message)
+            if message == "principal is required: route \"main\" has no identity binding"
+    ));
+    assert!(captured.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn unattributed_queued_ingress_is_witnessed_rejected_and_completed() {
+    let fixture_root = test_root("queue-unattributed-reject");
+    let (server, bridge, _rx) = test_bridge_at_root(&fixture_root).await;
+    let session_store_path = server.session_store_path().to_path_buf();
+    let mut envelope = telegram_queue_envelope_with_update("unattributed", "4701");
+    envelope.metadata.remove("cooldis_route_id");
+    let ingress_id = envelope.id.clone();
+    let queue = Arc::new(ScriptedIngressQueue::new(
+        "message-unattributed",
+        envelope,
+        std::iter::empty::<&str>(),
+    ));
+    let worker =
+        CooldisDaemonQueueWorker::new(queue.clone(), bridge.clone(), "worker-unattributed", 30);
+
+    assert_eq!(worker.drain_once().await.unwrap(), 1);
+    assert!(queue.completed().await);
+    assert_eq!(queue.retry_calls().await, 0);
+
+    let coordinates = only_thread_coordinates(&bridge).await;
+    let control = control_events_for(&session_store_path, &coordinates).await;
+    let admission = control
+        .iter()
+        .find(|event| event.kind == EventKind::AdmissionDecided)
+        .unwrap();
+    assert_eq!(admission.payload["decision"], "reject");
+    let claim = control
+        .iter()
+        .find(|event| event.kind == EventKind::IoIngressClaimed)
+        .unwrap();
+    assert_eq!(claim.payload["intent"]["outcome"], "reject");
+    assert!(claim.payload.to_string().contains("principal is required"));
+    assert!(control.iter().any(|event| {
+        event.kind == EventKind::IoIngressSettled
+            && event.payload["ingress_envelope_ids"]
+                .as_array()
+                .is_some_and(|ids| ids.iter().any(|id| id == &ingress_id))
+    }));
+    let _ = std::fs::remove_dir_all(fixture_root);
+}
+
+#[tokio::test]
+async fn principal_tenant_mismatch_is_witnessed_rejected_and_completed() {
+    let fixture_root = test_root("queue-tenant-mismatch-reject");
+    let (server, bridge, _rx) = test_bridge_at_root(&fixture_root).await;
+    let session_store_path = server.session_store_path().to_path_buf();
+    let envelope = telegram_queue_envelope_with_update("mismatch", "4702").with_principal(
+        IoPrincipal::new("other-tenant", bridge.user_id.clone(), "route:main"),
+    );
+    let queue = Arc::new(ScriptedIngressQueue::new(
+        "message-mismatch",
+        envelope,
+        std::iter::empty::<&str>(),
+    ));
+    let worker =
+        CooldisDaemonQueueWorker::new(queue.clone(), bridge.clone(), "worker-mismatch", 30);
+
+    assert_eq!(worker.drain_once().await.unwrap(), 1);
+    assert!(queue.completed().await);
+    assert_eq!(queue.retry_calls().await, 0);
+
+    let coordinates = only_thread_coordinates(&bridge).await;
+    let control = control_events_for(&session_store_path, &coordinates).await;
+    let claim = control
+        .iter()
+        .find(|event| event.kind == EventKind::IoIngressClaimed)
+        .unwrap();
+    assert_eq!(claim.payload["intent"]["outcome"], "reject");
+    assert!(
+        claim
+            .payload
+            .to_string()
+            .contains("does not match resolved target tenant")
+    );
+    assert!(
+        control
+            .iter()
+            .any(|event| event.kind == EventKind::IoIngressSettled)
+    );
+    let _ = std::fs::remove_dir_all(fixture_root);
+}
+
+#[tokio::test]
+async fn legacy_leased_delivery_derivation_is_stable_across_lost_ack_redelivery() {
+    let fixture_root = test_root("queue-legacy-delivery-redelivery");
+    let (server, bridge, _rx) = test_bridge_at_root(&fixture_root).await;
+    let session_store_path = server.session_store_path().to_path_buf();
+    let mut envelope = with_bridge_principal(
+        &bridge,
+        telegram_queue_envelope_with_update("legacy", "4703"),
+    );
+    envelope.delivery = None;
+    let ingress_id = envelope.id.clone();
+    let queue = Arc::new(ScriptedIngressQueue::new(
+        "message-legacy",
+        envelope,
+        ["lost queue completion acknowledgement"],
+    ));
+    let worker = CooldisDaemonQueueWorker::new(queue.clone(), bridge.clone(), "worker-legacy", 0);
+
+    let first = worker.drain_once().await.unwrap_err();
+    assert!(
+        first
+            .to_string()
+            .contains("lost queue completion acknowledgement")
+    );
+    assert_eq!(worker.drain_once().await.unwrap(), 1);
+    assert!(queue.completed().await);
+    assert_eq!(queue.retry_calls().await, 0);
+
+    let coordinates = only_thread_coordinates(&bridge).await;
+    let control = control_events_for(&session_store_path, &coordinates).await;
+    assert_eq!(
+        control
+            .iter()
+            .filter(|event| event.kind == EventKind::IoIngressReceived)
+            .count(),
+        1
+    );
+    assert!(matches!(
+        ingress_outcome_fold(&control, &[ingress_id]).unwrap(),
+        IngressOutcomeState::Settled { .. }
+    ));
+    let received = control
+        .iter()
+        .find(|event| event.kind == EventKind::IoIngressReceived)
+        .unwrap();
+    assert_eq!(
+        received.payload["dedupe_key"],
+        "telegram.bot:main:update:4703"
+    );
+    let _ = std::fs::remove_dir_all(fixture_root);
+}
+
+#[tokio::test]
+async fn unresolved_handle_target_remains_retryable_and_is_not_witnessed_rejected() {
+    let fixture_root = test_root("queue-resolver-retry");
+    let (server, bridge, _rx) = test_bridge_at_root(&fixture_root).await;
+    let dispatch_id = DispatchId::new("missing-handle-binding");
+    let source = IoSource::new("cooldis.handle", "thread");
+    let envelope = IngressEnvelope::new(
+        source,
+        IoConversation::new("thread:missing", ConversationKind::System),
+        IngressContent::Event {
+            kind: HANDLE_OUTCOME_CONTENT_KIND.to_string(),
+            payload: serde_json::to_value(HandleTerminalEnvelope {
+                dispatch_id: dispatch_id.clone(),
+                handle: HandleId::thread(ThreadId::new()),
+                outcome: HandleTerminalOutcome::Completed,
+                outcome_reason: None,
+                result: None,
+                result_schema_id: None,
+                artifact_refs: Vec::new(),
+                usage: None,
+                retryable: false,
+            })
+            .unwrap(),
+        },
+        now_ms(),
+    )
+    .with_dedupe_key(IoDedupeKey::new(
+        HANDLE_OUTCOME_CONTENT_KIND,
+        dispatch_id.to_string(),
+    ))
+    .with_delivery(IoDelivery::new(dispatch_id.to_string()))
+    .with_principal(IoPrincipal::new(
+        bridge.tenant_id.clone(),
+        bridge.user_id.clone(),
+        format!("handle:{dispatch_id}"),
+    ));
+    let queue = Arc::new(ScriptedIngressQueue::new(
+        "message-resolver-retry",
+        envelope,
+        std::iter::empty::<&str>(),
+    ));
+    let worker = CooldisDaemonQueueWorker::new(queue.clone(), bridge, "worker-resolver-retry", 30);
+
+    let err = worker.drain_once().await.unwrap_err();
+    assert!(err.to_string().contains("has no durable spawn binding"));
+    assert_eq!(queue.retry_calls().await, 1);
+    assert!(!queue.completed().await);
+    let store = SqliteSessionStore::open(server.session_store_path())
+        .await
+        .unwrap();
+    assert!(
+        store
+            .list_control_stream_coordinates()
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    let _ = std::fs::remove_dir_all(fixture_root);
+}
+
 #[tokio::test(start_paused = true)]
 async fn reject_settled_before_complete_redelivery_dedupes_and_completes() {
     let fixture_root = test_root("reject-apply-complete-crash-cut");
@@ -5347,7 +5684,10 @@ async fn queue_worker_processes_sqlite_backed_envelope() {
             .await
             .unwrap(),
     );
-    queue.submit(test_envelope("hello queue")).await.unwrap();
+    queue
+        .submit(with_bridge_principal(&bridge, test_envelope("hello queue")))
+        .await
+        .unwrap();
 
     let worker = CooldisDaemonQueueWorker::new(queue, bridge, "worker-test", 30);
     assert_eq!(worker.drain_once().await.unwrap(), 1);
@@ -5375,7 +5715,7 @@ async fn content_policy_observe_only_event_does_not_start_turn() {
         "external.event".to_string(),
         "observe_only".to_string(),
     )]));
-    let sink = RouteIngressSink::new(bridge.direct_sink(), &route);
+    let sink = route_sink_for_bridge(bridge.direct_sink(), &route, &bridge);
 
     let ack = sink.submit(event_envelope("external.event")).await.unwrap();
 
@@ -5414,7 +5754,7 @@ async fn content_policy_queue_starts_turn_with_event_payload() {
         "external.event".to_string(),
         "queue_per_conversation".to_string(),
     )]));
-    let sink = RouteIngressSink::new(bridge.direct_sink(), &route);
+    let sink = route_sink_for_bridge(bridge.direct_sink(), &route, &bridge);
 
     let ack = sink.submit(event_envelope("external.event")).await.unwrap();
 
@@ -5443,7 +5783,7 @@ async fn content_policy_no_match_uses_route_default_for_event() {
         "other.event".to_string(),
         "observe_only".to_string(),
     )]));
-    let sink = RouteIngressSink::new(capture, &route);
+    let sink = capture_route_sink(capture, &route);
 
     sink.submit(event_envelope("external.event")).await.unwrap();
 
@@ -5469,7 +5809,7 @@ async fn content_policy_ignores_spoofed_kind_on_plain_message() {
         "external.event".to_string(),
         "observe_only".to_string(),
     )]));
-    let sink = RouteIngressSink::new(capture, &route);
+    let sink = capture_route_sink(capture, &route);
 
     sink.submit(
         telegram_queue_envelope("ordinary text mentioning external.event")
@@ -5504,7 +5844,7 @@ async fn content_policy_observe_only_bypasses_route_coalesce_metadata() {
         window_ms: 60_000,
         max_batch: 8,
     });
-    let sink = RouteIngressSink::new(capture, &route);
+    let sink = capture_route_sink(capture, &route);
 
     sink.submit(event_envelope("external.event")).await.unwrap();
 
@@ -5545,7 +5885,7 @@ async fn content_policy_coalesce_stamps_metadata_for_matching_event() {
         window_ms: 60_000,
         max_batch: 8,
     });
-    let sink = RouteIngressSink::new(capture, &route);
+    let sink = capture_route_sink(capture, &route);
 
     sink.submit(event_envelope("external.event")).await.unwrap();
 
@@ -5589,7 +5929,7 @@ async fn content_policy_reject_rejects_matching_event() {
         "external.event".to_string(),
         "reject".to_string(),
     )]));
-    let sink = RouteIngressSink::new(bridge.direct_sink(), &route);
+    let sink = route_sink_for_bridge(bridge.direct_sink(), &route, &bridge);
 
     let err = sink
         .submit(event_envelope("external.event"))
@@ -5620,7 +5960,7 @@ async fn content_policy_observe_only_bypasses_route_coalesce_in_queued_lane() {
             .await
             .unwrap(),
     );
-    let sink = RouteIngressSink::new(queue.clone(), &route);
+    let sink = route_sink_for_bridge(queue.clone(), &route, &bridge);
 
     let ack = sink.submit(event_envelope("external.event")).await.unwrap();
 
@@ -6013,7 +6353,10 @@ async fn queue_worker_recovers_held_coalesce_batch_after_restart() {
 async fn coalesce_composes_with_steer_when_active_as_one_merged_turn() {
     let (bridge, _rx, session_store_path) = test_bridge().await;
     let active = bridge
-        .submit_envelope(telegram_queue_envelope_with_update("active", "4000"))
+        .submit_envelope(with_bridge_principal(
+            &bridge,
+            telegram_queue_envelope_with_update("active", "4000"),
+        ))
         .await
         .unwrap();
     let thread_id = active.thread_id.as_deref().unwrap();
@@ -6131,7 +6474,10 @@ async fn active_steer_settles_on_persisted_input_evidence() {
     register_route_state(&bridge, &route_with_egress(Vec::new(), None), &egress_db).await;
 
     bridge
-        .submit_envelope(telegram_queue_envelope("active turn"))
+        .submit_envelope(with_bridge_principal(
+            &bridge,
+            telegram_queue_envelope("active turn"),
+        ))
         .await
         .unwrap();
     client.wait_for_requests(1).await;
@@ -6188,7 +6534,10 @@ async fn idle_rejected_steer_persists_input_and_settles_on_it() {
     register_route_state(&bridge, &route_with_egress(Vec::new(), None), &egress_db).await;
 
     bridge
-        .submit_envelope(telegram_queue_envelope("finished turn"))
+        .submit_envelope(with_bridge_principal(
+            &bridge,
+            telegram_queue_envelope("finished turn"),
+        ))
         .await
         .unwrap();
     let coordinates = only_thread_coordinates(&bridge).await;
@@ -6270,10 +6619,11 @@ async fn idle_rejected_steer_persists_input_and_settles_on_it() {
 async fn fork_on_new_dm_invokes_thread_fork_and_witnesses_spawn_lineage() {
     let (bridge, _rx, session_store_path) = test_bridge().await;
     let receipt = bridge
-        .submit_envelope(
+        .submit_envelope(with_bridge_principal(
+            &bridge,
             telegram_queue_envelope_with_update("fork me", "5001")
                 .with_metadata("cooldis_route_policy", "fork_on_new_dm"),
-        )
+        ))
         .await
         .unwrap();
     assert!(receipt.thread_id.is_some());
@@ -6892,7 +7242,7 @@ async fn configured_route_rejects_ingress_until_durable_state_is_seeded() {
         .register_egress_route_config(&source.protocol, &source.instance_id, &route)
         .await
         .unwrap();
-    let envelope = test_envelope("during startup");
+    let envelope = with_bridge_principal(&bridge, test_envelope("during startup"));
     let target = bridge.resolve_target(&envelope).await.unwrap();
     let existing = start_thread_for_target(&bridge, &target).await;
     let state = DaemonEgressState::connect(sqlite_dsn(&db)).unwrap();
@@ -6997,7 +7347,7 @@ async fn reserved_root_start_failure_retries_the_same_durable_binding() {
     let db = root.join("io.sqlite");
     let route = route_with_egress(Vec::new(), None);
     let (bridge, failure_probe) = bridge_with_runtime_build_failure(&root).await;
-    let envelope = test_envelope("fresh thread");
+    let envelope = with_bridge_principal(&bridge, test_envelope("fresh thread"));
     let target = bridge.resolve_target(&envelope).await.unwrap();
     let stale_coordinates = ThreadCoordinates {
         tenant_id: target.address.tenant_id.clone(),
@@ -7063,7 +7413,7 @@ async fn seeded_binding_unloaded_before_ingress_is_reloaded() {
     let db = root.join("io.sqlite");
     let route = route_with_egress(Vec::new(), None);
     let (_server, bridge, _rx) = test_bridge_at_root(&root).await;
-    let envelope = test_envelope("fresh thread");
+    let envelope = with_bridge_principal(&bridge, test_envelope("fresh thread"));
     let target = bridge.resolve_target(&envelope).await.unwrap();
     let stale_coordinates = start_thread_for_target(&bridge, &target).await;
     let state = DaemonEgressState::connect(sqlite_dsn(&db)).unwrap();
@@ -7481,7 +7831,7 @@ async fn duplicate_ingress_bindings_seed_the_latest_thread() {
     let db = root.join("io.sqlite");
     let route = route_with_egress(Vec::new(), None);
     let (_server, bridge, _rx) = test_bridge_at_root(&root).await;
-    let envelope = test_envelope("latest thread");
+    let envelope = with_bridge_principal(&bridge, test_envelope("latest thread"));
     let target = bridge.resolve_target(&envelope).await.unwrap();
     let older = start_thread_for_target(&bridge, &target).await;
     let latest = start_thread_for_target(&bridge, &target).await;
@@ -7691,7 +8041,10 @@ async fn egress_projector_delivers_requested_platform_action_after_bridge_restar
     let (server, bridge, mut first_rx) = test_bridge_at_root(&root).await;
     register_route_state(&bridge, &route, &db).await;
     let receipt = bridge
-        .submit_envelope(telegram_queue_envelope("please send action"))
+        .submit_envelope(with_bridge_principal(
+            &bridge,
+            telegram_queue_envelope("please send action"),
+        ))
         .await
         .unwrap();
     let thread_id = receipt.thread_id.expect("receipt should include thread id");
@@ -7834,7 +8187,10 @@ async fn egress_projector_skips_invalid_requested_egress_and_continues() {
     let (_server, bridge, mut rx) = test_bridge_at_root(&root).await;
     register_route_state(&bridge, &route, &db).await;
     let receipt = bridge
-        .submit_envelope(telegram_queue_envelope("poison skip"))
+        .submit_envelope(with_bridge_principal(
+            &bridge,
+            telegram_queue_envelope("poison skip"),
+        ))
         .await
         .unwrap();
     let thread_id = receipt.thread_id.expect("receipt should include thread id");
@@ -8246,7 +8602,10 @@ async fn telegram_webhook_accepts_update_and_uses_sink() {
     drop(captured);
 
     let (bridge, _rx, session_store_path) = test_bridge().await;
-    let receipt = bridge.submit_envelope(envelope).await.unwrap();
+    let receipt = bridge
+        .submit_envelope(with_bridge_principal(&bridge, envelope))
+        .await
+        .unwrap();
     let thread_id = receipt.thread_id.unwrap();
     wait_for_assistant_text(&bridge, &thread_id, "local:hello webhook").await;
     let store = SqliteSessionStore::open(session_store_path).await.unwrap();

--- a/crates/cooldis-kernel/src/daemon/handle_ingress.rs
+++ b/crates/cooldis-kernel/src/daemon/handle_ingress.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 use cooldis_io_core::{
     ConversationKind, IngressContent, IngressEnvelope, IngressSink, IoConversation, IoDedupeKey,
-    IoSource,
+    IoDelivery, IoPrincipal, IoSource,
 };
 use cooldis_runtime_contracts::{
     HANDLE_OUTCOME_CONTENT_KIND, HandleId, HandleTerminalEnvelope, HandleTerminalOutcome,
@@ -258,6 +258,12 @@ impl ThreadTerminalSettlement {
         .with_dedupe_key(IoDedupeKey::new(
             HANDLE_OUTCOME_CONTENT_KIND,
             self.dispatch_id.to_string(),
+        ))
+        .with_delivery(IoDelivery::new(self.dispatch_id.to_string()))
+        .with_principal(IoPrincipal::new(
+            self.consumer.tenant_id.clone(),
+            self.consumer.user_id.clone(),
+            format!("handle:{}", self.dispatch_id),
         ))
         .with_metadata("cooldis_route_id", HANDLE_OUTCOME_CONTENT_KIND)
         .with_metadata("cooldis_route_policy", "queue_per_conversation"))

--- a/crates/cooldis-kernel/src/daemon/remote_store/process_executor.rs
+++ b/crates/cooldis-kernel/src/daemon/remote_store/process_executor.rs
@@ -39,7 +39,8 @@ use crate::{
 use async_trait::async_trait;
 use cooldis_io_core::{
     AdmissionDecision, ConversationKind, IngressContent, IngressEnvelope, IoConversation,
-    IoDedupeKey, IoError, IoSource, IoTurnInput, ResolvedIoTarget, ThreadAddress,
+    IoDedupeKey, IoDelivery, IoError, IoPrincipal, IoSource, IoTurnInput, ResolvedIoTarget,
+    ThreadAddress,
 };
 use cooldis_sqlite::{TransactionBehavior, params};
 use serde::{Deserialize, Serialize};
@@ -233,7 +234,7 @@ impl ProcessRemoteThreadExecutorInner {
 
         self.queue
             .enqueue(queue_entry(
-                thread_id,
+                &request.child.coordinates,
                 request.turn_id.clone(),
                 request.dispatch_id.clone(),
                 &request.input,
@@ -354,7 +355,7 @@ impl RemoteThreadExecutor for ProcessRemoteThreadExecutor {
         self.inner
             .queue
             .enqueue(queue_entry(
-                request.target_thread_id,
+                &state.child.coordinates,
                 request.turn_id,
                 request.dispatch_id,
                 &request.input,
@@ -579,11 +580,12 @@ async fn settle_remote_spawn_failure(
 }
 
 fn queue_entry(
-    target_thread_id: ThreadId,
+    target: &ThreadCoordinates,
     turn_id: String,
     dispatch_id: cooldis_runtime_contracts::DispatchId,
     input: &TurnInput,
 ) -> CooldisResult<RemoteIngressQueueEntryV1> {
+    let target_thread_id = target.thread_id;
     let source = IoSource::new("cooldis.remote", "ingress");
     let mut envelope = IngressEnvelope::new(
         source.clone(),
@@ -591,7 +593,13 @@ fn queue_entry(
         IngressContent::text(input.text_projection()),
         0,
     )
-    .with_dedupe_key(IoDedupeKey::for_source(&source, dispatch_id.as_str()));
+    .with_dedupe_key(IoDedupeKey::for_source(&source, dispatch_id.as_str()))
+    .with_delivery(IoDelivery::new(dispatch_id.to_string()))
+    .with_principal(IoPrincipal::new(
+        target.tenant_id.clone(),
+        target.user_id.clone(),
+        format!("remote:{dispatch_id}"),
+    ));
     envelope.id = format!("remote-ingress-{}", sha256_hex(dispatch_id.as_str()));
     envelope
         .metadata

--- a/crates/cooldis-kernel/src/kernel/process_handle_dispatch.rs
+++ b/crates/cooldis-kernel/src/kernel/process_handle_dispatch.rs
@@ -19,7 +19,8 @@ use crate::{
     RuntimeStore, ThreadCoordinates, control_stream_id,
 };
 use cooldis_io_core::{
-    ConversationKind, IngressContent, IngressEnvelope, IoConversation, IoDedupeKey, IoSource,
+    ConversationKind, IngressContent, IngressEnvelope, IoConversation, IoDedupeKey, IoDelivery,
+    IoPrincipal, IoSource,
 };
 use cooldis_process::{
     AsyncExecutionManager, AsyncProcessOutcome, AsyncProcessSnapshot, AsyncProcessStartRequest,
@@ -548,6 +549,12 @@ fn dispatch_envelope(binding: &HandleDispatchEnvelope) -> CooldisResult<IngressE
         HANDLE_DISPATCH_CONTENT_KIND,
         binding.dispatch_id.to_string(),
     ))
+    .with_delivery(IoDelivery::new(binding.dispatch_id.to_string()))
+    .with_principal(IoPrincipal::new(
+        binding.consumer.tenant_id.clone(),
+        binding.consumer.user_id.clone(),
+        format!("handle:{}", binding.dispatch_id),
+    ))
     .with_metadata("cooldis_route_id", HANDLE_DISPATCH_CONTENT_KIND)
     .with_metadata("cooldis_route_policy", "observe_only");
     envelope.id = deterministic_ingress_id("dispatch", &binding.dispatch_id);
@@ -637,6 +644,12 @@ fn outcome_envelope(
     .with_dedupe_key(IoDedupeKey::new(
         HANDLE_OUTCOME_CONTENT_KIND,
         binding.dispatch_id.to_string(),
+    ))
+    .with_delivery(IoDelivery::new(binding.dispatch_id.to_string()))
+    .with_principal(IoPrincipal::new(
+        binding.consumer.tenant_id.clone(),
+        binding.consumer.user_id.clone(),
+        format!("handle:{}", binding.dispatch_id),
     ))
     .with_metadata("cooldis_route_id", HANDLE_OUTCOME_CONTENT_KIND)
     .with_metadata("cooldis_route_policy", "queue_per_conversation");

--- a/crates/cooldis-kernel/tests/remote_store_queue_tail.rs
+++ b/crates/cooldis-kernel/tests/remote_store_queue_tail.rs
@@ -19,7 +19,8 @@ use cooldis::{
     NewEventRecord, SqliteSessionStore, ThreadCoordinates,
 };
 use cooldis_io_core::{
-    ConversationKind, IngressContent, IngressEnvelope, IoConversation, IoDedupeKey, IoSource,
+    ConversationKind, IngressContent, IngressEnvelope, IoConversation, IoDedupeKey, IoDelivery,
+    IoPrincipal, IoSource,
 };
 use cooldis_runtime_contracts::{DispatchId, ThreadId};
 use cooldis_sqlite::{TransactionBehavior, params};
@@ -53,6 +54,12 @@ fn entry(thread_id: ThreadId, dispatch: &str, text: &str) -> RemoteIngressQueueE
         .with_dedupe_key(IoDedupeKey::new(
             "cooldis.remote.dispatch",
             dispatch_id.to_string(),
+        ))
+        .with_delivery(IoDelivery::new(dispatch_id.to_string()))
+        .with_principal(IoPrincipal::new(
+            "remote-tenant",
+            "remote-user",
+            format!("remote:{dispatch_id}"),
         )),
         enqueued_at_ms: 0,
     }

--- a/crates/cooldis-kernel/tests/support/scenario.rs
+++ b/crates/cooldis-kernel/tests/support/scenario.rs
@@ -36,7 +36,8 @@ use super::{Inv6ClaimsSettle, fork_invariants_v1, invariant_set_v1};
 use async_trait::async_trait;
 use cooldis_io_core::{
     ConversationKind, IngressAck, IngressContent, IngressEnvelope, IngressQueueStore, IngressSink,
-    IoConversation, IoDedupeKey, IoResult, IoSource, LeasedIngressEnvelope, ThreadAddress,
+    IoConversation, IoDedupeKey, IoDelivery, IoPrincipal, IoResult, IoSource,
+    LeasedIngressEnvelope, ThreadAddress,
 };
 use cooldis_io_pgqrs::sqlite_dsn;
 use futures_util::FutureExt;
@@ -991,15 +992,19 @@ impl ScenarioHarness {
     fn envelope(&mut self, root_index: usize, policy: &str, text: &str) -> IngressEnvelope {
         self.envelope_index += 1;
         let source = Self::source();
+        let delivery_id = format!("{}:{}", self.plan.seed, self.envelope_index);
         let mut envelope = IngressEnvelope::new(
             source.clone(),
             Self::conversation(root_index),
             IngressContent::text(text),
             self.tick.load(std::sync::atomic::Ordering::SeqCst) * 1_000,
         )
-        .with_dedupe_key(IoDedupeKey::for_source(
-            &source,
-            format!("{}:{}", self.plan.seed, self.envelope_index),
+        .with_dedupe_key(IoDedupeKey::for_source(&source, delivery_id.clone()))
+        .with_delivery(IoDelivery::new(delivery_id))
+        .with_principal(IoPrincipal::new(
+            self.server.tenant_id(),
+            self.server.user_id(),
+            "route:scenario",
         ))
         .with_metadata("cooldis_route_id", "scenario")
         .with_metadata("cooldis_route_policy", policy);
@@ -2847,7 +2852,13 @@ mod tests {
             IngressContent::text("accepted stale completion"),
             0,
         )
-        .with_dedupe_key(IoDedupeKey::for_source(&source, "stale-completion"));
+        .with_dedupe_key(IoDedupeKey::for_source(&source, "stale-completion"))
+        .with_delivery(IoDelivery::new("stale-completion"))
+        .with_principal(IoPrincipal::new(
+            "scenario-tenant",
+            "scenario-user",
+            "route:scenario",
+        ));
         queue.submit(envelope).await.unwrap();
         let leased = queue.lease_ingress("worker-a", 1, 1).await.unwrap();
         assert_eq!(leased.len(), 1);

--- a/docs/adr/0007-adapter-envelope-contract-v0.md
+++ b/docs/adr/0007-adapter-envelope-contract-v0.md
@@ -1,0 +1,184 @@
+# ADR 0007: Adapter Envelope Contract v0 (Delivery Provenance and Principal Attribution)
+
+Status: accepted
+Date: 2026-07-18
+
+## Context
+
+Managed deployments put the ingress boundary in front of systems the runtime
+does not control: chat platforms, webhooks, queues, and the scheduler. The IO
+contracts in `cooldis-io-core` already model the pipeline (envelope, queue,
+dedupe, resolver, admission, bridge; ADR 0003 governs the admitted outcome),
+but three attributes of an ingress envelope are either optional or absent, and
+all three are unretrofittable: an event admitted without them produces a
+permanent record that cannot say where it came from or on whose authority it
+ran.
+
+1. **Delivery identity is optional.** `IngressEnvelope.dedupe_key` is an
+   `Option`, and there is no field naming the external delivery itself. The
+   internal `ing_` id names our receipt of the event, not the event. An
+   envelope submitted without a dedupe key silently loses redelivery
+   protection.
+2. **Principal attribution does not exist.** `resolve_target` in the daemon
+   assigns every envelope the daemon's own configured `tenant_id` and
+   `user_id`. Attribution is a deployment assumption, never a recorded fact.
+   Nothing in the admitted record says which principal an ingress event acted
+   for, and nothing validates tenant agreement between an envelope and the
+   thread it resolves into.
+3. **Existing sources smuggle both through untyped metadata.** The clock
+   route writes `cooldis_tenant_id`, `cooldis_user_id`, `cooldis_session_id`,
+   and `cooldis_mandate_event_id` as string metadata; `RouteIngressSink`
+   writes `cooldis_route_id`. These are load-bearing routing and attribution
+   facts traveling in a namespace with no schema and no validation.
+
+The invariant this ADR installs, stated once: **an envelope names its external
+delivery and resolves to a principal before admission, and redelivery dedupes
+on its delivery identity. An arrival the runtime cannot attribute to a
+delivery and a principal is not admissible as witnessed ingress.**
+
+## Decision
+
+### D1: Delivery identity becomes a typed field
+
+```rust
+pub struct IoDelivery {
+    /// The external system's own identifier for this delivery: a Telegram
+    /// update id, a webhook delivery id, a queue message id, or a scheduler
+    /// occurrence ("{mandate_event_id}:{occurrence_index}").
+    pub delivery_id: String,
+    /// Redelivery attempt ordinal when the external system reports one.
+    pub attempt: Option<u32>,
+    pub metadata: BTreeMap<String, String>,
+}
+```
+
+`IngressEnvelope` gains `delivery: Option<IoDelivery>`. The `Option` exists
+only for wire compatibility with already-queued envelopes; the boundary
+enforces presence (D3). The dedupe identity derives from the delivery: when
+`dedupe_key` is unset and `delivery` is set, the effective dedupe key is
+`IoDedupeKey::for_source(&source, &delivery.delivery_id)`. An explicitly set
+`dedupe_key` still wins, which keeps every existing producer's dedupe
+identity byte-stable through the migration.
+
+### D2: Principal attribution becomes a typed field
+
+```rust
+pub struct IoPrincipal {
+    pub tenant_id: String,
+    pub principal_id: String,
+    /// How attribution happened: "mandate:{event_id}", "route:{route_id}",
+    /// or a caller-auth scheme once boundary authentication lands.
+    pub via: String,
+}
+```
+
+`IngressEnvelope` gains `principal: Option<IoPrincipal>`. Two stamping
+patterns, by who can honestly attribute:
+
+- **Self-attributing sources** stamp at construction. The clock route knows
+  the mandate's coordinates from the record; its ticks carry the mandate
+  holder's tenant and user with `via = "mandate:{mandate_event_id}"`.
+- **Protocol adapters cannot attribute** and leave `principal` unset. The
+  daemon stamps during resolution from the route binding that accepted the
+  event (`via = "route:{route_id}"`). External actor identity
+  (`envelope.actor`) remains provenance and is never itself the principal.
+
+Internal durable authorities are self-attributing in the same sense as the
+clock: handle dispatch/outcome envelopes stamp from their durable consumer
+binding (`via = "handle:{dispatch_id}"`), and remote child ingress stamps
+from its durable target coordinates (`via = "remote:{dispatch_id}"`).
+
+There is deliberately no principal kind classification in v0. Whose authority
+and how it was established are unretrofittable; classifying the principal is
+not, and belongs to the full principal model.
+
+### D3: Two enforcement points
+
+```rust
+impl IngressEnvelope {
+    /// dedupe_key.clone() or the delivery-derived key (D1).
+    pub fn effective_dedupe_key(&self) -> Option<IoDedupeKey>;
+    /// Submit-boundary check: delivery present with a non-empty id, and an
+    /// effective dedupe key exists.
+    pub fn require_witnessed(&self) -> IoResult<()>;
+    /// Admission-boundary check: require_witnessed, principal present, and
+    /// principal.tenant_id equals the resolved target's tenant_id.
+    pub fn require_attributed(&self, target: &ResolvedIoTarget) -> IoResult<()>;
+}
+```
+
+Production submit paths (`RouteIngressSink`, `DirectRuntimeIngressSink`, the
+pgqrs queue store) call `require_witnessed` and reject early with
+`IoError::InvalidEnvelope`. The admission path calls `require_attributed`
+after resolution and before the decision, which is the guarantee: no sink,
+present or future, can get an unattributed envelope admitted, because the
+check the record depends on does not live in the sinks. The tenant-agreement
+clause closes cross-tenant injection: a resolver bug or hostile route cannot
+land one tenant's envelope in another tenant's thread without the mismatch
+being rejected and witnessed.
+
+### D4: Legacy derivation, bounded
+
+Envelopes queued before this contract deserialize with both new fields unset.
+At lease time the daemon derives what can be derived honestly: if
+`delivery` is unset but `dedupe_key` is set, `delivery_id` takes the dedupe
+key's `key` (deterministic across redeliveries, and dedupe-stable by D1's
+precedence rule). Legacy principal stamping happens at lease preparation,
+only for rows carrying a non-empty `cooldis_route_id` metadata tag, using the
+daemon's configured route identity; an untagged legacy row stays
+unattributed and is terminally rejected at admission. An envelope with
+neither `delivery` nor `dedupe_key` is rejected, in every era. Derivation is
+a migration ramp for in-flight queue contents, not an alternative contract;
+producers must set `delivery` directly.
+
+### D5: Receipts carry attribution
+
+`KernelIoReceipt` gains `principal: Option<IoPrincipal>`, copied from the
+validated envelope, so the admission receipt records on whose authority every
+outcome ran. The claim/settle protocol of ADR 0003 is unchanged; claims
+reference envelope ids and inherit attribution transitively through them.
+
+### D6: Existing sources migrate to the typed fields
+
+- The clock route sets `delivery` (mandate event id + occurrence index, the
+  same string it uses for dedupe today) and stamps `principal` from the
+  mandate's coordinates. The `cooldis_tenant_id` and `cooldis_user_id`
+  metadata entries are removed in favor of the typed principal; remaining
+  routing metadata is out of scope here (D7).
+- The Telegram adapter sets `delivery` from the update id it already uses
+  for dedupe. It does not stamp `principal`.
+- `RouteIngressSink` stamps `principal` from the daemon's route identity
+  (the same tenant and user `resolve_target` uses today, now recorded per
+  envelope instead of assumed).
+
+## Consequences
+
+- The envelope's serialized shape gains two optional fields; old records and
+  queued envelopes deserialize unchanged. Dedupe identities are byte-stable
+  through the migration, so in-flight redelivery cannot double-apply at
+  upgrade.
+- Admission gains a validation step whose rejections are witnessed like any
+  other reject outcome.
+- The untyped tenant and user metadata smuggle on clock ticks is deleted, and
+  its information becomes schema.
+- Pinning tests cover: unwitnessed submit rejection, unattributed admission
+  rejection, tenant-mismatch rejection, legacy derivation determinism, and
+  dedupe stability for clock and Telegram envelope shapes.
+
+## Out of scope (deferred deliberately, not forgotten)
+
+- **D7:** typed route policy. `cooldis_route_policy`, threading, and agent
+  ref stay metadata; they are re-derivable configuration, not permanent
+  attribution, and are retrofittable later.
+- Surfacing `principal` in the durable ingress witness payload. In v0 the
+  witness event commits to the full validated envelope (principal included)
+  through `envelope_digest`, and the admission receipt carries the principal
+  in memory, but the durable payload does not state it readably. Promoting it
+  into the witness payload is a schema evolution of the ADR 0003 record shape
+  and is ticketed separately rather than bundled here.
+- Caller authentication at the boundary (which supplies stronger `via`
+  values); this contract carries its outcome.
+- Conversation optionality and trigger routing semantics (start versus steer
+  versus resume as first-class outcomes); scheduler ticks keep their
+  `ConversationKind::System` conversations.
+- Adapter registry and lifecycle; egress-side attribution.

--- a/docs/io.md
+++ b/docs/io.md
@@ -25,12 +25,45 @@ The durable ingress queue wrapper lives in `crates/cooldis-io-pgqrs`.
 The daemon-owned runtime bridge lives in `crates/cooldis-kernel` so it can call
 `CooldisSupervisor` without making adapter crates depend on the kernel.
 
+## Adapter Envelope Contract
+
+Every admissible ingress envelope carries two typed facts defined by
+[ADR 0007](adr/0007-adapter-envelope-contract-v0.md):
+
+- `delivery: IoDelivery` names the external delivery. Its `delivery_id` is the
+  Telegram update id, webhook or queue message id, or the clock occurrence
+  `"{mandate_event_id}:{occurrence_index}"`. An explicit `dedupe_key` wins;
+  otherwise the effective key is derived by scoping `delivery_id` to the
+  envelope source.
+- `principal: IoPrincipal` records the tenant and principal on whose authority
+  the event acts, plus how that attribution was established. Self-attributing
+  sources such as the clock stamp the mandate holder at construction. Protocol
+  adapters leave it unset, and the daemon route binding stamps it before
+  admission. External actor identity is provenance, not authority.
+
+The contract is enforced twice. Production submit sinks reject an envelope
+without a non-empty delivery identity and effective dedupe key before it can be
+queued or applied. After target resolution, the admission boundary requires
+principal attribution and exact agreement between `principal.tenant_id` and
+the resolved target tenant. An attribution validation failure is admitted only
+as a witnessed, terminal Reject outcome; the durable queue completes it and
+redelivery folds to the settled reject. Resolver and other transient bridge
+errors remain retryable.
+
+The optional wire fields are a bounded upgrade ramp, not a second producer
+contract. When a pre-contract queued envelope is leased with `dedupe_key` but
+without `delivery`, the daemon deterministically uses the dedupe key's `key` as
+`delivery_id`; the explicit dedupe key still wins, so its effective key remains
+byte-identical across the upgrade. An envelope with neither identity is
+terminally rejected. New producers must always set `delivery` directly.
+
 ## Terms
 
 - **Protocol adapter**: understands one wire protocol, such as Telegram
   webhooks, a websocket TUI, local CLI stdin/stdout, or generic HTTP webhooks.
 - **Ingress envelope**: normalized inbound event with source, conversation,
-  actor, content, attachments, metadata, and a protocol-provided dedupe key.
+  actor, content, attachments, delivery provenance, principal attribution,
+  metadata, and a redelivery dedupe identity.
 - **Queue / dedupe**: durable admission buffer that enforces idempotency,
   ordering, retry, and dead-letter behavior before events touch the runtime.
 - **Resolver**: maps external source/conversation/actor identity into a
@@ -294,7 +327,13 @@ clock route
      source.instance_id = "clock-main",
      conversation.external_conversation_id = "thread:<thread_id>",
      conversation.kind = "system",
+     delivery.delivery_id = "<mandate_event_id>:<occurrence_index>",
      dedupe_key = "clock.tick:clock-main:<mandate_event_id>:<occurrence_index>",
+     principal = {
+       tenant_id = "<mandate tenant>",
+       principal_id = "<mandate user>",
+       via = "mandate:<mandate_event_id>"
+     },
      content = Event {
        kind = "timer.fired",
        payload = {


### PR DESCRIPTION
Installs the adapter envelope contract v0 (ADR 0007): delivery provenance and principal attribution as typed ingress envelope schema, enforced at the submit and admission boundaries.

## What changed

- `IoDelivery` names the external delivery (Telegram update id, clock occurrence, dispatch id). The effective dedupe identity derives from it; an explicit `dedupe_key` wins, so every existing producer's dedupe identity is byte-stable through the migration (pinned by literal-string tests).
- `IoPrincipal { tenant_id, principal_id, via }` records on whose authority an envelope acts and how attribution was established. Self-attributing sources (clock mandates, handle and remote authorities) stamp at construction; protocol adapters are stamped at resolution from the route binding; absence fails closed.
- Two enforcement points: production sinks reject unwitnessed envelopes synchronously with `IoError::InvalidEnvelope`; the admission boundary requires attribution plus tenant agreement between the stamped principal and the resolved target. Validation failures settle as terminal witnessed Rejects per ADR 0003 (they complete the queue message and dedupe on redelivery); transient resolver errors keep retry semantics.
- Clock route and Telegram adapter migrate to the typed fields; the untyped `cooldis_tenant_id`/`cooldis_user_id` metadata smuggle is deleted. Pre-contract queued envelopes ride a bounded lease-time derivation ramp.
- `KernelIoReceipt` carries the principal for every admitted outcome. Surfacing it in the durable witness payload is a schema evolution ticketed separately (EMO-494).

## Verification

- Full workspace suite green through the managed cargo lane (967 passed), fmt clean.
- Implementation dispatch audited six named security dimensions (enforcement bypass, poison vs retry, dedupe stability at upgrade, cross-tenant injection, serde compatibility, attribution honesty); an independent review pass re-audited seven more lenses (ADR 0003 claim/settle interplay, coalescing partial-settle, observable ack shape changes, clock-path reachability, legacy dedupe claiming, dev sink behavior, taste). Findings and fixes are on the Linear issue.

Linear: EMO-471
