### PR TITLE
EMO-497: boundary authentication with bearer tokens and peer uid mapping

### DIFF
--- a/apps/console/src/lib/app.svelte.ts
+++ b/apps/console/src/lib/app.svelte.ts
@@ -91,24 +91,13 @@ function injectedConsoleConfig(): ConsoleConfig | undefined {
   return typeof window === "undefined" ? undefined : window.__COOLDIS_CONSOLE_CONFIG__;
 }
 
-function endpointWithSessionToken(endpoint: string, sessionToken?: string) {
-  if (!sessionToken) return endpoint;
-  try {
-    const url = new URL(endpoint);
-    if (!url.searchParams.has("token")) url.searchParams.set("token", sessionToken);
-    return url.toString();
-  } catch {
-    return endpoint;
-  }
-}
-
 function defaultRpcEndpoint() {
   const config = injectedConsoleConfig();
-  if (config?.rpcUrl) return endpointWithSessionToken(config.rpcUrl, config.sessionToken);
+  if (config?.rpcUrl) return config.rpcUrl;
   if (typeof window !== "undefined" && window.location.protocol.startsWith("http")) {
     const url = new URL("/rpc", window.location.href);
     url.protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    return endpointWithSessionToken(url.toString(), config?.sessionToken);
+    return url.toString();
   }
   return "ws://127.0.0.1:49200/rpc";
 }
