### PR TITLE
EMO-498: dispatcher authorization at the choke point

### DIFF
--- a/crates/cooldis-history-sqlite/src/lib.rs
+++ b/crates/cooldis-history-sqlite/src/lib.rs
@@ -101,8 +101,13 @@ impl SqliteSessionStore {
     /// concurrent RPC tasks into 200 competing WAL writers. Each mutation
     /// keeps its existing immediate transaction and commit boundary; this gate
     /// changes concurrency only, not durability or journal ordering.
-    async fn write_guard(&self) -> MutexGuard<'_, ()> {
+    #[doc(hidden)]
+    pub async fn daemon_write_guard(&self) -> MutexGuard<'_, ()> {
         self.writer.lock().await
+    }
+
+    async fn write_guard(&self) -> MutexGuard<'_, ()> {
+        self.daemon_write_guard().await
     }
 
     /// Clone the engine-owner handle for daemon-owned tables that must share

--- a/crates/cooldis-io-core/src/lib.rs
+++ b/crates/cooldis-io-core/src/lib.rs
@@ -217,7 +217,7 @@ pub struct IoPrincipal {
     pub tenant_id: String,
     pub principal_id: String,
     /// How attribution happened: "mandate:{event_id}", "route:{route_id}",
-    /// or a caller-auth scheme once boundary authentication lands.
+    /// or "caller:{session_id}" for authenticated RPC ingress.
     pub via: String,
 }
 

--- a/crates/cooldis-kernel/src/adapters/app_server/connection.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/connection.rs
@@ -5,8 +5,9 @@ use super::*;
 #[derive(Clone)]
 pub(super) struct ConnectionState {
     pub(super) app: CooldisAppServer,
-    #[allow(dead_code)]
     pub(super) resolved_principal: ResolvedPrincipal,
+    pub(super) witnessed_session_id: String,
+    pub(super) boundary_surface: BoundarySurface,
     pub(super) outbound: mpsc::UnboundedSender<JsonRpcMessage>,
     pub(super) handshake: Arc<Mutex<HandshakeState>>,
     pub(super) opt_out_notifications: Arc<RwLock<HashSet<String>>>,
@@ -742,6 +743,125 @@ pub(super) struct GetConversationSummaryParams {
     pub(super) rollout_path: Option<String>,
 }
 
+const METHOD_NOT_AUTHORIZED_CODE: i64 = -32003;
+
+pub(super) const DISPATCH_METHOD_AUTHORITY_CLASSES: &[(&str, AuthorityClass)] = &[
+    ("account/read", AuthorityClass::Interactive),
+    ("account/rateLimits/read", AuthorityClass::Interactive),
+    ("app/list", AuthorityClass::Interactive),
+    ("capsule/binding/set", AuthorityClass::Host), // lexicon-allow: capsule - existing RPC method.
+    ("capsule/binding/delete", AuthorityClass::Host), // lexicon-allow: capsule - existing RPC method.
+    ("capsule/binding/list", AuthorityClass::Host), // lexicon-allow: capsule - existing RPC method.
+    ("capsule/binding/resolve", AuthorityClass::Host), // lexicon-allow: capsule - existing RPC method.
+    ("agent/list", AuthorityClass::Interactive),
+    ("agent/read", AuthorityClass::Interactive),
+    ("agent/plan", AuthorityClass::Interactive),
+    ("agent/publish", AuthorityClass::Host),
+    ("operation/list", AuthorityClass::Interactive),
+    ("command/exec", AuthorityClass::Host),
+    ("command/exec/write", AuthorityClass::Host),
+    ("command/exec/terminate", AuthorityClass::Host),
+    ("command/exec/resize", AuthorityClass::Host),
+    ("model/list", AuthorityClass::Interactive),
+    (
+        "modelProvider/capabilities/read",
+        AuthorityClass::Interactive,
+    ),
+    ("modelProvider/list", AuthorityClass::Host),
+    ("modelProvider/read", AuthorityClass::Host),
+    ("modelProvider/upsert", AuthorityClass::Host),
+    ("modelProvider/delete", AuthorityClass::Host),
+    ("modelProvider/auth/status", AuthorityClass::Host),
+    ("modelProvider/auth/set", AuthorityClass::Host),
+    ("modelProvider/auth/delete", AuthorityClass::Host),
+    ("experimentalFeature/list", AuthorityClass::Interactive),
+    (
+        "experimentalFeature/enablement/set",
+        AuthorityClass::Interactive,
+    ),
+    ("getAuthStatus", AuthorityClass::Interactive),
+    ("getConversationSummary", AuthorityClass::Host),
+    ("thread/start", AuthorityClass::Host),
+    ("thread/spawn", AuthorityClass::Host),
+    ("thread/submit", AuthorityClass::Interactive),
+    ("thread/fork", AuthorityClass::Interactive),
+    ("thread/rebindFork", AuthorityClass::Host),
+    ("thread/resume", AuthorityClass::Host),
+    ("thread/read", AuthorityClass::Interactive),
+    ("thread/events/list", AuthorityClass::Interactive),
+    ("thread/couplings/list", AuthorityClass::Interactive),
+    ("thread/approvals/list", AuthorityClass::Interactive),
+    ("thread/waiting/list", AuthorityClass::Interactive),
+    ("approval/resolve", AuthorityClass::Host),
+    ("mandate/start", AuthorityClass::Interactive),
+    ("mandate/revoke", AuthorityClass::Interactive),
+    ("mandate/list", AuthorityClass::Interactive),
+    ("thread/debug/export", AuthorityClass::Host),
+    ("thread/list", AuthorityClass::Interactive),
+    ("thread/loaded/list", AuthorityClass::Interactive),
+    ("thread/unsubscribe", AuthorityClass::Interactive),
+    ("thread/name/set", AuthorityClass::Interactive),
+    ("thread/metadata/update", AuthorityClass::Interactive),
+    ("thread/compact/start", AuthorityClass::Interactive),
+    ("thread/shellCommand", AuthorityClass::Host),
+    ("turn/start", AuthorityClass::Ingress),
+    ("turn/steer", AuthorityClass::Interactive),
+    ("turn/interrupt", AuthorityClass::Interactive),
+    ("skills/list", AuthorityClass::Interactive),
+    ("plugin/list", AuthorityClass::Interactive),
+    ("hooks/list", AuthorityClass::Interactive),
+    ("mcpServerStatus/list", AuthorityClass::Host),
+    ("mcpSource/list", AuthorityClass::Host),
+    ("mcpSource/read", AuthorityClass::Host),
+    ("mcpSource/upsert", AuthorityClass::Host),
+    ("mcpSource/discover", AuthorityClass::Host),
+    ("mcpSource/delete", AuthorityClass::Host),
+    ("mcpSource/testTool", AuthorityClass::Host),
+    ("mcpSource/manifestPatch", AuthorityClass::Host),
+    ("fs/readFile", AuthorityClass::Host),
+    ("fs/writeFile", AuthorityClass::Host),
+    ("fs/createDirectory", AuthorityClass::Host),
+    ("fs/getMetadata", AuthorityClass::Host),
+    ("fs/readDirectory", AuthorityClass::Host),
+    ("fs/remove", AuthorityClass::Host),
+    ("fs/copy", AuthorityClass::Host),
+    ("fs/watch", AuthorityClass::Host),
+    ("fs/unwatch", AuthorityClass::Host),
+    ("config/read", AuthorityClass::Interactive),
+    ("configRequirements/read", AuthorityClass::Interactive),
+];
+
+pub(super) const HOST_EFFECT_METHODS: &[&str] = &[
+    "capsule/binding/set",    // lexicon-allow: capsule - existing RPC method.
+    "capsule/binding/delete", // lexicon-allow: capsule - existing RPC method.
+    "agent/publish",
+    "command/exec",
+    "command/exec/write",
+    "command/exec/terminate",
+    "command/exec/resize",
+    "modelProvider/list",
+    "modelProvider/read",
+    "modelProvider/upsert",
+    "modelProvider/delete",
+    "modelProvider/auth/status",
+    "modelProvider/auth/set",
+    "modelProvider/auth/delete",
+    "thread/start",
+    "thread/spawn",
+    "thread/rebindFork",
+    "thread/resume",
+    "approval/resolve",
+    "thread/shellCommand",
+    "mcpSource/upsert",
+    "mcpSource/discover",
+    "mcpSource/delete",
+    "mcpSource/testTool",
+    "fs/writeFile",
+    "fs/createDirectory",
+    "fs/remove",
+    "fs/copy",
+];
+
 impl CooldisAppServer {
     pub async fn local_json_rpc_request(
         &self,
@@ -758,10 +878,32 @@ impl CooldisAppServer {
                     "local JSON-RPC requires the local-mode operator principal".to_string(),
                 )
             })?;
+        let session_id = format!("session_{}", Uuid::now_v7());
+        let surface = BoundarySurface::UnixSocket;
+        self.inner
+            .identity_authority
+            .witness_session_opened(&IdentitySessionV1 {
+                schema: IDENTITY_SESSION_SCHEMA_V1.to_string(),
+                session_id: session_id.clone(),
+                principal_id: resolved_principal.principal_id.clone(),
+                kind: resolved_principal.kind,
+                surface,
+                credential_ref: credential_ref(&resolved_principal.auth),
+                opened_at_ms: self.inner.identity_clock.now().timestamp_millis(),
+                closed_at_ms: None,
+            })
+            .await?;
+        let mut close_witness = SessionCloseWitness::new(
+            Arc::clone(&self.inner.identity_authority),
+            Arc::clone(&self.inner.identity_clock),
+            session_id.clone(),
+        );
         let (outbound, _rx) = mpsc::unbounded_channel::<JsonRpcMessage>();
         let connection = ConnectionState {
             app: self.clone(),
             resolved_principal,
+            witnessed_session_id: session_id,
+            boundary_surface: surface,
             outbound,
             handshake: Arc::new(Mutex::new(HandshakeState::default())),
             opt_out_notifications: Arc::new(RwLock::new(HashSet::new())),
@@ -779,9 +921,16 @@ impl CooldisAppServer {
             })))
             .await
             .map_err(jsonrpc_error_to_runtime_factory)?;
-        self.dispatch_request(&connection, method, Some(params))
+        let dispatch_result = self
+            .dispatch_request(&connection, method, Some(params))
             .await
