### PR TITLE
release: bump cooldis to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "cooldis"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/crates/cooldis-kernel/Cargo.toml
+++ b/crates/cooldis-kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cooldis"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 publish = false
 autobins = false


### PR DESCRIPTION
Version bump for the v0.2.0 release: the identity plane (connection authentication, per-method authorization, witnessed identity records, identity CLI), the adapter envelope contract (ADR 0007), effect-class tool recovery, manifest version snapshots, bind explain, grant expiry, and fail-closed webhook auth, since v0.1.0 (2026-07-13). Tag v0.2.0 follows on the merge commit.