@@ -409,7 +398,8 @@ export class AppState {
     this.status = "connecting";
     const generation = ++this.connectGeneration;
     this.activeEndpoint = this.endpoint;
-    const client = new CooldisRpcClient(this.endpoint);
+    const sessionToken = this.endpoint === DEFAULT_ENDPOINT ? injectedConsoleConfig()?.sessionToken : undefined;
+    const client = new CooldisRpcClient(this.endpoint, sessionToken);
     this.connectingClient = client;
     const unNotif = client.onNotification(this.handleNotification);
     const unEvt = client.onEvent((e) => {

--- a/apps/console/src/lib/cooldisRpc.ts
+++ b/apps/console/src/lib/cooldisRpc.ts
@@ -80,7 +80,10 @@ export class CooldisRpcClient {
   private notifications = new Set<(notification: RpcNotification) => void>();
   private events = new Set<(event: RpcEvent) => void>();
 
-  constructor(private readonly url: string) {}
+  constructor(
+    private readonly url: string,
+    private readonly sessionToken?: string,
+  ) {}
 
   get connected() {
     return this.socket?.readyState === WebSocket.OPEN;
@@ -311,7 +314,8 @@ export class CooldisRpcClient {
 
   private openSocket() {
     return new Promise<void>((resolve, reject) => {
-      const socket = new WebSocket(this.url);
+      const protocols = this.sessionToken ? [`cooldis-console-token.${this.sessionToken}`] : undefined;
+      const socket = new WebSocket(this.url, protocols);
       this.socket = socket;
 
       socket.addEventListener("open", () => {

--- a/crates/cooldis-kernel/src/adapters/app_server/connection.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/connection.rs
@@ -793,7 +793,7 @@ impl CooldisAppServer {
     where
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
-        let session_id = format!("session_{}", Uuid::new_v4());
+        let session_id = format!("session_{}", Uuid::now_v7());
         self.inner
             .identity_authority
             .witness_session_opened(&IdentitySessionV1 {
@@ -807,6 +807,11 @@ impl CooldisAppServer {
                 closed_at_ms: None,
             })
             .await?;
+        let mut close_witness = SessionCloseWitness::new(
+            Arc::clone(&self.inner.identity_authority),
+            Arc::clone(&self.inner.identity_clock),
+            session_id,
+        );
         let (mut sink, mut stream) = websocket.split();
         let (outbound, mut outbound_rx) = mpsc::unbounded_channel::<JsonRpcMessage>();
         let writer = tokio::spawn(async move {
@@ -859,14 +864,8 @@ impl CooldisAppServer {
 
         connection.abort_subscriptions().await;
         writer.abort();
-        self.inner
-            .identity_authority
-            .witness_session_closed(
-                &session_id,
-                self.inner.identity_clock.now().timestamp_millis(),
-            )
-            .await?;
-        read_result
+        let close_result = close_witness.close().await;
+        finish_websocket_session(read_result, close_result)
     }
 
     pub(super) async fn handle_request(
@@ -4181,6 +4180,23 @@ impl CooldisAppServer {
             "analytics": null,
             "desktop": null,
         })
+    }
+}
+
+pub(super) fn finish_websocket_session(
+    read_result: CooldisResult<()>,
+    close_result: CooldisResult<()>,
+) -> CooldisResult<()> {
+    match (read_result, close_result) {
+        (Err(read_error), Err(close_error)) => {
+            eprintln!(
+                "failed to witness closing a failed Cooldis app-server session: {close_error}"
+            );
+            Err(read_error)
+        }
+        (Err(read_error), Ok(())) => Err(read_error),
+        (Ok(()), Err(close_error)) => Err(close_error),
+        (Ok(()), Ok(())) => Ok(()),
     }
 }
 

--- a/crates/cooldis-kernel/src/adapters/app_server/connection.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/connection.rs
@@ -5,6 +5,8 @@ use super::*;
 #[derive(Clone)]
 pub(super) struct ConnectionState {
     pub(super) app: CooldisAppServer,
+    #[allow(dead_code)]
+    pub(super) resolved_principal: ResolvedPrincipal,
     pub(super) outbound: mpsc::UnboundedSender<JsonRpcMessage>,
     pub(super) handshake: Arc<Mutex<HandshakeState>>,
     pub(super) opt_out_notifications: Arc<RwLock<HashSet<String>>>,
@@ -746,9 +748,20 @@ impl CooldisAppServer {
         method: &str,
         params: Value,
     ) -> CooldisResult<Value> {
+        let resolved_principal = self
+            .inner
+            .identity_authority
+            .resolve_peer_uid(current_effective_uid())
+            .await?
+            .ok_or_else(|| {
+                CooldisError::RuntimeFactory(
+                    "local JSON-RPC requires the local-mode operator principal".to_string(),
+                )
+            })?;
         let (outbound, _rx) = mpsc::unbounded_channel::<JsonRpcMessage>();
         let connection = ConnectionState {
             app: self.clone(),
+            resolved_principal,
             outbound,
             handshake: Arc::new(Mutex::new(HandshakeState::default())),
             opt_out_notifications: Arc::new(RwLock::new(HashSet::new())),
@@ -774,10 +787,26 @@ impl CooldisAppServer {
     pub(super) async fn handle_websocket<S>(
         &self,
         websocket: WebSocketStream<S>,
+        resolved_principal: ResolvedPrincipal,
+        surface: BoundarySurface,
     ) -> CooldisResult<()>
     where
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
+        let session_id = format!("session_{}", Uuid::new_v4());
+        self.inner
+            .identity_authority
+            .witness_session_opened(&IdentitySessionV1 {
+                schema: IDENTITY_SESSION_SCHEMA_V1.to_string(),
+                session_id: session_id.clone(),
+                principal_id: resolved_principal.principal_id.clone(),
+                kind: resolved_principal.kind,
+                surface,
+                credential_ref: credential_ref(&resolved_principal.auth),
+                opened_at_ms: self.inner.identity_clock.now().timestamp_millis(),
+                closed_at_ms: None,
+            })
+            .await?;
         let (mut sink, mut stream) = websocket.split();
         let (outbound, mut outbound_rx) = mpsc::unbounded_channel::<JsonRpcMessage>();
         let writer = tokio::spawn(async move {
@@ -798,6 +827,7 @@ impl CooldisAppServer {
 
         let connection = ConnectionState {
             app: self.clone(),
+            resolved_principal,
             outbound,
             handshake: Arc::new(Mutex::new(HandshakeState::default())),
             opt_out_notifications: Arc::new(RwLock::new(HashSet::new())),
@@ -805,6 +835,7 @@ impl CooldisAppServer {
             fs_watches: Arc::new(Mutex::new(HashMap::new())),
         };
 
+        let mut read_result = Ok(());
         while let Some(message) = stream.next().await {
             match message {
                 Ok(Message::Text(text)) => {
@@ -818,16 +849,24 @@ impl CooldisAppServer {
                 | Ok(Message::Pong(_))
                 | Ok(Message::Frame(_)) => {}
                 Err(err) => {
-                    return Err(CooldisError::RuntimeFactory(format!(
+                    read_result = Err(CooldisError::RuntimeFactory(format!(
                         "Cooldis app-server websocket read failed: {err}"
                     )));
+                    break;
                 }
             }
         }
 
         connection.abort_subscriptions().await;
         writer.abort();
-        Ok(())
+        self.inner
+            .identity_authority
+            .witness_session_closed(
+                &session_id,
+                self.inner.identity_clock.now().timestamp_millis(),
+            )
+            .await?;
+        read_result
     }
 
     pub(super) async fn handle_request(

--- a/crates/cooldis-kernel/src/adapters/app_server/mod.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/mod.rs
@@ -56,6 +56,7 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io;
+use std::io::Write as _;
 use std::net::SocketAddr;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -64,7 +65,7 @@ use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 #[cfg(unix)]
@@ -114,6 +115,9 @@ const APP_SERVER_HEALTH_RESPONSE_BODY: &str = "{\"status\":\"ok\"}";
 const APP_SERVER_USER_AGENT: &str = "cooldis-app-server/0.1";
 const HTTP_UNAUTHORIZED_BODY: &str = "authentication required";
 const MAX_HTTP_REQUEST_HEADER_BYTES: usize = 8192;
+const HTTP_REQUEST_HEADER_TIMEOUT: Duration = Duration::from_secs(10);
+const CONSOLE_TOKEN_PROTOCOL_PREFIX: &str = "cooldis-console-token.";
+const CONSOLE_CREDENTIAL_ID_FILE: &str = "console-credential-id";
 const DEFAULT_COMMAND_TIMEOUT_MS: u64 = 30_000;
 const DEFAULT_COMMAND_OUTPUT_CAP_BYTES: usize = 1024 * 1024;
 const DEFAULT_AGENT_REGISTRY_ROOT: &str = ".cooldis/agents";
@@ -518,6 +522,7 @@ struct CooldisAppServerInner {
     identity_authority: Arc<dyn IdentityAuthority>,
     identity_clock: Arc<dyn crate::DaemonClock>,
     identity_mode: IdentityMode,
+    console_credential: Option<ConsoleCredentialLease>,
     cwd: PathBuf,
     codex_home: PathBuf,
     metadata_store_path: PathBuf,
@@ -529,6 +534,95 @@ struct CooldisAppServerInner {
     process_dispatcher: OnceCell<ProcessHandleDispatcher>,
     subscriptions: Mutex<AppServerSubscriptions>,
     state: RwLock<AppServerState>,
+}
+
+struct ConsoleCredentialLease {
+    credential_id: String,
+    principal_id: PrincipalId,
+    record_path: PathBuf,
+}
+
+struct SessionCloseWitness {
+    authority: Arc<dyn IdentityAuthority>,
+    clock: Arc<dyn crate::DaemonClock>,
+    session_id: String,
+    armed: bool,
+}
+
+impl SessionCloseWitness {
+    fn new(
+        authority: Arc<dyn IdentityAuthority>,
+        clock: Arc<dyn crate::DaemonClock>,
+        session_id: String,
+    ) -> Self {
+        Self {
+            authority,
+            clock,
+            session_id,
+            armed: true,
+        }
+    }
+
+    async fn close(&mut self) -> CooldisResult<()> {
+        // `witness_session_closed` starts its cancellation-safe transaction on
+        // the first poll, so disarming here prevents a cancelled await from
+        // scheduling a duplicate close witness.
+        self.armed = false;
+        self.authority
+            .witness_session_closed(&self.session_id, self.clock.now().timestamp_millis())
+            .await
+    }
+}
+
+impl Drop for SessionCloseWitness {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let authority = Arc::clone(&self.authority);
+        let session_id = self.session_id.clone();
+        let closed_at_ms = self.clock.now().timestamp_millis();
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                if let Err(error) = authority
+                    .witness_session_closed(&session_id, closed_at_ms)
+                    .await
+                {
+                    eprintln!("failed to witness aborted Cooldis app-server session: {error}");
+                }
+            });
+        }
+    }
+}
+
+impl Drop for CooldisAppServerInner {
+    fn drop(&mut self) {
+        let Some(credential) = self.console_credential.take() else {
+            return;
+        };
+        let authority = Arc::clone(&self.identity_authority);
+        let cleanup = std::thread::Builder::new()
+            .name("cooldis-console-credential-cleanup".to_string())
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|error| error.to_string())?;
+                runtime
+                    .block_on(retire_console_credential(authority, &credential))
+                    .map_err(|error| error.to_string())
+            });
+        match cleanup {
+            Ok(cleanup) => match cleanup.join() {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    eprintln!("failed to retire Cooldis console credential: {error}")
+                }
+                Err(_) => eprintln!("Cooldis console credential cleanup thread panicked"),
+            },
+            Err(error) => eprintln!("failed to start Cooldis console credential cleanup: {error}"),
+        }
+    }
 }
 
 struct AppServerProcessHandleIngress {
@@ -766,13 +860,18 @@ impl CooldisAppServer {
         let identity_store = SqliteSessionStore::open(&session_store_path)
             .await
             .map_err(|err| CooldisError::History(err.to_string()))?;
-        let identity_authority = initialize_boundary_identity(
+        let console_credential_record_path = session_store_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(CONSOLE_CREDENTIAL_ID_FILE);
+        let (identity_authority, console_credential) = initialize_boundary_identity(
             identity_store,
             Arc::clone(&identity_clock),
             identity.mode,
             identity.console_principal,
             &config.user_id,
             config.console_assets.as_mut(),
+            &console_credential_record_path,
         )
         .await?;
         let app = Self {
@@ -794,6 +893,7 @@ impl CooldisAppServer {
                 identity_authority,
                 identity_clock,
                 identity_mode: identity.mode,
+                console_credential,
                 cwd: config.cwd,
                 codex_home,
                 metadata_store_path,
@@ -1177,17 +1277,17 @@ impl CooldisAppServer {
                         credential_id: credential.credential_id,
                     });
                 }
+                if principal.revoked_at_ms.is_some() {
+                    return Ok(IdentityAuthRejectionReason::PrincipalRevoked {
+                        principal_id: principal.principal_id,
+                    });
+                }
                 if credential
                     .expires_at_ms
                     .is_some_and(|expires_at_ms| expires_at_ms <= now_ms)
                 {
                     return Ok(IdentityAuthRejectionReason::CredentialExpired {
                         credential_id: credential.credential_id,
-                    });
-                }
-                if principal.revoked_at_ms.is_some() {
-                    return Ok(IdentityAuthRejectionReason::PrincipalRevoked {
-                        principal_id: principal.principal_id,
                     });
                 }
             }
@@ -1232,7 +1332,8 @@ async fn initialize_boundary_identity(
     console_principal: Option<PrincipalId>,
     default_operator_id: &str,
     console_assets: Option<&mut ConsoleAssetConfig>,
-) -> CooldisResult<Arc<dyn IdentityAuthority>> {
+    console_credential_record_path: &Path,
+) -> CooldisResult<(Arc<dyn IdentityAuthority>, Option<ConsoleCredentialLease>)> {
     let authority = SqliteIdentityAuthority::new(store.clone(), Arc::clone(&clock), None).await?;
     let mut operator = authority
         .list_principals()
@@ -1253,6 +1354,7 @@ async fn initialize_boundary_identity(
         .then(|| operator.clone())
         .flatten();
     let authority = SqliteIdentityAuthority::new(store, clock, peer_operator).await?;
+    let mut console_credential = None;
     if let Some(console) = console_assets {
         let principal_id = console_principal
             .or_else(|| (mode == IdentityMode::Local).then_some(operator).flatten())
@@ -1262,12 +1364,129 @@ async fn initialize_boundary_identity(
                         .to_string(),
                 )
             })?;
-        let (_, token) = authority
+        if let Some(predecessor_id) = read_console_credential_id(console_credential_record_path)? {
+            ignore_missing_credential(
+                authority
+                    .revoke_credential(&principal_id, &predecessor_id)
+                    .await,
+            )?;
+        }
+        let (credential, token) = authority
             .mint_credential(&principal_id, &principal_id, None)
             .await?;
+        // A purpose-labeled or ephemeral credential class in the identity
+        // schema should replace this lifecycle file in a future ticket.
+        if let Err(error) =
+            persist_console_credential_id(console_credential_record_path, &credential.credential_id)
+        {
+            let _ = authority
+                .revoke_credential(&principal_id, &credential.credential_id)
+                .await;
+            return Err(error);
+        }
         console.session_token = token;
+        console_credential = Some(ConsoleCredentialLease {
+            credential_id: credential.credential_id,
+            principal_id,
+            record_path: console_credential_record_path.to_path_buf(),
+        });
     }
-    Ok(Arc::new(authority))
+    Ok((Arc::new(authority), console_credential))
+}
+
+fn read_console_credential_id(path: &Path) -> CooldisResult<Option<String>> {
+    let value = match std::fs::read_to_string(path) {
+        Ok(value) => value,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(CooldisError::RuntimeFactory(format!(
+                "failed to read Cooldis console credential record {}: {error}",
+                path.display()
+            )));
+        }
+    };
+    let credential_id = value.trim();
+    if credential_id.is_empty() || credential_id.chars().any(char::is_whitespace) {
+        return Err(CooldisError::RuntimeFactory(format!(
+            "Cooldis console credential record {} is malformed",
+            path.display()
+        )));
+    }
+    Ok(Some(credential_id.to_string()))
+}
+
+fn persist_console_credential_id(path: &Path, credential_id: &str) -> CooldisResult<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent).map_err(|error| {
+        CooldisError::RuntimeFactory(format!(
+            "failed to prepare Cooldis console credential record directory {}: {error}",
+            parent.display()
+        ))
+    })?;
+    let temporary = parent.join(format!(
+        ".{CONSOLE_CREDENTIAL_ID_FILE}.{}.tmp",
+        Uuid::now_v7()
+    ));
+    let write_result = (|| -> io::Result<()> {
+        let mut options = std::fs::OpenOptions::new();
+        options.create_new(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&temporary)?;
+        file.write_all(credential_id.as_bytes())?;
+        file.sync_all()?;
+        std::fs::rename(&temporary, path)?;
+        Ok(())
+    })();
+    if let Err(error) = write_result {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(CooldisError::RuntimeFactory(format!(
+            "failed to persist Cooldis console credential record {}: {error}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn ignore_missing_credential(result: CooldisResult<()>) -> CooldisResult<()> {
+    match result {
+        Err(error)
+            if error
+                .to_string()
+                .contains("identity credential was not found") =>
+        {
+            Ok(())
+        }
+        other => other,
+    }
+}
+
+async fn retire_console_credential(
+    authority: Arc<dyn IdentityAuthority>,
+    credential: &ConsoleCredentialLease,
+) -> CooldisResult<()> {
+    ignore_missing_credential(
+        authority
+            .revoke_credential(&credential.principal_id, &credential.credential_id)
+            .await,
+    )?;
+    let current = read_console_credential_id(&credential.record_path)?;
+    if current.as_deref() == Some(credential.credential_id.as_str()) {
+        match std::fs::remove_file(&credential.record_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(CooldisError::RuntimeFactory(format!(
+                    "failed to clear Cooldis console credential record {}: {error}",
+                    credential.record_path.display()
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 struct ResolvedCatalogOpenAIChatCompletionsProvider {
@@ -1877,15 +2096,17 @@ async fn accept_authenticated_websocket<S>(
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
-    accept_hdr_async_with_config(
+    let upgrade = accept_hdr_async_with_config(
         stream,
         |request: &tokio_tungstenite::tungstenite::handshake::server::Request,
          mut response: tokio_tungstenite::tungstenite::handshake::server::Response| {
             if let Some(protocol) = request
                 .headers()
-                .get(SEC_WEBSOCKET_PROTOCOL)
-                .and_then(|value| value.to_str().ok())
-                .and_then(|value| value.split(',').map(str::trim).next())
+                .get_all(SEC_WEBSOCKET_PROTOCOL)
+                .iter()
+                .filter_map(|value| value.to_str().ok())
+                .flat_map(|value| value.split(',').map(str::trim))
+                .find(|protocol| console_protocol_token(protocol).is_some())
                 .and_then(|protocol| HeaderValue::from_str(protocol).ok())
             {
                 response
@@ -1895,8 +2116,15 @@ where
             Ok(response)
         },
         Some(websocket_config()),
-    )
-    .await
+    );
+    tokio::time::timeout(HTTP_REQUEST_HEADER_TIMEOUT, upgrade)
+        .await
+        .map_err(|_| {
+            tokio_tungstenite::tungstenite::Error::Io(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "Cooldis app-server websocket upgrade timed out",
+            ))
+        })?
 }
 
 async fn bind_websocket_listener(addr: SocketAddr) -> CooldisResult<TcpListener> {
@@ -1920,58 +2148,84 @@ struct HttpRequestHead {
 
 async fn peek_http_request(stream: &TcpStream) -> CooldisResult<Option<HttpRequestHead>> {
     let mut request = [0_u8; MAX_HTTP_REQUEST_HEADER_BYTES];
-    let len = stream.peek(&mut request).await.map_err(|err| {
-        CooldisError::RuntimeFactory(format!(
-            "failed to inspect Cooldis app-server tcp request: {err}"
-        ))
-    })?;
-    if len == 0 {
-        return Ok(None);
+    let inspected = tokio::time::timeout(HTTP_REQUEST_HEADER_TIMEOUT, async {
+        loop {
+            let len = stream.peek(&mut request).await.map_err(|err| {
+                CooldisError::RuntimeFactory(format!(
+                    "failed to inspect Cooldis app-server tcp request: {err}"
+                ))
+            })?;
+            if len == 0 {
+                return Ok(None);
+            }
+            if request[..len].windows(4).any(|bytes| bytes == b"\r\n\r\n") {
+                return Ok(parse_http_request_head(&request[..len]));
+            }
+            if len == request.len() {
+                return Ok(None);
+            }
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+    })
+    .await;
+    request.fill(0);
+    match inspected {
+        Ok(result) => result,
+        Err(_) => Ok(None),
     }
-    let parsed = parse_http_request_head(&request[..len]);
-    request[..len].fill(0);
-    Ok(parsed)
 }
 
 #[cfg(unix)]
 async fn peek_unix_http_request(stream: &UnixStream) -> CooldisResult<Option<HttpRequestHead>> {
     let mut request = [0_u8; MAX_HTTP_REQUEST_HEADER_BYTES];
-    loop {
-        stream.readable().await.map_err(|err| {
-            CooldisError::RuntimeFactory(format!(
-                "failed to inspect Cooldis app-server unix request: {err}"
-            ))
-        })?;
-        let len = unsafe {
-            libc::recv(
-                stream.as_raw_fd(),
-                request.as_mut_ptr().cast(),
-                request.len(),
-                libc::MSG_PEEK,
-            )
-        };
-        if len < 0 {
-            let error = io::Error::last_os_error();
-            if error.kind() == io::ErrorKind::WouldBlock {
-                continue;
+    let inspected = tokio::time::timeout(HTTP_REQUEST_HEADER_TIMEOUT, async {
+        loop {
+            stream.readable().await.map_err(|err| {
+                CooldisError::RuntimeFactory(format!(
+                    "failed to inspect Cooldis app-server unix request: {err}"
+                ))
+            })?;
+            let len = unsafe {
+                libc::recv(
+                    stream.as_raw_fd(),
+                    request.as_mut_ptr().cast(),
+                    request.len(),
+                    libc::MSG_PEEK,
+                )
+            };
+            if len < 0 {
+                let error = io::Error::last_os_error();
+                if error.kind() == io::ErrorKind::WouldBlock {
+                    continue;
+                }
+                return Err(CooldisError::RuntimeFactory(format!(
+                    "failed to inspect Cooldis app-server unix request: {error}"
+                )));
             }
-            return Err(CooldisError::RuntimeFactory(format!(
-                "failed to inspect Cooldis app-server unix request: {error}"
-            )));
+            if len == 0 {
+                return Ok(None);
+            }
+            let len = len as usize;
+            if request[..len].windows(4).any(|bytes| bytes == b"\r\n\r\n") {
+                return Ok(parse_http_request_head(&request[..len]));
+            }
+            if len == request.len() {
+                return Ok(None);
+            }
+            tokio::time::sleep(Duration::from_millis(2)).await;
         }
-        if len == 0 {
-            return Ok(None);
-        }
-        let len = len as usize;
-        let parsed = parse_http_request_head(&request[..len]);
-        request[..len].fill(0);
-        return Ok(parsed);
+    })
+    .await;
+    request.fill(0);
+    match inspected {
+        Ok(result) => result,
+        Err(_) => Ok(None),
     }
 }
 
 fn parse_http_request_head(bytes: &[u8]) -> Option<HttpRequestHead> {
     let text = std::str::from_utf8(bytes).ok()?;
-    let header_end = text.find("\r\n\r\n").unwrap_or(text.len());
+    let header_end = text.find("\r\n\r\n")?;
     let mut lines = text[..header_end].split("\r\n");
     let request_line = lines.next()?;
     let mut parts = request_line.split_whitespace();
@@ -2039,9 +2293,8 @@ fn request_bearer_token(request: &HttpRequestHead) -> Option<(&str, BoundarySurf
     if let Some(token) = request
         .headers
         .iter()
-        .find(|(name, _)| name == "authorization")
-        .and_then(|(_, value)| value.strip_prefix("Bearer "))
-        .filter(|token| !token.is_empty() && !token.chars().any(char::is_whitespace))
+        .filter(|(name, _)| name == "authorization")
+        .find_map(|(_, value)| authorization_bearer_token(value))
     {
         return Some((token, BoundarySurface::Websocket));
     }
@@ -2051,11 +2304,21 @@ fn request_bearer_token(request: &HttpRequestHead) -> Option<(&str, BoundarySurf
         .filter(|(name, _)| name == "sec-websocket-protocol")
         .flat_map(|(_, value)| value.split(',').map(str::trim))
         .find_map(|protocol| {
-            let token = protocol
-                .strip_prefix("cooldis-console-token.")
-                .unwrap_or(protocol);
-            (!token.is_empty()).then_some((token, BoundarySurface::Console))
+            console_protocol_token(protocol).map(|token| (token, BoundarySurface::Console))
         })
+}
+
+fn authorization_bearer_token(value: &str) -> Option<&str> {
+    let mut parts = value.split_ascii_whitespace();
+    let scheme = parts.next()?;
+    let token = parts.next()?;
+    (scheme.eq_ignore_ascii_case("bearer") && parts.next().is_none()).then_some(token)
+}
+
+fn console_protocol_token(protocol: &str) -> Option<&str> {
+    protocol
+        .strip_prefix(CONSOLE_TOKEN_PROTOCOL_PREFIX)
+        .filter(|token| !token.is_empty() && !token.chars().any(char::is_whitespace))
 }
 
 fn content_type_for_path(path: &Path) -> &'static str {
@@ -2106,37 +2369,47 @@ where
     S: AsyncRead + Unpin,
 {
     let mut chunk = [0_u8; 512];
-    let mut matched = 0;
-    loop {
-        let len = stream.read(&mut chunk).await.map_err(|err| {
-            CooldisError::RuntimeFactory(format!(
-                "failed to read Cooldis app-server HTTP request: {err}"
-            ))
-        })?;
-        if len == 0 {
-            return Ok(());
-        }
-        let mut complete = false;
-        for byte in &chunk[..len] {
-            matched = match (matched, *byte) {
-                (0, b'\r') => 1,
-                (1, b'\n') => 2,
-                (2, b'\r') => 3,
-                (3, b'\n') => {
-                    complete = true;
-                    4
+    let consumed = tokio::time::timeout(HTTP_REQUEST_HEADER_TIMEOUT, async {
+        let mut matched = 0;
+        let mut total = 0;
+        loop {
+            let len = stream.read(&mut chunk).await.map_err(|err| {
+                CooldisError::RuntimeFactory(format!(
+                    "failed to read Cooldis app-server HTTP request: {err}"
+                ))
+            })?;
+            if len == 0 {
+                return Ok(());
+            }
+            total += len;
+            let mut complete = false;
+            for byte in &chunk[..len] {
+                matched = match (matched, *byte) {
+                    (0, b'\r') => 1,
+                    (1, b'\n') => 2,
+                    (2, b'\r') => 3,
+                    (3, b'\n') => {
+                        complete = true;
+                        4
+                    }
+                    (_, b'\r') => 1,
+                    _ => 0,
+                };
+                if complete {
+                    break;
                 }
-                (_, b'\r') => 1,
-                _ => 0,
-            };
-            if complete {
-                break;
+            }
+            chunk[..len].fill(0);
+            if complete || total >= MAX_HTTP_REQUEST_HEADER_BYTES {
+                return Ok(());
             }
         }
-        chunk[..len].fill(0);
-        if complete {
-            return Ok(());
-        }
+    })
+    .await;
+    chunk.fill(0);
+    match consumed {
+        Ok(result) => result,
+        Err(_) => Ok(()),
     }
 }
 

--- a/crates/cooldis-kernel/src/adapters/app_server/mod.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/mod.rs
@@ -1,5 +1,11 @@
 use crate::ProcessHandleIngressSink;
 use crate::daemon::daemon_io::CooldisDaemonIoBridge;
+use crate::daemon::identity::{
+    AuthenticationPath, BoundarySurface, CooldisDaemonIdentityConfig,
+    IDENTITY_AUTH_REJECTION_SCHEMA_V1, IDENTITY_SESSION_SCHEMA_V1, IdentityAuthRejectionReason,
+    IdentityAuthRejectionV1, IdentityAuthority, IdentityMode, IdentitySessionV1, PrincipalId,
+    PrincipalKind, ResolvedPrincipal, SqliteIdentityAuthority, identity_token_digest,
+};
 use crate::daemon::recovery_sweep::StartupRecoverySweep;
 use crate::kernel::process_handle_dispatch::ProcessHandleDispatcher;
 use crate::{
@@ -25,7 +31,7 @@ use crate::{
     ProviderToolResultConstraints, ProviderWireAdapter, RuntimeEventKind, RuntimeStore,
     RuntimeTerminalState, RuntimeThreadHandle, SecretResolver, SecretSourceKind, SecretStoreError,
     SessionEntry, SessionEntryKind, SessionStore, SqliteMcpSourceRegistry, SqliteMetadataStore,
-    SqliteSecretStore, SqliteSessionStore, SystemBlock,
+    SqliteSecretStore, SqliteSessionStore, SystemBlock, SystemDaemonClock,
     THREAD_AGENT_SKILL_CONTEXT_SEGMENTS_METADATA, THREAD_AGENT_SKILL_DISCOVERY_METADATA,
     THREAD_AGENT_SKILL_PACKAGES_METADATA, THREAD_BOUND_COUPLING_SET_METADATA,
     THREAD_OPERATION_REGISTRY_ROOT_METADATA, TenantRegistration, TenantRuntimeContext,
@@ -53,6 +59,8 @@ use std::io;
 use std::net::SocketAddr;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
@@ -65,8 +73,10 @@ use tokio::process::Command;
 use tokio::sync::{Mutex, OnceCell, RwLock, mpsc};
 use tokio::task::JoinHandle;
 use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::http::HeaderValue;
+use tokio_tungstenite::tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL;
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
-use tokio_tungstenite::{WebSocketStream, accept_async_with_config};
+use tokio_tungstenite::{WebSocketStream, accept_hdr_async_with_config};
 use uuid::Uuid;
 mod connection;
 mod default_manifest;
@@ -102,7 +112,7 @@ pub const APP_SERVER_ANTHROPIC_BEDROCK_MODEL: &str =
 const MAX_WEBSOCKET_MESSAGE_SIZE: usize = 128 << 20;
 const APP_SERVER_HEALTH_RESPONSE_BODY: &str = "{\"status\":\"ok\"}";
 const APP_SERVER_USER_AGENT: &str = "cooldis-app-server/0.1";
-const HTTP_UNAUTHORIZED_BODY: &str = "missing or invalid Cooldis console session token";
+const HTTP_UNAUTHORIZED_BODY: &str = "authentication required";
 const MAX_HTTP_REQUEST_HEADER_BYTES: usize = 8192;
 const DEFAULT_COMMAND_TIMEOUT_MS: u64 = 30_000;
 const DEFAULT_COMMAND_OUTPUT_CAP_BYTES: usize = 1024 * 1024;
@@ -373,10 +383,19 @@ impl CooldisAppServerConfig {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct ConsoleAssetConfig {
     pub root: PathBuf,
     pub session_token: String,
+}
+
+impl std::fmt::Debug for ConsoleAssetConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConsoleAssetConfig")
+            .field("root", &self.root)
+            .field("session_token", &"<redacted>")
+            .finish()
+    }
 }
 
 fn operation_registry_root_for_kernel_publish(config: &CooldisAppServerConfig) -> Option<&Path> {
@@ -496,6 +515,9 @@ struct CooldisAppServerInner {
     default_workspace: Option<AgentManifestWorkspaceBinding>,
     remote_event_store_served: Arc<AtomicBool>,
     console_assets: Option<ConsoleAssetConfig>,
+    identity_authority: Arc<dyn IdentityAuthority>,
+    identity_clock: Arc<dyn crate::DaemonClock>,
+    identity_mode: IdentityMode,
     cwd: PathBuf,
     codex_home: PathBuf,
     metadata_store_path: PathBuf,
@@ -581,7 +603,14 @@ impl ProviderClient for AppServerOfflineProviderClient {
 }
 
 impl CooldisAppServer {
-    pub async fn new_local(mut config: CooldisAppServerConfig) -> CooldisResult<Self> {
+    pub async fn new_local(config: CooldisAppServerConfig) -> CooldisResult<Self> {
+        Self::new(config, CooldisDaemonIdentityConfig::default()).await
+    }
+
+    pub async fn new(
+        mut config: CooldisAppServerConfig,
+        identity: CooldisDaemonIdentityConfig,
+    ) -> CooldisResult<Self> {
         let metadata_store = open_and_seed_metadata_store(config.metadata_store_path()).await?;
         let user_metadata_store =
             open_and_seed_metadata_store(config.user_metadata_store_path()).await?;
@@ -594,6 +623,7 @@ impl CooldisAppServer {
             runtime_factory,
             metadata_store,
             user_metadata_store,
+            identity,
         )
         .await
     }
@@ -601,6 +631,19 @@ impl CooldisAppServer {
     pub async fn with_runtime_factory(
         config: CooldisAppServerConfig,
         runtime_factory: Arc<dyn crate::AgentRuntimeFactory>,
+    ) -> CooldisResult<Self> {
+        Self::with_runtime_factory_and_identity(
+            config,
+            runtime_factory,
+            CooldisDaemonIdentityConfig::default(),
+        )
+        .await
+    }
+
+    pub async fn with_runtime_factory_and_identity(
+        config: CooldisAppServerConfig,
+        runtime_factory: Arc<dyn crate::AgentRuntimeFactory>,
+        identity: CooldisDaemonIdentityConfig,
     ) -> CooldisResult<Self> {
         let metadata_store = SqliteMetadataStore::in_memory()
             .await
@@ -613,6 +656,7 @@ impl CooldisAppServer {
             runtime_factory,
             metadata_store,
             user_metadata_store,
+            identity,
         )
         .await
     }
@@ -635,6 +679,7 @@ impl CooldisAppServer {
             metadata_store,
             user_metadata_store,
             Some(Box::new(decorate)),
+            CooldisDaemonIdentityConfig::default(),
         )
         .await
     }
@@ -652,6 +697,7 @@ impl CooldisAppServer {
             runtime_factory,
             metadata_store,
             user_metadata_store,
+            CooldisDaemonIdentityConfig::default(),
         )
         .await
     }
@@ -661,6 +707,7 @@ impl CooldisAppServer {
         runtime_factory: Arc<dyn crate::AgentRuntimeFactory>,
         metadata_store: SqliteMetadataStore,
         user_metadata_store: SqliteMetadataStore,
+        identity: CooldisDaemonIdentityConfig,
     ) -> CooldisResult<Self> {
         Self::with_runtime_factory_and_metadata_stores_inner(
             config,
@@ -668,6 +715,7 @@ impl CooldisAppServer {
             metadata_store,
             user_metadata_store,
             None,
+            identity,
         )
         .await
     }
@@ -680,6 +728,7 @@ impl CooldisAppServer {
         session_store_decorator: Option<
             Box<dyn FnOnce(Arc<dyn RuntimeStore>) -> Arc<dyn RuntimeStore> + Send>,
         >,
+        identity: CooldisDaemonIdentityConfig,
     ) -> CooldisResult<Self> {
         normalize_registry_roots(&mut config);
         let provider_surface =
@@ -713,6 +762,19 @@ impl CooldisAppServer {
                 runtime_factory,
             })
             .await?;
+        let identity_clock: Arc<dyn crate::DaemonClock> = Arc::new(SystemDaemonClock);
+        let identity_store = SqliteSessionStore::open(&session_store_path)
+            .await
+            .map_err(|err| CooldisError::History(err.to_string()))?;
+        let identity_authority = initialize_boundary_identity(
+            identity_store,
+            Arc::clone(&identity_clock),
+            identity.mode,
+            identity.console_principal,
+            &config.user_id,
+            config.console_assets.as_mut(),
+        )
+        .await?;
         let app = Self {
             inner: Arc::new(CooldisAppServerInner {
                 supervisor,
@@ -729,6 +791,9 @@ impl CooldisAppServer {
                 default_workspace: config.default_workspace,
                 remote_event_store_served: config.remote_event_store_served,
                 console_assets: config.console_assets,
+                identity_authority,
+                identity_clock,
+                identity_mode: identity.mode,
                 cwd: config.cwd,
                 codex_home,
                 metadata_store_path,
@@ -855,6 +920,12 @@ impl CooldisAppServer {
                 path.display()
             ))
         })?;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).map_err(|err| {
+            CooldisError::RuntimeFactory(format!(
+                "failed to secure Cooldis app-server socket {}: {err}",
+                path.display()
+            ))
+        })?;
 
         loop {
             let (stream, _) = listener.accept().await.map_err(|err| {
@@ -862,9 +933,17 @@ impl CooldisAppServer {
                     "failed to accept Cooldis app-server connection: {err}"
                 ))
             })?;
+            let peer_uid = stream
+                .peer_cred()
+                .map_err(|err| {
+                    CooldisError::RuntimeFactory(format!(
+                        "failed to inspect Cooldis app-server peer credentials: {err}"
+                    ))
+                })?
+                .uid();
             let app = self.clone();
             tokio::spawn(async move {
-                if let Err(err) = app.handle_unix_stream(stream).await {
+                if let Err(err) = app.handle_unix_stream(stream, peer_uid).await {
                     eprintln!("cooldis app-server connection failed: {err}");
                 }
             });
@@ -911,15 +990,22 @@ impl CooldisAppServer {
     }
 
     #[cfg(unix)]
-    async fn handle_unix_stream(&self, stream: UnixStream) -> CooldisResult<()> {
-        let websocket = accept_async_with_config(stream, Some(websocket_config()))
+    async fn handle_unix_stream(&self, mut stream: UnixStream, peer_uid: u32) -> CooldisResult<()> {
+        let Some(resolved_principal) = self
+            .authenticate_unix_websocket(&mut stream, peer_uid)
+            .await?
+        else {
+            return Ok(());
+        };
+        let websocket = accept_authenticated_websocket(stream)
             .await
             .map_err(|err| {
                 CooldisError::RuntimeFactory(format!(
                     "failed to upgrade Cooldis app-server unix socket websocket: {err}"
                 ))
             })?;
-        self.handle_websocket(websocket).await
+        self.handle_websocket(websocket, resolved_principal, BoundarySurface::UnixSocket)
+            .await
     }
 
     async fn handle_tcp_stream(&self, stream: TcpStream) -> CooldisResult<()> {
@@ -927,17 +1013,20 @@ impl CooldisAppServer {
         if self.handle_http_request(&mut stream).await? {
             return Ok(());
         }
-        if !self.authorize_console_websocket(&mut stream).await? {
+        let Some((resolved_principal, surface)) =
+            self.authenticate_tcp_websocket(&mut stream).await?
+        else {
             return Ok(());
-        }
-        let websocket = accept_async_with_config(stream, Some(websocket_config()))
+        };
+        let websocket = accept_authenticated_websocket(stream)
             .await
             .map_err(|err| {
                 CooldisError::RuntimeFactory(format!(
                     "failed to upgrade Cooldis app-server tcp websocket: {err}"
                 ))
             })?;
-        self.handle_websocket(websocket).await
+        self.handle_websocket(websocket, resolved_principal, surface)
+            .await
     }
 
     async fn handle_http_request(&self, stream: &mut TcpStream) -> CooldisResult<bool> {
@@ -1006,19 +1095,125 @@ impl CooldisAppServer {
         Ok(true)
     }
 
-    async fn authorize_console_websocket(&self, stream: &mut TcpStream) -> CooldisResult<bool> {
-        let Some(console) = &self.inner.console_assets else {
-            return Ok(true);
-        };
-        let Some(request) = peek_http_request(stream).await? else {
-            return Ok(true);
-        };
-        if request.path != "/rpc" {
-            return Ok(true);
+    async fn authenticate_tcp_websocket(
+        &self,
+        stream: &mut TcpStream,
+    ) -> CooldisResult<Option<(ResolvedPrincipal, BoundarySurface)>> {
+        let request = peek_http_request(stream).await?;
+        let token_and_surface = request.as_ref().and_then(request_bearer_token);
+        if let Some((token, surface)) = token_and_surface
+            && let Some(principal) = self.inner.identity_authority.verify_token(token).await?
+        {
+            return Ok(Some((principal, surface)));
         }
-        if console_request_has_token(&request, &console.session_token) {
-            return Ok(true);
+        let surface = token_and_surface
+            .map(|(_, surface)| surface)
+            .unwrap_or(BoundarySurface::Websocket);
+        let reason = match token_and_surface {
+            Some((token, _)) => self.token_rejection_reason(token).await?,
+            None => IdentityAuthRejectionReason::CredentialUnknown,
+        };
+        self.reject_websocket_auth(stream, surface, reason).await?;
+        Ok(None)
+    }
+
+    #[cfg(unix)]
+    async fn authenticate_unix_websocket(
+        &self,
+        stream: &mut UnixStream,
+        peer_uid: u32,
+    ) -> CooldisResult<Option<ResolvedPrincipal>> {
+        let same_uid = peer_uid == current_effective_uid();
+        if self.inner.identity_mode == IdentityMode::Local
+            && same_uid
+            && let Some(principal) = self
+                .inner
+                .identity_authority
+                .resolve_peer_uid(peer_uid)
+                .await?
+        {
+            return Ok(Some(principal));
         }
+        let request = peek_unix_http_request(stream).await?;
+        let token = request
+            .as_ref()
+            .and_then(request_bearer_token)
+            .map(|(token, _)| token);
+        if let Some(token) = token
+            && let Some(principal) = self.inner.identity_authority.verify_token(token).await?
+        {
+            return Ok(Some(principal));
+        }
+        let reason = match token {
+            Some(token) => self.token_rejection_reason(token).await?,
+            None if same_uid && self.inner.identity_mode == IdentityMode::Managed => {
+                IdentityAuthRejectionReason::PeerMappingDisabled { uid: peer_uid }
+            }
+            None => IdentityAuthRejectionReason::CredentialUnknown,
+        };
+        self.reject_websocket_auth(stream, BoundarySurface::UnixSocket, reason)
+            .await?;
+        Ok(None)
+    }
+
+    async fn token_rejection_reason(
+        &self,
+        token: &str,
+    ) -> CooldisResult<IdentityAuthRejectionReason> {
+        let digest = identity_token_digest(token);
+        let now_ms = self.inner.identity_clock.now().timestamp_millis();
+        for principal in self.inner.identity_authority.list_principals().await? {
+            for credential in self
+                .inner
+                .identity_authority
+                .list_credentials(&principal.principal_id)
+                .await?
+            {
+                if credential.token_digest != digest {
+                    continue;
+                }
+                if credential.revoked_at_ms.is_some() {
+                    return Ok(IdentityAuthRejectionReason::CredentialRevoked {
+                        credential_id: credential.credential_id,
+                    });
+                }
+                if credential
+                    .expires_at_ms
+                    .is_some_and(|expires_at_ms| expires_at_ms <= now_ms)
+                {
+                    return Ok(IdentityAuthRejectionReason::CredentialExpired {
+                        credential_id: credential.credential_id,
+                    });
+                }
+                if principal.revoked_at_ms.is_some() {
+                    return Ok(IdentityAuthRejectionReason::PrincipalRevoked {
+                        principal_id: principal.principal_id,
+                    });
+                }
+            }
+        }
+        Ok(IdentityAuthRejectionReason::CredentialUnknown)
+    }
+
+    async fn reject_websocket_auth<S>(
+        &self,
+        stream: &mut S,
+        surface: BoundarySurface,
+        reason: IdentityAuthRejectionReason,
+    ) -> CooldisResult<()>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        self.inner
+            .identity_authority
+            .witness_auth_rejected(&IdentityAuthRejectionV1 {
+                schema: IDENTITY_AUTH_REJECTION_SCHEMA_V1.to_string(),
+                surface,
+                reason,
+                principal_id: None,
+                rejected_at_ms: self.inner.identity_clock.now().timestamp_millis(),
+            })
+            .await?;
         consume_http_request_headers(stream).await?;
         write_http_response(
             stream,
@@ -1026,9 +1221,53 @@ impl CooldisAppServer {
             "text/plain; charset=utf-8",
             HTTP_UNAUTHORIZED_BODY.as_bytes(),
         )
-        .await?;
-        Ok(false)
+        .await
     }
+}
+
+async fn initialize_boundary_identity(
+    store: SqliteSessionStore,
+    clock: Arc<dyn crate::DaemonClock>,
+    mode: IdentityMode,
+    console_principal: Option<PrincipalId>,
+    default_operator_id: &str,
+    console_assets: Option<&mut ConsoleAssetConfig>,
+) -> CooldisResult<Arc<dyn IdentityAuthority>> {
+    let authority = SqliteIdentityAuthority::new(store.clone(), Arc::clone(&clock), None).await?;
+    let mut operator = authority
+        .list_principals()
+        .await?
+        .into_iter()
+        .find(|principal| {
+            principal.kind == PrincipalKind::Operator && principal.revoked_at_ms.is_none()
+        })
+        .map(|principal| principal.principal_id);
+    if mode == IdentityMode::Local && operator.is_none() {
+        let principal_id = PrincipalId::new(default_operator_id);
+        authority
+            .bootstrap_operator(&principal_id, "Local operator")
+            .await?;
+        operator = Some(principal_id);
+    }
+    let peer_operator = (mode == IdentityMode::Local)
+        .then(|| operator.clone())
+        .flatten();
+    let authority = SqliteIdentityAuthority::new(store, clock, peer_operator).await?;
+    if let Some(console) = console_assets {
+        let principal_id = console_principal
+            .or_else(|| (mode == IdentityMode::Local).then_some(operator).flatten())
+            .ok_or_else(|| {
+                CooldisError::RuntimeFactory(
+                    "console authentication requires a configured active operator principal"
+                        .to_string(),
+                )
+            })?;
+        let (_, token) = authority
+            .mint_credential(&principal_id, &principal_id, None)
+            .await?;
+        console.session_token = token;
+    }
+    Ok(Arc::new(authority))
 }
 
 struct ResolvedCatalogOpenAIChatCompletionsProvider {
@@ -1631,6 +1870,35 @@ fn websocket_config() -> WebSocketConfig {
         .max_message_size(Some(MAX_WEBSOCKET_MESSAGE_SIZE))
 }
 
+#[allow(clippy::result_large_err)]
+async fn accept_authenticated_websocket<S>(
+    stream: S,
+) -> Result<WebSocketStream<S>, tokio_tungstenite::tungstenite::Error>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    accept_hdr_async_with_config(
+        stream,
+        |request: &tokio_tungstenite::tungstenite::handshake::server::Request,
+         mut response: tokio_tungstenite::tungstenite::handshake::server::Response| {
+            if let Some(protocol) = request
+                .headers()
+                .get(SEC_WEBSOCKET_PROTOCOL)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.split(',').map(str::trim).next())
+                .and_then(|protocol| HeaderValue::from_str(protocol).ok())
+            {
+                response
+                    .headers_mut()
+                    .insert(SEC_WEBSOCKET_PROTOCOL, protocol);
+            }
+            Ok(response)
+        },
+        Some(websocket_config()),
+    )
+    .await
+}
+
 async fn bind_websocket_listener(addr: SocketAddr) -> CooldisResult<TcpListener> {
     if !addr.ip().is_loopback() {
         return Err(CooldisError::RuntimeFactory(format!(
@@ -1644,11 +1912,9 @@ async fn bind_websocket_listener(addr: SocketAddr) -> CooldisResult<TcpListener>
     })
 }
 
-#[derive(Debug)]
 struct HttpRequestHead {
     method: String,
     path: String,
-    query: Option<String>,
     headers: Vec<(String, String)>,
 }
 
@@ -1662,7 +1928,45 @@ async fn peek_http_request(stream: &TcpStream) -> CooldisResult<Option<HttpReque
     if len == 0 {
         return Ok(None);
     }
-    Ok(parse_http_request_head(&request[..len]))
+    let parsed = parse_http_request_head(&request[..len]);
+    request[..len].fill(0);
+    Ok(parsed)
+}
+
+#[cfg(unix)]
+async fn peek_unix_http_request(stream: &UnixStream) -> CooldisResult<Option<HttpRequestHead>> {
+    let mut request = [0_u8; MAX_HTTP_REQUEST_HEADER_BYTES];
+    loop {
+        stream.readable().await.map_err(|err| {
+            CooldisError::RuntimeFactory(format!(
+                "failed to inspect Cooldis app-server unix request: {err}"
+            ))
+        })?;
+        let len = unsafe {
+            libc::recv(
+                stream.as_raw_fd(),
+                request.as_mut_ptr().cast(),
+                request.len(),
+                libc::MSG_PEEK,
+            )
+        };
+        if len < 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::WouldBlock {
+                continue;
+            }
+            return Err(CooldisError::RuntimeFactory(format!(
+                "failed to inspect Cooldis app-server unix request: {error}"
+            )));
+        }
+        if len == 0 {
+            return Ok(None);
+        }
+        let len = len as usize;
+        let parsed = parse_http_request_head(&request[..len]);
+        request[..len].fill(0);
+        return Ok(parsed);
+    }
 }
 
 fn parse_http_request_head(bytes: &[u8]) -> Option<HttpRequestHead> {
@@ -1673,10 +1977,11 @@ fn parse_http_request_head(bytes: &[u8]) -> Option<HttpRequestHead> {
     let mut parts = request_line.split_whitespace();
     let method = parts.next()?.to_string();
     let target = parts.next()?;
-    let (path, query) = match target.split_once('?') {
-        Some((path, query)) => (path.to_string(), Some(query.to_string())),
-        None => (target.to_string(), None),
-    };
+    let path = target
+        .split_once('?')
+        .map(|(path, _)| path)
+        .unwrap_or(target)
+        .to_string();
     let headers = lines
         .filter_map(|line| {
             let (name, value) = line.split_once(':')?;
@@ -1686,7 +1991,6 @@ fn parse_http_request_head(bytes: &[u8]) -> Option<HttpRequestHead> {
     Some(HttpRequestHead {
         method,
         path,
-        query,
         headers,
     })
 }
@@ -1731,29 +2035,27 @@ fn inject_console_config(html: &str, session_token: &str) -> String {
     }
 }
 
-fn console_request_has_token(request: &HttpRequestHead, expected: &str) -> bool {
+fn request_bearer_token(request: &HttpRequestHead) -> Option<(&str, BoundarySurface)> {
+    if let Some(token) = request
+        .headers
+        .iter()
+        .find(|(name, _)| name == "authorization")
+        .and_then(|(_, value)| value.strip_prefix("Bearer "))
+        .filter(|token| !token.is_empty() && !token.chars().any(char::is_whitespace))
+    {
+        return Some((token, BoundarySurface::Websocket));
+    }
     request
-        .query
-        .as_deref()
-        .is_some_and(|query| query_parameter_matches(query, "token", expected))
-        || request
-            .headers
-            .iter()
-            .filter(|(name, _)| name == "sec-websocket-protocol")
-            .flat_map(|(_, value)| value.split(',').map(str::trim))
-            .any(|protocol| {
-                protocol == expected
-                    || protocol
-                        .strip_prefix("cooldis-console-token.")
-                        .is_some_and(|token| token == expected)
-            })
-}
-
-fn query_parameter_matches(query: &str, key: &str, expected: &str) -> bool {
-    query.split('&').any(|pair| {
-        let (name, value) = pair.split_once('=').unwrap_or((pair, ""));
-        name == key && value == expected
-    })
+        .headers
+        .iter()
+        .filter(|(name, _)| name == "sec-websocket-protocol")
+        .flat_map(|(_, value)| value.split(',').map(str::trim))
+        .find_map(|protocol| {
+            let token = protocol
+                .strip_prefix("cooldis-console-token.")
+                .unwrap_or(protocol);
+            (!token.is_empty()).then_some((token, BoundarySurface::Console))
+        })
 }
 
 fn content_type_for_path(path: &Path) -> &'static str {
@@ -1773,12 +2075,15 @@ fn content_type_for_path(path: &Path) -> &'static str {
     }
 }
 
-async fn write_http_response(
-    stream: &mut TcpStream,
+async fn write_http_response<S>(
+    stream: &mut S,
     status: &str,
     content_type: &str,
     body: &[u8],
-) -> CooldisResult<()> {
+) -> CooldisResult<()>
+where
+    S: AsyncWrite + Unpin,
+{
     let response = format!(
         "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
         body.len()
@@ -1796,9 +2101,12 @@ async fn write_http_response(
     Ok(())
 }
 
-async fn consume_http_request_headers(stream: &mut TcpStream) -> CooldisResult<()> {
-    let mut consumed = Vec::new();
+async fn consume_http_request_headers<S>(stream: &mut S) -> CooldisResult<()>
+where
+    S: AsyncRead + Unpin,
+{
     let mut chunk = [0_u8; 512];
+    let mut matched = 0;
     loop {
         let len = stream.read(&mut chunk).await.map_err(|err| {
             CooldisError::RuntimeFactory(format!(
@@ -1808,11 +2116,45 @@ async fn consume_http_request_headers(stream: &mut TcpStream) -> CooldisResult<(
         if len == 0 {
             return Ok(());
         }
-        consumed.extend_from_slice(&chunk[..len]);
-        if consumed.windows(4).any(|window| window == b"\r\n\r\n") || consumed.len() > 8192 {
+        let mut complete = false;
+        for byte in &chunk[..len] {
+            matched = match (matched, *byte) {
+                (0, b'\r') => 1,
+                (1, b'\n') => 2,
+                (2, b'\r') => 3,
+                (3, b'\n') => {
+                    complete = true;
+                    4
+                }
+                (_, b'\r') => 1,
+                _ => 0,
+            };
+            if complete {
+                break;
+            }
+        }
+        chunk[..len].fill(0);
+        if complete {
             return Ok(());
         }
     }
+}
+
+fn credential_ref(auth: &AuthenticationPath) -> String {
+    match auth {
+        AuthenticationPath::Credential { credential_id } => credential_id.clone(),
+        AuthenticationPath::PeerUid { uid } => format!("peer_uid:{uid}"),
+    }
+}
+
+#[cfg(unix)]
+fn current_effective_uid() -> u32 {
+    unsafe { libc::geteuid() }
+}
+
+#[cfg(not(unix))]
+fn current_effective_uid() -> u32 {
+    0
 }
 
 fn split_websocket_listen_url(value: &str) -> (&str, &str) {

--- a/crates/cooldis-kernel/src/adapters/app_server/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/tests.rs
@@ -10416,6 +10416,187 @@ async fn app_server_websocket_listen_requires_console_session_token() {
 }
 
 #[test]
+fn boundary_bearer_parser_accepts_case_and_whitespace_and_skips_unrelated_protocols() {
+    let authorization = parse_http_request_head(
+        b"GET /rpc HTTP/1.1\r\naUtHoRiZaTiOn:   bEaReR\t boundary-token   \r\n\r\n",
+    )
+    .unwrap();
+    assert_eq!(
+        request_bearer_token(&authorization),
+        Some(("boundary-token", BoundarySurface::Websocket))
+    );
+
+    let protocols = parse_http_request_head(
+        b"GET /rpc HTTP/1.1\r\nSec-WebSocket-Protocol: unrelated.v1\r\nsEc-WeBsOcKeT-pRoToCoL: metrics.v1, cooldis-console-token.console-secret\r\n\r\n",
+    )
+    .unwrap();
+    assert_eq!(
+        request_bearer_token(&protocols),
+        Some(("console-secret", BoundarySurface::Console))
+    );
+}
+
+#[test]
+fn session_close_witness_failure_does_not_mask_the_read_error() {
+    let read_error = CooldisError::RuntimeFactory("original websocket read error".to_string());
+    let close_error = CooldisError::History("close witness failed".to_string());
+    let error = finish_websocket_session(Err(read_error), Err(close_error)).unwrap_err();
+    assert!(error.to_string().contains("original websocket read error"));
+    assert!(!error.to_string().contains("close witness failed"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn unix_peer_mapping_rejects_a_uid_other_than_the_daemon_euid() {
+    let app = test_app().await;
+    let store_path = app.session_store_path().to_path_buf();
+    let (mut client, mut server) = tokio::net::UnixStream::pair().unwrap();
+    let request = b"GET /rpc HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+    client.write_all(request).await.unwrap();
+
+    let mismatched_uid = current_effective_uid().wrapping_add(1);
+    let resolved = app
+        .authenticate_unix_websocket(&mut server, mismatched_uid)
+        .await
+        .unwrap();
+    assert!(resolved.is_none());
+    drop(server);
+    let mut response = Vec::new();
+    client.read_to_end(&mut response).await.unwrap();
+    assert!(response.starts_with(b"HTTP/1.1 401 Unauthorized"));
+    assert_eq!(
+        identity_sql_count(
+            &store_path,
+            "SELECT COUNT(*) FROM cooldis_identity_auth_rejections WHERE surface = 'unix_socket'",
+        )
+        .await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn aborted_websocket_session_still_witnesses_its_close() {
+    let app = test_app().await;
+    let store_path = app.session_store_path().to_path_buf();
+    let resolved_principal = app
+        .inner
+        .identity_authority
+        .resolve_peer_uid(current_effective_uid())
+        .await
+        .unwrap()
+        .unwrap();
+    let (_client_io, server_io) = tokio::io::duplex(1024);
+    let websocket = tokio_tungstenite::WebSocketStream::from_raw_socket(
+        server_io,
+        tokio_tungstenite::tungstenite::protocol::Role::Server,
+        Some(websocket_config()),
+    )
+    .await;
+    let server = app.clone();
+    let task = tokio::spawn(async move {
+        server
+            .handle_websocket(websocket, resolved_principal, BoundarySurface::UnixSocket)
+            .await
+    });
+
+    wait_for_identity_sql_count(
+        &store_path,
+        "SELECT COUNT(*) FROM cooldis_identity_sessions WHERE closed_at_ms IS NULL",
+        1,
+    )
+    .await;
+    task.abort();
+    let _ = task.await;
+    wait_for_identity_sql_count(
+        &store_path,
+        "SELECT COUNT(*) FROM cooldis_identity_sessions WHERE closed_at_ms IS NOT NULL",
+        1,
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn pre_upgrade_reads_and_upgrade_are_bounded_when_no_data_arrives() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::spawn(async move { TcpStream::connect(addr).await.unwrap() });
+    let (mut server, _) = listener.accept().await.unwrap();
+    let _client = connect.await.unwrap();
+
+    assert!(peek_http_request(&server).await.unwrap().is_none());
+    consume_http_request_headers(&mut server).await.unwrap();
+
+    #[cfg(unix)]
+    {
+        let (_client, mut server) = tokio::net::UnixStream::pair().unwrap();
+        assert!(peek_unix_http_request(&server).await.unwrap().is_none());
+        consume_http_request_headers(&mut server).await.unwrap();
+    }
+
+    let (_client_io, server_io) = tokio::io::duplex(1024);
+    let error = accept_authenticated_websocket(server_io).await.unwrap_err();
+    assert!(error.to_string().contains("timed out"));
+}
+
+#[tokio::test]
+async fn oversized_pre_upgrade_headers_fail_closed_with_one_witness() {
+    let app = test_app().await;
+    let store_path = app.session_store_path().to_path_buf();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::spawn(async move { TcpStream::connect(addr).await.unwrap() });
+    let (mut server, _) = listener.accept().await.unwrap();
+    let mut client = connect.await.unwrap();
+    let request = format!(
+        "GET /rpc HTTP/1.1\r\nHost: {addr}\r\nX-Oversized: {}\r\n\r\n",
+        "x".repeat(MAX_HTTP_REQUEST_HEADER_BYTES)
+    );
+    client.write_all(request.as_bytes()).await.unwrap();
+
+    assert!(
+        app.authenticate_tcp_websocket(&mut server)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    let mut response = vec![0_u8; 256];
+    let len = tokio::time::timeout(Duration::from_secs(2), client.read(&mut response))
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(response[..len].starts_with(b"HTTP/1.1 401 Unauthorized"));
+    assert_eq!(
+        identity_sql_count(
+            &store_path,
+            "SELECT COUNT(*) FROM cooldis_identity_auth_rejections WHERE surface = 'websocket'",
+        )
+        .await,
+        1
+    );
+    response.fill(0);
+}
+
+async fn identity_sql_count(path: &Path, query: &str) -> i64 {
+    let store = SqliteSessionStore::open(path).await.unwrap();
+    let connection = store.sqlite_database().connect().await.unwrap();
+    let mut rows = connection.query(query, ()).await.unwrap();
+    rows.next().await.unwrap().unwrap().get(0).unwrap()
+}
+
+async fn wait_for_identity_sql_count(path: &Path, query: &str, expected: i64) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if identity_sql_count(path, query).await >= expected {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+}
+
+#[test]
 fn app_server_listen_addr_parses_websocket_urls() {
     let addr: std::net::SocketAddr = "127.0.0.1:8765".parse().unwrap();
     assert_eq!(

--- a/crates/cooldis-kernel/src/adapters/app_server/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/tests.rs
@@ -10143,8 +10143,10 @@ async fn app_server_websocket_listen_accepts_codex_tui_client() {
         CapsuleBindingsConfig::default(), // lexicon-allow: capsule - existing test helper parameter type
     )
     .await;
-    let server_task = tokio::spawn(async move { app.serve(listen).await });
-    let mut client = connect_ws_tui_test_client(&format!("ws://{addr}/rpc")).await;
+    let token = mint_app_server_test_token(&app).await;
+    let server = app.clone();
+    let server_task = tokio::spawn(async move { server.serve(listen).await });
+    let mut client = connect_ws_tui_test_client(&format!("ws://{addr}/rpc"), &token).await;
 
     assert_eq!(
         client.initialize_result()["userAgent"],
@@ -10190,9 +10192,10 @@ async fn app_server_websocket_query_methods_are_callable() {
     config.state_home = root.join("state");
     config.agent_registry_root = agent_registry_root;
     let app = CooldisAppServer::new_local(config).await.unwrap();
+    let token = mint_app_server_test_token(&app).await;
     let server = app.clone();
     let server_task = tokio::spawn(async move { server.serve(listen).await });
-    let mut client = connect_ws_tui_test_client(&format!("ws://{addr}/rpc")).await;
+    let mut client = connect_ws_tui_test_client(&format!("ws://{addr}/rpc"), &token).await;
 
     let agents = client.request("agent/list", json!({})).await.unwrap();
     assert!(
@@ -10325,7 +10328,8 @@ async fn app_server_websocket_listen_serves_console_assets() {
     );
     assert!(response.contains("Content-Type: text/html"));
     assert!(response.contains("__COOLDIS_CONSOLE_CONFIG__"));
-    assert!(response.contains("fixture-token"));
+    assert!(!response.contains("fixture-token"));
+    assert!(response.contains("cooldis_id_"));
 
     let response = get_tcp_response(addr, "/index.html").await;
     assert!(
@@ -10372,6 +10376,8 @@ async fn app_server_websocket_listen_requires_console_session_token() {
     config.agent_registry_root = root.join("agents");
     let app = CooldisAppServer::new_local(config).await.unwrap();
     let server_task = tokio::spawn(async move { app.serve(listen).await });
+    let index = get_tcp_response(addr, "/").await;
+    let session_token = console_token_from_response(&index);
 
     let missing = get_tcp_raw_response(
         addr,
@@ -10388,7 +10394,7 @@ async fn app_server_websocket_listen_requires_console_session_token() {
     let wrong = get_tcp_raw_response(
         addr,
         &format!(
-            "GET /rpc?token=wrong HTTP/1.1\r\nHost: {addr}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n"
+            "GET /rpc?token={session_token} HTTP/1.1\r\nHost: {addr}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n"
         ),
     )
     .await;
@@ -10397,8 +10403,7 @@ async fn app_server_websocket_listen_requires_console_session_token() {
         "unexpected wrong-token response: {wrong:?}"
     );
 
-    let mut client =
-        connect_ws_tui_test_client(&format!("ws://{addr}/rpc?token=fixture-token")).await;
+    let mut client = connect_ws_tui_test_client(&format!("ws://{addr}/rpc"), &session_token).await;
     assert_eq!(
         client.initialize_result()["userAgent"],
         "cooldis-app-server/0.1"
@@ -11494,9 +11499,17 @@ fn test_connection(
     app: CooldisAppServer,
 ) -> (ConnectionState, mpsc::UnboundedReceiver<JsonRpcMessage>) {
     let (outbound, rx) = mpsc::unbounded_channel::<JsonRpcMessage>();
+    let resolved_principal = ResolvedPrincipal {
+        principal_id: PrincipalId::new(app.user_id()),
+        kind: PrincipalKind::Operator,
+        auth: AuthenticationPath::PeerUid {
+            uid: current_effective_uid(),
+        },
+    };
     (
         ConnectionState {
             app,
+            resolved_principal,
             outbound,
             handshake: Arc::new(Mutex::new(HandshakeState::default())),
             opt_out_notifications: Arc::new(RwLock::new(HashSet::new())),
@@ -13511,13 +13524,17 @@ async fn connect_tui_test_client(
     );
 }
 
-async fn connect_ws_tui_test_client(url: &str) -> crate::CodexTuiTestClient<tokio::net::TcpStream> {
+async fn connect_ws_tui_test_client(
+    url: &str,
+    token: &str,
+) -> crate::CodexTuiTestClient<tokio::net::TcpStream> {
     let mut last_error = None;
     for _ in 0..100 {
         match crate::CodexTuiTestClient::connect_websocket(
             url,
             crate::CodexTuiConnectConfig {
                 client_name: "websocket-listen-test".to_string(),
+                bearer_token: Some(token.to_string()),
                 ..crate::CodexTuiConnectConfig::default()
             },
         )
@@ -13534,6 +13551,28 @@ async fn connect_ws_tui_test_client(url: &str) -> crate::CodexTuiTestClient<toki
         "timed out connecting Codex TUI test client to {url}; last error: {}",
         last_error.unwrap_or_else(|| "none".to_string())
     );
+}
+
+async fn mint_app_server_test_token(app: &CooldisAppServer) -> String {
+    let store = SqliteSessionStore::open(app.session_store_path())
+        .await
+        .unwrap();
+    let authority = SqliteIdentityAuthority::new(store, Arc::new(SystemDaemonClock), None)
+        .await
+        .unwrap();
+    let principal = PrincipalId::new(app.user_id());
+    authority
+        .mint_credential(&principal, &principal, None)
+        .await
+        .unwrap()
+        .1
+}
+
+fn console_token_from_response(response: &str) -> String {
+    let marker = "sessionToken:";
+    let start = response.find(marker).unwrap() + marker.len();
+    let value = response[start..].split('}').next().unwrap();
+    serde_json::from_str(value).unwrap()
 }
 
 fn unused_loopback_addr() -> std::net::SocketAddr {

--- a/crates/cooldis-kernel/src/adapters/codex_tui.rs
+++ b/crates/cooldis-kernel/src/adapters/codex_tui.rs
@@ -13,6 +13,8 @@ use tokio::net::TcpStream;
 use tokio::net::UnixStream;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::header::AUTHORIZATION;
+use tokio_tungstenite::tungstenite::http::{HeaderValue, Request};
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 use tokio_tungstenite::{WebSocketStream, client_async_with_config};
 
@@ -24,22 +26,48 @@ const CODEX_TUI_INITIALIZE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Cooldis-owned copy of the Codex TUI remote-client path, trimmed to a
 /// headless driver for app-server tests.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct CodexTuiConnectConfig {
     pub client_name: String,
     pub client_version: String,
     pub experimental_api: bool,
     pub opt_out_notification_methods: Vec<String>,
+    pub bearer_token: Option<String>,
 }
 
 impl Default for CodexTuiConnectConfig {
     fn default() -> Self {
+        // MCP, ACP, debug RPC, and other daemon clients inherit this config.
+        // Managed callers provide their boundary credential via
+        // COOLDIS_APP_SERVER_TOKEN; an explicit field value may override it.
+        let bearer_token = std::env::var("COOLDIS_APP_SERVER_TOKEN")
+            .ok()
+            .filter(|token| !token.trim().is_empty());
         Self {
             client_name: CODEX_TUI_TEST_CLIENT_NAME.to_string(),
             client_version: env!("CARGO_PKG_VERSION").to_string(),
             experimental_api: true,
             opt_out_notification_methods: Vec::new(),
+            bearer_token,
         }
+    }
+}
+
+impl std::fmt::Debug for CodexTuiConnectConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CodexTuiConnectConfig")
+            .field("client_name", &self.client_name)
+            .field("client_version", &self.client_version)
+            .field("experimental_api", &self.experimental_api)
+            .field(
+                "opt_out_notification_methods",
+                &self.opt_out_notification_methods,
+            )
+            .field(
+                "bearer_token",
+                &self.bearer_token.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
     }
 }
 
@@ -88,9 +116,10 @@ impl CodexTuiTestClient<UnixStream> {
     ) -> CooldisResult<Self> {
         let socket_path = socket_path.into();
         let endpoint = format!("unix://{}", socket_path.display());
-        let request = CODEX_TUI_UDS_WEBSOCKET_HANDSHAKE_URL
+        let mut request = CODEX_TUI_UDS_WEBSOCKET_HANDSHAKE_URL
             .into_client_request()
             .map_err(|err| tui_error(format!("invalid UDS websocket handshake URL: {err}")))?;
+        set_bearer_token(&mut request, config.bearer_token.as_deref())?;
         let stream = UnixStream::connect(&socket_path).await.map_err(|err| {
             tui_error(format!(
                 "failed to connect Codex TUI test client to `{endpoint}`: {err}"
@@ -115,9 +144,10 @@ impl CodexTuiTestClient<TcpStream> {
     ) -> CooldisResult<Self> {
         let endpoint = url.to_string();
         let authority = websocket_tcp_authority(url)?;
-        let request = url
+        let mut request = url
             .into_client_request()
             .map_err(|err| tui_error(format!("invalid TCP websocket URL `{endpoint}`: {err}")))?;
+        set_bearer_token(&mut request, config.bearer_token.as_deref())?;
         let stream = TcpStream::connect(authority).await.map_err(|err| {
             tui_error(format!(
                 "failed to connect Codex TUI test client to `{endpoint}`: {err}"
@@ -133,6 +163,16 @@ impl CodexTuiTestClient<TcpStream> {
                 })?;
         Self::connect_with_websocket(websocket, endpoint, config).await
     }
+}
+
+fn set_bearer_token(request: &mut Request<()>, token: Option<&str>) -> CooldisResult<()> {
+    let Some(token) = token else {
+        return Ok(());
+    };
+    let value = HeaderValue::from_str(&format!("Bearer {token}"))
+        .map_err(|_| tui_error("Cooldis app-server bearer token is not a valid HTTP header"))?;
+    request.headers_mut().insert(AUTHORIZATION, value);
+    Ok(())
 }
 
 impl<S> CodexTuiTestClient<S>

--- a/crates/cooldis-kernel/src/adapters/codex_tui/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/codex_tui/tests.rs
@@ -3,6 +3,17 @@ use crate::{AppServerListenAddr, CooldisAppServer, CooldisAppServerConfig};
 use uuid::Uuid;
 
 #[test]
+fn codex_tui_connect_config_redacts_bearer_token() {
+    let config = CodexTuiConnectConfig {
+        bearer_token: Some("do-not-log-this-token".to_string()),
+        ..CodexTuiConnectConfig::default()
+    };
+    let debug = format!("{config:?}");
+    assert!(debug.contains("<redacted>"));
+    assert!(!debug.contains("do-not-log-this-token"));
+}
+
+#[test]
 fn codex_tui_initialize_request_uses_codex_remote_shape() {
     let message = JsonRpcMessage::Request(JsonRpcRequest {
         id: RequestId::String("initialize".to_string()),

--- a/crates/cooldis-kernel/src/cli/console.rs
+++ b/crates/cooldis-kernel/src/cli/console.rs
@@ -30,7 +30,6 @@ pub(super) async fn run_console(args: Vec<OsString>) -> CooldisResult<()> {
         .map_err(|err| usage_error(format!("failed to inspect Cooldis console listener: {err}")))?;
     let listen = AppServerListenAddr::WebSocket(bound_addr);
     let assets = resolve_console_asset_root()?;
-    let session_token = generate_console_session_token()?;
     let resolved = resolve_console_app_server_config(&options, listen.clone())?;
     let project_root = resolved.project_root.clone();
     let config_path = resolved.config_path.clone();
@@ -38,7 +37,7 @@ pub(super) async fn run_console(args: Vec<OsString>) -> CooldisResult<()> {
     let state_home = config.state_home.clone();
     config.console_assets = Some(ConsoleAssetConfig {
         root: assets,
-        session_token,
+        session_token: String::new(),
     });
     prepare_console_project_storage(&config)?;
 
@@ -215,20 +214,6 @@ pub(super) fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
     if !paths.iter().any(|existing| existing == &path) {
         paths.push(path);
     }
-}
-
-pub(super) fn generate_console_session_token() -> CooldisResult<String> {
-    let mut random = [0_u8; 32];
-    getrandom::fill(&mut random)
-        .map_err(|err| usage_error(format!("failed to generate console session token: {err}")))?;
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut token = String::with_capacity("cooldis_console_".len() + random.len() * 2);
-    token.push_str("cooldis_console_");
-    for byte in random {
-        token.push(HEX[(byte >> 4) as usize] as char);
-        token.push(HEX[(byte & 0x0f) as usize] as char);
-    }
-    Ok(token)
 }
 
 pub(super) fn resolve_console_asset_root() -> CooldisResult<PathBuf> {

--- a/crates/cooldis-kernel/src/cli/console.rs
+++ b/crates/cooldis-kernel/src/cli/console.rs
@@ -30,7 +30,7 @@ pub(super) async fn run_console(args: Vec<OsString>) -> CooldisResult<()> {
         .map_err(|err| usage_error(format!("failed to inspect Cooldis console listener: {err}")))?;
     let listen = AppServerListenAddr::WebSocket(bound_addr);
     let assets = resolve_console_asset_root()?;
-    let session_token = generate_console_session_token();
+    let session_token = generate_console_session_token()?;
     let resolved = resolve_console_app_server_config(&options, listen.clone())?;
     let project_root = resolved.project_root.clone();
     let config_path = resolved.config_path.clone();
@@ -217,8 +217,18 @@ pub(super) fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
     }
 }
 
-pub(super) fn generate_console_session_token() -> String {
-    format!("{}{}", Uuid::now_v7().simple(), Uuid::now_v7().simple())
+pub(super) fn generate_console_session_token() -> CooldisResult<String> {
+    let mut random = [0_u8; 32];
+    getrandom::fill(&mut random)
+        .map_err(|err| usage_error(format!("failed to generate console session token: {err}")))?;
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut token = String::with_capacity("cooldis_console_".len() + random.len() * 2);
+    token.push_str("cooldis_console_");
+    for byte in random {
+        token.push(HEX[(byte >> 4) as usize] as char);
+        token.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    Ok(token)
 }
 
 pub(super) fn resolve_console_asset_root() -> CooldisResult<PathBuf> {

--- a/crates/cooldis-kernel/src/cli/console/tests.rs
+++ b/crates/cooldis-kernel/src/cli/console/tests.rs
@@ -1,16 +1,6 @@
 use super::*;
 
 #[test]
-fn console_session_tokens_use_fresh_csprng_material() {
-    let first = generate_console_session_token().unwrap();
-    let second = generate_console_session_token().unwrap();
-    assert_ne!(first, second);
-    let random = first.strip_prefix("cooldis_console_").unwrap();
-    assert_eq!(random.len(), 64);
-    assert!(random.bytes().all(|byte| byte.is_ascii_hexdigit()));
-}
-
-#[test]
 fn parse_chat_args_collects_prompt_and_homes() {
     let args = vec![
         "--cwd",

--- a/crates/cooldis-kernel/src/cli/console/tests.rs
+++ b/crates/cooldis-kernel/src/cli/console/tests.rs
@@ -1,4 +1,15 @@
 use super::*;
+
+#[test]
+fn console_session_tokens_use_fresh_csprng_material() {
+    let first = generate_console_session_token().unwrap();
+    let second = generate_console_session_token().unwrap();
+    assert_ne!(first, second);
+    let random = first.strip_prefix("cooldis_console_").unwrap();
+    assert_eq!(random.len(), 64);
+    assert!(random.bytes().all(|byte| byte.is_ascii_hexdigit()));
+}
+
 #[test]
 fn parse_chat_args_collects_prompt_and_homes() {
     let args = vec![

--- a/crates/cooldis-kernel/src/cli/daemon/tests.rs
+++ b/crates/cooldis-kernel/src/cli/daemon/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::daemon::identity::{IdentityMode, PrincipalId};
+use crate::daemon::identity::{
+    IdentityAuthority, IdentityMode, PrincipalId, SqliteIdentityAuthority,
+};
 use crate::{
     AgentManifestPlacementBinding, AgentManifestWorkspaceBinding, AgentManifestWorkspaceMode,
     CooldisDaemonConfig,
@@ -100,6 +102,105 @@ fn daemon_app_server_config_from_loaded_applies_identity_config() {
         app_config.console_principal,
         Some(PrincipalId::new("operator-configured"))
     );
+}
+
+#[tokio::test]
+async fn managed_identity_toml_reaches_initialized_boundary_authority() {
+    let root = daemon_test_root("managed-identity-boundary");
+    let workspace = root.join("workspace");
+    let console_assets = root.join("console");
+    fs::create_dir_all(&workspace).unwrap();
+    fs::create_dir_all(&console_assets).unwrap();
+    fs::write(
+        console_assets.join("index.html"),
+        "<html><head></head><body>console</body></html>",
+    )
+    .unwrap();
+    let path = root.join("cooldis.toml");
+    fs::write(
+        &path,
+        r#"
+[daemon.identity]
+mode = "managed"
+tenant_id = "tenant-managed"
+console_principal = "operator-managed"
+
+[daemon.runtime]
+cwd = "workspace"
+runtime_home = "runtime"
+state_home = "state"
+
+[daemon.app_server]
+listen = "unix://run/cooldis.sock"
+
+[daemon.registries]
+operations = "operations"
+agents = "agents"
+"#,
+    )
+    .unwrap();
+
+    let loaded = load_cooldis_daemon_config(Some(&path)).unwrap();
+    let mut app_config = daemon_app_server_config_from_loaded(&loaded).unwrap();
+    app_config.user_state_home = root.join("user-state");
+    app_config.console_assets = Some(ConsoleAssetConfig {
+        root: console_assets,
+        session_token: "replaced-at-construction".to_string(),
+    });
+
+    let operator = PrincipalId::new("operator-managed");
+    let identity_store =
+        SqliteSessionStore::open(app_config.state_home.join("session_history.sqlite3"))
+            .await
+            .unwrap();
+    let authority = SqliteIdentityAuthority::new(identity_store, Arc::new(SystemDaemonClock), None)
+        .await
+        .unwrap();
+    let _ = authority
+        .bootstrap_operator(&operator, "Managed operator")
+        .await
+        .unwrap();
+    let baseline_active_credentials = authority
+        .list_credentials(&operator)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|credential| credential.revoked_at_ms.is_none())
+        .count();
+
+    let app = CooldisAppServer::new_local(app_config).await.unwrap();
+
+    assert_eq!(app.tenant_id(), "tenant-managed");
+    assert_eq!(app.user_id(), "operator-managed");
+    assert_eq!(
+        app.identity_boundary_config(),
+        (IdentityMode::Managed, Some(&operator))
+    );
+    assert_eq!(
+        authority
+            .list_credentials(&operator)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|credential| credential.revoked_at_ms.is_none())
+            .count(),
+        baseline_active_credentials + 1,
+        "console initialization did not mint for the configured managed principal"
+    );
+
+    drop(app);
+    assert_eq!(
+        authority
+            .list_credentials(&operator)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|credential| credential.revoked_at_ms.is_none())
+            .count(),
+        baseline_active_credentials,
+        "managed console credential was not retired on shutdown"
+    );
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]

--- a/crates/cooldis-kernel/tests/boundary_auth.rs
+++ b/crates/cooldis-kernel/tests/boundary_auth.rs
@@ -1,0 +1,475 @@
+use cooldis::daemon::identity::{
+    CooldisDaemonIdentityConfig, IdentityAuthority, IdentityMode, PrincipalId,
+    SqliteIdentityAuthority,
+};
+use cooldis::{
+    AppServerListenAddr, CodexTuiConnectConfig, CodexTuiTestClient, ConsoleAssetConfig,
+    CooldisAppServer, CooldisAppServerConfig, SqliteSessionStore, SystemDaemonClock,
+};
+use cooldis_sqlite::params;
+use futures_util::SinkExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::HeaderValue;
+use tokio_tungstenite::tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL;
+
+const OPERATOR_ID: &str = "operator:root";
+
+#[tokio::test]
+async fn tcp_boundary_authenticates_before_upgrade_and_witnesses_sessions() {
+    let root = test_root("tcp");
+    let assets = root.join("console");
+    std::fs::create_dir_all(&assets).unwrap();
+    std::fs::write(
+        assets.join("index.html"),
+        "<html><head></head><body>console</body></html>",
+    )
+    .unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let listen = AppServerListenAddr::WebSocket(addr);
+    let mut config = app_config(&root, listen);
+    config.console_assets = Some(ConsoleAssetConfig {
+        root: assets,
+        session_token: "replaced-at-construction".to_string(),
+    });
+
+    let authority = identity_authority(&config).await;
+    let operator = PrincipalId::new(OPERATOR_ID);
+    let (_, _, accepted_token) = authority
+        .bootstrap_operator(&operator, "Root operator")
+        .await
+        .unwrap();
+    let (_, expired_token) = authority
+        .mint_credential(&operator, &operator, Some(1))
+        .await
+        .unwrap();
+    let (revoked, revoked_token) = authority
+        .mint_credential(&operator, &operator, None)
+        .await
+        .unwrap();
+    authority
+        .revoke_credential(&operator, &revoked.credential_id)
+        .await
+        .unwrap();
+    drop(authority);
+
+    let app = CooldisAppServer::new(
+        config,
+        CooldisDaemonIdentityConfig {
+            mode: IdentityMode::Managed,
+            tenant_id: Some("test-tenant".to_string()),
+            console_principal: Some(operator),
+        },
+    )
+    .await
+    .unwrap();
+    let store_path = app.session_store_path().to_path_buf();
+    let server = app.clone();
+    let server_task = tokio::spawn(async move { server.serve_websocket_listener(listener).await });
+
+    let mut client = CodexTuiTestClient::connect_websocket(
+        &format!("ws://{addr}/rpc"),
+        CodexTuiConnectConfig {
+            bearer_token: Some(accepted_token.clone()),
+            ..CodexTuiConnectConfig::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        client.initialize_result()["userAgent"],
+        "cooldis-app-server/0.1"
+    );
+    client.close().await.unwrap();
+
+    for request in [
+        websocket_request(addr, "/rpc", None),
+        websocket_request(addr, "/rpc", Some("unknown-token")),
+        websocket_request(addr, "/rpc", Some(&expired_token)),
+        websocket_request(addr, "/rpc", Some(&revoked_token)),
+        websocket_request(addr, &format!("/rpc?token={accepted_token}"), None),
+    ] {
+        let response = raw_tcp_request(addr, &request).await;
+        assert!(
+            response.starts_with("HTTP/1.1 401 Unauthorized"),
+            "unexpected authentication response: {response:?}"
+        );
+        assert!(!response.contains(&accepted_token));
+        assert!(!response.contains(&expired_token));
+        assert!(!response.contains(&revoked_token));
+    }
+
+    let index = raw_tcp_request(
+        addr,
+        &format!("GET / HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"),
+    )
+    .await;
+    let console_token = injected_console_token(&index);
+    let mut request = format!("ws://{addr}/rpc").into_client_request().unwrap();
+    request.headers_mut().insert(
+        SEC_WEBSOCKET_PROTOCOL,
+        HeaderValue::from_str(&format!("cooldis-console-token.{console_token}")).unwrap(),
+    );
+    let stream = TcpStream::connect(addr).await.unwrap();
+    let (mut console, _) = tokio_tungstenite::client_async(request, stream)
+        .await
+        .unwrap();
+    console.send(Message::Close(None)).await.unwrap();
+
+    for path in ["/healthz", "/readyz"] {
+        let response = raw_tcp_request(
+            addr,
+            &format!("GET {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"),
+        )
+        .await;
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.ends_with("{\"status\":\"ok\"}"));
+        assert!(!response.contains(OPERATOR_ID));
+        assert!(!response.contains("managed"));
+    }
+
+    wait_for_sql_count(
+        &store_path,
+        "SELECT COUNT(*) FROM cooldis_identity_sessions WHERE closed_at_ms IS NOT NULL",
+        2,
+    )
+    .await;
+    assert_eq!(
+        sql_count(
+            &store_path,
+            "SELECT COUNT(*) FROM cooldis_identity_sessions WHERE surface IN ('websocket', 'console') AND principal_id = ?1",
+            params![OPERATOR_ID],
+        )
+        .await,
+        4
+    );
+    assert_eq!(
+        sql_count(
+            &store_path,
+            "SELECT COUNT(*) FROM cooldis_identity_auth_rejections WHERE surface = 'websocket'",
+            (),
+        )
+        .await,
+        5
+    );
+    assert_eq!(
+        sql_count(
+            &store_path,
+            "SELECT COUNT(*) FROM cooldis_identity_auth_rejections WHERE reason_json LIKE '%credential_expired%'",
+            (),
+        )
+        .await,
+        1
+    );
+    assert_eq!(
+        sql_count(
+            &store_path,
+            "SELECT COUNT(*) FROM cooldis_identity_auth_rejections WHERE reason_json LIKE '%credential_revoked%'",
+            (),
+        )
+        .await,
+        1
+    );
+
+    server_task.abort();
+    let _ = server_task.await;
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn unix_boundary_maps_same_uid_only_in_local_mode_and_secures_socket() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let local_root = test_root("unix-local");
+    let local_socket = local_root.join("app-server.sock");
+    let local_config = app_config(&local_root, AppServerListenAddr::Unix(local_socket.clone()));
+    let local_app = CooldisAppServer::new_local(local_config).await.unwrap();
+    let local_store = local_app.session_store_path().to_path_buf();
+    let local_server = local_app.clone();
+    let local_listen = AppServerListenAddr::Unix(local_socket.clone());
+    let mut local_task = tokio::spawn(async move { local_server.serve(local_listen).await });
+    wait_for_path(&local_socket, &mut local_task).await;
+    assert_eq!(
+        std::fs::metadata(&local_socket)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+
+    let mut local_client =
+        CodexTuiTestClient::connect_unix(&local_socket, CodexTuiConnectConfig::default())
+            .await
+            .unwrap();
+    local_client.close().await.unwrap();
+    wait_for_sql_count(
+        &local_store,
+        "SELECT COUNT(*) FROM cooldis_identity_sessions WHERE surface = 'unix_socket' AND credential_ref LIKE 'peer_uid:%' AND closed_at_ms IS NOT NULL",
+        1,
+    )
+    .await;
+
+    let managed_root = test_root("unix-managed");
+    let managed_socket = managed_root.join("app-server.sock");
+    let managed_config = app_config(
+        &managed_root,
+        AppServerListenAddr::Unix(managed_socket.clone()),
+    );
+    let authority = identity_authority(&managed_config).await;
+    let operator = PrincipalId::new(OPERATOR_ID);
+    let (_, credential, token) = authority
+        .bootstrap_operator(&operator, "Root operator")
+        .await
+        .unwrap();
+    let (_, expired_token) = authority
+        .mint_credential(&operator, &operator, Some(1))
+        .await
+        .unwrap();
+    let (revoked_credential, revoked_token) = authority
+        .mint_credential(&operator, &operator, None)
+        .await
+        .unwrap();
+    authority
+        .revoke_credential(&operator, &revoked_credential.credential_id)
+        .await
+        .unwrap();
+    drop(authority);
+    let managed_app = CooldisAppServer::new(
+        managed_config,
+        CooldisDaemonIdentityConfig {
+            mode: IdentityMode::Managed,
+            tenant_id: Some("test-tenant".to_string()),
+            console_principal: None,
+        },
+    )
+    .await
+    .unwrap();
+    let managed_store = managed_app.session_store_path().to_path_buf();
+    let managed_server = managed_app.clone();
+    let managed_listen = AppServerListenAddr::Unix(managed_socket.clone());
+    let mut managed_task = tokio::spawn(async move { managed_server.serve(managed_listen).await });
+    wait_for_path(&managed_socket, &mut managed_task).await;
+    assert_eq!(
+        std::fs::metadata(&managed_socket)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+
+    let no_token = CodexTuiTestClient::connect_unix(
+        &managed_socket,
+        CodexTuiConnectConfig {
+            bearer_token: None,
+            ..CodexTuiConnectConfig::default()
+        },
+    )
+    .await;
+    let no_token = match no_token {
+        Ok(_) => panic!("managed same-uid connection unexpectedly authenticated"),
+        Err(error) => error,
+    };
+    assert!(no_token.to_string().contains("401"));
+
+    let unknown_token = CodexTuiTestClient::connect_unix(
+        &managed_socket,
+        CodexTuiConnectConfig {
+            bearer_token: Some("unknown-token".to_string()),
+            ..CodexTuiConnectConfig::default()
+        },
+    )
+    .await;
+    let unknown_token = match unknown_token {
+        Ok(_) => panic!("unknown Unix bearer token unexpectedly authenticated"),
+        Err(error) => error,
+    };
+    assert!(unknown_token.to_string().contains("401"));
+
+    for rejected_token in [expired_token, revoked_token] {
+        let rejected = CodexTuiTestClient::connect_unix(
+            &managed_socket,
+            CodexTuiConnectConfig {
+                bearer_token: Some(rejected_token),
+                ..CodexTuiConnectConfig::default()
+            },
+        )
+        .await;
+        let rejected = match rejected {
+            Ok(_) => panic!("inactive Unix bearer token unexpectedly authenticated"),
+            Err(error) => error,
+        };
+        assert!(rejected.to_string().contains("401"));
+    }
+
+    let mut token_client = CodexTuiTestClient::connect_unix(
+        &managed_socket,
+        CodexTuiConnectConfig {
+            bearer_token: Some(token),
+            ..CodexTuiConnectConfig::default()
+        },
+    )
+    .await
+    .unwrap();
+    token_client.close().await.unwrap();
+    wait_for_sql_count(
+        &managed_store,
+        "SELECT COUNT(*) FROM cooldis_identity_sessions WHERE closed_at_ms IS NOT NULL",
+        1,
+    )
+    .await;
+    assert_eq!(
+        sql_count(
+            &managed_store,
+            "SELECT COUNT(*) FROM cooldis_identity_sessions WHERE surface = 'unix_socket' AND credential_ref = ?1",
+            params![credential.credential_id],
+        )
+        .await,
+        2
+    );
+    assert_eq!(
+        sql_count(
+            &managed_store,
+            "SELECT COUNT(*) FROM cooldis_identity_auth_rejections WHERE surface = 'unix_socket' AND reason_json LIKE '%peer_mapping_disabled%'",
+            (),
+        )
+        .await,
+        1
+    );
+    assert_eq!(
+        sql_count(
+            &managed_store,
+            "SELECT COUNT(*) FROM cooldis_identity_auth_rejections WHERE surface = 'unix_socket' AND reason_json LIKE '%credential_unknown%'",
+            (),
+        )
+        .await,
+        1
+    );
+    assert_eq!(
+        sql_count(
+            &managed_store,
+            "SELECT COUNT(*) FROM cooldis_identity_auth_rejections WHERE surface = 'unix_socket' AND reason_json LIKE '%credential_expired%'",
+            (),
+        )
+        .await,
+        1
+    );
+    assert_eq!(
+        sql_count(
+            &managed_store,
+            "SELECT COUNT(*) FROM cooldis_identity_auth_rejections WHERE surface = 'unix_socket' AND reason_json LIKE '%credential_revoked%'",
+            (),
+        )
+        .await,
+        1
+    );
+
+    local_task.abort();
+    managed_task.abort();
+    let _ = local_task.await;
+    let _ = managed_task.await;
+    let _ = std::fs::remove_dir_all(local_root);
+    let _ = std::fs::remove_dir_all(managed_root);
+}
+
+fn app_config(root: &Path, listen: AppServerListenAddr) -> CooldisAppServerConfig {
+    let mut config = CooldisAppServerConfig::local(listen, root.join("workspace"));
+    config.runtime_home = root.join("runtime");
+    config.state_home = root.join("state");
+    config.user_state_home = root.join("user-state");
+    config.agent_registry_root = root.join("agents");
+    config.tenant_id = "test-tenant".to_string();
+    config
+}
+
+async fn identity_authority(config: &CooldisAppServerConfig) -> SqliteIdentityAuthority {
+    let store = SqliteSessionStore::open(config.state_home.join("session_history.sqlite3"))
+        .await
+        .unwrap();
+    SqliteIdentityAuthority::new(store, Arc::new(SystemDaemonClock), None)
+        .await
+        .unwrap()
+}
+
+fn websocket_request(addr: std::net::SocketAddr, path: &str, token: Option<&str>) -> String {
+    let authorization = token
+        .map(|token| format!("Authorization: Bearer {token}\r\n"))
+        .unwrap_or_default();
+    format!(
+        "GET {path} HTTP/1.1\r\nHost: {addr}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n{authorization}\r\n"
+    )
+}
+
+async fn raw_tcp_request(addr: std::net::SocketAddr, request: &str) -> String {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    stream.write_all(request.as_bytes()).await.unwrap();
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response).await.unwrap();
+    String::from_utf8(response).unwrap()
+}
+
+fn injected_console_token(response: &str) -> String {
+    let marker = "sessionToken:";
+    let start = response.find(marker).unwrap() + marker.len();
+    let value = response[start..].split('}').next().unwrap();
+    serde_json::from_str(value).unwrap()
+}
+
+async fn wait_for_path(
+    path: &Path,
+    task: &mut tokio::task::JoinHandle<cooldis::CooldisResult<()>>,
+) {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if path.exists() {
+                break;
+            }
+            if task.is_finished() {
+                let outcome = (&mut *task).await;
+                panic!(
+                    "app-server exited before creating {}: {outcome:?}",
+                    path.display()
+                );
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+}
+
+async fn wait_for_sql_count(path: &Path, query: &str, expected: i64) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if sql_count(path, query, ()).await >= expected {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+}
+
+async fn sql_count<P>(path: &Path, query: &str, params: P) -> i64
+where
+    P: cooldis_sqlite::IntoParams,
+{
+    let store = SqliteSessionStore::open(path).await.unwrap();
+    let database = store.sqlite_database();
+    let connection = database.connect().await.unwrap();
+    let mut rows = connection.query(query, params).await.unwrap();
+    rows.next().await.unwrap().unwrap().get(0).unwrap()
+}
+
+fn test_root(label: &str) -> PathBuf {
+    PathBuf::from("/tmp").join(format!("cdis-ba-{label}-{}", uuid::Uuid::new_v4().simple()))
+}

--- a/crates/cooldis-kernel/tests/boundary_auth.rs
+++ b/crates/cooldis-kernel/tests/boundary_auth.rs
@@ -1,5 +1,5 @@
 use cooldis::daemon::identity::{
-    CooldisDaemonIdentityConfig, IdentityAuthority, IdentityMode, PrincipalId,
+    CooldisDaemonIdentityConfig, IdentityAuthority, IdentityMode, PrincipalId, PrincipalKind,
     SqliteIdentityAuthority,
 };
 use cooldis::{
@@ -57,6 +57,64 @@ async fn tcp_boundary_authenticates_before_upgrade_and_witnesses_sessions() {
         .revoke_credential(&operator, &revoked.credential_id)
         .await
         .unwrap();
+    let revoked_operator = PrincipalId::new("operator:revoked");
+    authority
+        .declare_principal(
+            &operator,
+            &revoked_operator,
+            PrincipalKind::Operator,
+            "Revoked operator",
+        )
+        .await
+        .unwrap();
+    let (_, revoked_operator_token) = authority
+        .mint_credential(&operator, &revoked_operator, None)
+        .await
+        .unwrap();
+    authority
+        .revoke_principal(&operator, &revoked_operator)
+        .await
+        .unwrap();
+    let expired_revoked_operator = PrincipalId::new("operator:expired-and-revoked");
+    authority
+        .declare_principal(
+            &operator,
+            &expired_revoked_operator,
+            PrincipalKind::Operator,
+            "Expired and revoked operator",
+        )
+        .await
+        .unwrap();
+    let (_, expired_revoked_operator_token) = authority
+        .mint_credential(&operator, &expired_revoked_operator, Some(1))
+        .await
+        .unwrap();
+    authority
+        .revoke_principal(&operator, &expired_revoked_operator)
+        .await
+        .unwrap();
+    let fully_revoked_operator = PrincipalId::new("operator:credential-and-principal-revoked");
+    authority
+        .declare_principal(
+            &operator,
+            &fully_revoked_operator,
+            PrincipalKind::Operator,
+            "Credential and principal revoked operator",
+        )
+        .await
+        .unwrap();
+    let (fully_revoked_credential, fully_revoked_token) = authority
+        .mint_credential(&operator, &fully_revoked_operator, Some(1))
+        .await
+        .unwrap();
+    authority
+        .revoke_credential(&operator, &fully_revoked_credential.credential_id)
+        .await
+        .unwrap();
+    authority
+        .revoke_principal(&operator, &fully_revoked_operator)
+        .await
+        .unwrap();
     drop(authority);
 
     let app = CooldisAppServer::new(
@@ -93,6 +151,9 @@ async fn tcp_boundary_authenticates_before_upgrade_and_witnesses_sessions() {
         websocket_request(addr, "/rpc", Some("unknown-token")),
         websocket_request(addr, "/rpc", Some(&expired_token)),
         websocket_request(addr, "/rpc", Some(&revoked_token)),
+        websocket_request(addr, "/rpc", Some(&revoked_operator_token)),
+        websocket_request(addr, "/rpc", Some(&expired_revoked_operator_token)),
+        websocket_request(addr, "/rpc", Some(&fully_revoked_token)),
         websocket_request(addr, &format!("/rpc?token={accepted_token}"), None),
     ] {
         let response = raw_tcp_request(addr, &request).await;
@@ -103,7 +164,29 @@ async fn tcp_boundary_authenticates_before_upgrade_and_witnesses_sessions() {
         assert!(!response.contains(&accepted_token));
         assert!(!response.contains(&expired_token));
         assert!(!response.contains(&revoked_token));
+        assert!(!response.contains(&revoked_operator_token));
+        assert!(!response.contains(&expired_revoked_operator_token));
+        assert!(!response.contains(&fully_revoked_token));
+        assert!(response.ends_with("authentication required"));
+        assert!(!response.contains("credential_revoked"));
+        assert!(!response.contains("credential_expired"));
+        assert!(!response.contains("principal_revoked"));
     }
+
+    let fragmented_request = websocket_request(addr, "/rpc", Some(&accepted_token));
+    let fragmented_response = fragmented_tcp_response_head(addr, &fragmented_request).await;
+    assert!(
+        fragmented_response.starts_with("HTTP/1.1 101 Switching Protocols"),
+        "fragmented authenticated handshake was not upgraded"
+    );
+
+    let case_insensitive_request =
+        websocket_request_with_authorization(addr, &format!("   bEaReR\t  {accepted_token}   "));
+    let case_insensitive_response = tcp_response_head(addr, &case_insensitive_request).await;
+    assert!(
+        case_insensitive_response.starts_with("HTTP/1.1 101 Switching Protocols"),
+        "case-insensitive bearer handshake was not upgraded"
+    );
 
     let index = raw_tcp_request(
         addr,
@@ -117,10 +200,33 @@ async fn tcp_boundary_authenticates_before_upgrade_and_witnesses_sessions() {
         HeaderValue::from_str(&format!("cooldis-console-token.{console_token}")).unwrap(),
     );
     let stream = TcpStream::connect(addr).await.unwrap();
-    let (mut console, _) = tokio_tungstenite::client_async(request, stream)
+    let (mut console, response) = tokio_tungstenite::client_async(request, stream)
         .await
-        .unwrap();
+        .unwrap_or_else(|_| panic!("console WebSocket handshake failed"));
+    let expected_protocol = format!("cooldis-console-token.{console_token}");
+    assert!(
+        response
+            .headers()
+            .get(SEC_WEBSOCKET_PROTOCOL)
+            .and_then(|value| value.to_str().ok())
+            == Some(expected_protocol.as_str()),
+        "server did not echo the authenticated console subprotocol"
+    );
     console.send(Message::Close(None)).await.unwrap();
+
+    let listed_protocol_request = format!(
+        "GET /rpc HTTP/1.1\r\nHost: {addr}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Protocol: unrelated.v1\r\nSec-WebSocket-Protocol: metrics.v1, cooldis-console-token.{console_token}\r\n\r\n"
+    );
+    let listed_protocol_response = tcp_response_head(addr, &listed_protocol_request).await;
+    assert!(
+        listed_protocol_response.starts_with("HTTP/1.1 101 Switching Protocols"),
+        "recognized non-first console subprotocol was not upgraded"
+    );
+    assert!(
+        response_header(&listed_protocol_response, "sec-websocket-protocol")
+            == Some(expected_protocol.as_str()),
+        "server did not select the recognized console subprotocol"
+    );
 
     for path in ["/healthz", "/readyz"] {
         let response = raw_tcp_request(
@@ -137,7 +243,7 @@ async fn tcp_boundary_authenticates_before_upgrade_and_witnesses_sessions() {
     wait_for_sql_count(
         &store_path,
         "SELECT COUNT(*) FROM cooldis_identity_sessions WHERE closed_at_ms IS NOT NULL",
-        2,
+        5,
     )
     .await;
     assert_eq!(
@@ -147,7 +253,7 @@ async fn tcp_boundary_authenticates_before_upgrade_and_witnesses_sessions() {
             params![OPERATOR_ID],
         )
         .await,
-        4
+        10
     );
     assert_eq!(
         sql_count(
@@ -156,7 +262,7 @@ async fn tcp_boundary_authenticates_before_upgrade_and_witnesses_sessions() {
             (),
         )
         .await,
-        5
+        8
     );
     assert_eq!(
         sql_count(
@@ -170,15 +276,25 @@ async fn tcp_boundary_authenticates_before_upgrade_and_witnesses_sessions() {
     assert_eq!(
         sql_count(
             &store_path,
+            "SELECT COUNT(*) FROM cooldis_identity_auth_rejections WHERE reason_json LIKE '%principal_revoked%'",
+            (),
+        )
+        .await,
+        2
+    );
+    assert_eq!(
+        sql_count(
+            &store_path,
             "SELECT COUNT(*) FROM cooldis_identity_auth_rejections WHERE reason_json LIKE '%credential_revoked%'",
             (),
         )
         .await,
-        1
+        2
     );
 
     server_task.abort();
     let _ = server_task.await;
+    drop(app);
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -241,6 +357,24 @@ async fn unix_boundary_maps_same_uid_only_in_local_mode_and_secures_socket() {
         .revoke_credential(&operator, &revoked_credential.credential_id)
         .await
         .unwrap();
+    let revoked_operator = PrincipalId::new("operator:revoked");
+    authority
+        .declare_principal(
+            &operator,
+            &revoked_operator,
+            PrincipalKind::Operator,
+            "Revoked operator",
+        )
+        .await
+        .unwrap();
+    let (_, revoked_operator_token) = authority
+        .mint_credential(&operator, &revoked_operator, None)
+        .await
+        .unwrap();
+    authority
+        .revoke_principal(&operator, &revoked_operator)
+        .await
+        .unwrap();
     drop(authority);
     let managed_app = CooldisAppServer::new(
         managed_config,
@@ -253,6 +387,15 @@ async fn unix_boundary_maps_same_uid_only_in_local_mode_and_secures_socket() {
     .await
     .unwrap();
     let managed_store = managed_app.session_store_path().to_path_buf();
+    let local_dispatch = managed_app
+        .local_json_rpc_request("account/read", serde_json::json!({}))
+        .await
+        .unwrap_err();
+    assert!(
+        local_dispatch
+            .to_string()
+            .contains("local-mode operator principal")
+    );
     let managed_server = managed_app.clone();
     let managed_listen = AppServerListenAddr::Unix(managed_socket.clone());
     let mut managed_task = tokio::spawn(async move { managed_server.serve(managed_listen).await });
@@ -294,7 +437,7 @@ async fn unix_boundary_maps_same_uid_only_in_local_mode_and_secures_socket() {
     };
     assert!(unknown_token.to_string().contains("401"));
 
-    for rejected_token in [expired_token, revoked_token] {
+    for rejected_token in [expired_token, revoked_token, revoked_operator_token] {
         let rejected = CodexTuiTestClient::connect_unix(
             &managed_socket,
             CodexTuiConnectConfig {
@@ -313,17 +456,25 @@ async fn unix_boundary_maps_same_uid_only_in_local_mode_and_secures_socket() {
     let mut token_client = CodexTuiTestClient::connect_unix(
         &managed_socket,
         CodexTuiConnectConfig {
-            bearer_token: Some(token),
+            bearer_token: Some(token.clone()),
             ..CodexTuiConnectConfig::default()
         },
     )
     .await
     .unwrap();
     token_client.close().await.unwrap();
+    let fragmented_request =
+        websocket_request("127.0.0.1:80".parse().unwrap(), "/rpc", Some(&token));
+    let fragmented_response =
+        fragmented_unix_response_head(&managed_socket, &fragmented_request).await;
+    assert!(
+        fragmented_response.starts_with("HTTP/1.1 101 Switching Protocols"),
+        "fragmented authenticated Unix handshake was not upgraded"
+    );
     wait_for_sql_count(
         &managed_store,
         "SELECT COUNT(*) FROM cooldis_identity_sessions WHERE closed_at_ms IS NOT NULL",
-        1,
+        2,
     )
     .await;
     assert_eq!(
@@ -333,12 +484,21 @@ async fn unix_boundary_maps_same_uid_only_in_local_mode_and_secures_socket() {
             params![credential.credential_id],
         )
         .await,
-        2
+        4
     );
     assert_eq!(
         sql_count(
             &managed_store,
             "SELECT COUNT(*) FROM cooldis_identity_auth_rejections WHERE surface = 'unix_socket' AND reason_json LIKE '%peer_mapping_disabled%'",
+            (),
+        )
+        .await,
+        1
+    );
+    assert_eq!(
+        sql_count(
+            &managed_store,
+            "SELECT COUNT(*) FROM cooldis_identity_auth_rejections WHERE surface = 'unix_socket' AND reason_json LIKE '%principal_revoked%'",
             (),
         )
         .await,
@@ -380,6 +540,70 @@ async fn unix_boundary_maps_same_uid_only_in_local_mode_and_secures_socket() {
     let _ = std::fs::remove_dir_all(managed_root);
 }
 
+#[tokio::test]
+async fn console_credential_lifecycle_keeps_one_active_credential_across_restarts() {
+    let root = test_root("console-lifecycle");
+    let assets = root.join("console");
+    std::fs::create_dir_all(&assets).unwrap();
+    std::fs::write(
+        assets.join("index.html"),
+        "<html><head></head><body>console</body></html>",
+    )
+    .unwrap();
+    let operator = PrincipalId::new(OPERATOR_ID);
+    let bootstrap_config = app_config(
+        &root,
+        AppServerListenAddr::WebSocket("127.0.0.1:0".parse().unwrap()),
+    );
+    let authority = identity_authority(&bootstrap_config).await;
+    authority
+        .bootstrap_operator(&operator, "Root operator")
+        .await
+        .unwrap();
+    drop(authority);
+    let store_path = bootstrap_config.state_home.join("session_history.sqlite3");
+    let baseline = active_credential_count(&store_path, OPERATOR_ID).await;
+
+    let mut generations = Vec::new();
+    for _ in 0..4 {
+        let mut config = app_config(
+            &root,
+            AppServerListenAddr::WebSocket("127.0.0.1:0".parse().unwrap()),
+        );
+        config.console_assets = Some(ConsoleAssetConfig {
+            root: assets.clone(),
+            session_token: "replaced-at-construction".to_string(),
+        });
+        let app = CooldisAppServer::new(
+            config,
+            CooldisDaemonIdentityConfig {
+                mode: IdentityMode::Managed,
+                tenant_id: Some("test-tenant".to_string()),
+                console_principal: Some(operator.clone()),
+            },
+        )
+        .await
+        .unwrap();
+        generations.push(app);
+        assert_eq!(
+            active_credential_count(&store_path, OPERATOR_ID).await,
+            baseline + 1,
+            "a restart left more than one active console credential"
+        );
+    }
+
+    let record_path = root.join("state").join("console-credential-id");
+    assert!(record_path.is_file());
+    drop(generations);
+    assert_eq!(
+        active_credential_count(&store_path, OPERATOR_ID).await,
+        baseline,
+        "graceful app-server shutdown did not revoke its console credential"
+    );
+    assert!(!record_path.exists());
+    let _ = std::fs::remove_dir_all(root);
+}
+
 fn app_config(root: &Path, listen: AppServerListenAddr) -> CooldisAppServerConfig {
     let mut config = CooldisAppServerConfig::local(listen, root.join("workspace"));
     config.runtime_home = root.join("runtime");
@@ -408,12 +632,92 @@ fn websocket_request(addr: std::net::SocketAddr, path: &str, token: Option<&str>
     )
 }
 
+fn websocket_request_with_authorization(addr: std::net::SocketAddr, authorization: &str) -> String {
+    format!(
+        "GET /rpc HTTP/1.1\r\nHost: {addr}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\naUtHoRiZaTiOn:{authorization}\r\n\r\n"
+    )
+}
+
 async fn raw_tcp_request(addr: std::net::SocketAddr, request: &str) -> String {
     let mut stream = TcpStream::connect(addr).await.unwrap();
     stream.write_all(request.as_bytes()).await.unwrap();
     let mut response = Vec::new();
     stream.read_to_end(&mut response).await.unwrap();
     String::from_utf8(response).unwrap()
+}
+
+async fn fragmented_tcp_response_head(addr: std::net::SocketAddr, request: &str) -> String {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let first = request.len() / 3;
+    let second = first * 2;
+    stream
+        .write_all(&request.as_bytes()[..first])
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    stream
+        .write_all(&request.as_bytes()[first..second])
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    stream
+        .write_all(&request.as_bytes()[second..])
+        .await
+        .unwrap();
+    read_response_head(&mut stream).await
+}
+
+#[cfg(unix)]
+async fn fragmented_unix_response_head(path: &Path, request: &str) -> String {
+    let mut stream = tokio::net::UnixStream::connect(path).await.unwrap();
+    let first = request.len() / 3;
+    let second = first * 2;
+    stream
+        .write_all(&request.as_bytes()[..first])
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    stream
+        .write_all(&request.as_bytes()[first..second])
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    stream
+        .write_all(&request.as_bytes()[second..])
+        .await
+        .unwrap();
+    read_response_head(&mut stream).await
+}
+
+async fn tcp_response_head(addr: std::net::SocketAddr, request: &str) -> String {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    stream.write_all(request.as_bytes()).await.unwrap();
+    read_response_head(&mut stream).await
+}
+
+async fn read_response_head<S>(stream: &mut S) -> String
+where
+    S: tokio::io::AsyncRead + Unpin,
+{
+    let mut response = Vec::new();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        let mut byte = [0_u8; 1];
+        while !response.ends_with(b"\r\n\r\n") {
+            stream.read_exact(&mut byte).await.unwrap();
+            response.push(byte[0]);
+        }
+    })
+    .await
+    .unwrap();
+    String::from_utf8(response).unwrap()
+}
+
+fn response_header<'a>(response: &'a str, expected_name: &str) -> Option<&'a str> {
+    response.split("\r\n").find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        name.eq_ignore_ascii_case(expected_name)
+            .then_some(value.trim())
+    })
 }
 
 fn injected_console_token(response: &str) -> String {
@@ -468,6 +772,15 @@ where
     let connection = database.connect().await.unwrap();
     let mut rows = connection.query(query, params).await.unwrap();
     rows.next().await.unwrap().unwrap().get(0).unwrap()
+}
+
+async fn active_credential_count(path: &Path, principal_id: &str) -> i64 {
+    sql_count(
+        path,
+        "SELECT COUNT(*) FROM cooldis_identity_credentials WHERE principal_id = ?1 AND revoked_at_ms IS NULL",
+        params![principal_id],
+    )
+    .await
 }
 
 fn test_root(label: &str) -> PathBuf {

--- a/crates/cooldis-kernel/tests/cooldis_debug_rpc.rs
+++ b/crates/cooldis-kernel/tests/cooldis_debug_rpc.rs
@@ -1,11 +1,14 @@
+use cooldis::daemon::identity::{IdentityAuthority, PrincipalId, SqliteIdentityAuthority};
 use cooldis::{
     AppServerListenAddr, CodexTuiConnectConfig, CodexTuiTestClient, CooldisAppServer,
     CooldisAppServerConfig, EventKind, EventStore, EventStreamId, SqliteSessionStore,
+    SystemDaemonClock,
 };
 use serde_json::Value;
 use std::net::{SocketAddr, TcpListener};
 use std::path::{Path, PathBuf};
 use std::process::{Output, Stdio};
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::process::Command;
 use tokio::task::JoinHandle;
@@ -20,21 +23,28 @@ async fn debug_rpc_cli_calls_and_streams_turns_over_websocket() {
     let url = format!("ws://{addr}/rpc");
     let server = DebugRpcServer::start(&root, &workspace, addr).await;
 
-    let call = run_cooldis(["debug", "rpc", "call", "thread/list", "--url", url.as_str()]).await;
+    let call = run_cooldis(
+        ["debug", "rpc", "call", "thread/list", "--url", url.as_str()],
+        Some(&server.token),
+    )
+    .await;
     assert_success(&call);
     let thread_list: Value = serde_json::from_slice(&call.stdout).unwrap();
     assert!(thread_list["data"].as_array().is_some());
 
-    let first = run_cooldis([
-        "debug",
-        "rpc",
-        "turn",
-        "--new",
-        "--json",
-        "first debug rpc turn",
-        "--url",
-        url.as_str(),
-    ])
+    let first = run_cooldis(
+        [
+            "debug",
+            "rpc",
+            "turn",
+            "--new",
+            "--json",
+            "first debug rpc turn",
+            "--url",
+            url.as_str(),
+        ],
+        Some(&server.token),
+    )
     .await;
     assert_success(&first);
     let thread_id = String::from_utf8(first.stderr.clone())
@@ -58,14 +68,17 @@ async fn debug_rpc_cli_calls_and_streams_turns_over_websocket() {
         "completed text did not include prompt: {completed_text:?}"
     );
 
-    let live_bind = run_cooldis([
-        "debug",
-        "bind",
-        thread_id.as_str(),
-        "--json",
-        "--url",
-        url.as_str(),
-    ])
+    let live_bind = run_cooldis(
+        [
+            "debug",
+            "bind",
+            thread_id.as_str(),
+            "--json",
+            "--url",
+            url.as_str(),
+        ],
+        Some(&server.token),
+    )
     .await;
     assert_success(&live_bind);
     let live_explanation: Value = serde_json::from_slice(&live_bind.stdout).unwrap();
@@ -73,13 +86,16 @@ async fn debug_rpc_cli_calls_and_streams_turns_over_websocket() {
     assert_eq!(live_explanation["model"]["origin"], "manifest-default");
 
     let missing_thread_id = Uuid::now_v7().to_string();
-    let missing_bind = run_cooldis([
-        "debug",
-        "bind",
-        missing_thread_id.as_str(),
-        "--url",
-        url.as_str(),
-    ])
+    let missing_bind = run_cooldis(
+        [
+            "debug",
+            "bind",
+            missing_thread_id.as_str(),
+            "--url",
+            url.as_str(),
+        ],
+        Some(&server.token),
+    )
     .await;
     assert!(!missing_bind.status.success());
     assert!(
@@ -88,16 +104,19 @@ async fn debug_rpc_cli_calls_and_streams_turns_over_websocket() {
         String::from_utf8_lossy(&missing_bind.stderr)
     );
 
-    let resumed = run_cooldis([
-        "debug",
-        "rpc",
-        "turn",
-        "--thread",
-        thread_id.as_str(),
-        "second debug rpc turn",
-        "--url",
-        url.as_str(),
-    ])
+    let resumed = run_cooldis(
+        [
+            "debug",
+            "rpc",
+            "turn",
+            "--thread",
+            thread_id.as_str(),
+            "second debug rpc turn",
+            "--url",
+            url.as_str(),
+        ],
+        Some(&server.token),
+    )
     .await;
     assert_success(&resumed);
     let resumed_stdout = String::from_utf8(resumed.stdout).unwrap();
@@ -121,14 +140,17 @@ async fn debug_rpc_cli_calls_and_streams_turns_over_websocket() {
 
     server.stop().await;
     let journal = root.join("state/session_history.sqlite3");
-    let offline_bind = run_cooldis([
-        "debug",
-        "bind",
-        thread_id.as_str(),
-        "--json",
-        "--journal",
-        journal.to_str().unwrap(),
-    ])
+    let offline_bind = run_cooldis(
+        [
+            "debug",
+            "bind",
+            thread_id.as_str(),
+            "--json",
+            "--journal",
+            journal.to_str().unwrap(),
+        ],
+        None,
+    )
     .await;
     assert_success(&offline_bind);
     let offline_explanation: Value = serde_json::from_slice(&offline_bind.stdout).unwrap();
@@ -171,6 +193,7 @@ fn assert_admission_precedes_execution(
 }
 
 struct DebugRpcServer {
+    token: String,
     task: JoinHandle<cooldis::CooldisResult<()>>,
 }
 
@@ -181,9 +204,21 @@ impl DebugRpcServer {
         config.runtime_home = root.join("runtime");
         config.state_home = root.join("state");
         let app = CooldisAppServer::new_local(config).await.unwrap();
+        let store = SqliteSessionStore::open(app.session_store_path())
+            .await
+            .unwrap();
+        let authority = SqliteIdentityAuthority::new(store, Arc::new(SystemDaemonClock), None)
+            .await
+            .unwrap();
+        let principal = PrincipalId::new(app.user_id());
+        let token = authority
+            .mint_credential(&principal, &principal, None)
+            .await
+            .unwrap()
+            .1;
         let task = tokio::spawn(async move { app.serve(listen).await });
-        wait_for_websocket(&format!("ws://{addr}/rpc")).await;
-        Self { task }
+        wait_for_websocket(&format!("ws://{addr}/rpc"), &token).await;
+        Self { token, task }
     }
 
     async fn stop(self) {
@@ -192,13 +227,14 @@ impl DebugRpcServer {
     }
 }
 
-async fn wait_for_websocket(url: &str) {
+async fn wait_for_websocket(url: &str, token: &str) {
     let mut last_error = None;
     for _ in 0..100 {
         match CodexTuiTestClient::connect_websocket(
             url,
             CodexTuiConnectConfig {
                 client_name: "cooldis-debug-rpc-test-wait".to_string(),
+                bearer_token: Some(token.to_string()),
                 ..CodexTuiConnectConfig::default()
             },
         )
@@ -220,13 +256,13 @@ async fn wait_for_websocket(url: &str) {
     );
 }
 
-async fn run_cooldis<const N: usize>(args: [&str; N]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_cooldis"))
-        .args(args)
-        .stdin(Stdio::null())
-        .output()
-        .await
-        .unwrap()
+async fn run_cooldis<const N: usize>(args: [&str; N], token: Option<&str>) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_cooldis"));
+    command.args(args).stdin(Stdio::null());
+    if let Some(token) = token {
+        command.env("COOLDIS_APP_SERVER_TOKEN", token);
+    }
+    command.output().await.unwrap()
 }
 
 fn assert_success(output: &Output) {

--- a/crates/cooldis-kernel/tests/smokes/cooldis-app-server-smoke.rs
+++ b/crates/cooldis-kernel/tests/smokes/cooldis-app-server-smoke.rs
@@ -1,8 +1,10 @@
+use cooldis::daemon::identity::{IdentityAuthority, PrincipalId, SqliteIdentityAuthority};
 use cooldis::{
     AppServerListenAddr, CodexTuiConnectConfig, CodexTuiTestClient, CooldisAppServer,
-    CooldisAppServerConfig,
+    CooldisAppServerConfig, SqliteSessionStore, SystemDaemonClock,
 };
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpStream, UnixStream};
@@ -89,7 +91,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _ = restarted_task.await;
 
     let tcp_addr = unused_loopback_addr()?;
-    let tcp_task = start_tcp_server(&root, tcp_addr).await?;
+    let (tcp_task, tcp_token) = start_tcp_server(&root, tcp_addr).await?;
     let health = tcp_health_response(tcp_addr, "/healthz").await?;
     if !health.starts_with("HTTP/1.1 200 OK") || !health.contains("{\"status\":\"ok\"}") {
         return Err(format!("unexpected TCP health response: {health:?}").into());
@@ -97,6 +99,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut tcp_client = connect_tcp_client(
         &format!("ws://{tcp_addr}/rpc"),
         "cooldis-app-server-smoke-tcp",
+        &tcp_token,
     )
     .await?;
     let tcp_completed = tcp_client
@@ -134,13 +137,23 @@ async fn start_server(
 async fn start_tcp_server(
     root: &Path,
     addr: std::net::SocketAddr,
-) -> Result<JoinHandle<cooldis::CooldisResult<()>>, Box<dyn std::error::Error>> {
+) -> Result<(JoinHandle<cooldis::CooldisResult<()>>, String), Box<dyn std::error::Error>> {
     let listen = AppServerListenAddr::WebSocket(addr);
     let mut config = CooldisAppServerConfig::local(listen.clone(), std::env::current_dir()?);
     config.runtime_home = root.join("runtime");
     config.state_home = root.join("state");
     let server = CooldisAppServer::new_local(config).await?;
-    Ok(tokio::spawn(async move { server.serve(listen).await }))
+    let store = SqliteSessionStore::open(server.session_store_path()).await?;
+    let authority = SqliteIdentityAuthority::new(store, Arc::new(SystemDaemonClock), None).await?;
+    let principal = PrincipalId::new(server.user_id());
+    let token = authority
+        .mint_credential(&principal, &principal, None)
+        .await?
+        .1;
+    Ok((
+        tokio::spawn(async move { server.serve(listen).await }),
+        token,
+    ))
 }
 
 async fn connect_client(
@@ -176,6 +189,7 @@ async fn connect_client(
 async fn connect_tcp_client(
     url: &str,
     client_name: &str,
+    token: &str,
 ) -> Result<CodexTuiTestClient<TcpStream>, Box<dyn std::error::Error>> {
     let mut last_error = None;
     for _ in 0..100 {
@@ -183,6 +197,7 @@ async fn connect_tcp_client(
             url,
             CodexTuiConnectConfig {
                 client_name: client_name.to_string(),
+                bearer_token: Some(token.to_string()),
                 ..CodexTuiConnectConfig::default()
             },
         )

--- a/crates/cooldis-kernel/tests/smokes/cooldis-workbench-smoke.rs
+++ b/crates/cooldis-kernel/tests/smokes/cooldis-workbench-smoke.rs
@@ -1,13 +1,16 @@
+use cooldis::daemon::identity::{IdentityAuthority, PrincipalId, SqliteIdentityAuthority};
 use cooldis::{
     AppServerListenAddr, CapsuleBindingsConfig, CodexTuiConnectConfig, CodexTuiTestClient,
     CooldisAppServer, CooldisAppServerConfig, LocalAgentRegistry, LocalOperationRegistry,
     PublishedOperationBuild, PublishedOperationRecord, PublishedOperationSource,
-    RegisteredOperation, WasmOperationDefinition, WasmOperationEventKind, WasmOperationManifest,
-    WasmOperationMode, WasmOperationValueKind, wasm_sha256,
+    RegisteredOperation, SqliteSessionStore, SystemDaemonClock, WasmOperationDefinition,
+    WasmOperationEventKind, WasmOperationManifest, WasmOperationMode, WasmOperationValueKind,
+    wasm_sha256,
 };
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::net::TcpStream;
 use tokio::task::JoinHandle;
@@ -41,7 +44,7 @@ async fn run(root: &Path) -> Result<(), Box<dyn std::error::Error>> {
 
     let addr = unused_loopback_addr()?;
     let listen = AppServerListenAddr::WebSocket(addr);
-    let server_task = start_server(
+    let (server_task, token) = start_server(
         root,
         &workspace,
         &agent_registry_root,
@@ -50,7 +53,7 @@ async fn run(root: &Path) -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
     let result: Result<(), Box<dyn std::error::Error>> = async {
-        let mut client = connect_client(&format!("ws://{addr}/rpc")).await?;
+        let mut client = connect_client(&format!("ws://{addr}/rpc"), &token).await?;
         assert_eq!(
             client.initialize_result()["userAgent"],
             "cooldis-app-server/0.1"
@@ -142,7 +145,7 @@ async fn start_server(
     agent_registry_root: &Path,
     operation_registry_root: &Path,
     listen: AppServerListenAddr,
-) -> Result<JoinHandle<cooldis::CooldisResult<()>>, Box<dyn std::error::Error>> {
+) -> Result<(JoinHandle<cooldis::CooldisResult<()>>, String), Box<dyn std::error::Error>> {
     let mut config = CooldisAppServerConfig::local(listen.clone(), workspace)
         .with_capsule_bindings(
             CapsuleBindingsConfig::default().with_registry_root(operation_registry_root),
@@ -151,11 +154,22 @@ async fn start_server(
     config.state_home = root.join("state");
     config.agent_registry_root = agent_registry_root.to_path_buf();
     let server = CooldisAppServer::new_local(config).await?;
-    Ok(tokio::spawn(async move { server.serve(listen).await }))
+    let store = SqliteSessionStore::open(server.session_store_path()).await?;
+    let authority = SqliteIdentityAuthority::new(store, Arc::new(SystemDaemonClock), None).await?;
+    let principal = PrincipalId::new(server.user_id());
+    let token = authority
+        .mint_credential(&principal, &principal, None)
+        .await?
+        .1;
+    Ok((
+        tokio::spawn(async move { server.serve(listen).await }),
+        token,
+    ))
 }
 
 async fn connect_client(
     url: &str,
+    token: &str,
 ) -> Result<CodexTuiTestClient<TcpStream>, Box<dyn std::error::Error>> {
     let mut last_error = None;
     for _ in 0..100 {
@@ -163,6 +177,7 @@ async fn connect_client(
             url,
             CodexTuiConnectConfig {
                 client_name: "cooldis-workbench-smoke".to_string(),
+                bearer_token: Some(token.to_string()),
                 ..CodexTuiConnectConfig::default()
             },
         )


### PR DESCRIPTION
Authenticates every app-server connection at the boundary before the WebSocket upgrade or local dispatch proceeds.

- Bearer tokens on the shared upgrade path (Authorization header, case-insensitive) and the console subprotocol carrier (exact recognition of cooldis-console-token.<token>, echoed exactly).
- Unix peer uid mapping to the local operator in local mode only; managed mode never maps a peer uid. Socket mode 0o600, forged-uid regression pinned.
- Fail-closed handshake bounds: 10 second per-stage deadline, 8192 byte header cap, uniform 401 externally with witnessed rejection reasons internally.
- Console credential lifecycle: construction mints the console credential from the identity authority, records its id under state/, revokes a recorded predecessor at startup and its own on graceful shutdown (at most one active console credential per state home, pinned across four restart generations).
- Session open/close witnessing with append-only identity session records (UUIDv7 ids).
- Merge with the EMO-499 config wiring unifies identity onto CooldisAppServerConfig: apply_daemon_identity_config is the single projection seam and the boundary authority initializes from config fields; a regression test pins a managed TOML end to end through the production constructor.

Linear: https://linear.app/emotionscientific/issue/EMO-497