-            .map_err(jsonrpc_error_to_runtime_factory)
+            .map_err(jsonrpc_error_to_runtime_factory);
+        let close_result = close_witness.close().await;
+        match (dispatch_result, close_result) {
+            (Err(error), _) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+            (Ok(value), Ok(())) => Ok(value),
+        }
     }
 
     pub(super) async fn handle_websocket<S>(
@@ -810,7 +959,7 @@ impl CooldisAppServer {
         let mut close_witness = SessionCloseWitness::new(
             Arc::clone(&self.inner.identity_authority),
             Arc::clone(&self.inner.identity_clock),
-            session_id,
+            session_id.clone(),
         );
         let (mut sink, mut stream) = websocket.split();
         let (outbound, mut outbound_rx) = mpsc::unbounded_channel::<JsonRpcMessage>();
@@ -833,6 +982,8 @@ impl CooldisAppServer {
         let connection = ConnectionState {
             app: self.clone(),
             resolved_principal,
+            witnessed_session_id: session_id,
+            boundary_surface: surface,
             outbound,
             handshake: Arc::new(Mutex::new(HandshakeState::default())),
             opt_out_notifications: Arc::new(RwLock::new(HashSet::new())),
@@ -904,6 +1055,50 @@ impl CooldisAppServer {
         method: &str,
         params: Option<Value>,
     ) -> Result<Value, JsonRpcErrorError> {
+        let authority_class = authority_class_for_method(method);
+        debug_assert_eq!(
+            DISPATCH_METHOD_AUTHORITY_CLASSES
+                .iter()
+                .find_map(|(listed_method, class)| (*listed_method == method).then_some(*class)),
+            DISPATCH_METHOD_AUTHORITY_CLASSES
+                .iter()
+                .any(|(listed_method, _)| *listed_method == method)
+                .then_some(authority_class),
+            "dispatcher authority-class table drifted for {method}",
+        );
+        if !connection.resolved_principal.kind.permits(authority_class) {
+            self.inner
+                .identity_authority
+                .witness_auth_rejected(&IdentityAuthRejectionV1 {
+                    schema: IDENTITY_AUTH_REJECTION_SCHEMA_V1.to_string(),
+                    surface: connection.boundary_surface,
+                    reason: IdentityAuthRejectionReason::MethodNotAuthorized {
+                        method: method.to_string(),
+                        class: authority_class,
+                    },
+                    principal_id: Some(connection.resolved_principal.principal_id.clone()),
+                    rejected_at_ms: self.inner.identity_clock.now().timestamp_millis(),
+                })
+                .await
+                .map_err(internal_error)?;
+            return Err(jsonrpc_error(
+                METHOD_NOT_AUTHORIZED_CODE,
+                "request is not authorized for this principal",
+            ));
+        }
+        if HOST_EFFECT_METHODS.contains(&method) {
+            self.inner
+                .identity_authority
+                .witness_host_effect(&IdentityHostEffectV1 {
+                    schema: IDENTITY_HOST_EFFECT_SCHEMA_V1.to_string(),
+                    session_id: connection.witnessed_session_id.clone(),
+                    principal_id: connection.resolved_principal.principal_id.clone(),
+                    method: method.to_string(),
+                    witnessed_at_ms: self.inner.identity_clock.now().timestamp_millis(),
+                })
+                .await
+                .map_err(internal_error)?;
+        }
         match method {
             "account/read" => Ok(json!({
                 "account": null,
@@ -3304,15 +3499,22 @@ impl CooldisAppServer {
 
     async fn record_rpc_ingress_received(
         &self,
+        connection: &ConnectionState,
         handle: &RuntimeThreadHandle,
         method: &str,
         input: &[Value],
         surface: &str,
     ) -> Result<crate::EventRecord, JsonRpcErrorError> {
         let coordinates = handle.context().coordinates.clone();
+        let principal = cooldis_io_core::IoPrincipal::new(
+            self.inner.tenant_id.clone(),
+            connection.resolved_principal.principal_id.to_string(),
+            format!("caller:{}", connection.witnessed_session_id),
+        );
         let envelope_digest = crate::agent::manifest_bind::canonical_json_hash(&json!({
             "method": method,
             "input": input,
+            "principal": principal,
         }))
         .map_err(internal_error)?;
         let payload = crate::IoIngressReceivedPayload {
@@ -3329,6 +3531,10 @@ impl CooldisAppServer {
             object.insert(
                 "schema".to_string(),
                 json!(crate::EventKind::IoIngressReceived.payload_schema_id()),
+            );
+            object.insert(
+                "principal".to_string(),
+                serde_json::to_value(principal).map_err(json_codec_error)?,
             );
         }
         handle
@@ -3488,7 +3694,7 @@ impl CooldisAppServer {
         };
         let surface = connection.admission_surface().await;
         let ingress_event = self
-            .record_rpc_ingress_received(&handle, "turn/start", &params.input, surface)
+            .record_rpc_ingress_received(connection, &handle, "turn/start", &params.input, surface)
             .await?;
         let admission = crate::kernel::admission::AdmissionGateContext::surface_default(
             surface,

--- a/crates/cooldis-kernel/src/adapters/app_server/connection.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/connection.rs
@@ -746,6 +746,7 @@ pub(super) struct GetConversationSummaryParams {
 const METHOD_NOT_AUTHORIZED_CODE: i64 = -32003;
 
 pub(super) const DISPATCH_METHOD_AUTHORITY_CLASSES: &[(&str, AuthorityClass)] = &[
+    // Compatibility reads and local registry projections.
     ("account/read", AuthorityClass::Interactive),
     ("account/rateLimits/read", AuthorityClass::Interactive),
     ("app/list", AuthorityClass::Interactive),
@@ -775,16 +776,23 @@ pub(super) const DISPATCH_METHOD_AUTHORITY_CLASSES: &[(&str, AuthorityClass)] = 
     ("modelProvider/auth/set", AuthorityClass::Host),
     ("modelProvider/auth/delete", AuthorityClass::Host),
     ("experimentalFeature/list", AuthorityClass::Interactive),
+    // This is currently an echo-only compatibility stub. Reclassify it before
+    // wiring the method to daemon configuration or other host state.
     (
         "experimentalFeature/enablement/set",
         AuthorityClass::Interactive,
     ),
     ("getAuthStatus", AuthorityClass::Interactive),
     ("getConversationSummary", AuthorityClass::Host),
+    // These construct or reconstruct runtime bindings and may resolve secrets.
     ("thread/start", AuthorityClass::Host),
     ("thread/spawn", AuthorityClass::Host),
     ("thread/submit", AuthorityClass::Interactive),
+    // A clone fork replays the source thread's witnessed standing grant. It
+    // cannot select a new manifest, placement, manifest workspace binding, or
+    // tool policy; its cwd/model fields are presentation/runtime controls.
     ("thread/fork", AuthorityClass::Interactive),
+    // A rebind fork can select all of those surfaces, so it remains Host.
     ("thread/rebindFork", AuthorityClass::Host),
     ("thread/resume", AuthorityClass::Host),
     ("thread/read", AuthorityClass::Interactive),
@@ -802,9 +810,13 @@ pub(super) const DISPATCH_METHOD_AUTHORITY_CLASSES: &[(&str, AuthorityClass)] = 
     ("thread/unsubscribe", AuthorityClass::Interactive),
     ("thread/name/set", AuthorityClass::Interactive),
     ("thread/metadata/update", AuthorityClass::Interactive),
+    // Compaction runs inside an existing bound thread and obtains no new grant.
     ("thread/compact/start", AuthorityClass::Interactive),
     ("thread/shellCommand", AuthorityClass::Host),
+    // Ingress may lazily reconstruct the thread from its witnessed standing
+    // grant. Ingress-only principals are separately barred from turn controls.
     ("turn/start", AuthorityClass::Ingress),
+    // Steering only adds input to an already-running, already-bound turn.
     ("turn/steer", AuthorityClass::Interactive),
     ("turn/interrupt", AuthorityClass::Interactive),
     ("skills/list", AuthorityClass::Interactive),
@@ -832,13 +844,16 @@ pub(super) const DISPATCH_METHOD_AUTHORITY_CLASSES: &[(&str, AuthorityClass)] = 
 ];
 
 pub(super) const HOST_EFFECT_METHODS: &[&str] = &[
+    // Local registry mutations.
     "capsule/binding/set",    // lexicon-allow: capsule - existing RPC method.
     "capsule/binding/delete", // lexicon-allow: capsule - existing RPC method.
     "agent/publish",
+    // Processes and process-handle control.
     "command/exec",
     "command/exec/write",
     "command/exec/terminate",
     "command/exec/resize",
+    // Provider configuration and secret status/mutations.
     "modelProvider/list",
     "modelProvider/read",
     "modelProvider/upsert",
@@ -846,16 +861,21 @@ pub(super) const HOST_EFFECT_METHODS: &[&str] = &[
     "modelProvider/auth/status",
     "modelProvider/auth/set",
     "modelProvider/auth/delete",
+    // Runtime construction, reconstruction, and standing-grant changes.
     "thread/start",
     "thread/spawn",
     "thread/rebindFork",
     "thread/resume",
+    // Effects that may release or directly invoke host tools.
     "approval/resolve",
     "thread/shellCommand",
+    // MCP secret/network effects. Plain list/read and manifestPatch are
+    // redacted registry projections and do not resolve secret material.
     "mcpSource/upsert",
     "mcpSource/discover",
     "mcpSource/delete",
     "mcpSource/testTool",
+    // Filesystem mutations; read/watch methods remain Host but are not effects.
     "fs/writeFile",
     "fs/createDirectory",
     "fs/remove",
@@ -927,7 +947,13 @@ impl CooldisAppServer {
             .map_err(jsonrpc_error_to_runtime_factory);
         let close_result = close_witness.close().await;
         match (dispatch_result, close_result) {
-            (Err(error), _) => Err(error),
+            (Err(error), Err(close_error)) => {
+                eprintln!(
+                    "failed to witness closing a failed local JSON-RPC session: {close_error}"
+                );
+                Err(error)
+            }
+            (Err(error), Ok(())) => Err(error),
             (Ok(_), Err(error)) => Err(error),
             (Ok(value), Ok(())) => Ok(value),
         }
@@ -1084,6 +1110,34 @@ impl CooldisAppServer {
             return Err(jsonrpc_error(
                 METHOD_NOT_AUTHORIZED_CODE,
                 "request is not authorized for this principal",
+            ));
+        }
+        let ingress_only = connection
+            .resolved_principal
+            .kind
+            .permits(AuthorityClass::Ingress)
+            && !connection
+                .resolved_principal
+                .kind
+                .permits(AuthorityClass::Interactive)
+            && !connection
+                .resolved_principal
+                .kind
+                .permits(AuthorityClass::Host);
+        if method == "turn/start"
+            && ingress_only
+            && params
+                .as_ref()
+                .and_then(Value::as_object)
+                .is_some_and(|params| {
+                    ["cwd", "model", "thinking"]
+                        .iter()
+                        .any(|name| params.contains_key(*name))
+                })
+        {
+            return Err(jsonrpc_error(
+                -32602,
+                "turn/start parameter overrides are not available to this principal",
             ));
         }
         if HOST_EFFECT_METHODS.contains(&method) {

--- a/crates/cooldis-kernel/src/adapters/app_server/mod.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/mod.rs
@@ -2,10 +2,11 @@ use crate::ProcessHandleIngressSink;
 use crate::daemon::daemon_config::synthesized_local_daemon_identity_config;
 use crate::daemon::daemon_io::CooldisDaemonIoBridge;
 use crate::daemon::identity::{
-    AuthenticationPath, BoundarySurface, CooldisDaemonIdentityConfig,
-    IDENTITY_AUTH_REJECTION_SCHEMA_V1, IDENTITY_SESSION_SCHEMA_V1, IdentityAuthRejectionReason,
-    IdentityAuthRejectionV1, IdentityAuthority, IdentityMode, IdentitySessionV1, PrincipalId,
-    PrincipalKind, ResolvedPrincipal, SqliteIdentityAuthority, identity_token_digest,
+    AuthenticationPath, AuthorityClass, BoundarySurface, CooldisDaemonIdentityConfig,
+    IDENTITY_AUTH_REJECTION_SCHEMA_V1, IDENTITY_HOST_EFFECT_SCHEMA_V1, IDENTITY_SESSION_SCHEMA_V1,
+    IdentityAuthRejectionReason, IdentityAuthRejectionV1, IdentityAuthority, IdentityHostEffectV1,
+    IdentityMode, IdentitySessionV1, PrincipalId, PrincipalKind, ResolvedPrincipal,
+    SqliteIdentityAuthority, authority_class_for_method, identity_token_digest,
 };
 use crate::daemon::recovery_sweep::StartupRecoverySweep;
 use crate::kernel::process_handle_dispatch::ProcessHandleDispatcher;
@@ -845,14 +846,15 @@ impl CooldisAppServer {
         );
         let codex_home = tenant_context.codex_home();
         let session_store_path = tenant_context.session_history_path();
-        if let Some(decorate) = session_store_decorator {
-            let session_store = Arc::new(
-                SqliteSessionStore::open(&session_store_path)
-                    .await
-                    .map_err(|err| CooldisError::History(err.to_string()))?,
-            ) as Arc<dyn RuntimeStore>;
-            tenant_context = tenant_context.with_session_store(decorate(session_store));
-        }
+        let identity_store = SqliteSessionStore::open(&session_store_path)
+            .await
+            .map_err(|err| CooldisError::History(err.to_string()))?;
+        let runtime_store = Arc::new(identity_store.clone()) as Arc<dyn RuntimeStore>;
+        let runtime_store = match session_store_decorator {
+            Some(decorate) => decorate(runtime_store),
+            None => runtime_store,
+        };
+        tenant_context = tenant_context.with_session_store(runtime_store);
         supervisor
             .register_tenant(TenantRegistration {
                 context: tenant_context,
@@ -860,9 +862,6 @@ impl CooldisAppServer {
             })
             .await?;
         let identity_clock: Arc<dyn crate::DaemonClock> = Arc::new(SystemDaemonClock);
-        let identity_store = SqliteSessionStore::open(&session_store_path)
-            .await
-            .map_err(|err| CooldisError::History(err.to_string()))?;
         let console_credential_record_path = session_store_path
             .parent()
             .unwrap_or_else(|| Path::new("."))

--- a/crates/cooldis-kernel/src/adapters/app_server/mod.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/mod.rs
@@ -592,9 +592,14 @@ impl SessionCloseWitness {
         // the first poll, so disarming here prevents a cancelled await from
         // scheduling a duplicate close witness.
         self.armed = false;
-        self.authority
+        let result = self
+            .authority
             .witness_session_closed(&self.session_id, self.clock.now().timestamp_millis())
-            .await
+            .await;
+        // A completed failure has no transaction left to finish in the
+        // background. Re-arm the idempotent Drop path for one best-effort retry.
+        self.armed = result.is_err();
+        result
     }
 }
 

--- a/crates/cooldis-kernel/src/adapters/app_server/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/tests.rs
@@ -10681,6 +10681,67 @@ async fn aborted_websocket_session_still_witnesses_its_close() {
     .await;
 }
 
+#[tokio::test]
+async fn local_dispatch_error_still_witnesses_its_session_close() {
+    let app = test_app().await;
+    let store_path = app.session_store_path().to_path_buf();
+
+    let error = app
+        .local_json_rpc_request("not/a-method", json!({}))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("unsupported method"));
+    assert_eq!(
+        identity_sql_count(
+            &store_path,
+            "SELECT COUNT(*) FROM cooldis_identity_sessions WHERE closed_at_ms IS NOT NULL",
+        )
+        .await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn failed_session_close_rearms_the_drop_witness() {
+    let app = test_app().await;
+    let store_path = app.session_store_path().to_path_buf();
+    let (connection_state, _outbound_rx) = test_connection(app.clone()).await;
+    let mut close_witness = SessionCloseWitness::new(
+        Arc::clone(&app.inner.identity_authority),
+        Arc::clone(&app.inner.identity_clock),
+        connection_state.witnessed_session_id.clone(),
+    );
+    let store = SqliteSessionStore::open(&store_path).await.unwrap();
+    let database = store.sqlite_database();
+    let database_connection = database.connect().await.unwrap();
+    database_connection
+        .execute_batch(
+            "ALTER TABLE cooldis_identity_sessions RENAME TO cooldis_identity_sessions_offline",
+        )
+        .await
+        .unwrap();
+
+    assert!(close_witness.close().await.is_err());
+    assert!(
+        close_witness.armed,
+        "a completed close failure must retry on drop"
+    );
+
+    database_connection
+        .execute_batch(
+            "ALTER TABLE cooldis_identity_sessions_offline RENAME TO cooldis_identity_sessions",
+        )
+        .await
+        .unwrap();
+    drop(close_witness);
+    wait_for_identity_sql_count(
+        &store_path,
+        "SELECT COUNT(*) FROM cooldis_identity_sessions WHERE closed_at_ms IS NOT NULL",
+        1,
+    )
+    .await;
+}
+
 #[tokio::test(start_paused = true)]
 async fn pre_upgrade_reads_and_upgrade_are_bounded_when_no_data_arrives() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/crates/cooldis-kernel/src/adapters/app_server/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/tests.rs
@@ -8,6 +8,7 @@ use super::threads::{
     turn_input_from_values, user_input_preview,
 };
 use super::*;
+use crate::daemon::identity::{AuthorityClass, authority_class_for_method};
 use crate::{
     CHANNEL_EMIT_OPERATION, COOLDIS_NOTIFY_PACKAGE, COOLDIS_PROCESS_PACKAGE,
     COOLDIS_SCHEDULE_PACKAGE, COOLDIS_THREADS_PACKAGE, EffectClass, EventKind, EventOrigin,
@@ -21,6 +22,127 @@ use crate::{
     THREADS_CONTROL_CAPABILITY, THREADS_READ_CAPABILITY, THREADS_SPAWN_CAPABILITY, TOOL_CALL_TOOL,
     TOOL_DESCRIBE_TOOL, TOOL_SEARCH_TOOL, ThinkingConfig, ThinkingEffort,
 };
+
+#[test]
+fn dispatcher_method_authority_classes_are_exhaustive_and_explicit() {
+    use AuthorityClass::{Host, Ingress, Interactive};
+
+    const EXPECTED: &[(&str, AuthorityClass)] = &[
+        ("account/read", Interactive),
+        ("account/rateLimits/read", Interactive),
+        ("app/list", Interactive),
+        ("capsule/binding/set", Host), // lexicon-allow: capsule - existing RPC method.
+        ("capsule/binding/delete", Host), // lexicon-allow: capsule - existing RPC method.
+        ("capsule/binding/list", Host), // lexicon-allow: capsule - existing RPC method.
+        ("capsule/binding/resolve", Host), // lexicon-allow: capsule - existing RPC method.
+        ("agent/list", Interactive),
+        ("agent/read", Interactive),
+        ("agent/plan", Interactive),
+        ("agent/publish", Host),
+        ("operation/list", Interactive),
+        ("command/exec", Host),
+        ("command/exec/write", Host),
+        ("command/exec/terminate", Host),
+        ("command/exec/resize", Host),
+        ("model/list", Interactive),
+        ("modelProvider/capabilities/read", Interactive),
+        ("modelProvider/list", Host),
+        ("modelProvider/read", Host),
+        ("modelProvider/upsert", Host),
+        ("modelProvider/delete", Host),
+        ("modelProvider/auth/status", Host),
+        ("modelProvider/auth/set", Host),
+        ("modelProvider/auth/delete", Host),
+        ("experimentalFeature/list", Interactive),
+        ("experimentalFeature/enablement/set", Interactive),
+        ("getAuthStatus", Interactive),
+        ("getConversationSummary", Host),
+        ("thread/start", Host),
+        ("thread/spawn", Host),
+        ("thread/submit", Interactive),
+        ("thread/fork", Interactive),
+        ("thread/rebindFork", Host),
+        ("thread/resume", Host),
+        ("thread/read", Interactive),
+        ("thread/events/list", Interactive),
+        ("thread/couplings/list", Interactive),
+        ("thread/approvals/list", Interactive),
+        ("thread/waiting/list", Interactive),
+        ("approval/resolve", Host),
+        ("mandate/start", Interactive),
+        ("mandate/revoke", Interactive),
+        ("mandate/list", Interactive),
+        ("thread/debug/export", Host),
+        ("thread/list", Interactive),
+        ("thread/loaded/list", Interactive),
+        ("thread/unsubscribe", Interactive),
+        ("thread/name/set", Interactive),
+        ("thread/metadata/update", Interactive),
+        ("thread/compact/start", Interactive),
+        ("thread/shellCommand", Host),
+        ("turn/start", Ingress),
+        ("turn/steer", Interactive),
+        ("turn/interrupt", Interactive),
+        ("skills/list", Interactive),
+        ("plugin/list", Interactive),
+        ("hooks/list", Interactive),
+        ("mcpServerStatus/list", Host),
+        ("mcpSource/list", Host),
+        ("mcpSource/read", Host),
+        ("mcpSource/upsert", Host),
+        ("mcpSource/discover", Host),
+        ("mcpSource/delete", Host),
+        ("mcpSource/testTool", Host),
+        ("mcpSource/manifestPatch", Host),
+        ("fs/readFile", Host),
+        ("fs/writeFile", Host),
+        ("fs/createDirectory", Host),
+        ("fs/getMetadata", Host),
+        ("fs/readDirectory", Host),
+        ("fs/remove", Host),
+        ("fs/copy", Host),
+        ("fs/watch", Host),
+        ("fs/unwatch", Host),
+        ("config/read", Interactive),
+        ("configRequirements/read", Interactive),
+    ];
+
+    let dispatch_source = include_str!("connection.rs")
+        .split_once("pub(super) async fn dispatch_request")
+        .expect("dispatch_request source")
+        .1
+        .split_once("pub(super) async fn mcp_server_status_list")
+        .expect("method following dispatch_request")
+        .0;
+    let dispatch_methods = dispatch_source
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim_start();
+            let rest = line.strip_prefix('"')?;
+            rest.split_once("\" =>").map(|(method, _)| method)
+        })
+        .collect::<Vec<_>>();
+    let expected_methods = EXPECTED
+        .iter()
+        .map(|(method, _)| *method)
+        .collect::<Vec<_>>();
+
+    assert_eq!(dispatch_methods, expected_methods);
+    assert_eq!(DISPATCH_METHOD_AUTHORITY_CLASSES, EXPECTED);
+    for (method, expected_class) in EXPECTED {
+        assert_eq!(
+            authority_class_for_method(method),
+            *expected_class,
+            "authority class drifted for {method}"
+        );
+    }
+    for method in HOST_EFFECT_METHODS {
+        assert!(
+            EXPECTED.contains(&(*method, Host)),
+            "host-effect witness method must have Host authority: {method}"
+        );
+    }
+}
 
 #[test]
 fn jsonrpc_decodes_initialize_without_jsonrpc_field() {
@@ -152,7 +274,7 @@ async fn app_server_turn_start_records_surface_admission_before_execution() {
     use crate::EventStore;
 
     let app = test_app().await;
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -241,7 +363,7 @@ async fn concurrent_new_thread_turn_burst_surfaces_no_history_lock_errors() {
         let app = app.clone();
         let barrier = Arc::clone(&barrier);
         tasks.spawn(async move {
-            let (connection, _outbound_rx) = test_connection(app.clone());
+            let (connection, _outbound_rx) = test_connection(app.clone()).await;
             initialize_for_test(&connection).await;
             barrier.wait().await;
             let thread = app
@@ -472,7 +594,7 @@ fn reconcile_turn_assistant_text_keeps_prior_stream_when_saved_text_diverges() {
 #[tokio::test]
 async fn thread_compact_start_dispatches_to_runtime() {
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -585,7 +707,7 @@ async fn model_provider_auth_methods_store_redacted_credentials() {
     drop(metadata_store);
 
     let app = CooldisAppServer::new_local(config.clone()).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let initial = app
@@ -730,7 +852,7 @@ async fn model_provider_list_and_read_return_redacted_endpoint_records() {
         .await
         .unwrap();
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let list = app
@@ -799,7 +921,7 @@ async fn model_provider_upsert_creates_and_updates_endpoint_records() {
     config.agent_registry_root = root.join("agents");
     let metadata_path = config.metadata_store_path();
     let app = CooldisAppServer::new_local(config.clone()).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let created = app
@@ -895,7 +1017,7 @@ async fn model_provider_upsert_rejects_inline_api_keys_and_command_values() {
     config.state_home = root.join("state");
     config.agent_registry_root = root.join("agents");
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let inline = app
@@ -1002,7 +1124,7 @@ async fn model_provider_delete_removes_record_and_stored_credential() {
         .await
         .unwrap();
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let deleted = app
@@ -1094,7 +1216,7 @@ async fn cancelling_model_provider_delete_finishes_all_credential_cleanup() {
         .unwrap();
 
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let user_db =
@@ -1222,7 +1344,7 @@ async fn app_server_mcp_source_methods_register_discover_test_and_delete_remote_
     let metadata_path = config.metadata_store_path();
     let user_metadata_path = config.user_metadata_store_path();
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
     let (mcp_url, mcp_task) = spawn_app_mcp_http_fixture("string").await;
 
@@ -1393,7 +1515,7 @@ server_ref = "mcp://arcade"
         )
         .await
         .unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let preview = app
@@ -1486,7 +1608,7 @@ async fn agent_query_methods_project_local_registry_records() {
     config.state_home = root.join("state");
     config.agent_registry_root = agent_registry_root.clone();
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let list = app
@@ -1615,7 +1737,7 @@ async fn agent_plan_validates_source_and_manifest_without_writes() {
     config.state_home = root.join("state");
     config.agent_registry_root = agent_registry_root.clone();
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let source = r#"
@@ -1711,7 +1833,7 @@ async fn agent_publish_writes_new_version_and_rejects_stale_base() {
     config.state_home = root.join("state");
     config.agent_registry_root = agent_registry_root.clone();
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let read = app
@@ -1797,7 +1919,7 @@ async fn operation_list_projects_published_registry_records() {
         CapsuleBindingsConfig::default().with_registry_root(&registry_root),
     )
     .await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let list = app
@@ -1854,7 +1976,7 @@ async fn registry_roots_resolve_against_configured_cwd() {
     config.runtime_home = root.join("runtime");
     config.state_home = root.join("state");
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let agents = app
@@ -1926,7 +2048,7 @@ async fn model_list_projects_catalog_provider_models() {
     )
     .await
     .unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let models = app
@@ -1990,7 +2112,7 @@ async fn model_list_appends_configured_default_when_catalog_omits_it() {
     )
     .await
     .unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let models = app
@@ -2034,7 +2156,7 @@ async fn app_server_persists_thread_lifecycle_to_metadata_store() {
     let metadata_path = config.metadata_store_path();
 
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app);
+    let (connection, _outbound_rx) = test_connection(app).await;
     initialize_for_test(&connection).await;
 
     let thread_start = connection
@@ -2080,7 +2202,7 @@ async fn thread_handle_dispatch_retries_fold_through_rpc() {
     config.agent_registry_root = root.join("agents");
 
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
     let started = app
         .dispatch_request(&connection, "thread/start", Some(json!({})))
@@ -2297,7 +2419,7 @@ async fn ref_less_thread_start_binds_default_manifest() {
     assert_eq!(default_record.tool_count, 0);
     assert_eq!(default_record.resource_count, 0);
 
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
     let thread_start = app
         .dispatch_request(
@@ -2402,7 +2524,7 @@ async fn thread_start_placement_override_wins_daemon_default_and_is_witnessed_on
         config: BTreeMap::new(),
     };
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let rejected = app
@@ -2472,7 +2594,7 @@ async fn thread_spawn_placement_requires_agent_ref_and_override_is_witnessed_onc
         config: BTreeMap::new(),
     };
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
     let started = app
         .dispatch_request(
@@ -2633,7 +2755,7 @@ allow = ["default_cwd"]
     )
     .await
     .unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -2796,7 +2918,7 @@ allow = ["default_cwd"]
     )
     .await
     .unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let model_err = app
@@ -3081,7 +3203,7 @@ async fn startup_publishes_cooldis_threads_and_default_manifest_direct_rows() {
         );
     }
 
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
     let thread_start = app
         .dispatch_request(&connection, "thread/start", Some(json!({})))
@@ -3218,7 +3340,7 @@ streaming = false
         CapsuleBindingsConfig::default().with_registry_root(&operation_registry_root),
     )
     .await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
     let thread = app
         .dispatch_request(
@@ -3337,7 +3459,7 @@ streaming = false
     )
     .await
     .unwrap();
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -3582,7 +3704,7 @@ streaming = false
     )
     .await
     .unwrap();
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -3833,7 +3955,7 @@ budget_share = 0.75
     )
     .await
     .unwrap();
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -3965,7 +4087,7 @@ streaming = false
         CapsuleBindingsConfig::default().with_registry_root(&operation_registry_root),
     )
     .await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
     let err = app
         .dispatch_request(
@@ -4076,7 +4198,7 @@ streaming = false
         CapsuleBindingsConfig::default().with_registry_root(&operation_registry_root),
     )
     .await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -4190,7 +4312,7 @@ max_tool_rounds = 64
     )
     .await
     .unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
     let thread = app
         .dispatch_request(&connection, "thread/start", Some(json!({})))
@@ -4404,7 +4526,7 @@ async fn default_manifest_thread_rebinds_after_config_model_changes() {
         config.model = "echo-v1".to_string();
         metadata_path = config.metadata_store_path();
         let app = CooldisAppServer::new_local(config).await.unwrap();
-        let (connection, _outbound_rx) = test_connection(app.clone());
+        let (connection, _outbound_rx) = test_connection(app.clone()).await;
         initialize_for_test(&connection).await;
 
         let thread_start = app
@@ -4432,7 +4554,7 @@ async fn default_manifest_thread_rebinds_after_config_model_changes() {
     restarted_config.agent_registry_root = agent_registry_root.clone();
     restarted_config.model = "echo-v2".to_string();
     let restarted = CooldisAppServer::new_local(restarted_config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(restarted.clone());
+    let (connection, _outbound_rx) = test_connection(restarted.clone()).await;
     initialize_for_test(&connection).await;
 
     let latest = LocalAgentRegistry::new(&agent_registry_root)
@@ -4499,7 +4621,7 @@ async fn app_server_startup_skips_stale_manifest_threads() {
         config.agent_registry_root = agent_registry_root.clone();
         metadata_path = config.metadata_store_path();
         let app = CooldisAppServer::new_local(config).await.unwrap();
-        let (connection, _outbound_rx) = test_connection(app.clone());
+        let (connection, _outbound_rx) = test_connection(app.clone()).await;
         initialize_for_test(&connection).await;
 
         let thread_start = app
@@ -4531,7 +4653,7 @@ async fn app_server_startup_skips_stale_manifest_threads() {
     restarted_config.state_home = root.join("state");
     restarted_config.agent_registry_root = agent_registry_root.clone();
     let restarted = CooldisAppServer::new_local(restarted_config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(restarted.clone());
+    let (connection, _outbound_rx) = test_connection(restarted.clone()).await;
     initialize_for_test(&connection).await;
 
     let err = restarted
@@ -4599,7 +4721,7 @@ allow = ["streaming"]
     let metadata_path = config.metadata_store_path();
     let session_path = config.state_home.join("session_history.sqlite3");
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -4862,7 +4984,7 @@ streaming = false
     )
     .await
     .unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let caller_app = app.clone();
@@ -4996,7 +5118,7 @@ server_ref = "mcp://arcade"
         )
         .await
         .unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -5117,7 +5239,7 @@ pin = "mcptool://arcade/cooldis_mcp_echo@{schema_hash}"
         )
         .await
         .unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -5184,7 +5306,7 @@ async fn thread_events_list_pages_filters_and_reports_clear_errors() {
     config.state_home = root.join("state");
     config.agent_registry_root = agent_registry_root;
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -6126,7 +6248,7 @@ async fn thread_events_list_pages_filters_and_reports_clear_errors() {
 #[tokio::test]
 async fn mandate_rpc_validates_and_folds_control_stream_events() {
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
     let thread = app
         .dispatch_request(&connection, "thread/start", Some(json!({})))
@@ -6380,7 +6502,7 @@ streaming = false
     let metadata_path = config.metadata_store_path();
     let session_path = config.state_home.join("session_history.sqlite3");
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let cwd_start = app
@@ -6615,7 +6737,7 @@ streaming = false
     let app = CooldisAppServer::with_runtime_factory(config, runtime_factory)
         .await
         .unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -6719,7 +6841,7 @@ streaming = false
     let app = CooldisAppServer::with_runtime_factory(config, runtime_factory)
         .await
         .unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -6806,7 +6928,7 @@ streaming = false
         CapsuleBindingsConfig::default(),
     )
     .await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let undeclared = app
@@ -6988,7 +7110,7 @@ streaming = false
     config.state_home = root.join("state");
     config.agent_registry_root = agent_registry_root;
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -7175,7 +7297,7 @@ streaming = false
     let app = CooldisAppServer::with_runtime_factory(config, runtime_factory)
         .await
         .unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -7414,7 +7536,7 @@ async fn catalog_provider_resolution_uses_seeded_openai_compatible_store_and_sto
 #[tokio::test]
 async fn thread_fork_creates_child_app_server_thread() {
     let app = test_app().await;
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -7486,7 +7608,7 @@ async fn thread_fork_creates_child_app_server_thread() {
 #[tokio::test]
 async fn thread_fork_can_use_explicit_checkpoint_id() {
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -7564,7 +7686,7 @@ async fn thread_fork_can_use_explicit_checkpoint_id() {
 #[tokio::test]
 async fn thread_fork_rejects_invalid_checkpoint_id() {
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -7592,7 +7714,7 @@ async fn thread_fork_rejects_invalid_checkpoint_id() {
 #[tokio::test]
 async fn thread_fork_rejects_unavailable_checkpoint_id() {
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -7622,7 +7744,7 @@ async fn thread_fork_rejects_unavailable_checkpoint_id() {
 #[tokio::test]
 async fn thread_rebind_fork_creates_borrowed_prefix_manifest_child() {
     let app = test_app().await;
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -7779,7 +7901,7 @@ async fn thread_rebind_fork_creates_borrowed_prefix_manifest_child() {
 #[tokio::test]
 async fn thread_rebind_fork_rejects_active_source_thread() {
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -7814,7 +7936,7 @@ async fn thread_rebind_fork_rejects_active_source_thread() {
 #[tokio::test]
 async fn thread_start_accepts_parent_thread_shorthand() {
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let root = app
@@ -7855,7 +7977,7 @@ async fn thread_start_accepts_parent_thread_shorthand() {
 #[tokio::test]
 async fn thread_resume_returns_loaded_thread() {
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -7888,7 +8010,7 @@ async fn thread_resume_returns_loaded_thread() {
 #[tokio::test]
 async fn thread_resume_loads_thread_from_metadata_when_not_resident() {
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -7962,7 +8084,7 @@ async fn reload_keeps_bind_time_placement_when_metadata_is_absent_or_corrupt() {
     let first = CooldisAppServer::new_local(config_for(AgentManifestPlacementBinding::default()))
         .await
         .unwrap();
-    let (connection, _outbound_rx) = test_connection(first.clone());
+    let (connection, _outbound_rx) = test_connection(first.clone()).await;
     initialize_for_test(&connection).await;
 
     let absent = first
@@ -8030,7 +8152,7 @@ async fn reload_keeps_bind_time_placement_when_metadata_is_absent_or_corrupt() {
     }))
     .await
     .unwrap();
-    let (restarted_connection, _outbound_rx) = test_connection(restarted.clone());
+    let (restarted_connection, _outbound_rx) = test_connection(restarted.clone()).await;
     initialize_for_test(&restarted_connection).await;
     let loaded = restarted
         .dispatch_request(&restarted_connection, "thread/loaded/list", Some(json!({})))
@@ -8139,7 +8261,7 @@ streaming = false
     let first = CooldisAppServer::new_local(config_for(&first_workspace))
         .await
         .unwrap();
-    let (connection, _outbound_rx) = test_connection(first.clone());
+    let (connection, _outbound_rx) = test_connection(first.clone()).await;
     initialize_for_test(&connection).await;
     let absent = first
         .dispatch_request(
@@ -8288,7 +8410,7 @@ streaming = false
     let restarted = CooldisAppServer::new_local(config_for(&replacement_workspace))
         .await
         .unwrap();
-    let (restarted_connection, _outbound_rx) = test_connection(restarted.clone());
+    let (restarted_connection, _outbound_rx) = test_connection(restarted.clone()).await;
     initialize_for_test(&restarted_connection).await;
     let loaded = restarted
         .dispatch_request(&restarted_connection, "thread/loaded/list", Some(json!({})))
@@ -8374,7 +8496,7 @@ async fn thread_resume_ignores_pre_manifest_operation_name_metadata() {
         CapsuleBindingsConfig::default(),
     )
     .await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -8443,7 +8565,7 @@ async fn thread_resume_ignores_pre_manifest_operation_name_metadata() {
 #[tokio::test]
 async fn model_provider_capabilities_read_returns_local_capabilities() {
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let capabilities = app
@@ -8479,7 +8601,7 @@ async fn model_provider_capabilities_read_reports_bedrock_streaming() {
     config.state_home = root.join("state");
     config.agent_registry_root = root.join("agents");
     let app = CooldisAppServer::new_local(config).await.unwrap();
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let capabilities = app
@@ -8509,7 +8631,7 @@ async fn app_server_capsule_bindings_expose_published_operation_to_tools_and_bas
             .with_global_operation_name("search"),
     )
     .await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -8571,7 +8693,7 @@ async fn default_manifest_synthesizes_load_all_active_operation_rows() {
             .with_load_all_active_when_unbound(true),
     )
     .await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -8678,7 +8800,7 @@ async fn default_manifest_load_all_accepts_registry_with_only_kernel_native_reco
             .with_load_all_active_when_unbound(true),
     )
     .await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -8752,7 +8874,7 @@ async fn app_server_capsule_bindings_reject_thread_operation_scope_injection() {
             .with_global_operation_name("global"),
     )
     .await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let err = app
@@ -8787,7 +8909,7 @@ async fn app_server_capsule_binding_methods_do_not_update_manifest_runtime_scope
         CapsuleBindingsConfig::default().with_registry_root(&registry_root),
     )
     .await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let set = app
@@ -8899,7 +9021,7 @@ async fn app_server_capsule_binding_methods_do_not_reload_as_manifest_runtime_sc
         CapsuleBindingsConfig::default().with_registry_root(&registry_root),
     )
     .await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     app.dispatch_request(
@@ -8922,7 +9044,7 @@ async fn app_server_capsule_binding_methods_do_not_reload_as_manifest_runtime_sc
         CapsuleBindingsConfig::default().with_registry_root(&registry_root),
     )
     .await;
-    let (restarted_connection, _outbound_rx) = test_connection(restarted.clone());
+    let (restarted_connection, _outbound_rx) = test_connection(restarted.clone()).await;
     initialize_for_test(&restarted_connection).await;
 
     let thread = restarted
@@ -8966,7 +9088,7 @@ async fn app_server_loads_threads_and_rebuilds_context_from_shared_session_store
             CapsuleBindingsConfig::default(),
         )
         .await;
-        let (connection, _outbound_rx) = test_connection(app.clone());
+        let (connection, _outbound_rx) = test_connection(app.clone()).await;
         initialize_for_test(&connection).await;
 
         let thread = app
@@ -9002,7 +9124,7 @@ async fn app_server_loads_threads_and_rebuilds_context_from_shared_session_store
         CapsuleBindingsConfig::default(),
     )
     .await;
-    let (restarted_connection, _outbound_rx) = test_connection(restarted.clone());
+    let (restarted_connection, _outbound_rx) = test_connection(restarted.clone()).await;
     initialize_for_test(&restarted_connection).await;
 
     let loaded = restarted
@@ -9077,7 +9199,7 @@ async fn restored_thread_start_streams_and_thread_read_returns_persisted_turns()
             CapsuleBindingsConfig::default(),
         )
         .await;
-        let (connection, mut outbound_rx) = test_connection(app.clone());
+        let (connection, mut outbound_rx) = test_connection(app.clone()).await;
         initialize_for_test(&connection).await;
 
         let thread = app
@@ -9137,7 +9259,8 @@ async fn restored_thread_start_streams_and_thread_read_returns_persisted_turns()
         CapsuleBindingsConfig::default(),
     )
     .await;
-    let (restarted_connection, mut restarted_outbound_rx) = test_connection(restarted.clone());
+    let (restarted_connection, mut restarted_outbound_rx) =
+        test_connection(restarted.clone()).await;
     initialize_for_test(&restarted_connection).await;
 
     let listed = restarted
@@ -9212,7 +9335,7 @@ async fn fast_stream_completion_reads_saved_assistant_when_projection_is_empty()
         true,
     )
     .await;
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -9277,7 +9400,7 @@ async fn lagged_thread_stream_resnapshots_from_durable_truth() {
         true,
     )
     .await;
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -9353,7 +9476,7 @@ async fn lagged_thread_stream_resnapshots_from_durable_truth() {
 #[tokio::test(flavor = "current_thread")]
 async fn lag_resync_degrades_when_turn_submission_has_no_entry_id() {
     let app = test_app().await;
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -9436,7 +9559,7 @@ async fn lag_resync_degrades_when_turn_submission_has_no_entry_id() {
 #[tokio::test(flavor = "current_thread")]
 async fn lagged_idle_thread_resynchronizes_without_another_status_change() {
     let app = test_app().await;
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -9496,7 +9619,7 @@ async fn lag_resync_does_not_apply_stale_idle_to_a_new_running_turn() {
         true,
     )
     .await;
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -9597,7 +9720,7 @@ async fn fast_stream_after_thread_start_idle_completes_with_assistant_text() {
         true,
     )
     .await;
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -9653,7 +9776,7 @@ async fn provider_failure_turn_completed_carries_error() {
         true,
     )
     .await;
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -9707,7 +9830,7 @@ async fn restored_thread_provider_requests_end_with_current_input() {
             CapsuleBindingsConfig::default(),
         )
         .await;
-        let (connection, mut outbound_rx) = test_connection(app.clone());
+        let (connection, mut outbound_rx) = test_connection(app.clone()).await;
         initialize_for_test(&connection).await;
 
         let thread = app
@@ -9749,7 +9872,8 @@ async fn restored_thread_provider_requests_end_with_current_input() {
         CapsuleBindingsConfig::default(),
     )
     .await;
-    let (restarted_connection, mut restarted_outbound_rx) = test_connection(restarted.clone());
+    let (restarted_connection, mut restarted_outbound_rx) =
+        test_connection(restarted.clone()).await;
     initialize_for_test(&restarted_connection).await;
 
     restarted
@@ -9816,7 +9940,7 @@ async fn restored_thread_notifications_use_current_completion_and_persist_once()
             true,
         )
         .await;
-        let (connection, mut outbound_rx) = test_connection(app.clone());
+        let (connection, mut outbound_rx) = test_connection(app.clone()).await;
         initialize_for_test(&connection).await;
 
         let thread = app
@@ -9859,7 +9983,8 @@ async fn restored_thread_notifications_use_current_completion_and_persist_once()
         true,
     )
     .await;
-    let (restarted_connection, mut restarted_outbound_rx) = test_connection(restarted.clone());
+    let (restarted_connection, mut restarted_outbound_rx) =
+        test_connection(restarted.clone()).await;
     initialize_for_test(&restarted_connection).await;
 
     restarted
@@ -9938,7 +10063,7 @@ async fn restored_thread_multiple_subscribers_receive_single_applied_turns() {
             true,
         )
         .await;
-        let (connection, mut outbound_rx) = test_connection(app.clone());
+        let (connection, mut outbound_rx) = test_connection(app.clone()).await;
         initialize_for_test(&connection).await;
 
         let thread = app
@@ -9976,8 +10101,8 @@ async fn restored_thread_multiple_subscribers_receive_single_applied_turns() {
         true,
     )
     .await;
-    let (requesting_connection, mut requesting_rx) = test_connection(restarted.clone());
-    let (observer_connection, mut observer_rx) = test_connection(restarted.clone());
+    let (requesting_connection, mut requesting_rx) = test_connection(restarted.clone()).await;
+    let (observer_connection, mut observer_rx) = test_connection(restarted.clone()).await;
     initialize_for_test(&requesting_connection).await;
     initialize_for_test(&observer_connection).await;
 
@@ -10693,7 +10818,7 @@ async fn app_server_websocket_listen_rejects_non_loopback_without_auth() {
 #[tokio::test]
 async fn fs_methods_cover_basic_host_file_operations() {
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
     let root = std::env::temp_dir().join(format!("cooldis-vfs-test-{}", Uuid::now_v7()));
     let nested = root.join("nested");
@@ -10810,7 +10935,7 @@ async fn fs_methods_cover_basic_host_file_operations() {
 #[tokio::test]
 async fn command_exec_returns_buffered_output() {
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
     let root = std::env::temp_dir().join(format!("cooldis-command-test-{}", Uuid::now_v7()));
     std::fs::create_dir_all(&root).unwrap();
@@ -10842,7 +10967,7 @@ async fn command_exec_returns_buffered_output() {
 #[tokio::test]
 async fn command_exec_streaming_session_can_poll_write_and_terminate() {
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
     let thread = app
         .dispatch_request(&connection, "thread/start", Some(json!({})))
@@ -10951,7 +11076,7 @@ async fn command_exec_streaming_session_can_poll_write_and_terminate() {
 #[tokio::test]
 async fn command_exec_streaming_start_returns_running_process_id_then_poll_completes() {
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
     let thread = app
         .dispatch_request(&connection, "thread/start", Some(json!({})))
@@ -11005,7 +11130,7 @@ async fn process_dispatch_retry_and_duplicate_terminal_deliver_once() {
     };
 
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
     let thread = app
         .dispatch_request(&connection, "thread/start", Some(json!({})))
@@ -11180,7 +11305,7 @@ async fn process_dispatch_retry_and_duplicate_terminal_deliver_once() {
 #[tokio::test]
 async fn local_ui_affordance_methods_return_safe_shapes() {
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     assert_eq!(
@@ -11249,7 +11374,7 @@ async fn local_ui_affordance_methods_return_safe_shapes() {
 #[tokio::test]
 async fn thread_shell_command_emits_command_execution_item() {
     let app = test_app().await;
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -11317,7 +11442,7 @@ async fn thread_shell_command_emits_command_execution_item() {
 #[tokio::test]
 async fn bridge_flow_uses_local_offline_provider() {
     let app = test_app().await;
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -11407,7 +11532,7 @@ async fn thinking_precedence_flows_to_provider_requests() {
     let app = CooldisAppServer::with_runtime_factory(config, runtime_factory)
         .await
         .unwrap();
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let default_thread = app
@@ -11506,7 +11631,7 @@ async fn thinking_stream_projects_as_distinct_items() {
         true,
     )
     .await;
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -11579,7 +11704,7 @@ async fn non_stream_thinking_delta_precedes_text_when_content_does() {
         false,
     )
     .await;
-    let (connection, mut outbound_rx) = test_connection(app.clone());
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread = app
@@ -11605,7 +11730,7 @@ async fn non_stream_thinking_delta_precedes_text_when_content_does() {
 #[tokio::test]
 async fn local_thread_read_echoes_thread_thinking_config() {
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -11693,7 +11818,7 @@ async fn local_thread_read_echoes_thread_thinking_config() {
 #[tokio::test]
 async fn unsupported_methods_return_method_not_found() {
     let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone());
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
     let err = app
         .dispatch_request(&connection, "not/a-method", None)
@@ -11717,7 +11842,7 @@ async fn test_app_at_root(root: &Path) -> CooldisAppServer {
     CooldisAppServer::new_local(config).await.unwrap()
 }
 
-fn test_connection(
+async fn test_connection(
     app: CooldisAppServer,
 ) -> (ConnectionState, mpsc::UnboundedReceiver<JsonRpcMessage>) {
     let (outbound, rx) = mpsc::unbounded_channel::<JsonRpcMessage>();
@@ -11728,10 +11853,27 @@ fn test_connection(
             uid: current_effective_uid(),
         },
     };
+    let witnessed_session_id = format!("test-session-{}", Uuid::now_v7());
+    app.inner
+        .identity_authority
+        .witness_session_opened(&IdentitySessionV1 {
+            schema: IDENTITY_SESSION_SCHEMA_V1.to_string(),
+            session_id: witnessed_session_id.clone(),
+            principal_id: resolved_principal.principal_id.clone(),
+            kind: resolved_principal.kind,
+            surface: BoundarySurface::UnixSocket,
+            credential_ref: credential_ref(&resolved_principal.auth),
+            opened_at_ms: app.inner.identity_clock.now().timestamp_millis(),
+            closed_at_ms: None,
+        })
+        .await
+        .unwrap();
     (
         ConnectionState {
             app,
             resolved_principal,
+            witnessed_session_id,
+            boundary_surface: BoundarySurface::UnixSocket,
             outbound,
             handshake: Arc::new(Mutex::new(HandshakeState::default())),
             opt_out_notifications: Arc::new(RwLock::new(HashSet::new())),

--- a/crates/cooldis-kernel/src/daemon/identity.rs
+++ b/crates/cooldis-kernel/src/daemon/identity.rs
@@ -33,6 +33,8 @@ pub const IDENTITY_CREDENTIAL_SCHEMA_V1: &str = "cooldis.identity.credential/1";
 pub const IDENTITY_SESSION_SCHEMA_V1: &str = "cooldis.identity.session/1";
 /// Schema id for a witnessed authentication/authorization rejection.
 pub const IDENTITY_AUTH_REJECTION_SCHEMA_V1: &str = "cooldis.identity.auth_rejection/1";
+/// Schema id for a witnessed host-authority effect.
+pub const IDENTITY_HOST_EFFECT_SCHEMA_V1: &str = "cooldis.identity.host_effect/1";
 
 /// A named identity within the tenant (ADR 0008 D1).
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
@@ -115,7 +117,15 @@ pub enum AuthorityClass {
 /// reconciliation with an exhaustive test: every dispatchable method appears
 /// here deliberately, or the test fails.
 pub fn authority_class_for_method(method: &str) -> AuthorityClass {
-    const HOST_METHODS: &[&str] = &["thread/shellCommand"];
+    const HOST_METHODS: &[&str] = &[
+        "agent/publish",
+        "thread/start",
+        "thread/spawn",
+        "thread/rebindFork",
+        "thread/resume",
+        "thread/debug/export",
+        "thread/shellCommand",
+    ];
     const HOST_PREFIXES: &[&str] = &[
         "command/",
         "fs/",
@@ -124,16 +134,35 @@ pub fn authority_class_for_method(method: &str) -> AuthorityClass {
         "mcpSource/",
         "debug/",
     ];
+    const INTERACTIVE_METHODS: &[&str] = &[
+        "account/read",
+        "account/rateLimits/read",
+        "app/list",
+        "operation/list",
+        "model/list",
+        "modelProvider/capabilities/read",
+        "experimentalFeature/list",
+        "experimentalFeature/enablement/set",
+        "getAuthStatus",
+        "skills/list",
+        "plugin/list",
+        "hooks/list",
+        "config/read",
+        "configRequirements/read",
+    ];
     const INTERACTIVE_PREFIXES: &[&str] = &["thread/", "turn/", "mandate/", "agent/", "session/"];
+    const INGRESS_METHODS: &[&str] = &["turn/start"];
     const INGRESS_PREFIXES: &[&str] = &["ingress/", "io/ingress/"];
 
     if HOST_METHODS.contains(&method) || HOST_PREFIXES.iter().any(|p| method.starts_with(p)) {
         return AuthorityClass::Host;
     }
-    if INGRESS_PREFIXES.iter().any(|p| method.starts_with(p)) {
+    if INGRESS_METHODS.contains(&method) || INGRESS_PREFIXES.iter().any(|p| method.starts_with(p)) {
         return AuthorityClass::Ingress;
     }
-    if INTERACTIVE_PREFIXES.iter().any(|p| method.starts_with(p)) {
+    if INTERACTIVE_METHODS.contains(&method)
+        || INTERACTIVE_PREFIXES.iter().any(|p| method.starts_with(p))
+    {
         return AuthorityClass::Interactive;
     }
     AuthorityClass::Host
@@ -267,6 +296,16 @@ pub struct IdentityAuthRejectionV1 {
     pub rejected_at_ms: i64,
 }
 
+/// A host-authority effect attributed to an authenticated boundary session.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct IdentityHostEffectV1 {
+    pub schema: String,
+    pub session_id: String,
+    pub principal_id: PrincipalId,
+    pub method: String,
+    pub witnessed_at_ms: i64,
+}
+
 /// The daemon's identity authority (ADR 0008 D1/D2/D6): the single owner of
 /// principal and credential records and of boundary witnessing.
 ///
@@ -340,6 +379,9 @@ pub trait IdentityAuthority: Send + Sync {
     /// Witness a rejected authentication or authorization attempt.
     async fn witness_auth_rejected(&self, rejection: &IdentityAuthRejectionV1)
     -> CooldisResult<()>;
+
+    /// Witness a host-authority effect before it is allowed to proceed.
+    async fn witness_host_effect(&self, effect: &IdentityHostEffectV1) -> CooldisResult<()>;
 }
 
 /// SQLite-backed durable authority for identity-plane records.
@@ -400,6 +442,7 @@ impl SqliteIdentityAuthority {
         let token = mint_identity_secret()?;
         let token_digest = identity_token_digest(&token);
         cancellation_safe(async move {
+            let _writer = store.daemon_write_guard().await;
             let database = store.sqlite_database();
             let mut connection = database.connect().await.map_err(storage_error)?;
             let transaction = connection
@@ -477,6 +520,7 @@ impl SqliteIdentityAuthority {
     async fn init_schema(&self) -> CooldisResult<()> {
         let store = self.store.clone();
         cancellation_safe(async move {
+            let _writer = store.daemon_write_guard().await;
             let database = store.sqlite_database();
             let mut connection = database.connect().await.map_err(storage_error)?;
             let transaction = connection
@@ -544,6 +588,18 @@ impl SqliteIdentityAuthority {
                         principal_id TEXT,
                         rejected_at_ms INTEGER NOT NULL
                     );
+
+                    CREATE TABLE IF NOT EXISTS cooldis_identity_host_effects (
+                        effect_sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                        schema TEXT NOT NULL,
+                        session_id TEXT NOT NULL,
+                        principal_id TEXT NOT NULL,
+                        method TEXT NOT NULL,
+                        witnessed_at_ms INTEGER NOT NULL
+                    );
+
+                    CREATE INDEX IF NOT EXISTS idx_cooldis_identity_host_effects_session
+                        ON cooldis_identity_host_effects(session_id, witnessed_at_ms);
                     "#,
                 )
                 .await
@@ -575,6 +631,7 @@ impl IdentityAuthority for SqliteIdentityAuthority {
         let principal_id = principal_id.clone();
         let display = display.to_string();
         cancellation_safe(async move {
+            let _writer = store.daemon_write_guard().await;
             let database = store.sqlite_database();
             let mut connection = database.connect().await.map_err(storage_error)?;
             let transaction = connection
@@ -635,6 +692,7 @@ impl IdentityAuthority for SqliteIdentityAuthority {
         let revoked_by = revoked_by.clone();
         let principal_id = principal_id.clone();
         cancellation_safe(async move {
+            let _writer = store.daemon_write_guard().await;
             let database = store.sqlite_database();
             let mut connection = database.connect().await.map_err(storage_error)?;
             let transaction = connection
@@ -676,6 +734,7 @@ impl IdentityAuthority for SqliteIdentityAuthority {
         let token = mint_identity_secret()?;
         let token_digest = identity_token_digest(&token);
         cancellation_safe(async move {
+            let _writer = store.daemon_write_guard().await;
             let database = store.sqlite_database();
             let mut connection = database.connect().await.map_err(storage_error)?;
             let transaction = connection
@@ -735,6 +794,7 @@ impl IdentityAuthority for SqliteIdentityAuthority {
         let revoked_by = revoked_by.clone();
         let credential_id = credential_id.to_string();
         cancellation_safe(async move {
+            let _writer = store.daemon_write_guard().await;
             let database = store.sqlite_database();
             let mut connection = database.connect().await.map_err(storage_error)?;
             let transaction = connection
@@ -890,6 +950,7 @@ impl IdentityAuthority for SqliteIdentityAuthority {
         let store = self.store.clone();
         let session = session.clone();
         cancellation_safe(async move {
+            let _writer = store.daemon_write_guard().await;
             let database = store.sqlite_database();
             let mut connection = database.connect().await.map_err(storage_error)?;
             let transaction = connection
@@ -929,6 +990,7 @@ impl IdentityAuthority for SqliteIdentityAuthority {
         let store = self.store.clone();
         let session_id = session_id.to_string();
         cancellation_safe(async move {
+            let _writer = store.daemon_write_guard().await;
             let database = store.sqlite_database();
             let mut connection = database.connect().await.map_err(storage_error)?;
             let transaction = connection
@@ -978,6 +1040,7 @@ impl IdentityAuthority for SqliteIdentityAuthority {
             authority_error(format!("failed to encode auth rejection: {error}"))
         })?;
         cancellation_safe(async move {
+            let _writer = store.daemon_write_guard().await;
             let database = store.sqlite_database();
             let mut connection = database.connect().await.map_err(storage_error)?;
             let transaction = connection
@@ -1004,6 +1067,63 @@ impl IdentityAuthority for SqliteIdentityAuthority {
                 .await
                 .map_err(storage_error)?;
             transaction.commit().await.map_err(storage_error)?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn witness_host_effect(&self, effect: &IdentityHostEffectV1) -> CooldisResult<()> {
+        if effect.schema != IDENTITY_HOST_EFFECT_SCHEMA_V1 {
+            return Err(authority_error(
+                "identity host effect schema id is not supported",
+            ));
+        }
+        if effect.session_id.trim().is_empty() || effect.method.trim().is_empty() {
+            return Err(authority_error(
+                "identity host effect requires a session id and method",
+            ));
+        }
+        let store = self.store.clone();
+        let effect = effect.clone();
+        cancellation_safe(async move {
+            let _writer = store.daemon_write_guard().await;
+            let database = store.sqlite_database();
+            let connection = database.connect().await.map_err(storage_error)?;
+            let inserted = connection
+                .execute(
+                    "INSERT INTO cooldis_identity_host_effects (
+                        schema, session_id, principal_id, method, witnessed_at_ms
+                     )
+                     SELECT ?1, ?2, ?3, ?4, ?5
+                     WHERE EXISTS (
+                         SELECT 1
+                         FROM cooldis_identity_sessions
+                         WHERE session_id = ?2
+                           AND principal_id = ?3
+                           AND closed_at_ms IS NULL
+                           AND NOT EXISTS (
+                               SELECT 1
+                               FROM cooldis_identity_sessions AS closed
+                               WHERE closed.session_id = ?2
+                                 AND closed.principal_id = ?3
+                                 AND closed.closed_at_ms IS NOT NULL
+                           )
+                     )",
+                    params![
+                        effect.schema,
+                        effect.session_id,
+                        effect.principal_id.as_str(),
+                        effect.method,
+                        effect.witnessed_at_ms,
+                    ],
+                )
+                .await
+                .map_err(storage_error)?;
+            if inserted != 1 {
+                return Err(authority_error(
+                    "identity host effect references an unwitnessed session or principal",
+                ));
+            }
             Ok(())
         })
         .await
@@ -1295,14 +1415,22 @@ mod tests {
     }
 
     #[test]
-    fn host_list_precedence_beats_interactive_prefix() {
+    fn explicit_overrides_beat_interactive_prefixes() {
         assert_eq!(
             authority_class_for_method("thread/shellCommand"),
             AuthorityClass::Host
         );
         assert_eq!(
             authority_class_for_method("thread/start"),
+            AuthorityClass::Host
+        );
+        assert_eq!(
+            authority_class_for_method("thread/submit"),
             AuthorityClass::Interactive
+        );
+        assert_eq!(
+            authority_class_for_method("turn/start"),
+            AuthorityClass::Ingress
         );
     }
 
@@ -1879,6 +2007,28 @@ mod tests {
         };
         authority.witness_session_opened(&session).await.unwrap();
         authority
+            .witness_host_effect(&IdentityHostEffectV1 {
+                schema: IDENTITY_HOST_EFFECT_SCHEMA_V1.to_string(),
+                session_id: "session-1".to_string(),
+                principal_id: operator.clone(),
+                method: "command/exec".to_string(),
+                witnessed_at_ms: 1_500,
+            })
+            .await
+            .unwrap();
+        assert!(
+            authority
+                .witness_host_effect(&IdentityHostEffectV1 {
+                    schema: IDENTITY_HOST_EFFECT_SCHEMA_V1.to_string(),
+                    session_id: "session-never-opened".to_string(),
+                    principal_id: operator.clone(),
+                    method: "fs/writeFile".to_string(),
+                    witnessed_at_ms: 1_600,
+                })
+                .await
+                .is_err()
+        );
+        authority
             .witness_session_closed("session-1", 2_000)
             .await
             .unwrap();
@@ -1907,6 +2057,17 @@ mod tests {
         assert_eq!(row.get::<i64>(1).unwrap(), 2_000);
         let mut rows = connection
             .query("SELECT COUNT(*) FROM cooldis_identity_auth_rejections", ())
+            .await
+            .unwrap();
+        assert_eq!(
+            rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap(),
+            1
+        );
+        let mut rows = connection
+            .query(
+                "SELECT COUNT(*) FROM cooldis_identity_host_effects WHERE session_id = ?1 AND principal_id = ?2 AND method = ?3 AND witnessed_at_ms = ?4",
+                params!["session-1", operator.as_str(), "command/exec", 1_500],
+            )
             .await
             .unwrap();
         assert_eq!(

--- a/crates/cooldis-kernel/tests/boundary_auth.rs
+++ b/crates/cooldis-kernel/tests/boundary_auth.rs
@@ -4,21 +4,222 @@ use cooldis::daemon::identity::{
 };
 use cooldis::{
     AppServerListenAddr, CodexTuiConnectConfig, CodexTuiTestClient, ConsoleAssetConfig,
-    CooldisAppServer, CooldisAppServerConfig, SqliteSessionStore, SystemDaemonClock,
+    CooldisAppServer, CooldisAppServerConfig, JsonRpcErrorError, JsonRpcMessage,
+    JsonRpcNotification, JsonRpcRequest, RequestId, SqliteSessionStore, SystemDaemonClock,
 };
 use cooldis_sqlite::params;
-use futures_util::SinkExt;
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::WebSocketStream;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::http::HeaderValue;
-use tokio_tungstenite::tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL;
+use tokio_tungstenite::tungstenite::http::header::{AUTHORIZATION, SEC_WEBSOCKET_PROTOCOL};
 
 const OPERATOR_ID: &str = "operator:root";
+const ADAPTER_ID: &str = "adapter:rpc";
+const METHOD_NOT_AUTHORIZED_CODE: i64 = -32003;
+
+#[tokio::test]
+async fn dispatcher_authorizes_at_the_rpc_choke_point_and_witnesses_decisions() {
+    let root = test_root("dispatcher-authorization");
+    std::fs::create_dir_all(root.join("workspace")).unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let listen = AppServerListenAddr::WebSocket(addr);
+    let mut config = app_config(&root, listen);
+    let authority = identity_authority(&config).await;
+    let operator = PrincipalId::new(OPERATOR_ID);
+    let (_, _, operator_token) = authority
+        .bootstrap_operator(&operator, "Root operator")
+        .await
+        .unwrap();
+    let adapter = PrincipalId::new(ADAPTER_ID);
+    authority
+        .declare_principal(&operator, &adapter, PrincipalKind::Adapter, "RPC adapter")
+        .await
+        .unwrap();
+    let (_, adapter_token) = authority
+        .mint_credential(&operator, &adapter, None)
+        .await
+        .unwrap();
+    drop(authority);
+
+    config.apply_daemon_identity_config(&CooldisDaemonIdentityConfig {
+        mode: IdentityMode::Managed,
+        tenant_id: Some("test-tenant".to_string()),
+        console_principal: Some(operator),
+    });
+    let app = CooldisAppServer::new(config).await.unwrap();
+    let store_path = app.session_store_path().to_path_buf();
+    let server = app.clone();
+    let server_task = tokio::spawn(async move { server.serve_websocket_listener(listener).await });
+
+    let mut operator_rpc = connect_rpc(addr, &operator_token).await;
+    let thread = rpc_call(
+        &mut operator_rpc,
+        RequestId::Integer(2),
+        "thread/start",
+        json!({}),
+    )
+    .await
+    .unwrap();
+    let thread_id = thread["thread"]["id"].as_str().unwrap().to_string();
+    let command = rpc_call(
+        &mut operator_rpc,
+        RequestId::Integer(3),
+        "command/exec",
+        json!({ "command": ["/bin/sh", "-c", "printf operator"] }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(command["stdout"], "operator");
+    rpc_call(
+        &mut operator_rpc,
+        RequestId::Integer(4),
+        "turn/start",
+        json!({
+            "threadId": thread_id,
+            "input": [{ "type": "text", "text": "operator ingress", "text_elements": [] }],
+        }),
+    )
+    .await
+    .unwrap();
+
+    let mut adapter_rpc = connect_rpc(addr, &adapter_token).await;
+    let denied_command = rpc_call(
+        &mut adapter_rpc,
+        RequestId::Integer(2),
+        "command/exec",
+        json!({ "command": ["/bin/sh", "-c", "printf adapter"] }),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(denied_command.code, METHOD_NOT_AUTHORIZED_CODE);
+    assert!(!denied_command.message.contains("command/exec"));
+
+    let denied_unknown = rpc_call(
+        &mut adapter_rpc,
+        RequestId::Integer(3),
+        "future/host-method",
+        json!({}),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(denied_unknown.code, denied_command.code);
+    assert_eq!(denied_unknown.message, denied_command.message);
+
+    let denied_interactive = rpc_call(
+        &mut adapter_rpc,
+        RequestId::Integer(4),
+        "thread/list",
+        json!({}),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(denied_interactive.code, METHOD_NOT_AUTHORIZED_CODE);
+
+    rpc_call(
+        &mut adapter_rpc,
+        RequestId::Integer(5),
+        "turn/start",
+        json!({
+            "threadId": thread_id,
+            "input": [{ "type": "text", "text": "adapter ingress", "text_elements": [] }],
+        }),
+    )
+    .await
+    .unwrap();
+
+    let ingress_events = rpc_call(
+        &mut operator_rpc,
+        RequestId::Integer(5),
+        "thread/events/list",
+        json!({
+            "threadId": thread_id,
+            "stream": "control",
+            "kinds": ["io.ingress.received"],
+        }),
+    )
+    .await
+    .unwrap();
+    let adapter_ingress = ingress_events["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|event| event["payload"]["principal"]["principal_id"] == ADAPTER_ID)
+        .expect("adapter ingress principal witness");
+    let via = adapter_ingress["payload"]["principal"]["via"]
+        .as_str()
+        .unwrap();
+    let adapter_session_id = via.strip_prefix("caller:").expect("caller attribution");
+    assert_eq!(
+        sql_count(
+            &store_path,
+            "SELECT COUNT(*) FROM cooldis_identity_sessions WHERE session_id = ?1 AND principal_id = ?2 AND closed_at_ms IS NULL",
+            params![adapter_session_id, ADAPTER_ID],
+        )
+        .await,
+        1
+    );
+    assert_eq!(
+        sql_count(
+            &store_path,
+            "SELECT COUNT(*) FROM cooldis_identity_auth_rejections WHERE principal_id = ?1 AND reason_json LIKE '%method_not_authorized%'",
+            params![ADAPTER_ID],
+        )
+        .await,
+        3
+    );
+    assert_eq!(
+        sql_count(
+            &store_path,
+            "SELECT COUNT(*) FROM cooldis_identity_host_effects WHERE principal_id = ?1 AND method = 'command/exec' AND witnessed_at_ms > 0",
+            params![OPERATOR_ID],
+        )
+        .await,
+        1
+    );
+    assert_eq!(
+        sql_count(
+            &store_path,
+            "SELECT COUNT(*) FROM cooldis_identity_host_effects WHERE principal_id = ?1",
+            params![ADAPTER_ID],
+        )
+        .await,
+        0
+    );
+
+    let marker = root.join("unwitnessed-command-ran");
+    execute_sql(&store_path, "DROP TABLE cooldis_identity_host_effects").await;
+    let witness_failure = rpc_call(
+        &mut operator_rpc,
+        RequestId::Integer(6),
+        "command/exec",
+        json!({
+            "command": ["/usr/bin/touch", marker.to_string_lossy()],
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(witness_failure.code, -32000);
+    assert!(
+        !marker.exists(),
+        "host effect ran without a durable witness"
+    );
+
+    operator_rpc.close(None).await.unwrap();
+    adapter_rpc.close(None).await.unwrap();
+    server_task.abort();
+    let _ = server_task.await;
+    drop(app);
+    let _ = std::fs::remove_dir_all(root);
+}
 
 #[tokio::test]
 async fn tcp_boundary_authenticates_before_upgrade_and_witnesses_sessions() {
@@ -611,6 +812,83 @@ async fn identity_authority(config: &CooldisAppServerConfig) -> SqliteIdentityAu
         .unwrap()
 }
 
+async fn connect_rpc(addr: std::net::SocketAddr, token: &str) -> WebSocketStream<TcpStream> {
+    let mut request = format!("ws://{addr}/rpc").into_client_request().unwrap();
+    request.headers_mut().insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+    );
+    let stream = TcpStream::connect(addr).await.unwrap();
+    let (mut websocket, _) = tokio_tungstenite::client_async(request, stream)
+        .await
+        .unwrap();
+    rpc_call(
+        &mut websocket,
+        RequestId::String("initialize".to_string()),
+        "initialize",
+        json!({
+            "clientInfo": {
+                "name": "boundary-auth-test",
+                "title": null,
+                "version": "0",
+            },
+            "capabilities": {
+                "experimentalApi": false,
+                "requestAttestation": false,
+            },
+        }),
+    )
+    .await
+    .unwrap();
+    websocket
+        .send(Message::Text(
+            serde_json::to_string(&JsonRpcMessage::Notification(JsonRpcNotification {
+                method: "initialized".to_string(),
+                params: None,
+            }))
+            .unwrap()
+            .into(),
+        ))
+        .await
+        .unwrap();
+    websocket
+}
+
+async fn rpc_call(
+    websocket: &mut WebSocketStream<TcpStream>,
+    id: RequestId,
+    method: &str,
+    params: Value,
+) -> Result<Value, JsonRpcErrorError> {
+    websocket
+        .send(Message::Text(
+            serde_json::to_string(&JsonRpcMessage::Request(JsonRpcRequest {
+                id: id.clone(),
+                method: method.to_string(),
+                params: Some(params),
+                trace: None,
+            }))
+            .unwrap()
+            .into(),
+        ))
+        .await
+        .unwrap();
+    loop {
+        let message = websocket.next().await.unwrap().unwrap();
+        let Message::Text(text) = message else {
+            continue;
+        };
+        match serde_json::from_str::<JsonRpcMessage>(&text).unwrap() {
+            JsonRpcMessage::Response(response) if response.id == id => return Ok(response.result),
+            JsonRpcMessage::Error(error) if error.id == id => return Err(error.error),
+            JsonRpcMessage::Request(_)
+            | JsonRpcMessage::Notification(_)
+            | JsonRpcMessage::Response(_)
+            | JsonRpcMessage::Error(_) => {}
+        }
+    }
+}
+
 fn websocket_request(addr: std::net::SocketAddr, path: &str, token: Option<&str>) -> String {
     let authorization = token
         .map(|token| format!("Authorization: Bearer {token}\r\n"))
@@ -760,6 +1038,13 @@ where
     let connection = database.connect().await.unwrap();
     let mut rows = connection.query(query, params).await.unwrap();
     rows.next().await.unwrap().unwrap().get(0).unwrap()
+}
+
+async fn execute_sql(path: &Path, statement: &str) {
+    let store = SqliteSessionStore::open(path).await.unwrap();
+    let database = store.sqlite_database();
+    let connection = database.connect().await.unwrap();
+    connection.execute_batch(statement).await.unwrap();
 }
 
 async fn active_credential_count(path: &Path, principal_id: &str) -> i64 {

--- a/crates/cooldis-kernel/tests/boundary_auth.rs
+++ b/crates/cooldis-kernel/tests/boundary_auth.rs
@@ -86,6 +86,7 @@ async fn dispatcher_authorizes_at_the_rpc_choke_point_and_witnesses_decisions() 
         json!({
             "threadId": thread_id,
             "input": [{ "type": "text", "text": "operator ingress", "text_elements": [] }],
+            "cwd": root.join("workspace"),
         }),
     )
     .await
@@ -124,9 +125,37 @@ async fn dispatcher_authorizes_at_the_rpc_choke_point_and_witnesses_decisions() 
     .unwrap_err();
     assert_eq!(denied_interactive.code, METHOD_NOT_AUTHORIZED_CODE);
 
+    for (id, method) in [
+        (5, "Command/exec"),
+        (6, "command/exec "),
+        (7, " command/exec"),
+    ] {
+        let denied_variant = rpc_call(&mut adapter_rpc, RequestId::Integer(id), method, json!({}))
+            .await
+            .unwrap_err();
+        assert_eq!(denied_variant.code, denied_command.code);
+        assert_eq!(denied_variant.message, denied_command.message);
+    }
+
+    let sensitive_cwd = root.join("adapter-secret-cwd");
+    let denied_override = rpc_call(
+        &mut adapter_rpc,
+        RequestId::Integer(8),
+        "turn/start",
+        json!({
+            "threadId": thread_id,
+            "input": [{ "type": "text", "text": "adapter override", "text_elements": [] }],
+            "cwd": sensitive_cwd,
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(denied_override.code, -32602);
+    assert!(!denied_override.message.contains("adapter-secret-cwd"));
+
     rpc_call(
         &mut adapter_rpc,
-        RequestId::Integer(5),
+        RequestId::Integer(9),
         "turn/start",
         json!({
             "threadId": thread_id,
@@ -174,7 +203,7 @@ async fn dispatcher_authorizes_at_the_rpc_choke_point_and_witnesses_decisions() 
             params![ADAPTER_ID],
         )
         .await,
-        3
+        6
     );
     assert_eq!(
         sql_count(


### PR DESCRIPTION
Adds the per-method authorization gate at the top of the RPC dispatcher, per ADR 0008 D4/D6.

- All 77 dispatch arms classified into an explicit authority-class table (Host / Interactive / Ingress), reconciled against authority_class_for_method with an exhaustive drift test plus a debug assertion that compiles out in release. Unknown methods fail closed to Host.
- Distinct refusal code -32003 with a fixed generic message; denied known methods, denied unknown methods, and casing variants are byte-identical (no method-existence oracle). Refusals witnessed with principal and surface.
- Host-authority effects (command exec, fs mutations, provider/secret access, runtime construction, approval release) write a durable witness row naming session, principal, method, and timestamp before the effect runs; a failed witness write blocks the effect. Rows require an open witnessed session for the same principal.
- turn/start is the sole Ingress arm: adapters can deliver input and nothing else. Lazy thread reconstruction replays the standing operator grant, and ingress-only principals are barred from the cwd/model/thinking turn controls (-32602, values never echoed).
- Authenticated RPC ingress is stamped via="caller:{session_id}" tied to the witnessed session, carried as a forward-compatible principal property on io.ingress.received/1 and included in the canonical digest.
- Local in-process dispatch now opens and closes a witnessed session per call; a transient close-write failure re-arms one idempotent Drop retry.
- Identity witnessing shares the session store's fair SQLite writer lane, removing the lock convoy under concurrent thread starts (200-request contention regression stress-run three consecutive times).

Two-pass reviewed: implementation thread plus an independent adversarial review thread; both Codex Reports and the architect dispositions are on the Linear issue.

Linear: https://linear.app/emotionscientific/issue/EMO-498