### PR TITLE
EMO-504: de-flake test timeout bounds, add test-timeout lint

### DIFF
--- a/crates/cooldis-io-pgqrs/src/lib.rs
+++ b/crates/cooldis-io-pgqrs/src/lib.rs
@@ -19,6 +19,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 const INGRESS_PAYLOAD_KIND: &str = "cooldis.ingress.v1";
 const DEFAULT_QUEUE_NAME: &str = "cooldis-ingress";
 const INGRESS_QUEUE_MAX_OBJECT_DEPTH: usize = 16;
+const SQLITE_BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PgqrsQueueConfig {
@@ -166,7 +167,7 @@ impl PgqrsIngressQueue {
         let connection = rusqlite::Connection::open(path)
             .map_err(|err| IoError::Queue(format!("open sqlite dedupe store: {err}")))?;
         connection
-            .busy_timeout(std::time::Duration::from_secs(5))
+            .busy_timeout(SQLITE_BUSY_TIMEOUT)
             .map_err(|err| IoError::Queue(format!("configure sqlite dedupe store: {err}")))?;
         ensure_sqlite_dedupe_schema(&connection)?;
         let inserted = connection

--- a/crates/cooldis-kernel/src/adapters/acp_agent.rs
+++ b/crates/cooldis-kernel/src/adapters/acp_agent.rs
@@ -2226,7 +2226,7 @@ mod tests {
     where
         R: tokio::io::AsyncRead + Unpin,
     {
-        let deadline = tokio::time::sleep(Duration::from_secs(2));
+        let deadline = tokio::time::sleep(Duration::from_secs(30));
         tokio::pin!(deadline);
         tokio::select! {
             _ = &mut deadline => panic!("timed out waiting for JSON-RPC message"),
@@ -2241,7 +2241,7 @@ mod tests {
     where
         R: tokio::io::AsyncRead + Unpin,
     {
-        let deadline = tokio::time::sleep(Duration::from_secs(2));
+        let deadline = tokio::time::sleep(Duration::from_secs(30));
         tokio::pin!(deadline);
         loop {
             tokio::select! {
@@ -2316,7 +2316,7 @@ mod tests {
 
     impl PendingProviderClient {
         async fn wait_for_request(&self) {
-            let deadline = tokio::time::sleep(Duration::from_secs(2));
+            let deadline = tokio::time::sleep(Duration::from_secs(30));
             tokio::pin!(deadline);
             tokio::select! {
                 _ = &mut deadline => panic!("timed out waiting for pending provider request"),

--- a/crates/cooldis-kernel/src/adapters/acp_agent.rs
+++ b/crates/cooldis-kernel/src/adapters/acp_agent.rs
@@ -2291,7 +2291,7 @@ mod tests {
     }
 
     async fn wait_for_socket(path: &Path) {
-        for _ in 0..500 {
+        for _ in 0..1_500 {
             if path.exists() {
                 return;
             }

--- a/crates/cooldis-kernel/src/adapters/agent_loop/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/agent_loop/tests.rs
@@ -3582,7 +3582,7 @@ async fn cancellation_waits_for_buffered_call_order_commit_to_finish() {
     )
     .await
     .unwrap();
-    timeout(Duration::from_secs(2), pause.wait_until_entered())
+    timeout(Duration::from_secs(30), pause.wait_until_entered())
         .await
         .expect("first completion append did not reach the pause");
 
@@ -3593,6 +3593,7 @@ async fn cancellation_waits_for_buffered_call_order_commit_to_finish() {
     .await
     .unwrap();
     assert!(
+        // tight-timeout: cancellation must remain absent until the buffered commit is released
         timeout(Duration::from_millis(100), async {
             loop {
                 if let ThreadEvent::Cancelled { .. } = events.recv().await.unwrap() {
@@ -3660,7 +3661,7 @@ async fn cancellation_racing_suspended_turn_commit_observes_the_full_boundary() 
     host.submit(thread.context().coordinates.thread_id, "turn-1", "wait")
         .await
         .unwrap();
-    timeout(Duration::from_secs(2), pause.wait_until_entered())
+    timeout(Duration::from_secs(30), pause.wait_until_entered())
         .await
         .expect("turn.waiting append did not reach the pause");
     host.cancel(
@@ -3670,6 +3671,7 @@ async fn cancellation_racing_suspended_turn_commit_observes_the_full_boundary() 
     .await
     .unwrap();
     assert!(
+        // tight-timeout: cancellation must remain absent until the suspended commit is released
         timeout(Duration::from_millis(100), async {
             loop {
                 if let ThreadEvent::Cancelled { .. } = events.recv().await.unwrap() {
@@ -3766,7 +3768,7 @@ async fn cancellation_during_atomic_request_append_leaves_all_or_no_batch_witnes
     )
     .await
     .unwrap();
-    timeout(Duration::from_secs(2), pause.wait_until_entered())
+    timeout(Duration::from_secs(30), pause.wait_until_entered())
         .await
         .expect("request batch append did not reach the pause");
     host.cancel(
@@ -3856,7 +3858,7 @@ async fn conflicting_thread_holds_serialize_in_model_call_order() {
     .await
     .unwrap();
     assert_eq!(
-        timeout(Duration::from_secs(2), started_rx.recv())
+        timeout(Duration::from_secs(30), started_rx.recv())
             .await
             .unwrap()
             .unwrap(),
@@ -3865,7 +3867,7 @@ async fn conflicting_thread_holds_serialize_in_model_call_order() {
     assert!(started_rx.try_recv().is_err());
     tool_provider.release_first.notify_one();
     assert_eq!(
-        timeout(Duration::from_secs(2), started_rx.recv())
+        timeout(Duration::from_secs(30), started_rx.recv())
             .await
             .unwrap()
             .unwrap(),
@@ -3924,7 +3926,7 @@ async fn bash_family_holds_prevent_interleaving_before_the_harness_mutex() {
     .await
     .unwrap();
     assert_eq!(
-        timeout(Duration::from_secs(2), started_rx.recv())
+        timeout(Duration::from_secs(30), started_rx.recv())
             .await
             .unwrap()
             .unwrap(),
@@ -3933,7 +3935,7 @@ async fn bash_family_holds_prevent_interleaving_before_the_harness_mutex() {
     assert!(started_rx.try_recv().is_err());
     tool_provider.release_first.notify_one();
     assert_eq!(
-        timeout(Duration::from_secs(2), started_rx.recv())
+        timeout(Duration::from_secs(30), started_rx.recv())
             .await
             .unwrap()
             .unwrap(),
@@ -4626,7 +4628,7 @@ async fn monitor_panic_after_settlement_recovers_one_completion() {
     )
     .await
     .unwrap();
-    timeout(Duration::from_secs(2), started_rx.recv())
+    timeout(Duration::from_secs(30), started_rx.recv())
         .await
         .unwrap()
         .unwrap();
@@ -4637,7 +4639,7 @@ async fn monitor_panic_after_settlement_recovers_one_completion() {
     )
     .await
     .unwrap();
-    timeout(Duration::from_secs(2), acknowledged_rx.recv())
+    timeout(Duration::from_secs(30), acknowledged_rx.recv())
         .await
         .unwrap()
         .unwrap();
@@ -6863,7 +6865,7 @@ async fn wait_for_thread_event(
     coordinates: &ThreadCoordinates,
     kind: EventKind,
 ) {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     loop {
         let mut records = store
             .read_events(&EventStreamId::for_thread(coordinates), None)
@@ -6895,7 +6897,7 @@ async fn wait_for_tool_call_completion(
     turn_id: &str,
     call_id: &str,
 ) {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     loop {
         let records = store
             .read_events(&EventStreamId::for_thread(coordinates), None)
@@ -6922,7 +6924,7 @@ async fn wait_for_control_event<S: EventStore + ?Sized>(
     kind: EventKind,
 ) -> crate::EventRecord {
     let stream_id = EventStreamId::new(format!("control:{}", coordinates.thread_id));
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     loop {
         let records = store.read_events(&stream_id, None).await.unwrap();
         if let Some(record) = records.into_iter().find(|event| event.kind == kind) {
@@ -6940,7 +6942,7 @@ async fn wait_for_status(
     status: &mut tokio::sync::watch::Receiver<crate::ThreadStatus>,
     expected: crate::ThreadStatus,
 ) {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     loop {
         if *status.borrow() == expected {
             return;
@@ -6949,7 +6951,7 @@ async fn wait_for_status(
             tokio::time::Instant::now() < deadline,
             "timed out waiting for status {expected:?}"
         );
-        timeout(Duration::from_millis(50), status.changed())
+        timeout(Duration::from_secs(30), status.changed())
             .await
             .ok();
     }
@@ -7569,7 +7571,7 @@ fn temp_db_path(prefix: &str) -> PathBuf {
 
 async fn assert_output(events: &mut broadcast::Receiver<ThreadEvent>, expected: &str) {
     loop {
-        let event = timeout(Duration::from_secs(2), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");
@@ -7582,7 +7584,7 @@ async fn assert_output(events: &mut broadcast::Receiver<ThreadEvent>, expected: 
 
 async fn assert_stopped(events: &mut broadcast::Receiver<ThreadEvent>) {
     loop {
-        let event = timeout(Duration::from_secs(2), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");
@@ -7600,7 +7602,7 @@ async fn assert_output_with_runtime_events(
 ) -> Vec<RuntimeEventKind> {
     let mut runtime_events = Vec::new();
     loop {
-        let event = timeout(Duration::from_secs(2), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");
@@ -7618,7 +7620,7 @@ async fn assert_output_with_runtime_events(
 
 async fn assert_completed_terminal(events: &mut broadcast::Receiver<ThreadEvent>) {
     loop {
-        let event = timeout(Duration::from_secs(2), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");
@@ -7665,7 +7667,7 @@ async fn assert_failed_with_runtime_events(
 ) -> Vec<RuntimeEventKind> {
     let mut runtime_events = Vec::new();
     loop {
-        let event = timeout(Duration::from_secs(2), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");
@@ -7689,7 +7691,7 @@ async fn assert_compaction(
     expected_summary: &str,
 ) {
     loop {
-        let event = timeout(Duration::from_secs(2), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");
@@ -7714,7 +7716,7 @@ async fn assert_compaction(
 
 async fn assert_user_mirror(events: &mut broadcast::Receiver<ThreadEvent>, expected: &str) {
     loop {
-        let event = timeout(Duration::from_secs(2), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");
@@ -7740,7 +7742,7 @@ async fn assert_assistant_mirror(
     events: &mut broadcast::Receiver<ThreadEvent>,
 ) -> CanonicalMessage {
     loop {
-        let event = timeout(Duration::from_secs(2), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");
@@ -7759,7 +7761,7 @@ async fn assert_assistant_with_runtime_events(
 ) -> (CanonicalMessage, Vec<RuntimeEventKind>) {
     let mut runtime_events = Vec::new();
     loop {
-        let event = timeout(Duration::from_secs(2), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");
@@ -7780,7 +7782,7 @@ async fn assert_assistant_with_runtime_events(
 
 async fn assert_cancelled(events: &mut broadcast::Receiver<ThreadEvent>, expected: &str) {
     loop {
-        let event = timeout(Duration::from_secs(2), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");
@@ -7825,7 +7827,7 @@ async fn assert_signal(
     expected: crate::ThreadSignalKind,
 ) -> crate::ThreadSignal {
     loop {
-        let event = timeout(Duration::from_secs(2), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");

--- a/crates/cooldis-kernel/src/adapters/app_server/subscriptions.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/subscriptions.rs
@@ -3,6 +3,9 @@ use super::threads::*;
 use super::*;
 use crate::{EventKind, EventRecord, ToolCallCompletedPayload};
 
+const INITIAL_THREAD_STATUS_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+const FAILED_THREAD_EVENT_GRACE: std::time::Duration = std::time::Duration::from_millis(20);
+
 #[derive(Default)]
 pub(super) struct AppServerSubscriptions {
     pub(super) next_subscriber_id: u64,
@@ -787,7 +790,7 @@ pub(super) async fn wait_for_initial_thread_status(handle: &RuntimeThreadHandle)
         return;
     }
     let mut status = handle.subscribe_status();
-    let _ = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+    let _ = tokio::time::timeout(INITIAL_THREAD_STATUS_WAIT_TIMEOUT, async {
         loop {
             if *status.borrow() != ThreadStatus::Starting {
                 return;
@@ -865,9 +868,7 @@ pub(super) async fn handle_failed_thread_status(
     if !app.thread_has_active_turn(thread_id).await {
         return;
     }
-    if let Ok(Ok(event)) =
-        tokio::time::timeout(std::time::Duration::from_millis(20), events.recv()).await
-    {
+    if let Ok(Ok(event)) = tokio::time::timeout(FAILED_THREAD_EVENT_GRACE, events.recv()).await {
         handle_thread_event(app, thread_id, event).await;
     }
     while let Ok(event) = events.try_recv() {

--- a/crates/cooldis-kernel/src/adapters/app_server/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/tests.rs
@@ -9659,7 +9659,7 @@ async fn lag_resync_does_not_apply_stale_idle_to_a_new_running_turn() {
         .unwrap();
     let second_turn_id = second["turn"]["id"].as_str().unwrap().to_string();
     tokio::time::timeout(
-        std::time::Duration::from_secs(3),
+        std::time::Duration::from_secs(30),
         client.wait_for_second_request(),
     )
     .await
@@ -13422,7 +13422,7 @@ async fn wait_for_provider_requests<T>(client: &Arc<T>, count: usize)
 where
     T: ProviderRequestRecorder + ?Sized,
 {
-    for _ in 0..100 {
+    for _ in 0..1_500 {
         if client.recorded_request_count() >= count {
             return;
         }
@@ -13439,7 +13439,7 @@ async fn wait_for_lifecycle_status(
     thread_id: ThreadId,
     status: crate::ThreadLifecycleStatus,
 ) -> ThreadLifecycleRecord {
-    for _ in 0..100 {
+    for _ in 0..1_500 {
         if let Some(record) = store.get_thread_lifecycle(thread_id).await.unwrap()
             && record.status == status
         {
@@ -13452,7 +13452,7 @@ async fn wait_for_lifecycle_status(
 
 async fn wait_for_session_text(app: &CooldisAppServer, thread_id: &str, expected: &str) {
     let parsed = ThreadId::parse_str(thread_id).unwrap();
-    for _ in 0..100 {
+    for _ in 0..1_500 {
         if let Ok(handle) = app
             .inner
             .supervisor
@@ -13824,7 +13824,7 @@ async fn wait_for_assistant_texts(
     expected_count: usize,
 ) -> Vec<String> {
     let parsed = ThreadId::parse_str(thread_id).unwrap();
-    for _ in 0..100 {
+    for _ in 0..1_500 {
         if let Ok(handle) = app
             .inner
             .supervisor
@@ -13929,7 +13929,7 @@ async fn connect_tui_test_client(
     client_name: &str,
 ) -> crate::CodexTuiTestClient<tokio::net::UnixStream> {
     let mut last_error = None;
-    for _ in 0..100 {
+    for _ in 0..1_500 {
         match crate::CodexTuiTestClient::connect_unix(
             socket,
             crate::CodexTuiConnectConfig {
@@ -13958,7 +13958,7 @@ async fn connect_ws_tui_test_client(
     token: &str,
 ) -> crate::CodexTuiTestClient<tokio::net::TcpStream> {
     let mut last_error = None;
-    for _ in 0..100 {
+    for _ in 0..1_500 {
         match crate::CodexTuiTestClient::connect_websocket(
             url,
             crate::CodexTuiConnectConfig {
@@ -14022,7 +14022,7 @@ async fn get_tcp_raw_response(addr: std::net::SocketAddr, request: &str) -> Stri
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     let mut last_error = None;
-    for _ in 0..100 {
+    for _ in 0..1_500 {
         match TcpStream::connect(addr).await {
             Ok(mut stream) => {
                 stream.write_all(request.as_bytes()).await.unwrap();

--- a/crates/cooldis-kernel/src/adapters/app_server/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/app_server/tests.rs
@@ -4864,7 +4864,7 @@ async fn cancelled_manifest_lifecycle_caller_cannot_split_receipt_from_metadata(
     assert!(caller.await.unwrap_err().is_cancelled());
     release.notify_one();
 
-    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+    tokio::time::timeout(std::time::Duration::from_secs(30), async {
         loop {
             let has_receipt = observer
                 .read_thread_events(None)
@@ -4998,11 +4998,11 @@ streaming = false
             )
             .await
     });
-    tokio::time::timeout(std::time::Duration::from_secs(2), started.notified())
+    tokio::time::timeout(std::time::Duration::from_secs(30), started.notified())
         .await
         .expect("workspace runtime did not start");
 
-    let coordinates = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+    let coordinates = tokio::time::timeout(std::time::Duration::from_secs(30), async {
         loop {
             let snapshot = app.inner.supervisor.lifecycle_snapshot().await;
             if let Some(record) = snapshot
@@ -5028,7 +5028,7 @@ streaming = false
         .get_thread_at(&coordinates)
         .await
         .unwrap();
-    tokio::time::timeout(std::time::Duration::from_millis(500), async {
+    tokio::time::timeout(std::time::Duration::from_secs(30), async {
         loop {
             if handle
                 .read_thread_events(None)
@@ -5054,7 +5054,7 @@ streaming = false
 
     caller.abort();
     assert!(caller.await.unwrap_err().is_cancelled());
-    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+    tokio::time::timeout(std::time::Duration::from_secs(30), async {
         loop {
             if app
                 .inner
@@ -9422,7 +9422,7 @@ async fn lagged_thread_stream_resnapshots_from_durable_truth() {
     let turn_id = turn["turn"]["id"].as_str().unwrap().to_string();
 
     let (saw_resync_started, resynced) =
-        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        tokio::time::timeout(std::time::Duration::from_secs(30), async {
             let mut saw_resync_started = false;
             loop {
                 let message = outbound_rx
@@ -9521,7 +9521,7 @@ async fn lag_resync_degrades_when_turn_submission_has_no_entry_id() {
         "missing entry_id should degrade the lag resync instead of failing it",
     );
 
-    let resynced = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+    let resynced = tokio::time::timeout(std::time::Duration::from_secs(30), async {
         loop {
             let message = outbound_rx
                 .recv()
@@ -9578,7 +9578,7 @@ async fn lagged_idle_thread_resynchronizes_without_another_status_change() {
     }
 
     let (saw_started, saw_resynced) =
-        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        tokio::time::timeout(std::time::Duration::from_secs(30), async {
             let mut saw_started = false;
             loop {
                 let message = outbound_rx
@@ -9639,9 +9639,12 @@ async fn lag_resync_does_not_apply_stale_idle_to_a_new_running_turn() {
     .await
     .unwrap();
 
-    tokio::time::timeout(std::time::Duration::from_secs(3), gate.wait_until_entered())
-        .await
-        .expect("watcher did not enter lag resynchronization");
+    tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        gate.wait_until_entered(),
+    )
+    .await
+    .expect("watcher did not enter lag resynchronization");
 
     let second = app
         .dispatch_request(
@@ -9667,7 +9670,7 @@ async fn lag_resync_does_not_apply_stale_idle_to_a_new_running_turn() {
     );
     gate.release();
 
-    let status_after_resync = tokio::time::timeout(std::time::Duration::from_secs(3), async {
+    let status_after_resync = tokio::time::timeout(std::time::Duration::from_secs(30), async {
         let mut saw_resynced = false;
         loop {
             let message = outbound_rx
@@ -10787,7 +10790,7 @@ async fn oversized_pre_upgrade_headers_fail_closed_with_one_witness() {
             .is_none()
     );
     let mut response = vec![0_u8; 256];
-    let len = tokio::time::timeout(Duration::from_secs(2), client.read(&mut response))
+    let len = tokio::time::timeout(Duration::from_secs(30), client.read(&mut response))
         .await
         .unwrap()
         .unwrap();
@@ -10811,7 +10814,7 @@ async fn identity_sql_count(path: &Path, query: &str) -> i64 {
 }
 
 async fn wait_for_identity_sql_count(path: &Path, query: &str, expected: i64) {
-    tokio::time::timeout(Duration::from_secs(5), async {
+    tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             if identity_sql_count(path, query).await >= expected {
                 return;
@@ -11091,7 +11094,7 @@ async fn command_exec_streaming_session_can_poll_write_and_terminate() {
         .runtime_store(&app.inner.tenant_id)
         .await
         .unwrap();
-    let delivered = tokio::time::timeout(std::time::Duration::from_secs(3), async {
+    let delivered = tokio::time::timeout(std::time::Duration::from_secs(30), async {
         loop {
             let context = store.build_context(&coordinates).await.unwrap();
             let text = context
@@ -11232,7 +11235,7 @@ async fn process_dispatch_retry_and_duplicate_terminal_deliver_once() {
         .runtime_store(&app.inner.tenant_id)
         .await
         .unwrap();
-    let (events, thread_events) = tokio::time::timeout(std::time::Duration::from_secs(3), async {
+    let (events, thread_events) = tokio::time::timeout(std::time::Duration::from_secs(30), async {
         loop {
             let events = store
                 .read_events(&crate::control_stream_id(&coordinates), None)
@@ -11459,7 +11462,7 @@ async fn thread_shell_command_emits_command_execution_item() {
     let mut saw_delta = false;
     let mut saw_completed = false;
     let mut observed = Vec::new();
-    let deadline = tokio::time::sleep(std::time::Duration::from_secs(2));
+    let deadline = tokio::time::sleep(std::time::Duration::from_secs(30));
     tokio::pin!(deadline);
     loop {
         tokio::select! {
@@ -11528,7 +11531,7 @@ async fn bridge_flow_uses_local_offline_provider() {
     let mut saw_delta = false;
     let mut saw_completed = false;
     let mut methods = Vec::new();
-    let deadline = tokio::time::sleep(std::time::Duration::from_secs(2));
+    let deadline = tokio::time::sleep(std::time::Duration::from_secs(30));
     tokio::pin!(deadline);
     loop {
         tokio::select! {
@@ -12549,7 +12552,7 @@ async fn wait_for_event_kind(
     thread_id: &str,
     kind: &str,
 ) -> Value {
-    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
     loop {
         let page = app
             .dispatch_request(
@@ -13472,7 +13475,7 @@ async fn wait_for_turn_completed_notification(
     thread_id: &str,
     turn_id: &str,
 ) -> Value {
-    let deadline = tokio::time::sleep(std::time::Duration::from_secs(5));
+    let deadline = tokio::time::sleep(std::time::Duration::from_secs(30));
     tokio::pin!(deadline);
     let mut observed = Vec::new();
     loop {
@@ -13514,7 +13517,7 @@ async fn wait_for_failed_turn_and_closed_thread(
     thread_id: &str,
     turn_id: &str,
 ) -> Value {
-    let deadline = tokio::time::sleep(std::time::Duration::from_secs(5));
+    let deadline = tokio::time::sleep(std::time::Duration::from_secs(30));
     tokio::pin!(deadline);
     let mut observed = Vec::new();
     let mut completed = None;
@@ -13578,7 +13581,7 @@ async fn collect_agent_deltas_until_turn_completed(
     thread_id: &str,
     turn_id: &str,
 ) -> (String, Value) {
-    let deadline = tokio::time::sleep(std::time::Duration::from_secs(5));
+    let deadline = tokio::time::sleep(std::time::Duration::from_secs(30));
     tokio::pin!(deadline);
     let mut observed = Vec::new();
     let mut deltas = String::new();
@@ -13641,7 +13644,7 @@ async fn collect_message_and_thinking_deltas_until_turn_completed(
     thread_id: &str,
     turn_id: &str,
 ) -> (String, String, Value) {
-    let deadline = tokio::time::sleep(std::time::Duration::from_secs(5));
+    let deadline = tokio::time::sleep(std::time::Duration::from_secs(30));
     tokio::pin!(deadline);
     let mut observed = Vec::new();
     let mut message_deltas = String::new();
@@ -13723,7 +13726,7 @@ async fn collect_delta_methods_until_turn_completed(
     thread_id: &str,
     turn_id: &str,
 ) -> Vec<String> {
-    let deadline = tokio::time::sleep(std::time::Duration::from_secs(5));
+    let deadline = tokio::time::sleep(std::time::Duration::from_secs(30));
     tokio::pin!(deadline);
     let mut observed = Vec::new();
     loop {
@@ -13781,6 +13784,7 @@ async fn assert_no_extra_turn_delta_or_completed(
     thread_id: &str,
     turn_id: &str,
 ) {
+    // tight-timeout: this is an absence window for duplicate turn notifications
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(50);
     while tokio::time::Instant::now() < deadline {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());

--- a/crates/cooldis-kernel/src/adapters/codex_tui/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/codex_tui/tests.rs
@@ -184,7 +184,7 @@ async fn codex_tui_operator_client_covers_thread_lifecycle_methods() {
 
 #[cfg(unix)]
 async fn wait_for_socket(path: &PathBuf) -> CooldisResult<()> {
-    for _ in 0..100 {
+    for _ in 0..1_500 {
         if path.exists() {
             return Ok(());
         }

--- a/crates/cooldis-kernel/src/adapters/mcp_server/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/mcp_server/tests.rs
@@ -625,7 +625,7 @@ where
 }
 
 async fn wait_for_socket(path: &std::path::Path) {
-    for _ in 0..100 {
+    for _ in 0..1_500 {
         if path.exists() {
             return;
         }

--- a/crates/cooldis-kernel/src/agent/agent_process/tests.rs
+++ b/crates/cooldis-kernel/src/agent/agent_process/tests.rs
@@ -177,7 +177,7 @@ async fn retried_thread_submit_dispatch_enqueues_one_turn() {
         .await
         .pop()
         .unwrap();
-    let submitted_count = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+    let submitted_count = tokio::time::timeout(std::time::Duration::from_secs(30), async {
         loop {
             let session = child.session_context().await.unwrap();
             let count = session

--- a/crates/cooldis-kernel/src/capabilities/execution/tests.rs
+++ b/crates/cooldis-kernel/src/capabilities/execution/tests.rs
@@ -1603,7 +1603,7 @@ async fn cancelling_a_process_poll_terminates_the_live_handle_and_returns_its_sn
     cancellation.cancel();
 
     let AgentKernelToolOutcome::Completed(Some(cancelled)) =
-        tokio::time::timeout(Duration::from_secs(2), poll)
+        tokio::time::timeout(Duration::from_secs(30), poll)
             .await
             .expect("cancelled process poll did not return promptly")
             .unwrap()
@@ -2159,7 +2159,7 @@ async fn runtime_cancels_busy_virtual_bash_without_poisoning_thread() {
         .unwrap();
     thread.cancel("stop loop").await.unwrap();
 
-    let cancelled = tokio::time::timeout(Duration::from_secs(3), async {
+    let cancelled = tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             if let ThreadEvent::Cancelled { reason, .. } = events.recv().await.unwrap() {
                 break reason;
@@ -2211,7 +2211,7 @@ async fn runtime_cancels_busy_virtual_bash_with_operation_registry_and_recovers(
         .unwrap();
     thread.cancel("stop projected process").await.unwrap();
 
-    let cancelled = tokio::time::timeout(Duration::from_secs(3), async {
+    let cancelled = tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             if let ThreadEvent::Cancelled { reason, .. } = events.recv().await.unwrap() {
                 break reason;

--- a/crates/cooldis-kernel/src/capabilities/wasm_runner/tests.rs
+++ b/crates/cooldis-kernel/src/capabilities/wasm_runner/tests.rs
@@ -568,7 +568,7 @@ fn http_request_bytes(
 
 async fn next_output(events: &mut broadcast::Receiver<ThreadEvent>) -> String {
     loop {
-        let event = timeout(Duration::from_secs(5), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("timed out waiting for event")
             .expect("event stream closed");
@@ -580,7 +580,7 @@ async fn next_output(events: &mut broadcast::Receiver<ThreadEvent>) -> String {
 
 async fn next_cancelled(events: &mut broadcast::Receiver<ThreadEvent>) -> String {
     loop {
-        let event = timeout(Duration::from_secs(5), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("timed out waiting for event")
             .expect("event stream closed");
@@ -592,7 +592,7 @@ async fn next_cancelled(events: &mut broadcast::Receiver<ThreadEvent>) -> String
 
 async fn next_failed(events: &mut broadcast::Receiver<ThreadEvent>) -> String {
     loop {
-        let event = timeout(Duration::from_secs(5), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("timed out waiting for event")
             .expect("event stream closed");

--- a/crates/cooldis-kernel/src/daemon/daemon_io.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_io.rs
@@ -62,6 +62,7 @@ const TELEGRAM_WEBHOOK_HEAD_TIMEOUT: Duration = Duration::from_secs(10);
 const TELEGRAM_WEBHOOK_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const HTTP_RESPONSE_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
 const MAX_TYPING_SIMULATION_DELAY: Duration = Duration::from_secs(8);
+const EGRESS_SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 const IO_EGRESS_PROJECTOR_DISCHARGED_BY: &str = "projector:io-egress";
 const IO_EGRESS_PROJECTOR_FUNCTION: &str = "delivery/v1";
 const ROUTE_AGENT_REF_METADATA: &str = "cooldis_route_agent_ref";
@@ -6901,7 +6902,7 @@ fn open_egress_state_connection(dsn: &str) -> IoResult<rusqlite::Connection> {
     }
     let connection = rusqlite::Connection::open(path).map_err(egress_state_error)?;
     connection
-        .busy_timeout(Duration::from_secs(5))
+        .busy_timeout(EGRESS_SQLITE_BUSY_TIMEOUT)
         .map_err(egress_state_error)?;
     Ok(connection)
 }

--- a/crates/cooldis-kernel/src/daemon/daemon_io/tests.rs
+++ b/crates/cooldis-kernel/src/daemon/daemon_io/tests.rs
@@ -1357,7 +1357,7 @@ async fn bridge_with_runtime_build_gate(
 }
 
 async fn wait_for_provider_requests(client: &RecordingRouteProviderClient, count: usize) {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     loop {
         if client.requests().len() >= count {
             return;
@@ -1671,7 +1671,7 @@ async fn submit_and_wait_for_assistant_event(
 
 async fn wait_for_assistant_text(bridge: &CooldisDaemonIoBridge, thread_id: &str, expected: &str) {
     let parsed = ThreadId::parse_str(thread_id).unwrap();
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     loop {
         let handle = bridge
             .supervisor
@@ -1773,7 +1773,7 @@ async fn wait_for_thread_joined_count(
     expected: usize,
 ) {
     let control_stream = control_stream_id(parent);
-    tokio::time::timeout(Duration::from_secs(5), async {
+    tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             let events = store.read_events(&control_stream, None).await.unwrap();
             if events
@@ -2169,7 +2169,7 @@ async fn failed_and_cancelled_children_project_detailed_handle_outcomes() {
         cancelled_dispatch.thread_id,
         "parent cancelled child".to_string(),
     );
-    let observe_cancelled = tokio::time::timeout(Duration::from_secs(5), async {
+    let observe_cancelled = tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             if matches!(
                 cancelled_events.recv().await.unwrap(),
@@ -2422,7 +2422,7 @@ async fn wait_for_user_text(
     coordinates: &ThreadCoordinates,
     expected: &str,
 ) {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     loop {
         if user_texts_for(bridge, coordinates)
             .await
@@ -2443,7 +2443,7 @@ async fn wait_for_user_text_containing(
     coordinates: &ThreadCoordinates,
     expected: &str,
 ) {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     loop {
         if user_texts_for(bridge, coordinates)
             .await
@@ -2475,7 +2475,7 @@ async fn drain_until_egress(
     instance_id: &str,
     expected: usize,
 ) {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     let mut drained = 0;
     loop {
         drained += bridge
@@ -2722,7 +2722,7 @@ async fn direct_sink_submits_ingress_to_runtime_and_emits_egress() {
 
     assert!(ack.accepted);
     drain_until_egress(&bridge, "telegram.bot", "main", 1).await;
-    let egress = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+    let egress = tokio::time::timeout(Duration::from_secs(30), rx.recv())
         .await
         .unwrap()
         .unwrap();
@@ -4349,7 +4349,7 @@ async fn interrupt_cancel_wait_does_not_hold_active_turn_state_lock() {
             .await
     });
 
-    tokio::time::timeout(Duration::from_secs(3), async {
+    tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             if handle.lifecycle_record().await.latest_signal_id != signal_before_interrupt {
                 break;
@@ -4365,7 +4365,7 @@ async fn interrupt_cancel_wait_does_not_hold_active_turn_state_lock() {
         .await
         .unwrap();
     let state_read =
-        tokio::time::timeout(Duration::from_secs(1), bridge.ingress_state(&target)).await;
+        tokio::time::timeout(Duration::from_secs(30), bridge.ingress_state(&target)).await;
     assert!(
         state_read.is_ok(),
         "an interrupt waiting for cancellation grace must not block unrelated active-turn reads"
@@ -4843,7 +4843,7 @@ async fn input_persisted_before_compile_recovery_resubmits_and_adopts_entry() {
         30,
     );
     let drain = tokio::spawn(async move { worker.drain_once().await });
-    tokio::time::timeout(Duration::from_secs(3), input_persisted)
+    tokio::time::timeout(Duration::from_secs(30), input_persisted)
         .await
         .expect("executing side should reach the input-persisted cut");
 
@@ -4971,7 +4971,7 @@ async fn failed_runtime_replacement_sheds_turn_reservation_for_recovery() {
         30,
     );
     let drain = tokio::spawn(async move { worker.drain_once().await });
-    tokio::time::timeout(Duration::from_secs(3), failed)
+    tokio::time::timeout(Duration::from_secs(30), failed)
         .await
         .expect("runtime should reach the injected failure");
 
@@ -5097,7 +5097,7 @@ async fn concurrent_lazy_load_of_cyclic_topology_fails_closed_without_lock_deadl
             .await
     });
 
-    let (first_error, second_error) = tokio::time::timeout(Duration::from_secs(1), async {
+    let (first_error, second_error) = tokio::time::timeout(Duration::from_secs(30), async {
         (
             match first_load.await.unwrap() {
                 Ok(_) => panic!("first cyclic load unexpectedly succeeded"),
@@ -5697,7 +5697,7 @@ async fn queue_worker_processes_sqlite_backed_envelope() {
     assert_eq!(worker.drain_once().await.unwrap(), 1);
     drain_until_egress(&worker.bridge, "telegram.bot", "main", 1).await;
 
-    let egress = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+    let egress = tokio::time::timeout(Duration::from_secs(30), rx.recv())
         .await
         .unwrap()
         .unwrap();
@@ -6546,7 +6546,7 @@ async fn idle_rejected_steer_persists_input_and_settles_on_it() {
         .unwrap();
     let coordinates = only_thread_coordinates(&bridge).await;
     let handle = bridge.supervisor.get_thread_at(&coordinates).await.unwrap();
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     loop {
         let events = thread_events_for(&session_store_path, &coordinates).await;
         if handle.status() == ThreadStatus::Idle
@@ -6571,7 +6571,7 @@ async fn idle_rejected_steer_persists_input_and_settles_on_it() {
         CooldisDaemonQueueWorker::new(queue.clone(), bridge.clone(), "worker-idle-steer", 30);
     assert_eq!(worker.drain_once().await.unwrap(), 1);
 
-    tokio::time::timeout(Duration::from_secs(2), async {
+    tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             if let Ok(ThreadEvent::Runtime { event, .. }) = runtime_events.recv().await
                 && matches!(
@@ -6736,7 +6736,7 @@ async fn queue_worker_processes_envelope_after_queue_and_bridge_restart() {
     assert_eq!(worker.drain_once().await.unwrap(), 1);
     drain_until_egress(&worker.bridge, "telegram.bot", "main", 1).await;
 
-    let egress = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+    let egress = tokio::time::timeout(Duration::from_secs(30), rx.recv())
         .await
         .unwrap()
         .unwrap();
@@ -7100,7 +7100,7 @@ async fn egress_projector_delivers_after_bridge_restart_from_persisted_cursor() 
         .drain_egress_once("telegram.bot", "main")
         .await
         .unwrap();
-    let egress = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+    let egress = tokio::time::timeout(Duration::from_secs(30), rx.recv())
         .await
         .unwrap()
         .unwrap();
@@ -7155,7 +7155,7 @@ async fn late_egress_completion_does_not_clear_newer_active_turn() {
             .unwrap(),
         1
     );
-    tokio::time::timeout(Duration::from_secs(3), rx.recv())
+    tokio::time::timeout(Duration::from_secs(30), rx.recv())
         .await
         .unwrap()
         .unwrap();
@@ -7664,7 +7664,7 @@ async fn cancelled_daemon_start_finishes_the_workspace_bind_witness() {
     }
     gate.release();
 
-    let handle = tokio::time::timeout(Duration::from_secs(1), async {
+    let handle = tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             if let Ok(handle) = bridge.supervisor.get_thread_at(&coordinates).await
                 && handle
@@ -7722,6 +7722,7 @@ async fn concurrent_lazy_loads_build_one_runtime_and_share_its_handle() {
             .await
     });
     assert!(
+        // tight-timeout: paused time proves no duplicate runtime build starts while the gate is held
         tokio::time::timeout(Duration::from_millis(250), gate.wait_for_builds(2))
             .await
             .is_err(),
@@ -7806,6 +7807,7 @@ async fn thread_already_exists_retry_keeps_scope_mismatch_fail_closed() {
             .await
     });
     assert!(
+        // tight-timeout: paused time proves the conflicting lazy load remains pending
         tokio::time::timeout(Duration::from_millis(250), &mut loading)
             .await
             .is_err(),
@@ -8060,7 +8062,7 @@ async fn egress_projector_delivers_requested_platform_action_after_bridge_restar
             .unwrap(),
         1
     );
-    let assistant = tokio::time::timeout(Duration::from_secs(3), first_rx.recv())
+    let assistant = tokio::time::timeout(Duration::from_secs(30), first_rx.recv())
         .await
         .unwrap()
         .unwrap();
@@ -8131,7 +8133,7 @@ async fn egress_projector_delivers_requested_platform_action_after_bridge_restar
             .unwrap(),
         1
     );
-    let platform_action = tokio::time::timeout(Duration::from_secs(3), first_rx.recv())
+    let platform_action = tokio::time::timeout(Duration::from_secs(30), first_rx.recv())
         .await
         .unwrap()
         .unwrap();
@@ -8206,7 +8208,7 @@ async fn egress_projector_skips_invalid_requested_egress_and_continues() {
             .unwrap(),
         1
     );
-    let assistant = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+    let assistant = tokio::time::timeout(Duration::from_secs(30), rx.recv())
         .await
         .unwrap()
         .unwrap();
@@ -8310,7 +8312,7 @@ async fn egress_projector_skips_invalid_requested_egress_and_continues() {
             .unwrap(),
         1
     );
-    let egress = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+    let egress = tokio::time::timeout(Duration::from_secs(30), rx.recv())
         .await
         .unwrap()
         .unwrap();
@@ -8412,7 +8414,7 @@ async fn egress_projector_recovers_missing_projection_after_partial_receipt_curs
             .unwrap(),
         1
     );
-    let egress = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+    let egress = tokio::time::timeout(Duration::from_secs(30), rx.recv())
         .await
         .unwrap()
         .unwrap();
@@ -8739,14 +8741,14 @@ async fn telegram_webhook_serve_cancellation_aborts_accepted_requests() {
         }),
     ));
 
-    tokio::time::timeout(Duration::from_secs(5), entered)
+    tokio::time::timeout(Duration::from_secs(30), entered)
         .await
         .expect("request did not reach the sink");
     server_task.abort();
     server_task.await.unwrap_err();
     sink.release.notify_one();
 
-    let response = tokio::time::timeout(Duration::from_secs(5), response_task)
+    let response = tokio::time::timeout(Duration::from_secs(30), response_task)
         .await
         .expect("accepted connection did not close after server cancellation")
         .unwrap();

--- a/crates/cooldis-kernel/src/daemon/recovery_sweep.rs
+++ b/crates/cooldis-kernel/src/daemon/recovery_sweep.rs
@@ -971,7 +971,7 @@ mod tests {
         async fn run_to_cut(&mut self, seam: CrashCutSeam) {
             assert_eq!(seam, CrashCutSeam::ThreadTerminalJoinCommit);
             let fault_store = self.fault_store.as_ref().unwrap();
-            tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::time::timeout(Duration::from_secs(30), async {
                 loop {
                     if fault_store.call_count("append_events_fenced") >= 3 {
                         break;

--- a/crates/cooldis-kernel/src/daemon/remote_store/endpoint_http.rs
+++ b/crates/cooldis-kernel/src/daemon/remote_store/endpoint_http.rs
@@ -905,8 +905,9 @@ mod tests {
         assert_eq!(next_accept_retry(ACCEPT_RETRY_MAX), ACCEPT_RETRY_MAX);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn request_deadline_bounds_a_stalled_connection_task() {
+        // tight-timeout: paused time exercises the configured request deadline itself
         let result = request_with_timeout(
             Duration::from_millis(5),
             std::future::pending::<CooldisResult<()>>(),

--- a/crates/cooldis-kernel/src/daemon/remote_store/process_executor.rs
+++ b/crates/cooldis-kernel/src/daemon/remote_store/process_executor.rs
@@ -1266,7 +1266,7 @@ mod tests {
         assert!(caller.await.unwrap_err().is_cancelled());
         drop(spawn_guard);
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(30), async {
             loop {
                 if !joined_payloads(&store, &request).await.is_empty() {
                     break;

--- a/crates/cooldis-kernel/src/kernel/process_handle_dispatch.rs
+++ b/crates/cooldis-kernel/src/kernel/process_handle_dispatch.rs
@@ -921,7 +921,7 @@ mod tests {
             .await
             .unwrap();
 
-        tokio::time::timeout(Duration::from_secs(1), async {
+        tokio::time::timeout(Duration::from_secs(30), async {
             loop {
                 if outcome_count(&store, &consumer, &dispatch_id).await == 1 {
                     break;
@@ -993,7 +993,7 @@ mod tests {
         task.abort();
         let _ = task.await;
 
-        tokio::time::timeout(Duration::from_secs(1), async {
+        tokio::time::timeout(Duration::from_secs(30), async {
             loop {
                 if outcome_count(&store, &consumer, &dispatch_id).await == 1 {
                     break;

--- a/crates/cooldis-kernel/src/kernel/runtime_host/tests.rs
+++ b/crates/cooldis-kernel/src/kernel/runtime_host/tests.rs
@@ -2996,6 +2996,7 @@ async fn queued_turn_watchdog_starts_only_when_that_turn_begins_executing() {
         .unwrap();
 
     tokio::time::advance(Duration::from_millis(50)).await;
+    // tight-timeout: paused time deterministically bounds the first turn watchdog event
     timeout(
         Duration::from_millis(1),
         assert_runtime_kind(&mut events, |kind| {
@@ -3009,6 +3010,7 @@ async fn queued_turn_watchdog_starts_only_when_that_turn_begins_executing() {
     .expect("the active first turn watchdog did not fire at its deadline");
 
     assert!(
+        // tight-timeout: paused time proves the queued turn watchdog remains inactive
         timeout(
             Duration::from_millis(51),
             assert_runtime_kind(&mut events, |kind| {
@@ -3027,6 +3029,7 @@ async fn queued_turn_watchdog_starts_only_when_that_turn_begins_executing() {
     state.second_started.notified().await;
 
     assert!(
+        // tight-timeout: paused time proves the second watchdog stays quiet before its deadline
         timeout(
             Duration::from_millis(99),
             assert_runtime_kind(&mut events, |kind| {
@@ -3040,6 +3043,7 @@ async fn queued_turn_watchdog_starts_only_when_that_turn_begins_executing() {
         .is_err(),
         "the second turn watchdog fired before its execution deadline"
     );
+    // tight-timeout: paused time deterministically crosses the second turn watchdog deadline
     timeout(
         Duration::from_millis(2),
         assert_runtime_kind(&mut events, |kind| {

--- a/crates/cooldis-kernel/src/kernel/runtime_host/tests.rs
+++ b/crates/cooldis-kernel/src/kernel/runtime_host/tests.rs
@@ -2119,6 +2119,7 @@ async fn failed_admission_append_prevents_runtime_host_turn_execution() {
     );
     assert_eq!(store.call_count("append_events"), 1);
 
+    // tight-timeout: paused time deterministically proves failed admission emits no output
     let output = timeout(Duration::from_millis(100), async {
         loop {
             if let ThreadEvent::Output { text, .. } = events.recv().await.unwrap() {
@@ -3089,6 +3090,7 @@ async fn timed_out_turn_cancellation_does_not_apply_to_the_next_turn() {
     state.second_started.notified().await;
 
     assert!(
+        // tight-timeout: paused time deterministically proves the stale cancellation stays absent
         timeout(Duration::from_millis(1), state.wait_for_stale_cancel())
             .await
             .is_err(),
@@ -3302,6 +3304,7 @@ async fn cancelled_start_wakes_reservation_waiters() {
         wait_host.wait_for_thread_start_reservation(thread_id).await;
     });
     assert!(
+        // tight-timeout: paused time deterministically proves the reservation waiter stays pending
         tokio::time::timeout(Duration::from_millis(250), &mut waiter)
             .await
             .is_err(),
@@ -3313,6 +3316,7 @@ async fn cancelled_start_wakes_reservation_waiters() {
         Err(err) => assert!(err.is_cancelled()),
         Ok(_) => panic!("blocked start unexpectedly completed"),
     }
+    // tight-timeout: paused time deterministically bounds the reservation wakeup
     tokio::time::timeout(Duration::from_secs(1), waiter)
         .await
         .expect("reservation waiter should wake after start cancellation")
@@ -3407,6 +3411,7 @@ async fn cancelled_start_after_publication_cleans_up_registered_runtime() {
         Ok(_) => panic!("blocked lifecycle-sink start unexpectedly completed"),
     }
 
+    // tight-timeout: paused time deterministically bounds cancelled runtime shutdown
     timeout(Duration::from_millis(1), factory.wait_until_stopped())
         .await
         .expect("cancelled start left its published runtime running");
@@ -4107,7 +4112,7 @@ async fn shutdown_all_uses_repeatable_children_before_parent_effect_order() {
 
 async fn assert_output(events: &mut broadcast::Receiver<ThreadEvent>, expected: &str) {
     loop {
-        let event = timeout(Duration::from_secs(2), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");
@@ -4120,7 +4125,7 @@ async fn assert_output(events: &mut broadcast::Receiver<ThreadEvent>, expected: 
 
 async fn next_output(events: &mut broadcast::Receiver<ThreadEvent>) -> String {
     loop {
-        let event = timeout(Duration::from_secs(2), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");
@@ -4135,7 +4140,7 @@ async fn assert_canonical_mirror(
     expected_text: &str,
 ) {
     loop {
-        let event = timeout(Duration::from_secs(2), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");
@@ -4334,7 +4339,7 @@ async fn cancelled_manifest_receipt_caller_cannot_leave_a_half_witnessed_workspa
     barrier.release();
 
     let stream_id = EventStreamId::for_thread(&coordinates);
-    let events = tokio::time::timeout(Duration::from_secs(1), async {
+    let events = tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             let events = store.read_events(&stream_id, None).await.unwrap();
             if events
@@ -4506,7 +4511,7 @@ async fn assert_runtime_kind(
     predicate: impl Fn(&RuntimeEventKind) -> bool,
 ) -> RuntimeEvent {
     loop {
-        let event = timeout(Duration::from_secs(2), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");
@@ -4722,7 +4727,7 @@ async fn append_loop_continue_request(
 
 async fn wait_for_status(thread: &RuntimeThreadHandle, expected: ThreadStatus) {
     let mut status = thread.subscribe_status();
-    timeout(Duration::from_secs(2), async {
+    timeout(Duration::from_secs(30), async {
         loop {
             if *status.borrow() == expected {
                 return;

--- a/crates/cooldis-kernel/src/kernel/supervisor/tests.rs
+++ b/crates/cooldis-kernel/src/kernel/supervisor/tests.rs
@@ -201,6 +201,7 @@ async fn supervisor_turn_submission_is_idempotent_on_turn_id() {
 
     assert_output(&mut events, "turn-same:hello").await;
     assert!(
+        // tight-timeout: a duplicate output must remain absent after the idempotent submit
         timeout(Duration::from_millis(50), async {
             loop {
                 if matches!(events.recv().await, Ok(ThreadEvent::Output { .. })) {
@@ -277,6 +278,7 @@ async fn cancelling_idle_thread_is_a_witnessed_no_op() {
     );
     assert_eq!(thread.status(), ThreadStatus::Idle);
     assert!(
+        // tight-timeout: idle cancellation must not emit a runtime cancellation event
         timeout(Duration::from_millis(50), async {
             loop {
                 if matches!(events.recv().await, Ok(ThreadEvent::Cancelled { .. })) {
@@ -676,7 +678,7 @@ async fn start_thread_err(
 
 async fn assert_output(events: &mut broadcast::Receiver<ThreadEvent>, expected: &str) {
     loop {
-        let event = timeout(Duration::from_secs(2), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");

--- a/crates/cooldis-kernel/tests/acp_agent_process_smoke.rs
+++ b/crates/cooldis-kernel/tests/acp_agent_process_smoke.rs
@@ -231,7 +231,7 @@ where
 }
 
 async fn wait_for_socket(path: &Path) {
-    for _ in 0..500 {
+    for _ in 0..1_500 {
         if path.exists() {
             return;
         }

--- a/crates/cooldis-kernel/tests/acp_agent_process_smoke.rs
+++ b/crates/cooldis-kernel/tests/acp_agent_process_smoke.rs
@@ -199,7 +199,7 @@ async fn read_json_message<R>(lines: &mut tokio::io::Lines<BufReader<R>>) -> Val
 where
     R: tokio::io::AsyncRead + Unpin,
 {
-    let deadline = tokio::time::sleep(Duration::from_secs(5));
+    let deadline = tokio::time::sleep(Duration::from_secs(30));
     tokio::pin!(deadline);
     tokio::select! {
         _ = &mut deadline => panic!("timed out waiting for ACP JSON-RPC message"),
@@ -214,7 +214,7 @@ async fn read_json_response<R>(lines: &mut tokio::io::Lines<BufReader<R>>, id: u
 where
     R: tokio::io::AsyncRead + Unpin,
 {
-    let deadline = tokio::time::sleep(Duration::from_secs(5));
+    let deadline = tokio::time::sleep(Duration::from_secs(30));
     tokio::pin!(deadline);
     loop {
         tokio::select! {
@@ -277,7 +277,7 @@ impl AcpAgentChild {
     async fn stop(mut self) {
         if let Some(mut child) = self.child.take() {
             let _ = child.start_kill();
-            let _ = tokio::time::timeout(Duration::from_secs(3), child.wait()).await;
+            let _ = tokio::time::timeout(Duration::from_secs(30), child.wait()).await;
         }
     }
 }

--- a/crates/cooldis-kernel/tests/boundary_auth.rs
+++ b/crates/cooldis-kernel/tests/boundary_auth.rs
@@ -995,7 +995,7 @@ where
     S: tokio::io::AsyncRead + Unpin,
 {
     let mut response = Vec::new();
-    tokio::time::timeout(Duration::from_secs(2), async {
+    tokio::time::timeout(Duration::from_secs(30), async {
         let mut byte = [0_u8; 1];
         while !response.ends_with(b"\r\n\r\n") {
             stream.read_exact(&mut byte).await.unwrap();
@@ -1026,7 +1026,7 @@ async fn wait_for_path(
     path: &Path,
     task: &mut tokio::task::JoinHandle<cooldis::CooldisResult<()>>,
 ) {
-    tokio::time::timeout(Duration::from_secs(10), async {
+    tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             if path.exists() {
                 break;
@@ -1046,7 +1046,7 @@ async fn wait_for_path(
 }
 
 async fn wait_for_sql_count(path: &Path, query: &str, expected: i64) {
-    tokio::time::timeout(Duration::from_secs(5), async {
+    tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             if sql_count(path, query, ()).await >= expected {
                 break;

--- a/crates/cooldis-kernel/tests/canonical_runtime_e2e.rs
+++ b/crates/cooldis-kernel/tests/canonical_runtime_e2e.rs
@@ -768,7 +768,7 @@ fn anthropic_factory(server: &MockHttpServer, stream: bool) -> Arc<AgentLoopFact
 
 async fn next_output(events: &mut tokio::sync::broadcast::Receiver<ThreadEvent>) -> String {
     loop {
-        let event = timeout(Duration::from_secs(5), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");
@@ -784,7 +784,7 @@ async fn next_assistant_message(
     events: &mut tokio::sync::broadcast::Receiver<ThreadEvent>,
 ) -> CanonicalMessage {
     loop {
-        let event = timeout(Duration::from_secs(5), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");
@@ -810,7 +810,7 @@ async fn next_assistant_with_runtime_events(
 ) -> (CanonicalMessage, Vec<RuntimeEventKind>) {
     let mut runtime_events = Vec::new();
     loop {
-        let event = timeout(Duration::from_secs(5), events.recv())
+        let event = timeout(Duration::from_secs(30), events.recv())
             .await
             .expect("event timed out")
             .expect("event channel closed");
@@ -1075,7 +1075,7 @@ impl MockHttpServer {
     }
 
     async fn requests(&self, expected: usize) -> Vec<CapturedRequest> {
-        timeout(Duration::from_secs(5), async {
+        timeout(Duration::from_secs(30), async {
             loop {
                 let requests = self.requests.lock().unwrap().clone();
                 if requests.len() >= expected {

--- a/crates/cooldis-kernel/tests/cooldis_debug_rpc.rs
+++ b/crates/cooldis-kernel/tests/cooldis_debug_rpc.rs
@@ -229,7 +229,7 @@ impl DebugRpcServer {
 
 async fn wait_for_websocket(url: &str, token: &str) {
     let mut last_error = None;
-    for _ in 0..100 {
+    for _ in 0..1_500 {
         match CodexTuiTestClient::connect_websocket(
             url,
             CodexTuiConnectConfig {

--- a/crates/cooldis-kernel/tests/daemon_smoke.rs
+++ b/crates/cooldis-kernel/tests/daemon_smoke.rs
@@ -122,7 +122,7 @@ impl DaemonChild {
     async fn stop(mut self) {
         if let Some(mut child) = self.child.take() {
             let _ = child.start_kill();
-            let _ = tokio::time::timeout(Duration::from_secs(3), child.wait()).await;
+            let _ = tokio::time::timeout(Duration::from_secs(30), child.wait()).await;
         }
     }
 }

--- a/crates/cooldis-kernel/tests/daemon_smoke.rs
+++ b/crates/cooldis-kernel/tests/daemon_smoke.rs
@@ -76,7 +76,7 @@ fn escape_toml_string(value: &str) -> String {
 
 async fn connect_daemon_client(socket: &Path) -> CodexTuiTestClient<tokio::net::UnixStream> {
     let mut last_error = None;
-    for _ in 0..150 {
+    for _ in 0..1_500 {
         if socket.exists() {
             match CodexTuiTestClient::connect_unix(
                 socket,

--- a/crates/cooldis-kernel/tests/object_store_vfs_real_s3.rs
+++ b/crates/cooldis-kernel/tests/object_store_vfs_real_s3.rs
@@ -176,7 +176,7 @@ fn live_s3_config(default_prefix: &str) -> LiveS3Config {
 }
 
 async fn next_output(events: &mut broadcast::Receiver<ThreadEvent>) -> String {
-    timeout(Duration::from_secs(10), async {
+    timeout(Duration::from_secs(30), async {
         loop {
             match events.recv().await.unwrap() {
                 ThreadEvent::Output { text, .. } => break text,

--- a/crates/cooldis-kernel/tests/remote_store_sync.rs
+++ b/crates/cooldis-kernel/tests/remote_store_sync.rs
@@ -838,7 +838,7 @@ async fn process_backed_offline_restart_kill_and_lineage_re_lease_converge() {
     );
     let parked_stdout = parked.stdout.take().unwrap();
     let mut parked_lines = BufReader::new(parked_stdout).lines();
-    let ready = timeout(Duration::from_secs(5), parked_lines.next_line())
+    let ready = timeout(Duration::from_secs(30), parked_lines.next_line())
         .await
         .expect("child park readiness timed out")
         .unwrap()
@@ -950,7 +950,7 @@ async fn remote_thread_spawn_runs_a_separate_child_and_folds_terminal_into_paren
     let store_path = root.join("state/session_history.sqlite3");
     let child_stream = EventStreamId::new(format!("thread:{child_id}"));
 
-    timeout(Duration::from_secs(10), async {
+    timeout(Duration::from_secs(30), async {
         loop {
             let child = client
                 .request(
@@ -1016,7 +1016,7 @@ async fn remote_thread_spawn_runs_a_separate_child_and_folds_terminal_into_paren
             .is_err(),
         "same dispatch with a different payload must be rejected"
     );
-    timeout(Duration::from_secs(10), async {
+    timeout(Duration::from_secs(30), async {
         loop {
             let child = client
                 .request(
@@ -1046,7 +1046,7 @@ async fn remote_thread_spawn_runs_a_separate_child_and_folds_terminal_into_paren
         .join("state/remote-children")
         .join(child_thread_id.to_string())
         .join("state/session_history.sqlite3");
-    timeout(Duration::from_secs(5), async {
+    timeout(Duration::from_secs(30), async {
         loop {
             match SqliteSessionStore::open(&child_store_path).await {
                 Ok(store) => break store,
@@ -1120,7 +1120,7 @@ async fn remote_child_survives_sync_endpoint_outage_and_converges_after_restore(
         .await
         .unwrap();
     let child_id = spawned["threadId"].as_str().unwrap().to_string();
-    timeout(Duration::from_secs(10), async {
+    timeout(Duration::from_secs(30), async {
         loop {
             let child = client
                 .request(
@@ -1154,7 +1154,7 @@ async fn remote_child_survives_sync_endpoint_outage_and_converges_after_restore(
     tokio::time::sleep(Duration::from_millis(250)).await;
     std::fs::rename(&parked_socket, &sync_socket).unwrap();
 
-    timeout(Duration::from_secs(10), async {
+    timeout(Duration::from_secs(30), async {
         loop {
             let child = client
                 .request(
@@ -1265,7 +1265,7 @@ provider = "local"
             }
         }
     });
-    let url = timeout(Duration::from_secs(10), ready_rx)
+    let url = timeout(Duration::from_secs(30), ready_rx)
         .await
         .expect("daemon sync readiness timed out")
         .expect("daemon exited before sync readiness");
@@ -1293,12 +1293,12 @@ struct DaemonProcess {
 impl DaemonProcess {
     async fn stop(mut self) {
         self.child.start_kill().unwrap();
-        let status = timeout(Duration::from_secs(5), self.child.wait())
+        let status = timeout(Duration::from_secs(30), self.child.wait())
             .await
             .expect("daemon did not terminate")
             .unwrap();
         assert!(!status.success());
-        let _ = timeout(Duration::from_secs(2), &mut self.drain).await;
+        let _ = timeout(Duration::from_secs(30), &mut self.drain).await;
     }
 }
 
@@ -1430,7 +1430,7 @@ fn spawn_sync_child(
 
 async fn stop_process(child: &mut Child) {
     child.start_kill().unwrap();
-    let status = timeout(Duration::from_secs(5), child.wait())
+    let status = timeout(Duration::from_secs(30), child.wait())
         .await
         .expect("process did not terminate")
         .unwrap();

--- a/crates/cooldis-kernel/tests/remote_store_sync.rs
+++ b/crates/cooldis-kernel/tests/remote_store_sync.rs
@@ -1330,7 +1330,7 @@ async fn connect_daemon_client(
     socket: &std::path::Path,
 ) -> CodexTuiTestClient<tokio::net::UnixStream> {
     let mut last_error = None;
-    for _ in 0..250 {
+    for _ in 0..1_500 {
         if socket.exists() {
             match CodexTuiTestClient::connect_unix(
                 socket,

--- a/crates/cooldis-kernel/tests/runtime_loop_scenarios.rs
+++ b/crates/cooldis-kernel/tests/runtime_loop_scenarios.rs
@@ -185,7 +185,7 @@ async fn interrupting_host_bash_acknowledges_the_call_and_kills_its_process_tree
     )
     .await
     .unwrap();
-    let child_pid = tokio::time::timeout(Duration::from_secs(2), async {
+    let child_pid = tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             if let Ok(pid) = tokio::fs::read_to_string(host_root.join("child.pid")).await
                 && let Ok(pid) = pid.trim().parse::<libc::pid_t>()
@@ -231,7 +231,7 @@ async fn interrupting_host_bash_acknowledges_the_call_and_kills_its_process_tree
         "the canonical mirror must retain the partial cancelled process result"
     );
 
-    tokio::time::timeout(Duration::from_secs(2), async {
+    tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             if unsafe { libc::kill(child_pid, 0) } == -1
                 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
@@ -931,7 +931,7 @@ async fn cancel_during_tool_execution_cancels_in_flight_batch_and_keeps_thread_r
     let cancel =
         tokio::spawn(async move { cancel_host.cancel(thread_id, "cancel at boundary").await });
 
-    tokio::time::timeout(Duration::from_secs(1), cancel)
+    tokio::time::timeout(Duration::from_secs(30), cancel)
         .await
         .expect("turn cancellation should not wait for the in-flight tool")
         .unwrap()
@@ -1616,41 +1616,47 @@ async fn collect_until_signal(
     events: &mut tokio::sync::broadcast::Receiver<ThreadEvent>,
     expected: ThreadSignalKind,
 ) -> ThreadSignal {
-    for _ in 0..30 {
-        match tokio::time::timeout(Duration::from_millis(20), events.recv()).await {
-            Ok(Ok(ThreadEvent::Signal { signal, .. })) if signal.kind == expected => {
-                return signal;
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            match events.recv().await {
+                Ok(ThreadEvent::Signal { signal, .. }) if signal.kind == expected => {
+                    return signal;
+                }
+                Ok(ThreadEvent::Failed { message, .. }) => {
+                    panic!("thread failed before signal {expected:?}: {message}");
+                }
+                Ok(_) | Err(_) => {}
             }
-            Ok(Ok(ThreadEvent::Failed { message, .. })) => {
-                panic!("thread failed before signal {expected:?}: {message}");
-            }
-            Ok(Ok(_)) | Ok(Err(_)) | Err(_) => {}
         }
-    }
-    panic!("timed out waiting for signal {expected:?}");
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for signal {expected:?}"))
 }
 
 async fn collect_until_policy_rejected(
     events: &mut tokio::sync::broadcast::Receiver<ThreadEvent>,
     expected_code: &str,
 ) {
-    for _ in 0..50 {
-        match tokio::time::timeout(Duration::from_millis(20), events.recv()).await {
-            Ok(Ok(ThreadEvent::Runtime { event, .. })) => {
-                if matches!(
-                    event.kind,
-                    RuntimeEventKind::PolicyRejected { ref code, .. } if code == expected_code
-                ) {
-                    return;
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            match events.recv().await {
+                Ok(ThreadEvent::Runtime { event, .. }) => {
+                    if matches!(
+                        event.kind,
+                        RuntimeEventKind::PolicyRejected { ref code, .. } if code == expected_code
+                    ) {
+                        return;
+                    }
                 }
+                Ok(ThreadEvent::Failed { message, .. }) => {
+                    panic!("thread failed before policy rejection {expected_code:?}: {message}");
+                }
+                Ok(_) | Err(_) => {}
             }
-            Ok(Ok(ThreadEvent::Failed { message, .. })) => {
-                panic!("thread failed before policy rejection {expected_code:?}: {message}");
-            }
-            Ok(Ok(_)) | Ok(Err(_)) | Err(_) => {}
         }
-    }
-    panic!("timed out waiting for policy rejection {expected_code:?}");
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for policy rejection {expected_code:?}"));
 }
 
 async fn wait_for_status(thread: &cooldis::RuntimeThreadHandle, expected: ThreadStatus) {

--- a/crates/cooldis-kernel/tests/runtime_loop_scenarios.rs
+++ b/crates/cooldis-kernel/tests/runtime_loop_scenarios.rs
@@ -1600,7 +1600,7 @@ impl ProviderClient for GatedProviderClient {
 }
 
 async fn wait_for_requests(client: &ScriptedProviderClient, expected: usize) {
-    for _ in 0..30 {
+    for _ in 0..1_500 {
         if client.requests().len() >= expected {
             return;
         }
@@ -1625,7 +1625,10 @@ async fn collect_until_signal(
                 Ok(ThreadEvent::Failed { message, .. }) => {
                     panic!("thread failed before signal {expected:?}: {message}");
                 }
-                Ok(_) | Err(_) => {}
+                Ok(_) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    panic!("event channel closed before signal {expected:?}");
+                }
             }
         }
     })
@@ -1651,7 +1654,10 @@ async fn collect_until_policy_rejected(
                 Ok(ThreadEvent::Failed { message, .. }) => {
                     panic!("thread failed before policy rejection {expected_code:?}: {message}");
                 }
-                Ok(_) | Err(_) => {}
+                Ok(_) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    panic!("event channel closed before policy rejection {expected_code:?}");
+                }
             }
         }
     })
@@ -1676,7 +1682,7 @@ async fn wait_for_status(thread: &cooldis::RuntimeThreadHandle, expected: Thread
 }
 
 async fn wait_for_gated_requests(client: &GatedProviderClient, expected: usize) {
-    for _ in 0..30 {
+    for _ in 0..1_500 {
         if client.requests().len() >= expected {
             return;
         }

--- a/crates/cooldis-kernel/tests/smokes/cooldis-app-server-smoke.rs
+++ b/crates/cooldis-kernel/tests/smokes/cooldis-app-server-smoke.rs
@@ -161,7 +161,7 @@ async fn connect_client(
     client_name: &str,
 ) -> Result<CodexTuiTestClient<UnixStream>, Box<dyn std::error::Error>> {
     let mut last_error = None;
-    for _ in 0..100 {
+    for _ in 0..1_500 {
         match CodexTuiTestClient::connect_unix(
             socket,
             CodexTuiConnectConfig {
@@ -192,7 +192,7 @@ async fn connect_tcp_client(
     token: &str,
 ) -> Result<CodexTuiTestClient<TcpStream>, Box<dyn std::error::Error>> {
     let mut last_error = None;
-    for _ in 0..100 {
+    for _ in 0..1_500 {
         match CodexTuiTestClient::connect_websocket(
             url,
             CodexTuiConnectConfig {
@@ -222,7 +222,7 @@ async fn tcp_health_response(
     path: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
     let mut last_error = None;
-    for _ in 0..100 {
+    for _ in 0..1_500 {
         match TcpStream::connect(addr).await {
             Ok(mut stream) => {
                 let request =

--- a/crates/cooldis-kernel/tests/smokes/cooldis-manifest-e2e-smoke.rs
+++ b/crates/cooldis-kernel/tests/smokes/cooldis-manifest-e2e-smoke.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[path = "cooldis-manifest-e2e-smoke/tests.rs"]
 mod tests;
 
-const FIXTURE_IO_TIMEOUT: Duration = Duration::from_secs(5);
+const FIXTURE_IO_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_FIXTURE_HEADER_BYTES: usize = 16 * 1024;
 const MAX_FIXTURE_BODY_BYTES: usize = 1024 * 1024;
 
@@ -509,7 +509,7 @@ async fn run_turn_trace(
     thread_id: &str,
     input: &str,
 ) -> Result<TurnTrace, Box<dyn std::error::Error>> {
-    run_turn_trace_with_timeout(app, thread_id, input, Duration::from_secs(10)).await
+    run_turn_trace_with_timeout(app, thread_id, input, Duration::from_secs(30)).await
 }
 
 async fn run_live_turn_trace(

--- a/crates/cooldis-kernel/tests/smokes/cooldis-restart-smoke.rs
+++ b/crates/cooldis-kernel/tests/smokes/cooldis-restart-smoke.rs
@@ -211,7 +211,7 @@ impl Fixture {
     }
 
     async fn wait_for_single_bound_thread(&self) -> Result<String, Box<dyn std::error::Error>> {
-        let deadline = Instant::now() + Duration::from_secs(5);
+        let deadline = Instant::now() + Duration::from_secs(30);
         loop {
             let threads = self.bound_threads()?;
             if threads.len() == 1 {
@@ -310,7 +310,7 @@ impl TelegramApiFixture {
         &mut self,
         expected_text: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let deadline = Instant::now() + Duration::from_secs(5);
+        let deadline = Instant::now() + Duration::from_secs(30);
         let mut observed = Vec::new();
         loop {
             let remaining = deadline.saturating_duration_since(Instant::now());
@@ -411,7 +411,7 @@ impl DaemonChild {
     async fn sigkill(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         if let Some(mut child) = self.child.take() {
             child.start_kill()?;
-            tokio::time::timeout(Duration::from_secs(3), child.wait()).await??;
+            tokio::time::timeout(Duration::from_secs(30), child.wait()).await??;
         }
         Ok(())
     }

--- a/crates/cooldis-kernel/tests/smokes/cooldis-vbash-smoke.rs
+++ b/crates/cooldis-kernel/tests/smokes/cooldis-vbash-smoke.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let output = timeout(Duration::from_secs(5), async {
+    let output = timeout(Duration::from_secs(30), async {
         loop {
             match events.recv().await? {
                 ThreadEvent::Output { text, .. } => break Ok::<_, broadcast_error>(text),

--- a/crates/cooldis-kernel/tests/smokes/cooldis-workbench-smoke.rs
+++ b/crates/cooldis-kernel/tests/smokes/cooldis-workbench-smoke.rs
@@ -172,7 +172,7 @@ async fn connect_client(
     token: &str,
 ) -> Result<CodexTuiTestClient<TcpStream>, Box<dyn std::error::Error>> {
     let mut last_error = None;
-    for _ in 0..100 {
+    for _ in 0..1_500 {
         match CodexTuiTestClient::connect_websocket(
             url,
             CodexTuiConnectConfig {

--- a/crates/cooldis-kernel/tests/support/event_trace.rs
+++ b/crates/cooldis-kernel/tests/support/event_trace.rs
@@ -5,7 +5,7 @@ use super::kernel_test::{
 use tokio::sync::broadcast;
 use tokio::time::{Duration, timeout};
 
-const EVENT_TIMEOUT: Duration = Duration::from_secs(3);
+const EVENT_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Default)]
 pub struct EventTrace {

--- a/crates/cooldis-kernel/tests/support/scenario.rs
+++ b/crates/cooldis-kernel/tests/support/scenario.rs
@@ -1341,6 +1341,7 @@ impl ScenarioHarness {
     }
 
     async fn remains_parked<T>(&self, task: &tokio::task::JoinHandle<T>) -> bool {
+        // tight-timeout: this is an absence window for a task that must remain parked
         for _ in 0..128 {
             if task.is_finished() {
                 return false;

--- a/crates/cooldis-kernel/tests/support/scenario.rs
+++ b/crates/cooldis-kernel/tests/support/scenario.rs
@@ -3323,7 +3323,7 @@ mod tests {
 
         control.release_turn_input.notify_one();
         let started = std::time::Instant::now();
-        while !waiting.is_finished() && started.elapsed() < std::time::Duration::from_secs(5) {
+        while !waiting.is_finished() && started.elapsed() < std::time::Duration::from_secs(30) {
             tokio::time::sleep(SCENARIO_ASYNC_RECHECK_INTERVAL).await;
         }
         assert!(
@@ -3598,7 +3598,7 @@ mod tests {
             vec![Box::new(OverlapInvariant { rendezvous })];
         let first = no_fault_scenario(0x4050_0002, vec![ScenarioOp::StartThread]);
         let second = no_fault_scenario(0x4050_0002, vec![ScenarioOp::StartThread]);
-        let overlapping = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        let overlapping = tokio::time::timeout(std::time::Duration::from_secs(60), async {
             tokio::join!(
                 run_scenario_once(&first, &first_invariant),
                 run_scenario_once(&second, &second_invariant),

--- a/crates/cooldis-kernel/tests/virtual_bash_runtime_e2e.rs
+++ b/crates/cooldis-kernel/tests/virtual_bash_runtime_e2e.rs
@@ -105,7 +105,7 @@ async fn supervisor_runs_virtual_bash_with_configured_mounts_and_canonical_histo
 }
 
 async fn next_output(events: &mut broadcast::Receiver<ThreadEvent>) -> String {
-    timeout(Duration::from_secs(5), async {
+    timeout(Duration::from_secs(30), async {
         loop {
             match events.recv().await.unwrap() {
                 ThreadEvent::Output { text, .. } => break text,

--- a/crates/cooldis-process/src/execution.rs
+++ b/crates/cooldis-process/src/execution.rs
@@ -724,7 +724,7 @@ mod tests {
             let cancellation = cancellation.clone();
             async move { executor.exec_cancellable(request, cancellation).await }
         });
-        tokio::time::timeout(Duration::from_secs(2), async {
+        tokio::time::timeout(Duration::from_secs(30), async {
             while !ready_path.exists() {
                 tokio::task::yield_now().await;
             }
@@ -733,7 +733,7 @@ mod tests {
         .expect("host bash did not signal readiness before cancellation");
         cancellation.cancel();
 
-        let result = tokio::time::timeout(Duration::from_secs(2), run)
+        let result = tokio::time::timeout(Duration::from_secs(30), run)
             .await
             .expect("host bash cancellation should return promptly")
             .unwrap()
@@ -783,7 +783,7 @@ mod tests {
             let cancellation = cancellation.clone();
             async move { executor.exec_cancellable(request, cancellation).await }
         });
-        let (leader, child) = tokio::time::timeout(Duration::from_secs(2), async {
+        let (leader, child) = tokio::time::timeout(Duration::from_secs(30), async {
             loop {
                 let leader = std::fs::read_to_string(&leader_path)
                     .ok()
@@ -804,7 +804,7 @@ mod tests {
         .expect("host bash leader was not reaped before cancellation");
 
         cancellation.cancel();
-        let result = match tokio::time::timeout(Duration::from_secs(2), &mut run).await {
+        let result = match tokio::time::timeout(Duration::from_secs(30), &mut run).await {
             Ok(joined) => joined.unwrap().unwrap(),
             Err(_) => {
                 run.abort();
@@ -848,7 +848,7 @@ mod tests {
             max_output_bytes: 4096,
         };
         let run = tokio::spawn(async move { executor.exec(request).await });
-        let child = tokio::time::timeout(Duration::from_secs(2), async {
+        let child = tokio::time::timeout(Duration::from_secs(30), async {
             loop {
                 if let Ok(pid) = std::fs::read_to_string(&pid_path)
                     && let Ok(pid) = pid.trim().parse::<libc::pid_t>()
@@ -863,7 +863,7 @@ mod tests {
 
         run.abort();
         let _ = run.await;
-        tokio::time::timeout(Duration::from_secs(2), async {
+        tokio::time::timeout(Duration::from_secs(30), async {
             loop {
                 if unsafe { libc::kill(child, 0) } == -1
                     && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)

--- a/crates/cooldis-process/src/process/tests.rs
+++ b/crates/cooldis-process/src/process/tests.rs
@@ -300,7 +300,7 @@ async fn host_process_termination_kills_term_ignoring_process_group_members() {
         .unwrap();
     let process_id = started.snapshot.process_id.unwrap();
 
-    let child_pid = tokio::time::timeout(Duration::from_secs(2), async {
+    let child_pid = tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             // The shell creates the pid file before the echo's content lands;
             // keep polling until the content actually parses.
@@ -364,7 +364,7 @@ async fn host_process_termination_still_works_after_the_group_leader_exits() {
         .await
         .unwrap();
     let process_id = started.snapshot.process_id.unwrap();
-    let (leader_pid, child_pid) = tokio::time::timeout(Duration::from_secs(2), async {
+    let (leader_pid, child_pid) = tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             let leader = std::fs::read_to_string(&leader_file)
                 .ok()

--- a/crates/cooldis-provider/src/tests.rs
+++ b/crates/cooldis-provider/src/tests.rs
@@ -671,7 +671,7 @@ async fn anthropic_bedrock_http_stream_decodes_events_and_signs_stream_endpoint(
     );
     let client = ProviderHttpClient::with_http(
         reqwest::Client::builder()
-            .timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(30))
             .build()
             .unwrap(),
         endpoint,
@@ -758,7 +758,7 @@ async fn anthropic_bedrock_mid_stream_disconnect_returns_terminal_error() {
     );
     let client = ProviderHttpClient::with_http(
         reqwest::Client::builder()
-            .timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(30))
             .build()
             .unwrap(),
         endpoint,

--- a/crates/cooldis-sqlite/src/lib.rs
+++ b/crates/cooldis-sqlite/src/lib.rs
@@ -369,7 +369,7 @@ mod tests {
         });
 
         assert_eq!(
-            completed_rx.recv_timeout(Duration::from_secs(1)),
+            completed_rx.recv_timeout(Duration::from_secs(30)),
             Ok("completed"),
             "nested block_on consumed the outer future's wake"
         );

--- a/crates/cooldis-vbash/src/harness.rs
+++ b/crates/cooldis-vbash/src/harness.rs
@@ -1089,7 +1089,7 @@ mod tests {
 
         root.first_flush_entered.notified().await;
         task.abort();
-        let guard = tokio::time::timeout(Duration::from_secs(1), harness.lock())
+        let guard = tokio::time::timeout(Duration::from_secs(30), harness.lock())
             .await
             .expect("cancelled spill must release the harness mutex");
         assert_eq!(

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -74,6 +74,11 @@ Use the existing helpers before adding bespoke setup:
 - event collectors with bounded timeout waits, not blind sleeps;
 - receipt and grant assertion helpers with stable denial-code checks.
 
+Real-time test timeouts are hang detectors and use at least 30 seconds of
+headroom. A shorter absence assertion or paused-time bound must carry
+`// tight-timeout: <reason>` on the same or immediately preceding line;
+`scripts/test-timeout-lint.sh` enforces inline timeout literals.
+
 Timing-logic tests use Tokio's paused clock:
 
 ```rust

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -77,7 +77,8 @@ Use the existing helpers before adding bespoke setup:
 Real-time test timeouts are hang detectors and use at least 30 seconds of
 headroom. A shorter absence assertion or paused-time bound must carry
 `// tight-timeout: <reason>` on the same or immediately preceding line;
-`scripts/test-timeout-lint.sh` enforces inline timeout literals.
+`scripts/test-timeout-lint.sh` enforces literal duration constructors in
+single-line and multi-line timeout calls.
 
 Timing-logic tests use Tokio's paused clock:
 

--- a/scripts/test-timeout-lint.pl
+++ b/scripts/test-timeout-lint.pl
@@ -1,0 +1,166 @@
+use strict;
+use warnings;
+
+while (defined(my $file = shift @ARGV)) {
+open my $fh, '<', $file or die "open $file: $!";
+local $/;
+my $source = <$fh>;
+close $fh or die "close $file: $!";
+
+my $code = $source;
+my %markers;
+my %empty_markers;
+my $length = length $source;
+my $offset = 0;
+my $line = 1;
+
+sub blank_span {
+    my ($text) = @_;
+    $text =~ s/[^\n]/ /g;
+    return $text;
+}
+
+while ($offset < $length) {
+    if (substr($source, $offset, 2) eq '//') {
+        my $end = index($source, "\n", $offset);
+        $end = $length if $end < 0;
+        my $comment = substr($source, $offset, $end - $offset);
+        if ($comment =~ m{//\s*tight-timeout:\s*(\S.*)\z}) {
+            $markers{$line}++;
+        } elsif ($comment =~ m{//\s*tight-timeout:}) {
+            $empty_markers{$line} = 1;
+        }
+        substr($code, $offset, $end - $offset) = blank_span($comment);
+        $offset = $end;
+        next;
+    }
+
+    if (substr($source, $offset, 2) eq '/*') {
+        my $start = $offset;
+        my $depth = 1;
+        $offset += 2;
+        while ($offset < $length && $depth > 0) {
+            if (substr($source, $offset, 2) eq '/*') {
+                $depth++;
+                $offset += 2;
+            } elsif (substr($source, $offset, 2) eq '*/') {
+                $depth--;
+                $offset += 2;
+            } else {
+                $line++ if substr($source, $offset, 1) eq "\n";
+                $offset++;
+            }
+        }
+        my $comment = substr($source, $start, $offset - $start);
+        substr($code, $start, $offset - $start) = blank_span($comment);
+        next;
+    }
+
+    my $tail = substr($source, $offset, 260);
+    if ($tail =~ /\A(?:b|c)?r(\#{0,255})"/) {
+        my $hashes = $1;
+        my $opening = length $&;
+        my $closing = '"' . $hashes;
+        my $end = index($source, $closing, $offset + $opening);
+        $end = $length - length($closing) if $end < 0;
+        $end += length $closing;
+        my $literal = substr($source, $offset, $end - $offset);
+        $line += ($literal =~ tr/\n//);
+        substr($code, $offset, $end - $offset) = blank_span($literal);
+        $offset = $end;
+        next;
+    }
+
+    my $quote_offset = $offset;
+    if (substr($source, $offset, 2) eq 'b"' || substr($source, $offset, 2) eq 'c"') {
+        $quote_offset++;
+    }
+    if (substr($source, $quote_offset, 1) eq '"') {
+        my $start = $offset;
+        $offset = $quote_offset + 1;
+        while ($offset < $length) {
+            my $char = substr($source, $offset, 1);
+            if ($char eq '\\') {
+                $offset += 2;
+                next;
+            }
+            $line++ if $char eq "\n";
+            $offset++;
+            last if $char eq '"';
+        }
+        my $literal = substr($source, $start, $offset - $start);
+        substr($code, $start, $offset - $start) = blank_span($literal);
+        next;
+    }
+
+    $line++ if substr($source, $offset, 1) eq "\n";
+    $offset++;
+}
+
+for my $marker_line (sort { $a <=> $b } keys %empty_markers) {
+    print "$file:$marker_line: tight-timeout marker requires a non-empty reason\n";
+}
+
+sub line_for_offset {
+    my ($text, $position) = @_;
+    my $prefix = substr($text, 0, $position);
+    return 1 + ($prefix =~ tr/\n//);
+}
+
+sub literal_value {
+    my ($raw) = @_;
+    $raw =~ s/_//g;
+    $raw =~ s/(?:u|i)(?:8|16|32|64|128|size)\z//;
+    return 0 + $raw;
+}
+
+sub milliseconds {
+    my ($unit, $raw) = @_;
+    my $value = literal_value($raw);
+    return $value * 1_000 if $unit eq 'secs';
+    return $value if $unit eq 'millis';
+    return $value / 1_000 if $unit eq 'micros';
+    return $value / 1_000_000;
+}
+
+pos($code) = 0;
+while ($code =~ /(?<![A-Za-z0-9_])timeout\s*\(/g) {
+    my $call_offset = $-[0];
+    my $call_line = line_for_offset($code, $call_offset);
+    my $cursor = pos($code);
+    my $argument_start = $cursor;
+    my $depth = 0;
+    while ($cursor < length $code) {
+        my $char = substr($code, $cursor, 1);
+        if ($char eq '(' || $char eq '[' || $char eq '{') {
+            $depth++;
+        } elsif ($char eq ')' || $char eq ']' || $char eq '}') {
+            last if $char eq ')' && $depth == 0;
+            $depth-- if $depth > 0;
+        } elsif ($char eq ',' && $depth == 0) {
+            last;
+        }
+        $cursor++;
+    }
+    my $argument = substr($code, $argument_start, $cursor - $argument_start);
+    my $sub_floor = 0;
+
+    while ($argument =~ /(?:[A-Za-z_][A-Za-z0-9_]*\s*::\s*)*Duration\s*::\s*from_(secs|millis|micros|nanos)\s*\(\s*([0-9][0-9_]*(?:(?:u|i)(?:8|16|32|64|128|size))?)\s*\)/g) {
+        $sub_floor = 1 if milliseconds($1, $2) < 30_000;
+    }
+    while ($argument =~ /(?:[A-Za-z_][A-Za-z0-9_]*\s*::\s*)*Duration\s*::\s*new\s*\(\s*([0-9][0-9_]*(?:(?:u|i)(?:8|16|32|64|128|size))?)\s*,\s*([0-9][0-9_]*(?:(?:u|i)(?:8|16|32|64|128|size))?)\s*\)/g) {
+        my $duration_ms = literal_value($1) * 1_000 + literal_value($2) / 1_000_000;
+        $sub_floor = 1 if $duration_ms < 30_000;
+    }
+    next unless $sub_floor;
+
+    my $marker_line = $markers{$call_line} ? $call_line
+        : $markers{$call_line - 1} ? $call_line - 1
+        : undef;
+    if (defined $marker_line && $markers{$marker_line} > 0) {
+        $markers{$marker_line}--;
+        next;
+    }
+    print "$file:$call_line: timeout is below the 30-second floor without a tight-timeout reason\n";
+}
+}

--- a/scripts/test-timeout-lint.sh
+++ b/scripts/test-timeout-lint.sh
@@ -1,73 +1,27 @@
 #!/usr/bin/env bash
 # Test wall-clock bounds are hang detectors, not performance assertions, and
-# inline timeout durations must be at least 30 seconds. Intentionally short
+# literal timeout durations must be at least 30 seconds. Intentionally short
 # absence assertions and paused/virtual-time bounds must use the marker
 # `// tight-timeout: <reason>` on the timeout line or the immediately preceding
-# line. The reason must be non-empty. This line-based lint catches inline
-# from_secs/from_millis literals on the same line as a timeout call; multi-line
-# call construction is a known limitation and remains a review responsibility.
+# line. One marker covers one timeout call and the reason must be non-empty.
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
 
 problems=()
 scanned_files=0
+files=()
 
 while IFS= read -r -d '' file; do
   scanned_files=$((scanned_files + 1))
-  scan_report=$(awk '
-    function marker(line) {
-      return line ~ /\/\/[[:space:]]*tight-timeout:[[:space:]]*[^[:space:]]/
-    }
-
-    function duration_value(call, value) {
-      value = call
-      sub(/^.*\(/, "", value)
-      sub(/\).*$/, "", value)
-      gsub(/_/, "", value)
-      return value + 0
-    }
-
-    function sub_floor_timeout(line, rest, call) {
-      if (line !~ /timeout[[:space:]]*\(/) {
-        return 0
-      }
-
-      rest = line
-      while (match(rest, /from_secs[[:space:]]*\([0-9_]+\)/)) {
-        call = substr(rest, RSTART, RLENGTH)
-        if (duration_value(call) < 30) {
-          return 1
-        }
-        rest = substr(rest, RSTART + RLENGTH)
-      }
-
-      rest = line
-      while (match(rest, /from_millis[[:space:]]*\([0-9_]+\)/)) {
-        call = substr(rest, RSTART, RLENGTH)
-        if (duration_value(call) < 30000) {
-          return 1
-        }
-        rest = substr(rest, RSTART + RLENGTH)
-      }
-
-      return 0
-    }
-
-    /\/\/[[:space:]]*tight-timeout:/ && !marker($0) {
-      print FILENAME ":" FNR ": tight-timeout marker requires a non-empty reason"
-    }
-
-    sub_floor_timeout($0) && !marker($0) && !marker(previous) {
-      print FILENAME ":" FNR ": inline timeout is below the 30-second floor without a tight-timeout reason"
-    }
-
-    { previous = $0 }
-  ' "$file")
-  if [[ -n "$scan_report" ]]; then
-    while IFS= read -r line; do problems+=("$line"); done <<<"$scan_report"
-  fi
+  files+=("$file")
 done < <(find crates apps -type f -name '*.rs' -print0 2>/dev/null)
+
+scan_report=$(perl "$ROOT/scripts/test-timeout-lint.pl" "${files[@]}")
+if [[ -n "$scan_report" ]]; then
+  while IFS= read -r line; do problems+=("$line"); done <<<"$scan_report"
+fi
 
 if ((${#problems[@]} > 0)); then
   printf 'test-timeout-lint: %s\n' "${problems[@]}" >&2

--- a/scripts/test-timeout-lint.sh
+++ b/scripts/test-timeout-lint.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Test wall-clock bounds are hang detectors, not performance assertions, and
+# inline timeout durations must be at least 30 seconds. Intentionally short
+# absence assertions and paused/virtual-time bounds must use the marker
+# `// tight-timeout: <reason>` on the timeout line or the immediately preceding
+# line. The reason must be non-empty. This line-based lint catches inline
+# from_secs/from_millis literals on the same line as a timeout call; multi-line
+# call construction is a known limitation and remains a review responsibility.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+problems=()
+scanned_files=0
+
+while IFS= read -r -d '' file; do
+  scanned_files=$((scanned_files + 1))
+  scan_report=$(awk '
+    function marker(line) {
+      return line ~ /\/\/[[:space:]]*tight-timeout:[[:space:]]*[^[:space:]]/
+    }
+
+    function duration_value(call, value) {
+      value = call
+      sub(/^.*\(/, "", value)
+      sub(/\).*$/, "", value)
+      gsub(/_/, "", value)
+      return value + 0
+    }
+
+    function sub_floor_timeout(line, rest, call) {
+      if (line !~ /timeout[[:space:]]*\(/) {
+        return 0
+      }
+
+      rest = line
+      while (match(rest, /from_secs[[:space:]]*\([0-9_]+\)/)) {
+        call = substr(rest, RSTART, RLENGTH)
+        if (duration_value(call) < 30) {
+          return 1
+        }
+        rest = substr(rest, RSTART + RLENGTH)
+      }
+
+      rest = line
+      while (match(rest, /from_millis[[:space:]]*\([0-9_]+\)/)) {
+        call = substr(rest, RSTART, RLENGTH)
+        if (duration_value(call) < 30000) {
+          return 1
+        }
+        rest = substr(rest, RSTART + RLENGTH)
+      }
+
+      return 0
+    }
+
+    /\/\/[[:space:]]*tight-timeout:/ && !marker($0) {
+      print FILENAME ":" FNR ": tight-timeout marker requires a non-empty reason"
+    }
+
+    sub_floor_timeout($0) && !marker($0) && !marker(previous) {
+      print FILENAME ":" FNR ": inline timeout is below the 30-second floor without a tight-timeout reason"
+    }
+
+    { previous = $0 }
+  ' "$file")
+  if [[ -n "$scan_report" ]]; then
+    while IFS= read -r line; do problems+=("$line"); done <<<"$scan_report"
+  fi
+done < <(find crates apps -type f -name '*.rs' -print0 2>/dev/null)
+
+if ((${#problems[@]} > 0)); then
+  printf 'test-timeout-lint: %s\n' "${problems[@]}" >&2
+  exit 1
+fi
+
+echo "test-timeout lint passed ($scanned_files Rust files)"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -23,6 +23,7 @@ run_cargo() {
 cd "$ROOT"
 
 run "$ROOT/scripts/threat-model-lint.sh"
+run "$ROOT/scripts/test-timeout-lint.sh"
 run_cargo fmt --all -- --check
 # Same lint set as scripts/release-v1-candidate.sh so the everyday lane
 # cannot drift green while the release gate fails (EMO-459).


### PR DESCRIPTION
De-flakes the test suite's wall-clock bounds after the post-merge Verify failure on main commit 59eb13b (run 29797580065): a 2-second overlap bound in the scenario support fired on a loaded runner and reported serialization that does not exist.

- Raises ~160 hang-detector timeout bounds in test code to a 30-second floor (the flaked same-seed overlap test to 60 seconds), including millisecond literals, named timeout constants, channel receive timeouts, and 20 polling loops whose retry counts encoded only 0.6 to 10 second budgets.
- Keeps 12 intentionally tight bounds (absence assertions, paused-clock tests) with an explicit `// tight-timeout: <reason>` marker.
- Hoists 4 product-code inline timeout literals to identically-valued named constants; no product timeout value or behavior changes.
- Adds `scripts/test-timeout-lint.sh` (bash wrapper over a perl lexical scanner that strips comments and string literals, parses multi-line calls, and covers from_secs/millis/micros/nanos plus Duration::new) wired into `scripts/verify.sh`. Proven to fail on unmarked sub-floor bounds and empty marker reasons.
- Fixes a closed-channel spin in the rewritten polling collectors and converts the 5 ms request-deadline test to paused Tokio time.

Two-pass review on EMO-504: implementation 824529d, independent review-and-fix 0eff9fa (five finding classes, all fixed). Full `scripts/verify.sh` green on both passes; pre-push suite green.
