### PR TITLE
chore: ignore local .wt worktree container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ crates/cooldis-kernel/src/bin/cooldis-wafer-glm-host-author-smoke.rs
 
 # Upstream Codex test fixtures can be too large for this repo's commit hooks.
 vendor/codex/codex-rs/tui/tests/fixtures/oss-story.jsonl
+
+# Local worktrees and their shared caches live under .wt; never commit them.
+.wt/


### PR DESCRIPTION
Local worktrees and their shared build caches live under .wt/ and must never be committed. Without this line a broad git add can sweep the cache in (a staged-file incident during EMO-500 pulled in over 100k cache files before the commit hooks refused it). One line, no code changes.