### PR TITLE
EMO-473: identity plane skeleton (types, authority trait, config shape)

### DIFF
--- a/crates/cooldis-kernel/src/daemon/identity.rs
+++ b/crates/cooldis-kernel/src/daemon/identity.rs
@@ -1,0 +1,447 @@
+//! Identity plane v0: principals, credentials, and boundary authority.
+//!
+//! Design: `docs/adr/0008-identity-plane-v0.md` (accepted). The kernel is an
+//! identity receptor, not an identity provider: this module defines the slot
+//! a "who" plugs into (named principals, hash-only credentials, authority
+//! classes) and the witnessed records that make boundary decisions part of
+//! the permanent record. Nothing here provides identities; identity services
+//! live above the kernel.
+//!
+//! The storage pattern follows the one existing inbound-auth surface,
+//! `SyncCredentialAuthority` (`daemon/remote_store/lease.rs`): CSPRNG-minted
+//! bearer secrets returned exactly once, digest-only persistence, and
+//! append-only witnessed records with `.../1` schema ids. Identity records
+//! are daemon-authority facts (dedicated durable tables), not thread-stream
+//! events: the `EventKind` vocabulary is thread-scoped and frozen, and a
+//! boundary session has no thread.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::CooldisResult;
+
+/// Schema id for a principal declaration/revocation record.
+pub const IDENTITY_PRINCIPAL_SCHEMA_V1: &str = "cooldis.identity.principal/1";
+/// Schema id for a credential mint/revocation record.
+pub const IDENTITY_CREDENTIAL_SCHEMA_V1: &str = "cooldis.identity.credential/1";
+/// Schema id for a boundary session open/close witness.
+pub const IDENTITY_SESSION_SCHEMA_V1: &str = "cooldis.identity.session/1";
+/// Schema id for a witnessed authentication/authorization rejection.
+pub const IDENTITY_AUTH_REJECTION_SCHEMA_V1: &str = "cooldis.identity.auth_rejection/1";
+
+/// A named identity within the tenant (ADR 0008 D1).
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PrincipalId(String);
+
+impl PrincipalId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for PrincipalId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The kind of a principal, from which its authority derives (ADR 0008 D1).
+///
+/// `Member` is schema-reserved and unimplemented in v0: the variant exists so
+/// its later arrival is additive, but [`PrincipalKind::is_declarable`] is
+/// false for it and declaration must be rejected. End users reach agents
+/// through adapters; the envelope records them as adapter testimony.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrincipalKind {
+    /// Full host authority plus interactive use: whoever operates the daemon.
+    Operator,
+    /// Ingress submission only: a bridge, webhook, or the scheduler sidecar.
+    Adapter,
+    /// Reserved, unimplemented (ADR 0008 D1). Declaration is rejected in v0.
+    Member,
+}
+
+impl PrincipalKind {
+    /// Whether a principal of this kind may be declared in v0.
+    pub fn is_declarable(self) -> bool {
+        !matches!(self, Self::Member)
+    }
+
+    /// Whether this kind reaches the given authority class (ADR 0008 D4).
+    pub fn permits(self, class: AuthorityClass) -> bool {
+        match self {
+            Self::Operator => true,
+            Self::Adapter => matches!(class, AuthorityClass::Ingress),
+            Self::Member => matches!(class, AuthorityClass::Interactive | AuthorityClass::Ingress),
+        }
+    }
+}
+
+/// The authority class of a JSON-RPC method (ADR 0008 D4). The taxonomy is
+/// the durable part of the design; kinds map onto it via
+/// [`PrincipalKind::permits`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthorityClass {
+    /// Touches the host: command exec, filesystem, process handles, secrets,
+    /// debug. Operator only.
+    Host,
+    /// Interactive thread and agent use, and reads.
+    Interactive,
+    /// Envelope submission at the ingress boundary.
+    Ingress,
+}
+
+/// Classify a dispatcher method name into its authority class.
+///
+/// Precedence (ADR 0008 D4): the explicit host list wins over prefix rules
+/// (`thread/shellCommand` is host authority even though `thread/*` is
+/// interactive); a method matching nothing classifies as `Host`, so an
+/// unclassified method fails closed to operator-only.
+///
+/// The implementation ticket must reconcile this table against every arm of
+/// `dispatch_request` (`adapters/app_server/connection.rs`) and pin the
+/// reconciliation with an exhaustive test: every dispatchable method appears
+/// here deliberately, or the test fails.
+pub fn authority_class_for_method(method: &str) -> AuthorityClass {
+    const HOST_METHODS: &[&str] = &["thread/shellCommand"];
+    const HOST_PREFIXES: &[&str] = &[
+        "command/",
+        "fs/",
+        "process/",
+        "modelProvider/auth/",
+        "mcpSource/",
+        "debug/",
+    ];
+    const INTERACTIVE_PREFIXES: &[&str] = &["thread/", "turn/", "mandate/", "agent/", "session/"];
+    const INGRESS_PREFIXES: &[&str] = &["ingress/", "io/ingress/"];
+
+    if HOST_METHODS.contains(&method) || HOST_PREFIXES.iter().any(|p| method.starts_with(p)) {
+        return AuthorityClass::Host;
+    }
+    if INGRESS_PREFIXES.iter().any(|p| method.starts_with(p)) {
+        return AuthorityClass::Ingress;
+    }
+    if INTERACTIVE_PREFIXES.iter().any(|p| method.starts_with(p)) {
+        return AuthorityClass::Interactive;
+    }
+    AuthorityClass::Host
+}
+
+/// A declared principal, as persisted (ADR 0008 D1). Declaration and
+/// revocation are append-only witnessed records; the in-memory boundary set
+/// is rebuilt from them and refreshed on change.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PrincipalRecordV1 {
+    pub schema: String,
+    pub principal_id: PrincipalId,
+    pub kind: PrincipalKind,
+    pub display: String,
+    /// The principal that declared this one: the attestation trail's root
+    /// link. The bootstrap operator names itself.
+    pub declared_by: PrincipalId,
+    pub declared_at_ms: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revoked_at_ms: Option<i64>,
+}
+
+/// A credential binding a bearer secret to exactly one principal (ADR 0008
+/// D2). The secret is returned once at mint and persisted only as a digest.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct IdentityCredentialV1 {
+    pub schema: String,
+    pub credential_id: String,
+    pub principal_id: PrincipalId,
+    /// `sha256:<hex>` digest of the bearer secret. Never the secret itself.
+    pub token_digest: String,
+    /// The principal that authorized the mint ("who granted what").
+    pub minted_by: PrincipalId,
+    pub minted_at_ms: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at_ms: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revoked_at_ms: Option<i64>,
+}
+
+/// Digest a bearer secret for persistence or lookup. Same convention as the
+/// stream-sync authority (`daemon/remote_store/lease.rs`): high-entropy
+/// random secrets, so a plain SHA-256 digest is sufficient and no
+/// password-style slow hash applies.
+pub fn identity_token_digest(token: &str) -> String {
+    format!("sha256:{:x}", Sha256::digest(token.as_bytes()))
+}
+
+/// How a connection proved itself (ADR 0008 D3).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AuthenticationPath {
+    /// A bearer token verified against the credential set.
+    Credential { credential_id: String },
+    /// Same-uid peer mapping on the Unix socket: local mode only.
+    PeerUid { uid: u32 },
+}
+
+/// The identity a live connection carries after authentication. Attached to
+/// the connection state and consulted at the dispatcher choke point before
+/// every method (ADR 0008 D3/D4). A connection without one is admitted to no
+/// method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolvedPrincipal {
+    pub principal_id: PrincipalId,
+    pub kind: PrincipalKind,
+    pub auth: AuthenticationPath,
+}
+
+/// The boundary surface a session or rejection was witnessed on.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BoundarySurface {
+    UnixSocket,
+    Websocket,
+    Console,
+}
+
+/// A witnessed boundary session (ADR 0008 D6): open and close of one
+/// authenticated connection.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct IdentitySessionV1 {
+    pub schema: String,
+    pub session_id: String,
+    pub principal_id: PrincipalId,
+    pub kind: PrincipalKind,
+    pub surface: BoundarySurface,
+    /// Credential id for token auth; `peer_uid:<uid>` for the local-mode
+    /// peer mapping (which uses no credential).
+    pub credential_ref: String,
+    pub opened_at_ms: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub closed_at_ms: Option<i64>,
+}
+
+/// Why a boundary request was refused (ADR 0008 D3/D4). Persisted as a
+/// witnessed rejection so pre-guard intrusion attempts are not invisible;
+/// follows `SyncPushRejectionReason` (`daemon/remote_store/endpoint.rs`).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "reason")]
+pub enum IdentityAuthRejectionReason {
+    /// No credential matches the presented token.
+    CredentialUnknown,
+    CredentialExpired {
+        credential_id: String,
+    },
+    CredentialRevoked {
+        credential_id: String,
+    },
+    PrincipalRevoked {
+        principal_id: PrincipalId,
+    },
+    /// Authenticated, but the method is above the principal's authority.
+    MethodNotAuthorized {
+        method: String,
+        class: AuthorityClass,
+    },
+    /// A same-uid peer connected while the mapping is off (managed mode).
+    PeerMappingDisabled {
+        uid: u32,
+    },
+}
+
+/// A witnessed authentication/authorization rejection (ADR 0008 D6).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct IdentityAuthRejectionV1 {
+    pub schema: String,
+    pub surface: BoundarySurface,
+    pub reason: IdentityAuthRejectionReason,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub principal_id: Option<PrincipalId>,
+    pub rejected_at_ms: i64,
+}
+
+/// The daemon's identity authority (ADR 0008 D1/D2/D6): the single owner of
+/// principal and credential records and of boundary witnessing.
+///
+/// The implementation (`SqliteIdentityAuthority`, implementation ticket 1)
+/// follows `SqliteStreamLeaseAuthority` (`daemon/remote_store/lease.rs`):
+/// dedicated append-only tables on the daemon session store, an injected
+/// clock, digest-only credential persistence, and `Ok(None)` as the
+/// fail-closed verification outcome. Test conventions: inline unit tests
+/// against `SqliteSessionStore::in_memory()` with an injected clock, plus an
+/// integration file alongside `tests/remote_store_lease.rs`.
+#[async_trait]
+pub trait IdentityAuthority: Send + Sync {
+    /// Declare a principal. Rejects kinds where
+    /// [`PrincipalKind::is_declarable`] is false (the reserved `member`).
+    async fn declare_principal(
+        &self,
+        declared_by: &PrincipalId,
+        principal_id: &PrincipalId,
+        kind: PrincipalKind,
+        display: &str,
+    ) -> CooldisResult<PrincipalRecordV1>;
+
+    async fn revoke_principal(
+        &self,
+        revoked_by: &PrincipalId,
+        principal_id: &PrincipalId,
+    ) -> CooldisResult<()>;
+
+    /// Mint a credential for a principal. Returns the persisted record and
+    /// the bearer secret, which is shown exactly once and never persisted.
+    async fn mint_credential(
+        &self,
+        minted_by: &PrincipalId,
+        principal_id: &PrincipalId,
+        expires_at_ms: Option<i64>,
+    ) -> CooldisResult<(IdentityCredentialV1, String)>;
+
+    async fn revoke_credential(
+        &self,
+        revoked_by: &PrincipalId,
+        credential_id: &str,
+    ) -> CooldisResult<()>;
+
+    /// Resolve a bearer token to a principal. `Ok(None)` is the fail-closed
+    /// rejection outcome: unknown, expired, or revoked credentials and
+    /// revoked principals all resolve to nothing.
+    async fn verify_token(&self, token: &str) -> CooldisResult<Option<ResolvedPrincipal>>;
+
+    /// Resolve a same-uid Unix peer to the operator principal. Local mode
+    /// only (ADR 0008 D3): in managed mode this returns `Ok(None)` and the
+    /// attempt is witnessed with [`IdentityAuthRejectionReason::PeerMappingDisabled`].
+    async fn resolve_peer_uid(&self, uid: u32) -> CooldisResult<Option<ResolvedPrincipal>>;
+
+    async fn list_principals(&self) -> CooldisResult<Vec<PrincipalRecordV1>>;
+
+    async fn list_credentials(
+        &self,
+        principal_id: &PrincipalId,
+    ) -> CooldisResult<Vec<IdentityCredentialV1>>;
+
+    /// Witness a boundary session opening (ADR 0008 D6).
+    async fn witness_session_opened(&self, session: &IdentitySessionV1) -> CooldisResult<()>;
+
+    /// Witness a boundary session closing.
+    async fn witness_session_closed(
+        &self,
+        session_id: &str,
+        closed_at_ms: i64,
+    ) -> CooldisResult<()>;
+
+    /// Witness a rejected authentication or authorization attempt.
+    async fn witness_auth_rejected(&self, rejection: &IdentityAuthRejectionV1)
+    -> CooldisResult<()>;
+}
+
+/// Deployment mode (ADR 0008 D5).
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IdentityMode {
+    /// Single-user developer box: a missing `[daemon.identity]` section
+    /// synthesizes a default operator, and the same-uid peer mapping is on.
+    #[default]
+    Local,
+    /// Hosted instance: an explicit identity section and a bootstrapped
+    /// operator credential are required; starting without them is a hard
+    /// error. Peer mapping and debug RPC default off.
+    Managed,
+}
+
+/// The `[daemon.identity]` config section (ADR 0008 D5). Wiring into
+/// `CooldisDaemonConfig` (defaults, presence, layer merge, validation) is
+/// implementation ticket 4; this struct is the shape.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CooldisDaemonIdentityConfig {
+    #[serde(default)]
+    pub mode: IdentityMode,
+    /// Replaces the hard-coded `cooldis_app_server` tenant. Required in
+    /// managed mode; a local-mode default is synthesized when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    /// The principal the bundled console resolves to (in v0, the operator).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub console_principal: Option<PrincipalId>,
+}
+
+impl CooldisDaemonIdentityConfig {
+    /// The ratified hard-fail rule (ADR 0008 D5): managed mode without an
+    /// explicit tenant identity refuses to start. Local mode validates
+    /// vacuously.
+    pub fn validate(&self) -> Result<(), String> {
+        match self.mode {
+            IdentityMode::Local => Ok(()),
+            IdentityMode::Managed => {
+                if self.tenant_id.as_deref().unwrap_or("").is_empty() {
+                    return Err("managed mode requires [daemon.identity] tenant_id; \
+                         see docs/adr/0008-identity-plane-v0.md D5"
+                        .to_string());
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn member_kind_is_reserved_not_declarable() {
+        assert!(PrincipalKind::Operator.is_declarable());
+        assert!(PrincipalKind::Adapter.is_declarable());
+        assert!(!PrincipalKind::Member.is_declarable());
+    }
+
+    #[test]
+    fn kind_to_class_mapping_matches_adr() {
+        assert!(PrincipalKind::Operator.permits(AuthorityClass::Host));
+        assert!(PrincipalKind::Operator.permits(AuthorityClass::Interactive));
+        assert!(PrincipalKind::Operator.permits(AuthorityClass::Ingress));
+        assert!(!PrincipalKind::Adapter.permits(AuthorityClass::Host));
+        assert!(!PrincipalKind::Adapter.permits(AuthorityClass::Interactive));
+        assert!(PrincipalKind::Adapter.permits(AuthorityClass::Ingress));
+        assert!(!PrincipalKind::Member.permits(AuthorityClass::Host));
+    }
+
+    #[test]
+    fn host_list_precedence_beats_interactive_prefix() {
+        assert_eq!(
+            authority_class_for_method("thread/shellCommand"),
+            AuthorityClass::Host
+        );
+        assert_eq!(
+            authority_class_for_method("thread/start"),
+            AuthorityClass::Interactive
+        );
+    }
+
+    #[test]
+    fn unknown_method_fails_closed_to_host() {
+        assert_eq!(
+            authority_class_for_method("someFuture/method"),
+            AuthorityClass::Host
+        );
+    }
+
+    #[test]
+    fn managed_mode_without_tenant_hard_fails() {
+        let config = CooldisDaemonIdentityConfig {
+            mode: IdentityMode::Managed,
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+        let local = CooldisDaemonIdentityConfig::default();
+        assert!(local.validate().is_ok());
+    }
+
+    #[test]
+    fn token_digest_convention_matches_sync_authority() {
+        assert!(identity_token_digest("secret").starts_with("sha256:"));
+    }
+}

--- a/crates/cooldis-kernel/src/lib.rs
+++ b/crates/cooldis-kernel/src/lib.rs
@@ -206,6 +206,7 @@ pub mod daemon {
     pub mod daemon_config;
     pub mod daemon_io;
     pub(crate) mod handle_ingress;
+    pub mod identity;
     pub(crate) mod recovery_sweep;
     pub mod remote_store;
 }

--- a/docs/adr/0008-identity-plane-v0.md
+++ b/docs/adr/0008-identity-plane-v0.md
@@ -1,7 +1,8 @@
 # ADR 0008: Identity Plane v0 (Principals, Credentials, and the Authenticated Boundary)
 
-Status: proposed
-Date: 2026-07-18
+Status: accepted (ratified by the anchor 2026-07-20, with the member-kind
+deferral described in D1)
+Date: 2026-07-18 (revised 2026-07-20)
 
 ## Context
 
@@ -67,6 +68,18 @@ named principals. Multi-tenant boundary authentication, a role system, and the
 per-method grant algebra are foreclosed consciously (see Out of scope), not
 built.
 
+One layering principle governs every decision below: **the kernel is an
+identity receptor, not an identity provider.** The kernel needs a slot where
+"who" plugs in, because host authority can only be gated inside the dispatcher
+and because the record's attribution must be attested by the runtime itself,
+not relayed from a fronting proxy. Everything that provides identities (user
+accounts, login flows, SSO, directory sync) is a separate service above the
+kernel: Cooldis Cloud for the managed lane, or a deployment's own identity
+service for self-hosting. This mirrors the Unix split (user ids live in the
+kernel; login systems live outside it) and rejects the Docker split (no
+identity in the daemon at all, so socket access equals root and cannot be
+fixed after the fact).
+
 ## Decision
 
 ### D1: Principals are declared records
@@ -77,13 +90,25 @@ event in the stream and folded into a boundary-readable set. Fields:
 declaring principal (the "who granted what" attestation hook: a principal's
 existence names who created it).
 
-Kinds in v0:
+Kinds implemented in v0:
 
-- `operator`: full host authority (command exec, filesystem, secrets, debug).
-  The identity that possesses the host box.
-- `member`: interactive thread and agent use; no host authority.
+- `operator`: full host authority (command exec, filesystem, secrets, debug)
+  plus interactive use. The identity that possesses the host box.
 - `adapter`: ingress submission only; the identity a route binding names when
   it stamps `via="route:{route_id}"`.
+
+One kind is **reserved but not implemented**: `member`, interactive thread and
+agent use without host authority. The kind value exists in the record schema
+so its later arrival is additive, but declaring a member principal is rejected
+in v0. Rationale (the receptor-not-provider principle applied): no v0
+deployment gives an end user direct daemon access. Customers reach agents
+through adapters, and the envelope already records end-user attribution as
+adapter-supplied testimony: the kernel attests which authenticated adapter
+delivered the event, and records the external actor the adapter claims, as a
+claim. That split (attested carrier, claimed author) is the formally honest
+shape. Per-person accounts, when a deployment actually needs them, arrive as
+an external identity service that maps humans onto member principals; the
+kernel's job is only to have the slot ready.
 
 Principals are declared and revoked through witnessed events; the fold is the
 authority, and the boundary cache rebuilds from it at daemon start. Cache
@@ -145,6 +170,7 @@ both, and it happens at the upgrade, before the existing initialize-first rule
 - **Console:** the session token is regenerated from a CSPRNG (today it is two
   concatenated UUIDv7 values, `cli/console.rs:220-222`, which are time-ordered
   and guessable) and resolves the console connection to a configured principal
+  (in v0, the operator: every v0 console user is whoever operates the daemon)
   instead of standing in for an anonymous transport secret. Static asset serving
   is unchanged.
 - **MCP / ACP / debug RPC:** daemon clients, not surfaces of their own. Each
@@ -171,13 +197,20 @@ one gate. After authentication a connection carries a resolved principal; before
 dispatch, the method is checked against the principal's authority, derived
 directly from `principal.kind`:
 
-- **Host authority (operator only):** `command/exec` and its family,
-  `thread/shellCommand`, all `fs/*` methods, process-handle methods,
-  `modelProvider/auth/*`, `mcpSource/upsert`, and debug methods.
-- **Interactive (member and up):** `thread/*`, `turn/*`, `mandate/start`, and
-  the read methods.
-- **Ingress (adapter and up):** envelope submission; the route binding must
-  name the adapter principal it stamps.
+The method taxonomy has three classes; it is the durable part of this
+decision and does not change when the reserved `member` kind ships:
+
+- **Host authority:** `command/exec` and its family, `thread/shellCommand`,
+  all `fs/*` methods, process-handle methods, `modelProvider/auth/*`,
+  `mcpSource/upsert`, and debug methods.
+- **Interactive:** `thread/*`, `turn/*`, `mandate/start`, and the read
+  methods.
+- **Ingress:** envelope submission; the route binding must name the adapter
+  principal it stamps.
+
+The v0 kind-to-class mapping: `operator` reaches all three classes; `adapter`
+reaches ingress only. When `member` ships it will reach interactive and
+ingress but never host authority; nothing about the taxonomy moves.
 
 The host-authority list is explicit and takes precedence: `thread/shellCommand`
 is host authority even though it matches the `thread/*` interactive prefix. A
@@ -249,24 +282,33 @@ foreclosed to a later version.
 
 ## Consequences
 
-- The managed instance can name its operator, its console member, and its
-  adapter principals, and can prove each caller is who it claims before any host
-  authority is exercised. This is the precondition for standing the internal
-  managed instance up.
+- The managed instance can name its operator and its adapter principals, and
+  can prove each caller is who it claims before any host authority is
+  exercised. This is the precondition for standing the internal managed
+  instance up.
 - A single-user developer keeps working unchanged: `local` mode with no identity
   section plus the same-uid peer mapping means host CLI usage needs no token,
   while every remote or multi-principal path authenticates.
 - The console stops being authenticated by a guessable token.
-- The three authority classes are coarse. The first tenant with two humans, or
-  the first need to grant one principal a single host method, forces the grant
-  algebra; the declaration and mint events already record the attestation trail,
-  so adding per-method grant records then is additive.
+- The authority classes are coarse, and two future triggers are named. The
+  first deployment where an end user needs direct daemon access (rather than
+  reaching agents through an adapter) triggers implementing the reserved
+  `member` kind, fed by an external identity service. The first need to grant
+  one principal a single host method triggers the per-method grant algebra.
+  The declaration and mint events already record the attestation trail, so
+  both arrivals are additive.
 
 ## Out of scope (foreclosed consciously, not forgotten)
 
+- **Member principals and per-person accounts.** The `member` kind value is
+  reserved in the schema and rejected at declaration (D1). End users reach
+  agents through adapters, attributed as adapter testimony on the envelope.
+  When a deployment needs direct end-user daemon access, members ship, fed by
+  an external identity service (Cloud-side or deployment-owned); the kernel
+  never becomes an identity provider.
 - **Role / membership model (RBAC) and the per-method grant algebra.** Triggered
-  by a second human in one tenant, or the first per-method grant ask. v0
-  authority classes are not roles, and default authority is not persisted.
+  by the first per-method grant ask. v0 authority classes are not roles, and
+  default authority is not persisted.
 - **Agents as principals.** Agents act under ADR 0007 mandate/handle/remote
   schemes; giving an agent its own credential is a later, separate decision.
 - **Cross-tenant boundary authentication.** One tenant per daemon; no boundary
@@ -277,6 +319,30 @@ foreclosed to a later version.
   per-connection recheck waits for a killable-in-flight requirement.
 - **Durable ingress principal projection.** EMO-494, design-gated separately.
 
+## Related surfaces (public references)
+
+Two shipped systems were compared while revising this design; both citations
+are public.
+
+- **Everruns** (github.com/everruns/everruns) independently converged on the
+  same credential shape: high-entropy random tokens shown once at creation and
+  stored only as SHA-256 digests. Its role ladder measures organization
+  seniority rather than machine authority, its inbound channels authenticate
+  with shared per-channel tokens bound to no named principal, and its internal
+  worker fleet authenticates with a single shared token, which this design
+  treats as a counterexample: workers get per-worker scoped credentials, never
+  a fleet secret.
+- **Anthropic's Managed Agents API** (platform.claude.com docs) has one
+  data-plane authority class: any workspace API key holds full authority over
+  every agent, session, and stored credential in the workspace. Sessions
+  record no initiating user; end users exist only as caller-supplied metadata
+  on credential containers. Its credential rotation re-resolving into running
+  sessions is what prompted D6's explicit revocation-timing decision here.
+
+Neither system carries a data-plane distinction like operator / adapter /
+(reserved) member, and neither records who initiated a session in an attested
+record. That gap is the part of this design that is not catch-up.
+
 ## Lexicon additions (naming-law receipt)
 
 This ADR names four primitives the lexicon uses or now requires but has not
@@ -286,7 +352,8 @@ be added to `formalism/lexicon.md` before the phase-2 implementation tickets:
 
 - **principal**: a named identity within a tenant, on whose authority effects
   act; declared as a witnessed record. Already load-bearing in the `envelope`
-  entry ("resolves to a principal").
+  entry ("resolves to a principal"). The `member` kind value is reserved, not
+  implemented; it receives a full lexicon treatment when it ships.
 - **credential**: a witnessed binding of a bearer secret (stored as a digest
   only) to one principal, with which a caller authenticates at a boundary.
 - **tenant**: the isolation unit that owns principals, streams, and grants;
@@ -300,17 +367,19 @@ be added to `formalism/lexicon.md` before the phase-2 implementation tickets:
 Each kernel ticket is security-adjacent and dispatched with an explicit list of
 failure modes to defend against (enforcement bypass, cross-principal confusion,
 credential leakage, escalation through the peer mapping) and a second
-independent review before it lands.
+independent review before it lands. With the member deferral, every ticket
+builds two kinds, not three.
 
-1. Principal and credential records, the fold, and the CLI command that
-   bootstraps the first operator (declare + mint in one step).
+1. Principal and credential records (operator and adapter kinds; member
+   reserved and rejected), the fold, and the CLI command that bootstraps the
+   first operator (declare + mint in one step).
 2. Boundary authentication: token verification on the shared WebSocket upgrade,
    the same-uid peer mapping, and the resolved principal on the connection;
    regenerate the console token from a CSPRNG.
-3. Dispatcher authorization classes, host-authority gating with the precedence
-   rule, the distinct authorization error, and the witnessed session,
-   host-effect, and authentication-rejected events; stamp
-   `via="caller:{session_id}"` on caller-authenticated ingress.
+3. Dispatcher authorization: the method taxonomy, the operator / adapter
+   kind-to-class mapping with the precedence rule, the distinct authorization
+   error, and the witnessed session, host-effect, and authentication-rejected
+   events; stamp `via="caller:{session_id}"` on caller-authenticated ingress.
 4. Config: `[daemon.identity]` with `mode`, removal of the hard-coded tenant,
    and the migration note.
 5. Docs: `threat-model.md` update and an authentication section in

--- a/docs/adr/0008-identity-plane-v0.md
+++ b/docs/adr/0008-identity-plane-v0.md
@@ -1,0 +1,317 @@
+# ADR 0008: Identity Plane v0 (Principals, Credentials, and the Authenticated Boundary)
+
+Status: proposed
+Date: 2026-07-18
+
+## Context
+
+ADR 0007 gave every ingress envelope a principal: the admitted record now says
+on whose authority an event acted. But that principal is stamped from the
+daemon's own configuration, not proven. One hard-coded identity
+(`cooldis_app_server` / `local_user`, in `crates/cooldis-kernel/src/adapters/app_server/mod.rs:225-226`)
+is registered as the single tenant at startup (same file, `mod.rs:710-715`) and
+stamped on all route ingress
+(`crates/cooldis-kernel/src/daemon/daemon_io.rs:1066-1068`). Nothing at the
+boundary asks a caller who it is.
+
+Every locally reachable surface is unauthenticated, and the RPC dispatcher
+behind them exposes full host authority. File references below are relative to
+`crates/cooldis-kernel/src/`.
+
+- The app-server Unix socket accepts any connection; the accept path discards
+  peer credentials (`adapters/app_server/mod.rs:860`), and while the socket's
+  parent directory is chmod `0o700` on first creation (same file, `1835-1844`),
+  the socket file itself is left to the umask (`852`). Both the Unix socket and
+  the TCP listener carry a WebSocket upgrade
+  (`adapters/app_server/mod.rs:913-941`): the two surfaces share one handshake.
+- The loopback WebSocket is loopback-enforced (`adapters/app_server/mod.rs:892-896`)
+  but carries no token unless the bundled console is configured. `/healthz` and
+  `/readyz` are served unauthenticated (same file, `951-961`).
+- MCP, ACP, and `cooldis debug rpc` are clients that ride the Unix socket or the
+  loopback WebSocket; they inherit its absent authentication.
+- The RPC dispatcher is a flat `match method` with no per-method authorization
+  (`adapters/app_server/connection.rs:863-869`, unknown-method fallthrough
+  `1197-1200`). Any connected client can call `command/exec` (arbitrary argv,
+  sandbox `dangerFullAccess`, same file `3633`), the `fs/*` methods (absolute
+  paths with no workspace confinement, `4532-4541`), and the secret-writing
+  methods (`modelProvider/auth/set` `947`, `mcpSource/upsert` `1132`).
+
+Exactly one surface already authenticates: the remote-store stream sync
+endpoint. `SyncCredentialAuthority` (`daemon/remote_store/lease.rs:270-283`)
+mints credentials from a CSPRNG, persists only a digest (same file,
+`249,720`), scopes each credential to a stream prefix (`StreamPrefixScope`,
+`75`), fences writers with a single-writer lease (`189`), and witnesses
+rejections. Every request verifies a bearer token before it acts
+(`daemon/remote_store/endpoint.rs:518,584,602,647`). This is the shape to
+reuse, not reinvent.
+
+Security today rests entirely on loopback binding plus one directory's
+permission bits. That is adequate for a single-user laptop and disqualifying
+for a managed instance the moment a second principal, or an untrusted network
+path, exists.
+
+The invariant this ADR installs, stated once: **every connection to a
+privileged surface resolves to an authenticated principal before it may call
+any method, and each method it calls is authorized against that principal's
+authority. A connection that has not resolved to a principal is admitted to no
+method. Every authorization decision, allow or deny, is recorded with the
+principal it was made for.**
+
+Terms used below are the runtime's own (see `docs/kernel-invariants.md`): an
+*event* is an entry in the append-only stream; a *witnessed* fact is one the
+runtime recorded as such; a *fold* is the projection built by reducing over the
+stream, and it is the authority a boundary cache is rebuilt from.
+
+Scope discipline: this is a v0 sized to one internal tenant with a handful of
+named principals. Multi-tenant boundary authentication, a role system, and the
+per-method grant algebra are foreclosed consciously (see Out of scope), not
+built.
+
+## Decision
+
+### D1: Principals are declared records
+
+A **principal** is a named identity within a tenant, declared as a witnessed
+event in the stream and folded into a boundary-readable set. Fields:
+`principal_id`, `kind`, `display`, `status` (active / revoked), and the
+declaring principal (the "who granted what" attestation hook: a principal's
+existence names who created it).
+
+Kinds in v0:
+
+- `operator`: full host authority (command exec, filesystem, secrets, debug).
+  The identity that possesses the host box.
+- `member`: interactive thread and agent use; no host authority.
+- `adapter`: ingress submission only; the identity a route binding names when
+  it stamps `via="route:{route_id}"`.
+
+Principals are declared and revoked through witnessed events; the fold is the
+authority, and the boundary cache rebuilds from it at daemon start. Cache
+refresh after a mid-run declaration is covered in D6. Agents are not principals
+in v0: they act under the `mandate:` / `handle:` / `remote:` schemes ADR 0007
+already defines, never under a credential of their own.
+
+### D2: Credentials are hash-only witnessed records
+
+A **credential** binds a bearer secret to exactly one principal:
+`credential_id`, `principal_id`, the SHA-256 digest of a 256-bit CSPRNG secret,
+optional expiry, and a revoked flag. Minting and revoking are witnessed events;
+the secret material never enters the record, only its digest and metadata.
+High-entropy random secrets make the stored digest non-invertible, so no
+password-style slow hash is needed (these are tokens, not passwords).
+
+The mint event names the principal that authorized it: with D1's declaration
+event, this is the full "who granted what" trail, and it is a historical fact,
+not re-derivable configuration. This reuses the `SyncCredentialAuthority`
+vocabulary (CSPRNG mint, digest-only persistence) rather than introducing a
+second credential shape; the two authorities stay distinct objects but share
+the pattern.
+
+"The secret never enters the record" is a statement about the daemon: the
+daemon persists only digests. A client (MCP, ACP, debug RPC, an external
+adapter) holds its own credential secret in its own configuration or
+environment, which is the ordinary bearer-token custody model.
+
+Bootstrap: an `operator`-run CLI command on the host box, in one step, declares
+the first operator principal and mints its credential through direct store
+access. Possession of the box is the root of trust in v0; no secret is ever
+embedded in a daemon config file. A running daemon picks up the new principal
+and credential at the next fold refresh (D6); a cold bootstrap precedes daemon
+start and needs no refresh.
+
+### D3: Authentication rides the shared WebSocket handshake
+
+Both privileged transports (the Unix socket and the loopback TCP listener)
+speak a WebSocket upgrade before any JSON-RPC flows
+(`adapters/app_server/mod.rs:913-941`), so one authentication design covers
+both, and it happens at the upgrade, before the existing initialize-first rule
+(`adapters/app_server/connection.rs:838-843`).
+
+- **Token carrier:** an `Authorization: Bearer` header on the upgrade request,
+  verified against the credential fold, resolving the connection to a principal.
+  The console's `Sec-WebSocket-Protocol` token carrier
+  (`adapters/app_server/mod.rs:1734-1750`) is accepted as an equivalent because
+  browsers cannot set arbitrary headers on a WebSocket. The `?token=`
+  query-parameter carrier the same function also accepts is dropped: query
+  strings leak into logs and history.
+- **Auth failure:** the upgrade is answered `401` and the connection closes; no
+  JSON-RPC session opens. The failure is witnessed (D6). There is no
+  unauthenticated fallthrough to any method.
+- **Unix-socket peer mapping (local-mode ergonomics):** in `local` mode (D5) a
+  same-uid peer (checked via `SO_PEERCRED` / `getpeereid`) resolves to the
+  configured `operator` principal without a token, so `cooldis` CLI usage on the
+  host needs no credential. This is off in `managed` mode. The socket file gains
+  an explicit `0o600` chmod regardless of mode.
+- **Console:** the session token is regenerated from a CSPRNG (today it is two
+  concatenated UUIDv7 values, `cli/console.rs:220-222`, which are time-ordered
+  and guessable) and resolves the console connection to a configured principal
+  instead of standing in for an anonymous transport secret. Static asset serving
+  is unchanged.
+- **MCP / ACP / debug RPC:** daemon clients, not surfaces of their own. Each
+  presents a credential and inherits the principal it resolves to. Debug RPC
+  resolves to `operator` only.
+- **Health probes:** `/healthz` and `/readyz` stay unauthenticated for
+  orchestrator probing; `readyz` reports liveness only and must not leak
+  identity or configuration.
+- **Stream-sync endpoint:** already authenticated (see Context); untouched here
+  beyond noting the shared pattern.
+
+The same-uid peer mapping has one sharp consequence that must be named: the
+daemon runs agent host commands under its own uid, so with the mapping on, a
+process an agent spawns via `command/exec` could reconnect to the socket and be
+resolved as `operator`, escalating out of its sandbox. This is why the mapping
+is a `local`-mode developer convenience only. `managed` deployments run with it
+off, and their agents authenticate (or do not share the daemon's uid), so the
+loop is closed there.
+
+### D4: Authorization is authority classes at the dispatcher choke point
+
+The dispatcher's single `match` (`adapters/app_server/connection.rs:869`) is the
+one gate. After authentication a connection carries a resolved principal; before
+dispatch, the method is checked against the principal's authority, derived
+directly from `principal.kind`:
+
+- **Host authority (operator only):** `command/exec` and its family,
+  `thread/shellCommand`, all `fs/*` methods, process-handle methods,
+  `modelProvider/auth/*`, `mcpSource/upsert`, and debug methods.
+- **Interactive (member and up):** `thread/*`, `turn/*`, `mandate/start`, and
+  the read methods.
+- **Ingress (adapter and up):** envelope submission; the route binding must
+  name the adapter principal it stamps.
+
+The host-authority list is explicit and takes precedence: `thread/shellCommand`
+is host authority even though it matches the `thread/*` interactive prefix. A
+method's most restrictive matching class wins.
+
+An unauthorized call (an authenticated principal invoking a method above its
+authority) returns a distinct authorization error, not the `-32601`
+unknown-method code (`adapters/app_server/connection.rs:1197-1200`), so the
+boundary does not double as a method-enumeration oracle beyond what a caller's
+own class already reveals.
+
+Authority is derived from `principal.kind` at the gate, not stored as separate
+grant records. Default class-to-method mapping is re-derivable configuration,
+which by ADR 0007's own D7 test is retrofittable and should not be persisted
+before it is needed. When a real ask for per-method grants arrives (Out of
+scope), grants become witnessed records then; the declaration and mint events
+already carry the attestation trail in the meantime.
+
+### D5: Tenant and mode come from configuration, not code
+
+The daemon config file grows a `[daemon.identity]` section: `tenant_id`, a
+`mode` of `local` or `managed`, the console principal binding, and (in
+`managed` mode) the expected principals. The hard-coded `cooldis_app_server` /
+`local_user` defaults are removed from code.
+
+- `local` mode with no `[daemon.identity]` section synthesizes a single default
+  `operator` principal and enables the Unix-socket peer mapping (D3), so an
+  existing single-user developer keeps working with no migration and no token.
+- `managed` mode requires an explicit `[daemon.identity]` section and a
+  bootstrapped operator credential; starting `managed` without them is a hard
+  error with a migration note. Peer mapping and debug RPC default off.
+
+One tenant per daemon remains the deployment model. Per-tenant instances are the
+managed-lane isolation boundary; multi-tenant boundary authentication is
+foreclosed to a later version.
+
+### D6: Sessions, audit identity, and the caller-auth ingress scheme
+
+- **Sessions are witnessed.** RPC session open and close emit witnessed events
+  carrying the resolved principal, the surface, and the credential id, or, for a
+  peer-mapped `local` session that used no credential, the peer uid in the
+  credential id's place. Failed authentication is witnessed too (an
+  authentication-rejected event with the surface and the reason), so pre-guard
+  intrusion attempts are not invisible, matching the sync endpoint's existing
+  behavior.
+- **Host-authority effects carry the principal.** Command exec, filesystem
+  writes, and secret reads emit witnessed events carrying the session principal.
+- **Caller-authenticated ingress gets its `via` scheme, named now.** ADR 0007
+  reserved a caller-auth scheme for when boundary authentication landed; this is
+  that landing. Ingress an authenticated caller submits is stamped
+  `via="caller:{session_id}"`, pointing at the witnessed session event that
+  proves the authentication, the same way `mandate:` points at the clock event
+  and `handle:` at the dispatch. Choosing this string now matters because it
+  enters permanent ingress records the moment phase 2 ships; leaving it unnamed
+  would repeat the unretrofittable gap ADR 0007 closed.
+- **Revocation and expiry are checked at connection open.** A revoked or expired
+  credential resolves to no principal on the next connect. v0 does not forcibly
+  tear down a live session whose credential is revoked mid-connection; that
+  bounded gap is acceptable for a handful of trusted principals and is revisited
+  when a credential must be killable in flight (the trigger to add
+  per-connection recheck).
+- **Cache refresh.** The boundary principal and credential caches rebuild from
+  the fold at daemon start and refresh when a principal or credential event is
+  appended, so a mid-run mint or revoke takes effect on subsequent connections
+  without a restart.
+- Projecting the ingress principal into the durable ingress event schema is
+  EMO-494 and is not re-decided here; the session and host-effect events this
+  section adds are new record shapes, not changes to an existing one.
+
+## Consequences
+
+- The managed instance can name its operator, its console member, and its
+  adapter principals, and can prove each caller is who it claims before any host
+  authority is exercised. This is the precondition for standing the internal
+  managed instance up.
+- A single-user developer keeps working unchanged: `local` mode with no identity
+  section plus the same-uid peer mapping means host CLI usage needs no token,
+  while every remote or multi-principal path authenticates.
+- The console stops being authenticated by a guessable token.
+- The three authority classes are coarse. The first tenant with two humans, or
+  the first need to grant one principal a single host method, forces the grant
+  algebra; the declaration and mint events already record the attestation trail,
+  so adding per-method grant records then is additive.
+
+## Out of scope (foreclosed consciously, not forgotten)
+
+- **Role / membership model (RBAC) and the per-method grant algebra.** Triggered
+  by a second human in one tenant, or the first per-method grant ask. v0
+  authority classes are not roles, and default authority is not persisted.
+- **Agents as principals.** Agents act under ADR 0007 mandate/handle/remote
+  schemes; giving an agent its own credential is a later, separate decision.
+- **Cross-tenant boundary authentication.** One tenant per daemon; no boundary
+  path authenticates across tenants.
+- **Password auth, OIDC, SSO.** Cooldis Cloud concerns above the kernel, not
+  kernel primitives.
+- **Mid-connection revocation enforcement.** Checked at connect in v0 (D6);
+  per-connection recheck waits for a killable-in-flight requirement.
+- **Durable ingress principal projection.** EMO-494, design-gated separately.
+
+## Lexicon additions (naming-law receipt)
+
+This ADR names four primitives the lexicon uses or now requires but has not
+defined as headwords. All are conservative: they codify meanings already
+load-bearing in the code and the envelope entry, and change no existing word. To
+be added to `formalism/lexicon.md` before the phase-2 implementation tickets:
+
+- **principal**: a named identity within a tenant, on whose authority effects
+  act; declared as a witnessed record. Already load-bearing in the `envelope`
+  entry ("resolves to a principal").
+- **credential**: a witnessed binding of a bearer secret (stored as a digest
+  only) to one principal, with which a caller authenticates at a boundary.
+- **tenant**: the isolation unit that owns principals, streams, and grants;
+  already used throughout the code and the lexicon prose.
+- The `caller:{session_id}` **`via` scheme** on the envelope's principal
+  attribution, extending the schemes named with `envelope` (`route:`,
+  `mandate:`, `handle:`, `remote:`).
+
+## Phase-2 tickets (cut after ratification, skeletons planned)
+
+Each kernel ticket is security-adjacent and dispatched with an explicit list of
+failure modes to defend against (enforcement bypass, cross-principal confusion,
+credential leakage, escalation through the peer mapping) and a second
+independent review before it lands.
+
+1. Principal and credential records, the fold, and the CLI command that
+   bootstraps the first operator (declare + mint in one step).
+2. Boundary authentication: token verification on the shared WebSocket upgrade,
+   the same-uid peer mapping, and the resolved principal on the connection;
+   regenerate the console token from a CSPRNG.
+3. Dispatcher authorization classes, host-authority gating with the precedence
+   rule, the distinct authorization error, and the witnessed session,
+   host-effect, and authentication-rejected events; stamp
+   `via="caller:{session_id}"` on caller-authenticated ingress.
+4. Config: `[daemon.identity]` with `mode`, removal of the hard-coded tenant,
+   and the migration note.
+5. Docs: `threat-model.md` update and an authentication section in
+   `app-server.md`.


### PR DESCRIPTION
Architect skeleton for the identity plane per ADR 0008 (docs/adr/0008-identity-plane-v0.md, accepted).

Adds crates/cooldis-kernel/src/daemon/identity.rs: schema id constants, PrincipalId and PrincipalKind (member schema-reserved, not declarable), AuthorityClass and the method-to-class mapping (fail-closed to Host), record types for principals, credentials, sessions, and auth rejections, the IdentityAuthority trait, IdentityMode, and the [daemon.identity] config shape with hard-fail validation. Six pinned unit tests fix the taxonomy behavior.

Implementation lands separately on emo-496-identity-records (EMO-496), reviewed and stacked on this branch.