### PR TITLE
EMO-499: daemon identity config wiring, mode and tenant from config

### DIFF
--- a/crates/cooldis-kernel/src/adapters/app_server/mod.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/mod.rs
@@ -1,7 +1,7 @@
 use crate::ProcessHandleIngressSink;
 use crate::daemon::daemon_config::synthesized_local_daemon_identity_config;
 use crate::daemon::daemon_io::CooldisDaemonIoBridge;
-use crate::daemon::identity::{IdentityMode, PrincipalId};
+use crate::daemon::identity::{CooldisDaemonIdentityConfig, IdentityMode, PrincipalId};
 use crate::daemon::recovery_sweep::StartupRecoverySweep;
 use crate::kernel::process_handle_dispatch::ProcessHandleDispatcher;
 use crate::{
@@ -221,22 +221,16 @@ impl CooldisAppServerConfig {
     pub fn local(listen: AppServerListenAddr, cwd: impl Into<PathBuf>) -> Self {
         let root = std::env::temp_dir().join(format!("cooldis-app-server-{}", Uuid::now_v7()));
         let identity = synthesized_local_daemon_identity_config();
-        let tenant_id = identity.tenant_id.unwrap_or_default();
-        let user_id = identity
-            .console_principal
-            .as_ref()
-            .map(ToString::to_string)
-            .unwrap_or_default();
-        Self {
+        let mut config = Self {
             listen,
             runtime_home: root.join("runtime"),
             state_home: root.join("state"),
             user_state_home: root.join("user-state"),
             cwd: cwd.into(),
-            tenant_id,
-            user_id,
-            identity_mode: identity.mode,
-            console_principal: identity.console_principal,
+            tenant_id: String::new(),
+            user_id: String::new(),
+            identity_mode: IdentityMode::Local,
+            console_principal: None,
             model: APP_SERVER_LOCAL_MODEL.to_string(),
             model_provider: APP_SERVER_LOCAL_PROVIDER.to_string(),
             provider: AppServerProviderConfig::LocalOffline,
@@ -249,7 +243,20 @@ impl CooldisAppServerConfig {
             default_workspace: None,
             remote_event_store_served: Arc::new(AtomicBool::new(false)),
             console_assets: None,
-        }
+        };
+        config.apply_daemon_identity_config(&identity);
+        config
+    }
+
+    pub(crate) fn apply_daemon_identity_config(&mut self, identity: &CooldisDaemonIdentityConfig) {
+        self.identity_mode = identity.mode;
+        self.tenant_id = identity.tenant_id.clone().unwrap_or_default();
+        self.console_principal = identity.console_principal.clone();
+        self.user_id = self
+            .console_principal
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_default();
     }
 
     pub fn with_bifrost_openai(
@@ -498,6 +505,8 @@ struct CooldisAppServerInner {
     supervisor: CooldisSupervisor,
     tenant_id: String,
     user_id: String,
+    identity_mode: IdentityMode,
+    console_principal: Option<PrincipalId>,
     model: String,
     model_provider: String,
     provider: AppServerProviderConfig,
@@ -731,6 +740,8 @@ impl CooldisAppServer {
                 supervisor,
                 tenant_id: config.tenant_id,
                 user_id: config.user_id,
+                identity_mode: config.identity_mode,
+                console_principal: config.console_principal,
                 model: config.model,
                 model_provider: config.model_provider,
                 provider: config.provider,
@@ -831,6 +842,15 @@ impl CooldisAppServer {
 
     pub fn user_id(&self) -> &str {
         &self.inner.user_id
+    }
+
+    /// Constructor-injected seam consumed by boundary authentication.
+    #[allow(dead_code)]
+    pub(crate) fn identity_boundary_config(&self) -> (IdentityMode, Option<&PrincipalId>) {
+        (
+            self.inner.identity_mode,
+            self.inner.console_principal.as_ref(),
+        )
     }
 
     pub fn model(&self) -> &str {

--- a/crates/cooldis-kernel/src/adapters/app_server/mod.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/mod.rs
@@ -1,5 +1,7 @@
 use crate::ProcessHandleIngressSink;
+use crate::daemon::daemon_config::synthesized_local_daemon_identity_config;
 use crate::daemon::daemon_io::CooldisDaemonIoBridge;
+use crate::daemon::identity::{IdentityMode, PrincipalId};
 use crate::daemon::recovery_sweep::StartupRecoverySweep;
 use crate::kernel::process_handle_dispatch::ProcessHandleDispatcher;
 use crate::{
@@ -196,6 +198,8 @@ pub struct CooldisAppServerConfig {
     pub cwd: PathBuf,
     pub tenant_id: String,
     pub user_id: String,
+    pub identity_mode: IdentityMode,
+    pub console_principal: Option<PrincipalId>,
     pub model: String,
     pub model_provider: String,
     pub provider: AppServerProviderConfig,
@@ -216,14 +220,23 @@ pub struct CooldisAppServerConfig {
 impl CooldisAppServerConfig {
     pub fn local(listen: AppServerListenAddr, cwd: impl Into<PathBuf>) -> Self {
         let root = std::env::temp_dir().join(format!("cooldis-app-server-{}", Uuid::now_v7()));
+        let identity = synthesized_local_daemon_identity_config();
+        let tenant_id = identity.tenant_id.unwrap_or_default();
+        let user_id = identity
+            .console_principal
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_default();
         Self {
             listen,
             runtime_home: root.join("runtime"),
             state_home: root.join("state"),
             user_state_home: root.join("user-state"),
             cwd: cwd.into(),
-            tenant_id: "cooldis_app_server".to_string(),
-            user_id: "local_user".to_string(),
+            tenant_id,
+            user_id,
+            identity_mode: identity.mode,
+            console_principal: identity.console_principal,
             model: APP_SERVER_LOCAL_MODEL.to_string(),
             model_provider: APP_SERVER_LOCAL_PROVIDER.to_string(),
             provider: AppServerProviderConfig::LocalOffline,

--- a/crates/cooldis-kernel/src/adapters/app_server/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/tests.rs
@@ -493,6 +493,33 @@ async fn thread_compact_start_dispatches_to_runtime() {
 }
 
 #[tokio::test]
+async fn app_server_retains_identity_boundary_config() {
+    let listen = AppServerListenAddr::Unix(
+        std::env::temp_dir().join(format!("cooldis-identity-config-{}.sock", Uuid::now_v7())),
+    );
+    let root = unique_test_root("app-server-identity-config");
+    let mut config = CooldisAppServerConfig::local(listen, std::env::current_dir().unwrap());
+    config.runtime_home = root.join("runtime");
+    config.state_home = root.join("state");
+    config.agent_registry_root = root.join("agents");
+    config.apply_daemon_identity_config(&CooldisDaemonIdentityConfig {
+        mode: IdentityMode::Managed,
+        tenant_id: Some("tenant-managed".to_string()),
+        console_principal: Some(PrincipalId::new("operator-managed")),
+    });
+
+    let app = CooldisAppServer::new_local(config).await.unwrap();
+
+    assert_eq!(
+        app.identity_boundary_config(),
+        (
+            IdentityMode::Managed,
+            Some(&PrincipalId::new("operator-managed"))
+        )
+    );
+}
+
+#[tokio::test]
 async fn app_server_new_local_seeds_default_provider_store() {
     let listen = AppServerListenAddr::Unix(
         std::env::temp_dir().join(format!("cooldis-provider-store-{}.sock", Uuid::now_v7())),
@@ -1997,9 +2024,11 @@ async fn app_server_persists_thread_lifecycle_to_metadata_store() {
     config.runtime_home = root.join("runtime");
     config.state_home = root.join("state");
     config.agent_registry_root = root.join("agents");
-    config.tenant_id = "tenant-configured".to_string();
-    config.user_id = "principal-configured".to_string();
-    config.console_principal = Some(PrincipalId::new("principal-configured"));
+    config.apply_daemon_identity_config(&CooldisDaemonIdentityConfig {
+        mode: IdentityMode::Local,
+        tenant_id: Some("tenant-configured".to_string()),
+        console_principal: Some(PrincipalId::new("principal-configured")),
+    });
     let expected_tenant_id = config.tenant_id.clone();
     let expected_user_id = config.user_id.clone();
     let metadata_path = config.metadata_store_path();
@@ -6341,9 +6370,11 @@ streaming = false
     config.runtime_home = root.join("runtime");
     config.state_home = root.join("state");
     config.agent_registry_root = agent_registry_root;
-    config.tenant_id = "tenant-manifest".to_string();
-    config.user_id = "principal-manifest".to_string();
-    config.console_principal = Some(PrincipalId::new("principal-manifest"));
+    config.apply_daemon_identity_config(&CooldisDaemonIdentityConfig {
+        mode: IdentityMode::Local,
+        tenant_id: Some("tenant-manifest".to_string()),
+        console_principal: Some(PrincipalId::new("principal-manifest")),
+    });
     let tenant_id = config.tenant_id.clone();
     let user_id = config.user_id.clone();
     let metadata_path = config.metadata_store_path();

--- a/crates/cooldis-kernel/src/adapters/app_server/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/tests.rs
@@ -1997,6 +1997,11 @@ async fn app_server_persists_thread_lifecycle_to_metadata_store() {
     config.runtime_home = root.join("runtime");
     config.state_home = root.join("state");
     config.agent_registry_root = root.join("agents");
+    config.tenant_id = "tenant-configured".to_string();
+    config.user_id = "principal-configured".to_string();
+    config.console_principal = Some(PrincipalId::new("principal-configured"));
+    let expected_tenant_id = config.tenant_id.clone();
+    let expected_user_id = config.user_id.clone();
     let metadata_path = config.metadata_store_path();
 
     let app = CooldisAppServer::new_local(config).await.unwrap();
@@ -2019,8 +2024,8 @@ async fn app_server_persists_thread_lifecycle_to_metadata_store() {
         .await
         .unwrap()
         .expect("app-server thread/start should persist thread lifecycle metadata");
-    assert_eq!(record.coordinates.tenant_id, "cooldis_app_server");
-    assert_eq!(record.coordinates.user_id, "local_user");
+    assert_eq!(record.coordinates.tenant_id, expected_tenant_id);
+    assert_eq!(record.coordinates.user_id, expected_user_id);
     assert_eq!(record.status, crate::ThreadLifecycleStatus::Idle);
     assert_eq!(record.topology, ThreadTopology::root());
     assert_eq!(
@@ -6336,6 +6341,11 @@ streaming = false
     config.runtime_home = root.join("runtime");
     config.state_home = root.join("state");
     config.agent_registry_root = agent_registry_root;
+    config.tenant_id = "tenant-manifest".to_string();
+    config.user_id = "principal-manifest".to_string();
+    config.console_principal = Some(PrincipalId::new("principal-manifest"));
+    let tenant_id = config.tenant_id.clone();
+    let user_id = config.user_id.clone();
     let metadata_path = config.metadata_store_path();
     let session_path = config.state_home.join("session_history.sqlite3");
     let app = CooldisAppServer::new_local(config).await.unwrap();
@@ -6502,7 +6512,7 @@ streaming = false
     let metadata_store = SqliteMetadataStore::open(metadata_path).await.unwrap();
     assert_eq!(
         metadata_store
-            .list_thread_lifecycle_for_user("cooldis_app_server", "local_user")
+            .list_thread_lifecycle_for_user(&tenant_id, &user_id)
             .await
             .unwrap()
             .len(),

--- a/crates/cooldis-kernel/src/cli/daemon.rs
+++ b/crates/cooldis-kernel/src/cli/daemon.rs
@@ -61,14 +61,7 @@ pub(super) fn daemon_app_server_config_from_loaded(
         })?,
     };
     let mut config = CooldisAppServerConfig::local(listen, cwd);
-    config.identity_mode = loaded.config.identity.mode;
-    config.tenant_id = loaded.config.identity.tenant_id.clone().unwrap_or_default();
-    config.console_principal = loaded.config.identity.console_principal.clone();
-    config.user_id = config
-        .console_principal
-        .as_ref()
-        .map(ToString::to_string)
-        .unwrap_or_default();
+    config.apply_daemon_identity_config(&loaded.config.identity);
     if let Some(runtime_home) = loaded.config.runtime.runtime_home.clone() {
         config.runtime_home = runtime_home;
     }

--- a/crates/cooldis-kernel/src/cli/daemon.rs
+++ b/crates/cooldis-kernel/src/cli/daemon.rs
@@ -61,6 +61,14 @@ pub(super) fn daemon_app_server_config_from_loaded(
         })?,
     };
     let mut config = CooldisAppServerConfig::local(listen, cwd);
+    config.identity_mode = loaded.config.identity.mode;
+    config.tenant_id = loaded.config.identity.tenant_id.clone().unwrap_or_default();
+    config.console_principal = loaded.config.identity.console_principal.clone();
+    config.user_id = config
+        .console_principal
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_default();
     if let Some(runtime_home) = loaded.config.runtime.runtime_home.clone() {
         config.runtime_home = runtime_home;
     }

--- a/crates/cooldis-kernel/src/cli/daemon.rs
+++ b/crates/cooldis-kernel/src/cli/daemon.rs
@@ -53,6 +53,7 @@ pub(super) async fn daemon_run(args: Vec<OsString>) -> CooldisResult<()> {
 pub(super) fn daemon_app_server_config_from_loaded(
     loaded: &LoadedCooldisDaemonConfig,
 ) -> CooldisResult<CooldisAppServerConfig> {
+    loaded.config.validate()?;
     let listen = loaded.config.app_server.listen_addr()?;
     let cwd = match loaded.config.runtime.cwd.clone() {
         Some(cwd) => cwd,

--- a/crates/cooldis-kernel/src/cli/daemon/tests.rs
+++ b/crates/cooldis-kernel/src/cli/daemon/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::daemon::identity::{IdentityMode, PrincipalId};
 use crate::{
     AgentManifestPlacementBinding, AgentManifestWorkspaceBinding, AgentManifestWorkspaceMode,
     CooldisDaemonConfig,
@@ -80,6 +81,25 @@ fn daemon_app_server_config_from_loaded_keeps_registry_defaults_when_unset() {
         AgentManifestPlacementBinding::default()
     );
     assert_eq!(app_config.default_workspace, None);
+}
+
+#[test]
+fn daemon_app_server_config_from_loaded_applies_identity_config() {
+    let mut daemon_config = CooldisDaemonConfig::default();
+    daemon_config.identity.mode = IdentityMode::Managed;
+    daemon_config.identity.tenant_id = Some("tenant-configured".to_string());
+    daemon_config.identity.console_principal = Some(PrincipalId::new("operator-configured"));
+
+    let app_config =
+        daemon_app_server_config_from_loaded(&loaded_daemon_config(daemon_config)).unwrap();
+
+    assert_eq!(app_config.tenant_id, "tenant-configured");
+    assert_eq!(app_config.user_id, "operator-configured");
+    assert_eq!(app_config.identity_mode, IdentityMode::Managed);
+    assert_eq!(
+        app_config.console_principal,
+        Some(PrincipalId::new("operator-configured"))
+    );
 }
 
 #[test]

--- a/crates/cooldis-kernel/src/cli/daemon/tests.rs
+++ b/crates/cooldis-kernel/src/cli/daemon/tests.rs
@@ -103,6 +103,36 @@ fn daemon_app_server_config_from_loaded_applies_identity_config() {
 }
 
 #[test]
+fn daemon_app_server_config_from_loaded_revalidates_identity_config() {
+    for (tenant_id, console_principal, expected_field) in [
+        (
+            Some("   ".to_string()),
+            Some(PrincipalId::new("operator")),
+            "tenant_id",
+        ),
+        (Some("tenant".to_string()), None, "console_principal"),
+        (
+            Some("tenant".to_string()),
+            Some(PrincipalId::new("\t")),
+            "console_principal",
+        ),
+    ] {
+        let mut daemon_config = CooldisDaemonConfig::default();
+        daemon_config.identity.mode = IdentityMode::Managed;
+        daemon_config.identity.tenant_id = tenant_id;
+        daemon_config.identity.console_principal = console_principal;
+
+        let error =
+            daemon_app_server_config_from_loaded(&loaded_daemon_config(daemon_config)).unwrap_err();
+
+        assert!(
+            error.to_string().contains(expected_field),
+            "expected {expected_field} validation error, got {error}"
+        );
+    }
+}
+
+#[test]
 fn daemon_app_server_config_from_loaded_applies_placement_default() {
     let mut daemon_config = CooldisDaemonConfig::default();
     daemon_config.runtime.placement = Some(AgentManifestPlacementBinding {

--- a/crates/cooldis-kernel/src/daemon/daemon_config.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_config.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 use crate::AgentManifestWorkspaceMode;
+use crate::daemon::identity::{CooldisDaemonIdentityConfig, IdentityMode, PrincipalId};
 use crate::daemon::remote_store::endpoint::CooldisDaemonSyncConfig;
 use crate::{
     AgentManifestPlacementBinding, AgentManifestWorkspaceBinding, AgentRecordRef,
@@ -44,6 +45,8 @@ pub struct CooldisProjectDiscovery {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CooldisDaemonConfig {
     #[serde(default)]
+    pub identity: CooldisDaemonIdentityConfig,
+    #[serde(default)]
     pub runtime: CooldisRuntimeConfig,
     #[serde(default)]
     pub app_server: CooldisDaemonAppServerConfig,
@@ -62,6 +65,7 @@ pub struct CooldisDaemonConfig {
 impl Default for CooldisDaemonConfig {
     fn default() -> Self {
         Self {
+            identity: synthesized_local_daemon_identity_config(),
             runtime: CooldisRuntimeConfig::default(),
             app_server: CooldisDaemonAppServerConfig::default(),
             registries: CooldisDaemonRegistriesConfig::default(),
@@ -88,6 +92,10 @@ impl CooldisDaemonConfig {
 
     pub fn validation_errors(&self) -> Vec<String> {
         let mut errors = Vec::new();
+
+        if let Err(err) = self.identity.validate() {
+            errors.push(format!("identity: {err}"));
+        }
 
         if let Err(err) = self.app_server.listen_addr() {
             errors.push(format!("app_server.listen: {err}"));
@@ -153,6 +161,14 @@ impl CooldisDaemonConfig {
             self.provider.env_file = Some(resolve_config_path(base, path));
         }
         self.io.resolve_paths(base);
+    }
+}
+
+pub(crate) fn synthesized_local_daemon_identity_config() -> CooldisDaemonIdentityConfig {
+    CooldisDaemonIdentityConfig {
+        mode: IdentityMode::Local,
+        tenant_id: Some("cooldis_app_server".to_string()),
+        console_principal: Some(PrincipalId::new("local_user")),
     }
 }
 
@@ -866,6 +882,7 @@ pub fn discover_cooldis_project(start: &Path) -> CooldisResult<CooldisProjectDis
 
 #[derive(Default)]
 struct DaemonConfigPresence {
+    identity: bool,
     runtime: RuntimePresence,
     app_server: AppServerPresence,
     registries: RegistriesPresence,
@@ -933,6 +950,7 @@ fn daemon_config_presence(text: &str) -> CooldisResult<DaemonConfigPresence> {
         .unwrap_or(&root);
 
     Ok(DaemonConfigPresence {
+        identity: table.contains_key("identity"),
         runtime: RuntimePresence {
             cwd: section_has_key(table, "runtime", "cwd"),
             runtime_home: section_has_key(table, "runtime", "runtime_home"),
@@ -989,6 +1007,18 @@ fn merge_daemon_config_layer(
     mut layer: CooldisDaemonConfig,
     presence: DaemonConfigPresence,
 ) {
+    if presence.identity {
+        config.identity = layer.identity;
+        if config.identity.mode == IdentityMode::Local {
+            let defaults = synthesized_local_daemon_identity_config();
+            if config.identity.tenant_id.is_none() {
+                config.identity.tenant_id = defaults.tenant_id;
+            }
+            if config.identity.console_principal.is_none() {
+                config.identity.console_principal = defaults.console_principal;
+            }
+        }
+    }
     if presence.runtime.cwd {
         config.runtime.cwd = layer.runtime.cwd.take();
     }

--- a/crates/cooldis-kernel/src/daemon/daemon_config/tests.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_config/tests.rs
@@ -8,6 +8,93 @@ fn temp_root(name: &str) -> PathBuf {
     ))
 }
 
+fn merge_daemon_identity_layers(layers: &[&str]) -> CooldisResult<CooldisDaemonConfig> {
+    let mut config = CooldisDaemonConfig::default();
+    for text in layers {
+        let presence = daemon_config_presence(text)?;
+        let layer = decode_daemon_config(text)?;
+        merge_daemon_config_layer(&mut config, layer, presence);
+    }
+    config.validate()?;
+    Ok(config)
+}
+
+#[test]
+fn daemon_identity_presence_tracks_supported_nesting_forms() {
+    for text in [
+        "[daemon.identity]\n",
+        "[daemon]\nidentity = {}\n",
+        "[identity]\n",
+        "identity = {}\n",
+    ] {
+        assert!(
+            daemon_config_presence(text).unwrap().identity,
+            "identity section should be present in {text:?}"
+        );
+    }
+
+    assert!(
+        !daemon_config_presence("[daemon.runtime]\ncwd = \"work\"\n")
+            .unwrap()
+            .identity
+    );
+}
+
+#[test]
+fn daemon_identity_layers_are_section_atomic_across_mode_flips() {
+    let local_to_managed = merge_daemon_identity_layers(&[
+        r#"
+[daemon.identity]
+mode = "local"
+tenant_id = "tenant-local"
+console_principal = "operator-local"
+"#,
+        r#"
+[daemon.identity]
+mode = "managed"
+"#,
+    ])
+    .unwrap_err();
+    assert!(local_to_managed.to_string().contains(
+        "managed mode requires [daemon.identity] tenant_id; see docs/adr/0008-identity-plane-v0.md D5"
+    ));
+
+    let managed_to_empty_local = merge_daemon_identity_layers(&[
+        r#"
+[daemon.identity]
+mode = "managed"
+tenant_id = "tenant-managed"
+console_principal = "operator-managed"
+"#,
+        "[daemon]\nidentity = {}\n",
+    ])
+    .unwrap();
+    assert_eq!(
+        managed_to_empty_local.identity,
+        synthesized_local_daemon_identity_config()
+    );
+
+    let partial_managed_overlay = merge_daemon_identity_layers(&[
+        r#"
+[daemon.identity]
+mode = "managed"
+tenant_id = "tenant-base"
+console_principal = "operator-base"
+"#,
+        r#"
+[daemon.identity]
+mode = "managed"
+tenant_id = "tenant-overlay"
+"#,
+    ])
+    .unwrap();
+    assert_eq!(
+        partial_managed_overlay.identity.tenant_id.as_deref(),
+        Some("tenant-overlay")
+    );
+    assert_eq!(partial_managed_overlay.identity.console_principal, None);
+}
+
 #[test]
 fn loads_toml_daemon_identity_config() {
     let root = temp_root("identity");

--- a/crates/cooldis-kernel/src/daemon/daemon_config/tests.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_config/tests.rs
@@ -87,12 +87,10 @@ mode = "managed"
 tenant_id = "tenant-overlay"
 "#,
     ])
-    .unwrap();
-    assert_eq!(
-        partial_managed_overlay.identity.tenant_id.as_deref(),
-        Some("tenant-overlay")
-    );
-    assert_eq!(partial_managed_overlay.identity.console_principal, None);
+    .unwrap_err();
+    assert!(partial_managed_overlay.to_string().contains(
+        "managed mode requires [daemon.identity] console_principal; see docs/adr/0008-identity-plane-v0.md D5"
+    ));
 }
 
 #[test]
@@ -175,6 +173,44 @@ console_principal = "operator-managed"
             .to_string()
             .contains("managed mode requires [daemon.identity] tenant_id; see docs/adr/0008-identity-plane-v0.md D5")
     );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn managed_daemon_identity_with_blank_tenant_or_missing_console_principal_hard_fails() {
+    let root = temp_root("identity-managed-blank-fields");
+    std::fs::create_dir_all(&root).unwrap();
+    let path = root.join("cooldis.toml");
+
+    std::fs::write(
+        &path,
+        r#"
+[daemon.identity]
+mode = "managed"
+tenant_id = "   "
+console_principal = "operator-managed"
+"#,
+    )
+    .unwrap();
+    let error = load_cooldis_daemon_config(Some(&path)).unwrap_err();
+    assert!(error.to_string().contains(
+        "managed mode requires [daemon.identity] tenant_id; see docs/adr/0008-identity-plane-v0.md D5"
+    ));
+
+    std::fs::write(
+        &path,
+        r#"
+[daemon.identity]
+mode = "managed"
+tenant_id = "tenant-managed"
+"#,
+    )
+    .unwrap();
+    let error = load_cooldis_daemon_config(Some(&path)).unwrap_err();
+    assert!(error.to_string().contains(
+        "managed mode requires [daemon.identity] console_principal; see docs/adr/0008-identity-plane-v0.md D5"
+    ));
 
     let _ = std::fs::remove_dir_all(root);
 }

--- a/crates/cooldis-kernel/src/daemon/daemon_config/tests.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_config/tests.rs
@@ -1,10 +1,222 @@
 use super::*;
+use crate::daemon::identity::{IdentityMode, PrincipalId};
 
 fn temp_root(name: &str) -> PathBuf {
     std::env::temp_dir().join(format!(
         "cooldis-daemon-config-{name}-{}",
         uuid::Uuid::now_v7()
     ))
+}
+
+#[test]
+fn loads_toml_daemon_identity_config() {
+    let root = temp_root("identity");
+    std::fs::create_dir_all(&root).unwrap();
+    let path = root.join("cooldis.toml");
+    std::fs::write(
+        &path,
+        r#"
+[daemon.identity]
+mode = "managed"
+tenant_id = "tenant-managed"
+console_principal = "operator-managed"
+"#,
+    )
+    .unwrap();
+
+    let loaded = load_cooldis_daemon_config(Some(&path)).unwrap();
+
+    assert_eq!(loaded.config.identity.mode, IdentityMode::Managed);
+    assert_eq!(
+        loaded.config.identity.tenant_id.as_deref(),
+        Some("tenant-managed")
+    );
+    assert_eq!(
+        loaded.config.identity.console_principal,
+        Some(PrincipalId::new("operator-managed"))
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn managed_daemon_identity_without_tenant_hard_fails() {
+    let root = temp_root("identity-managed-missing-tenant");
+    std::fs::create_dir_all(&root).unwrap();
+    let path = root.join("cooldis.toml");
+    std::fs::write(
+        &path,
+        r#"
+[daemon.identity]
+mode = "managed"
+console_principal = "operator-managed"
+"#,
+    )
+    .unwrap();
+
+    let error = load_cooldis_daemon_config(Some(&path)).unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("managed mode requires [daemon.identity] tenant_id; see docs/adr/0008-identity-plane-v0.md D5")
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn managed_daemon_identity_with_empty_tenant_hard_fails() {
+    let root = temp_root("identity-managed-empty-tenant");
+    std::fs::create_dir_all(&root).unwrap();
+    let path = root.join("cooldis.toml");
+    std::fs::write(
+        &path,
+        r#"
+[daemon.identity]
+mode = "managed"
+tenant_id = ""
+console_principal = "operator-managed"
+"#,
+    )
+    .unwrap();
+
+    let error = load_cooldis_daemon_config(Some(&path)).unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("managed mode requires [daemon.identity] tenant_id; see docs/adr/0008-identity-plane-v0.md D5")
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn managed_identity_overlay_without_tenant_cannot_inherit_a_lower_layer_tenant() {
+    let root = temp_root("identity-managed-overlay-missing-tenant");
+    std::fs::create_dir_all(&root).unwrap();
+    let base = root.join("base.toml");
+    let overlay = root.join("overlay.toml");
+    std::fs::write(
+        &base,
+        r#"
+[daemon.identity]
+mode = "managed"
+tenant_id = "tenant-base"
+console_principal = "operator-base"
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        &overlay,
+        r#"
+[daemon.identity]
+mode = "managed"
+console_principal = "operator-overlay"
+"#,
+    )
+    .unwrap();
+
+    let error = load_cooldis_daemon_config_layers(&[base, overlay], root.clone()).unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("managed mode requires [daemon.identity] tenant_id; see docs/adr/0008-identity-plane-v0.md D5")
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn local_daemon_identity_without_section_synthesizes_current_defaults() {
+    let root = temp_root("identity-local-defaults");
+    std::fs::create_dir_all(&root).unwrap();
+    let path = root.join("cooldis.toml");
+    std::fs::write(&path, "[daemon.runtime]\ncwd = \"work\"\n").unwrap();
+
+    let loaded = load_cooldis_daemon_config(Some(&path)).unwrap();
+
+    assert_eq!(
+        loaded.config.identity,
+        synthesized_local_daemon_identity_config()
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn layered_daemon_identity_is_presence_tracked_and_merged_as_a_section() {
+    let root = temp_root("identity-layered");
+    std::fs::create_dir_all(&root).unwrap();
+    let base = root.join("base.toml");
+    let unrelated_overlay = root.join("unrelated-overlay.toml");
+    let identity_overlay = root.join("identity-overlay.toml");
+    std::fs::write(
+        &base,
+        r#"
+[daemon.identity]
+mode = "managed"
+tenant_id = "tenant-base"
+console_principal = "operator-base"
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        &unrelated_overlay,
+        r#"
+[daemon.app_server]
+listen = "ws://127.0.0.1:0/rpc"
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        &identity_overlay,
+        r#"
+[daemon.identity]
+mode = "managed"
+tenant_id = "tenant-overlay"
+console_principal = "operator-overlay"
+"#,
+    )
+    .unwrap();
+
+    let without_identity_overlay =
+        load_cooldis_daemon_config_layers(&[base.clone(), unrelated_overlay.clone()], root.clone())
+            .unwrap();
+    assert_eq!(
+        without_identity_overlay
+            .config
+            .identity
+            .tenant_id
+            .as_deref(),
+        Some("tenant-base")
+    );
+    assert_eq!(
+        without_identity_overlay.config.identity.console_principal,
+        Some(PrincipalId::new("operator-base"))
+    );
+
+    let with_identity_overlay = load_cooldis_daemon_config_layers(
+        &[base, unrelated_overlay, identity_overlay],
+        root.clone(),
+    )
+    .unwrap();
+    assert_eq!(
+        with_identity_overlay.config.identity.mode,
+        IdentityMode::Managed
+    );
+    assert_eq!(
+        with_identity_overlay.config.identity.tenant_id.as_deref(),
+        Some("tenant-overlay")
+    );
+    assert_eq!(
+        with_identity_overlay.config.identity.console_principal,
+        Some(PrincipalId::new("operator-overlay"))
+    );
+
+    let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]

--- a/crates/cooldis-kernel/src/daemon/daemon_io/tests.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_io/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::daemon::handle_ingress::ThreadHandleIngressAdapter;
+use crate::daemon::identity::{CooldisDaemonIdentityConfig, IdentityMode, PrincipalId};
 use crate::test_support::FaultingIngressQueue;
 use crate::{
     APP_SERVER_LOCAL_MODEL,
@@ -814,8 +815,11 @@ fn apply_test_identity(config: &mut CooldisAppServerConfig, fixture_root: &Path)
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("daemon-io");
-    config.tenant_id = format!("app-server-{suffix}");
-    config.user_id = format!("local-user-{suffix}");
+    config.apply_daemon_identity_config(&CooldisDaemonIdentityConfig {
+        mode: IdentityMode::Local,
+        tenant_id: Some(format!("app-server-{suffix}")),
+        console_principal: Some(PrincipalId::new(format!("local-user-{suffix}"))),
+    });
 }
 
 #[derive(Default)]

--- a/crates/cooldis-kernel/src/daemon/identity.rs
+++ b/crates/cooldis-kernel/src/daemon/identity.rs
@@ -1185,22 +1185,36 @@ pub struct CooldisDaemonIdentityConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tenant_id: Option<String>,
     /// The principal the bundled console resolves to (in v0, the operator).
+    /// In managed mode this is required and also serves as the daemon's
+    /// legacy single-user coordinate until per-principal attribution lands.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub console_principal: Option<PrincipalId>,
 }
 
 impl CooldisDaemonIdentityConfig {
     /// The ratified hard-fail rule (ADR 0008 D5): managed mode without an
-    /// explicit tenant identity refuses to start. Local mode validates
+    /// explicit tenant identity and console principal refuses to start.
+    /// Blank-after-trim values count as absent. Local mode validates
     /// vacuously.
     pub fn validate(&self) -> Result<(), String> {
         match self.mode {
             IdentityMode::Local => Ok(()),
             IdentityMode::Managed => {
-                if self.tenant_id.as_deref().unwrap_or("").is_empty() {
+                if self.tenant_id.as_deref().unwrap_or("").trim().is_empty() {
                     return Err("managed mode requires [daemon.identity] tenant_id; \
                          see docs/adr/0008-identity-plane-v0.md D5"
                         .to_string());
+                }
+                if self
+                    .console_principal
+                    .as_ref()
+                    .is_none_or(|principal| principal.as_str().trim().is_empty())
+                {
+                    return Err(
+                        "managed mode requires [daemon.identity] console_principal; \
+                         see docs/adr/0008-identity-plane-v0.md D5"
+                            .to_string(),
+                    );
                 }
                 Ok(())
             }
@@ -1309,6 +1323,47 @@ mod tests {
         assert!(config.validate().is_err());
         let local = CooldisDaemonIdentityConfig::default();
         assert!(local.validate().is_ok());
+    }
+
+    #[test]
+    fn managed_mode_rejects_blank_identity_fields() {
+        let blank_tenant = CooldisDaemonIdentityConfig {
+            mode: IdentityMode::Managed,
+            tenant_id: Some("   ".to_string()),
+            console_principal: Some(PrincipalId::new("operator:root")),
+        };
+        assert!(blank_tenant.validate().unwrap_err().contains("tenant_id"));
+
+        let missing_console = CooldisDaemonIdentityConfig {
+            mode: IdentityMode::Managed,
+            tenant_id: Some("tenant-a".to_string()),
+            console_principal: None,
+        };
+        assert!(
+            missing_console
+                .validate()
+                .unwrap_err()
+                .contains("console_principal")
+        );
+
+        let blank_console = CooldisDaemonIdentityConfig {
+            mode: IdentityMode::Managed,
+            tenant_id: Some("tenant-a".to_string()),
+            console_principal: Some(PrincipalId::new(" ")),
+        };
+        assert!(
+            blank_console
+                .validate()
+                .unwrap_err()
+                .contains("console_principal")
+        );
+
+        let complete = CooldisDaemonIdentityConfig {
+            mode: IdentityMode::Managed,
+            tenant_id: Some("tenant-a".to_string()),
+            console_principal: Some(PrincipalId::new("operator:root")),
+        };
+        assert!(complete.validate().is_ok());
     }
 
     #[test]

--- a/crates/cooldis-kernel/src/daemon/identity.rs
+++ b/crates/cooldis-kernel/src/daemon/identity.rs
@@ -1175,15 +1175,13 @@ pub enum IdentityMode {
     Managed,
 }
 
-/// The `[daemon.identity]` config section (ADR 0008 D5). Wiring into
-/// `CooldisDaemonConfig` (defaults, presence, layer merge, validation) is
-/// implementation ticket 4; this struct is the shape.
+/// The `[daemon.identity]` config section (ADR 0008 D5).
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CooldisDaemonIdentityConfig {
     #[serde(default)]
     pub mode: IdentityMode,
-    /// Replaces the hard-coded `cooldis_app_server` tenant. Required in
-    /// managed mode; a local-mode default is synthesized when absent.
+    /// Replaces the legacy hard-coded app-server tenant. Required in managed
+    /// mode; a local-mode default is synthesized when absent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tenant_id: Option<String>,
     /// The principal the bundled console resolves to (in v0, the operator).

--- a/crates/cooldis-kernel/src/daemon/recovery_sweep.rs
+++ b/crates/cooldis-kernel/src/daemon/recovery_sweep.rs
@@ -492,6 +492,7 @@ fn history_error(err: impl std::fmt::Display) -> CooldisError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::daemon::identity::{CooldisDaemonIdentityConfig, IdentityMode, PrincipalId};
     use crate::kernel::process_handle_dispatch::{command_digest, recovery_outcome_envelope};
     use crate::test_support::{CrashCutHost, CrashCutSeam, FaultingRuntimeStore, run_crash_cut};
     use crate::{
@@ -1247,8 +1248,11 @@ mod tests {
 
         let listen = crate::AppServerListenAddr::WebSocket("127.0.0.1:0".parse().unwrap());
         let mut config = CooldisAppServerConfig::local(listen, &root);
-        config.tenant_id = "tenant".to_string();
-        config.user_id = "user".to_string();
+        config.apply_daemon_identity_config(&CooldisDaemonIdentityConfig {
+            mode: IdentityMode::Local,
+            tenant_id: Some("tenant".to_string()),
+            console_principal: Some(PrincipalId::new("user")),
+        });
         config.runtime_home = runtime_home;
         config.state_home = state_home;
         config.user_state_home = root.join("user-state");

--- a/crates/cooldis-kernel/tests/support/scenario.rs
+++ b/crates/cooldis-kernel/tests/support/scenario.rs
@@ -715,6 +715,9 @@ impl ScenarioHarness {
         config.capsule_bindings.registry_root = None;
         config.tenant_id = format!("scenario-{:016x}", plan.seed);
         config.user_id = "scenario-user".to_string();
+        config.console_principal = Some(super::kernel_test::daemon::identity::PrincipalId::new(
+            "scenario-user",
+        ));
 
         let decorated_slot = Arc::new(Mutex::new(None::<Arc<dyn RuntimeStore>>));
         let decorated_capture = Arc::clone(&decorated_slot);


### PR DESCRIPTION
Wires [daemon.identity] into CooldisDaemonConfig per ADR 0008 D5 and threads mode/tenant/console-principal into the app server, retiring the hard-coded tenant.

- Config layering at all conventional sites: field + Default, validation, presence tracking, section-atomic layer merge. Legacy cooldis_app_server / local_user literals survive in exactly one local-mode synthesis site.
- Managed mode hard-fails at startup without a non-blank tenant_id AND console_principal (blank-after-trim counts as absent); local mode is unchanged with zero migration.
- App server retains the injected identity mode and console principal (review pass caught them being discarded) and exposes one seam for the boundary-auth ticket.
- Loaded configs are revalidated at the app-server projection, so programmatic construction cannot bypass the managed-mode checks.

Verification: scripts/verify.sh green; workspace all-targets locked suite green (996 kernel tests). Review trail: implementation, write-capable review pass, architect validation tightening, and confirm pass, all receipts on Linear EMO-499.