### PR TITLE
EMO-505: document the standalone rpc credential path

### DIFF
--- a/crates/cooldis-kernel/src/cli/rpc.rs
+++ b/crates/cooldis-kernel/src/cli/rpc.rs
@@ -32,7 +32,7 @@ pub(super) async fn run_rpc(args: Vec<OsString>) -> CooldisResult<()> {
     eprintln!("cooldis rpc state home: {}", state_home.display());
     match &options.listen {
         AppServerListenAddr::WebSocket(_) => eprintln!(
-            "WebSocket clients must set COOLDIS_APP_SERVER_TOKEN to a bearer token minted with `cooldis identity` against this state home before the server starts."
+            "Before starting this server, mint a bearer token with `cooldis identity` against this state home; WebSocket clients pass that token in COOLDIS_APP_SERVER_TOKEN."
         ),
         AppServerListenAddr::Unix(_) => {
             eprintln!("Same-uid Unix socket peers need no token.");

--- a/crates/cooldis-kernel/src/cli/rpc.rs
+++ b/crates/cooldis-kernel/src/cli/rpc.rs
@@ -26,8 +26,18 @@ pub(super) async fn run_rpc(args: Vec<OsString>) -> CooldisResult<()> {
     if let Some(state_home) = options.state_home {
         config.state_home = state_home;
     }
+    let state_home = config.state_home.clone();
     let server = CooldisAppServer::new_local(config).await?;
     eprintln!("cooldis rpc listening on {}", options.listen.display());
+    eprintln!("cooldis rpc state home: {}", state_home.display());
+    match &options.listen {
+        AppServerListenAddr::WebSocket(_) => eprintln!(
+            "WebSocket clients must set COOLDIS_APP_SERVER_TOKEN to a bearer token minted with `cooldis identity` against this state home before the server starts."
+        ),
+        AppServerListenAddr::Unix(_) => {
+            eprintln!("Same-uid Unix socket peers need no token.");
+        }
+    }
     server.serve(options.listen).await
 }
 
@@ -86,9 +96,10 @@ pub(super) fn print_rpc_help() {
         "cooldis rpc\n\
 \n\
 Usage:\n\
-  cooldis rpc --listen <unix://PATH|ws://HOST:PORT[/rpc]> [--cwd <path>]\n\
+  cooldis rpc --listen <unix://PATH|ws://HOST:PORT[/rpc]> [--runtime-home <path>] [--state-home <path>] [--cwd <path>]\n\
 \n\
 Starts the Cooldis control-plane RPC endpoint. This is the public entrypoint for\n\
-remote operation when Cooldis is running in a sandbox, daemon, or managed host.\n"
+remote operation when Cooldis is running in a sandbox, daemon, or managed host.\n\
+Without --state-home, the server uses a fresh temporary state home for each process.\n"
     );
 }

--- a/crates/cooldis-kernel/tests/cooldis_cli_publish.rs
+++ b/crates/cooldis-kernel/tests/cooldis_cli_publish.rs
@@ -326,6 +326,10 @@ fn cooldis_cli_uses_clean_public_entrypoints() {
     let rpc = run_cooldis(["rpc", "--help"]);
     assert!(rpc.contains("cooldis rpc"));
     assert!(rpc.contains("--listen"));
+    assert!(rpc.contains("--state-home"));
+    assert!(rpc.contains("--runtime-home"));
+    assert!(rpc.contains("--cwd"));
+    assert!(rpc.contains("fresh temporary state home"));
 
     let console = run_cooldis(["console", "--help"]);
     assert!(console.contains("local browser console"));

--- a/crates/cooldis-kernel/tests/cooldis_debug_rpc.rs
+++ b/crates/cooldis-kernel/tests/cooldis_debug_rpc.rs
@@ -6,19 +6,23 @@ use cooldis::{
 };
 use serde_json::Value;
 use std::net::{SocketAddr, TcpListener};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::{Output, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
+use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use uuid::Uuid;
 
+static RPC_PROCESS_TEST_LOCK: Mutex<()> = Mutex::const_new(());
+
 #[tokio::test]
 async fn rpc_cli_startup_names_websocket_state_home_and_credential_path() {
+    let _process_guard = RPC_PROCESS_TEST_LOCK.lock().await;
     let root =
-        PathBuf::from("/tmp").join(format!("cdis-rpc-startup-ws-{}", Uuid::now_v7().simple()));
+        std::env::temp_dir().join(format!("cdis-rpc-startup-ws-{}", Uuid::now_v7().simple()));
     let state_home = root.join("state");
     let runtime_home = root.join("runtime");
     let workspace = root.join("workspace");
@@ -34,7 +38,7 @@ async fn rpc_cli_startup_names_websocket_state_home_and_credential_path() {
     );
     assert_eq!(
         lines[2],
-        "WebSocket clients must set COOLDIS_APP_SERVER_TOKEN to a bearer token minted with `cooldis identity` against this state home before the server starts."
+        "Before starting this server, mint a bearer token with `cooldis identity` against this state home; WebSocket clients pass that token in COOLDIS_APP_SERVER_TOKEN."
     );
 
     let _ = std::fs::remove_dir_all(root);
@@ -43,8 +47,9 @@ async fn rpc_cli_startup_names_websocket_state_home_and_credential_path() {
 #[cfg(unix)]
 #[tokio::test]
 async fn rpc_cli_startup_names_unix_state_home_and_peer_authentication() {
+    let _process_guard = RPC_PROCESS_TEST_LOCK.lock().await;
     let root =
-        PathBuf::from("/tmp").join(format!("cdis-rpc-startup-unix-{}", Uuid::now_v7().simple()));
+        std::env::temp_dir().join(format!("cdis-rpc-startup-unix-{}", Uuid::now_v7().simple()));
     let state_home = root.join("state");
     let runtime_home = root.join("runtime");
     let workspace = root.join("workspace");
@@ -85,6 +90,7 @@ async fn rpc_startup_lines(
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
+        .kill_on_drop(true)
         .spawn()
         .expect("failed to spawn cooldis rpc");
     let stderr = child
@@ -107,7 +113,7 @@ async fn rpc_startup_lines(
             let line = line.trim_end();
             if line.starts_with("cooldis rpc listening on ")
                 || line.starts_with("cooldis rpc state home: ")
-                || line.starts_with("WebSocket clients must set ")
+                || line.starts_with("Before starting this server, mint ")
                 || line == "Same-uid Unix socket peers need no token."
             {
                 lines.push(line.to_string());
@@ -123,12 +129,12 @@ async fn rpc_startup_lines(
 
 #[tokio::test]
 async fn debug_rpc_cli_calls_and_streams_turns_over_websocket() {
-    let root = PathBuf::from("/tmp").join(format!("cdis-debug-rpc-{}", Uuid::now_v7().simple()));
+    let _process_guard = RPC_PROCESS_TEST_LOCK.lock().await;
+    let root = std::env::temp_dir().join(format!("cdis-debug-rpc-{}", Uuid::now_v7().simple()));
     let workspace = root.join("workspace");
     std::fs::create_dir_all(&workspace).unwrap();
-    let addr = unused_loopback_addr();
-    let url = format!("ws://{addr}/rpc");
-    let server = DebugRpcServer::start(&root, &workspace, addr).await;
+    let server = DebugRpcServer::start(&root, &workspace).await;
+    let url = server.url.clone();
 
     let call = run_cooldis(
         ["debug", "rpc", "call", "thread/list", "--url", url.as_str()],
@@ -300,12 +306,15 @@ fn assert_admission_precedes_execution(
 }
 
 struct DebugRpcServer {
+    url: String,
     token: String,
-    task: JoinHandle<cooldis::CooldisResult<()>>,
+    task: Option<JoinHandle<cooldis::CooldisResult<()>>>,
 }
 
 impl DebugRpcServer {
-    async fn start(root: &Path, workspace: &Path, addr: SocketAddr) -> Self {
+    async fn start(root: &Path, workspace: &Path) -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
         let listen = AppServerListenAddr::WebSocket(addr);
         let mut config = CooldisAppServerConfig::local(listen.clone(), workspace);
         config.runtime_home = root.join("runtime");
@@ -323,14 +332,28 @@ impl DebugRpcServer {
             .await
             .unwrap()
             .1;
-        let task = tokio::spawn(async move { app.serve(listen).await });
-        wait_for_websocket(&format!("ws://{addr}/rpc"), &token).await;
-        Self { token, task }
+        let task = tokio::spawn(async move { app.serve_websocket_listener(listener).await });
+        let url = format!("ws://{addr}/rpc");
+        wait_for_websocket(&url, &token).await;
+        Self {
+            url,
+            token,
+            task: Some(task),
+        }
     }
 
-    async fn stop(self) {
-        self.task.abort();
-        let _ = self.task.await;
+    async fn stop(mut self) {
+        let task = self.task.take().unwrap();
+        task.abort();
+        let _ = task.await;
+    }
+}
+
+impl Drop for DebugRpcServer {
+    fn drop(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
     }
 }
 

--- a/crates/cooldis-kernel/tests/cooldis_debug_rpc.rs
+++ b/crates/cooldis-kernel/tests/cooldis_debug_rpc.rs
@@ -10,9 +10,116 @@ use std::path::{Path, PathBuf};
 use std::process::{Output, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio::task::JoinHandle;
 use uuid::Uuid;
+
+#[tokio::test]
+async fn rpc_cli_startup_names_websocket_state_home_and_credential_path() {
+    let root =
+        PathBuf::from("/tmp").join(format!("cdis-rpc-startup-ws-{}", Uuid::now_v7().simple()));
+    let state_home = root.join("state");
+    let runtime_home = root.join("runtime");
+    let workspace = root.join("workspace");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let listen = format!("ws://{}/rpc", unused_loopback_addr());
+
+    let lines = rpc_startup_lines(&listen, &state_home, &runtime_home, &workspace).await;
+
+    assert_eq!(lines[0], format!("cooldis rpc listening on {listen}"));
+    assert_eq!(
+        lines[1],
+        format!("cooldis rpc state home: {}", state_home.display())
+    );
+    assert_eq!(
+        lines[2],
+        "WebSocket clients must set COOLDIS_APP_SERVER_TOKEN to a bearer token minted with `cooldis identity` against this state home before the server starts."
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn rpc_cli_startup_names_unix_state_home_and_peer_authentication() {
+    let root =
+        PathBuf::from("/tmp").join(format!("cdis-rpc-startup-unix-{}", Uuid::now_v7().simple()));
+    let state_home = root.join("state");
+    let runtime_home = root.join("runtime");
+    let workspace = root.join("workspace");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let socket = root.join("rpc.sock");
+    let listen = format!("unix://{}", socket.display());
+
+    let lines = rpc_startup_lines(&listen, &state_home, &runtime_home, &workspace).await;
+
+    assert_eq!(lines[0], format!("cooldis rpc listening on {listen}"));
+    assert_eq!(
+        lines[1],
+        format!("cooldis rpc state home: {}", state_home.display())
+    );
+    assert_eq!(lines[2], "Same-uid Unix socket peers need no token.");
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+async fn rpc_startup_lines(
+    listen: &str,
+    state_home: &Path,
+    runtime_home: &Path,
+    workspace: &Path,
+) -> Vec<String> {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_cooldis"))
+        .args([
+            "rpc",
+            "--listen",
+            listen,
+            "--state-home",
+            state_home.to_str().unwrap(),
+            "--runtime-home",
+            runtime_home.to_str().unwrap(),
+            "--cwd",
+            workspace.to_str().unwrap(),
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn cooldis rpc");
+    let stderr = child
+        .stderr
+        .take()
+        .expect("cooldis rpc stderr should be piped");
+    let mut reader = BufReader::new(stderr);
+    let lines = tokio::time::timeout(Duration::from_secs(30), async {
+        let mut lines = Vec::new();
+        while lines.len() < 3 {
+            let mut line = String::new();
+            let bytes = reader
+                .read_line(&mut line)
+                .await
+                .expect("failed to read cooldis rpc startup output");
+            assert_ne!(
+                bytes, 0,
+                "cooldis rpc exited before startup output completed"
+            );
+            let line = line.trim_end();
+            if line.starts_with("cooldis rpc listening on ")
+                || line.starts_with("cooldis rpc state home: ")
+                || line.starts_with("WebSocket clients must set ")
+                || line == "Same-uid Unix socket peers need no token."
+            {
+                lines.push(line.to_string());
+            }
+        }
+        lines
+    })
+    .await
+    .expect("timed out waiting for cooldis rpc startup output");
+    child.kill().await.expect("failed to stop cooldis rpc");
+    lines
+}
 
 #[tokio::test]
 async fn debug_rpc_cli_calls_and_streams_turns_over_websocket() {

--- a/docs/app-server.md
+++ b/docs/app-server.md
@@ -23,13 +23,15 @@ client parity is not the target of that topology surface.
 ### Standalone RPC quick start
 
 Bootstrap an operator into an explicit state home before starting a standalone
-TCP WebSocket server. The identity command prints the token once. Copy the
-value from its `token` line for the client command below:
+TCP WebSocket server. The identity command prints the token once on a line in
+the form `token <value>`. Copy only `<value>` for the client command below. The
+`$HOME`-anchored state home identifies the same store from both terminals,
+regardless of their working directories:
 
 ```sh
 cooldis identity bootstrap operator:quick-start \
   --display "Quick-start operator" \
-  --state-home .cooldis/rpc-quick-start-state
+  --state-home "$HOME/.cooldis/rpc-quick-start-state"
 ```
 
 Start the server in one terminal:
@@ -37,7 +39,7 @@ Start the server in one terminal:
 ```sh
 cooldis rpc \
   --listen ws://127.0.0.1:49200/rpc \
-  --state-home .cooldis/rpc-quick-start-state
+  --state-home "$HOME/.cooldis/rpc-quick-start-state"
 ```
 
 Then call it from another terminal, replacing `<token>` with the token printed
@@ -66,7 +68,7 @@ a TCP WebSocket client. A Unix socket server can be started with:
 ```sh
 cooldis rpc \
   --listen unix:///tmp/cooldis.sock \
-  --state-home .cooldis/rpc-quick-start-state
+  --state-home "$HOME/.cooldis/rpc-quick-start-state"
 ```
 
 `cooldis console` starts the same loopback app-server shape for local browser

--- a/docs/app-server.md
+++ b/docs/app-server.md
@@ -20,25 +20,54 @@ client parity is not the target of that topology surface.
 
 ## Current Surfaces
 
-`cooldis rpc` starts the Cooldis app-server on a Unix socket:
+### Standalone RPC quick start
+
+Bootstrap an operator into an explicit state home before starting a standalone
+TCP WebSocket server. The identity command prints the token once. Copy the
+value from its `token` line for the client command below:
 
 ```sh
-cargo run --bin cooldis -- rpc --listen unix:///tmp/cooldis.sock
+cooldis identity bootstrap operator:quick-start \
+  --display "Quick-start operator" \
+  --state-home .cooldis/rpc-quick-start-state
 ```
 
-It can also listen on a TCP WebSocket address:
+Start the server in one terminal:
 
 ```sh
-cargo run --bin cooldis -- rpc --listen ws://127.0.0.1:49200/rpc
+cooldis rpc \
+  --listen ws://127.0.0.1:49200/rpc \
+  --state-home .cooldis/rpc-quick-start-state
+```
+
+Then call it from another terminal, replacing `<token>` with the token printed
+by `identity bootstrap`:
+
+```sh
+COOLDIS_APP_SERVER_TOKEN="<token>" \
+  cooldis debug rpc call thread/list
 ```
 
 Both transports authenticate every connection before any method dispatch; see
-the Authentication section below. Both paths accept WebSocket frames, handle
+[Authentication](#authentication). A TCP WebSocket client must present a
+bearer token. A same-uid Unix socket peer needs no token in local mode. Both
+paths accept WebSocket frames, handle
 Codex-style JSON-RPC without requiring a `jsonrpc` field, and expose the V1
 method subset needed by Codex remote clients.
 The direct app-server command currently uses the deterministic local/offline
 provider. The TCP WebSocket listener also serves `GET /healthz` and `GET
 /readyz` with a small JSON `200 OK` response.
+
+`cooldis rpc` also accepts `--runtime-home` and `--cwd`. Without
+`--state-home`, it creates a fresh per-process temporary state home and prints
+that path at startup. Use an explicit state home when minting a credential for
+a TCP WebSocket client. A Unix socket server can be started with:
+
+```sh
+cooldis rpc \
+  --listen unix:///tmp/cooldis.sock \
+  --state-home .cooldis/rpc-quick-start-state
+```
 
 `cooldis console` starts the same loopback app-server shape for local browser
 operation, binds `127.0.0.1:<port>`, serves the bundled Svelte console from `/`,
@@ -62,13 +91,15 @@ With a prompt argument, it opens the terminal console and submits that prompt:
 cargo run --bin cooldis -- chat "hello from cooldis"
 ```
 
-`cooldis debug rpc` connects to a running daemon's WebSocket app server instead
-of starting a private one. It is useful for protocol debugging and for checking
-the live daemon state from scripts:
+`cooldis debug rpc` connects to a running standalone or daemon WebSocket app
+server instead of starting a private one. It is useful for protocol debugging
+and for checking live state from scripts. Export the credential first so each
+command presents it:
 
 ```sh
-cargo run --bin cooldis -- debug rpc call thread/list
-cargo run --bin cooldis -- debug rpc call thread/read '{"threadId":"...","includeTurns":false}'
+export COOLDIS_APP_SERVER_TOKEN="<token>"
+cooldis debug rpc call thread/list
+cooldis debug rpc call thread/read '{"threadId":"...","includeTurns":false}'
 ```
 
 By default it connects to `ws://127.0.0.1:49200/rpc`. Pass `--url` for another
@@ -76,9 +107,9 @@ running WebSocket endpoint, or `--config` to read `daemon.app_server.listen`
 from a `cooldis.toml`:
 
 ```sh
-cargo run --bin cooldis -- debug rpc turn --new "hello from the daemon"
-cargo run --bin cooldis -- debug rpc turn --thread <thread-id> --json "resume here"
-cargo run --bin cooldis -- debug rpc tail --thread <thread-id> --url ws://127.0.0.1:49200/rpc
+cooldis debug rpc turn --new "hello from the daemon"
+cooldis debug rpc turn --thread <thread-id> --json "resume here"
+cooldis debug rpc tail --thread <thread-id> --url ws://127.0.0.1:49200/rpc
 ```
 
 `cooldis debug bind` answers why a thread has its effective configuration by

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,7 +54,7 @@ Both redact stored values in status and list output.
 ## Advanced Commands
 
 ```sh
-cooldis rpc --listen <unix://PATH|ws://HOST:PORT[/rpc]> [--cwd <path>]
+cooldis rpc --listen <unix://PATH|ws://HOST:PORT[/rpc]> [--runtime-home <path>] [--state-home <path>] [--cwd <path>]
 cooldis debug bind <thread-id> [--json] [--url <ws-url> | --config <path> | --journal <db>]
 cooldis debug rpc call <method> [PARAMS_JSON]
 cooldis debug rpc turn (--thread <id> | --new) <text>
@@ -63,7 +63,11 @@ cooldis daemon run|config|service
 ```
 
 `cooldis rpc` is the app-server control plane for scripts, local hosts, MCP,
-ACP, and other clients. `cooldis debug bind` explains the effective model,
+ACP, and other clients. Without `--state-home`, it uses a fresh temporary state
+home. TCP WebSocket clients supply a token through
+`COOLDIS_APP_SERVER_TOKEN`; see the standalone quick start and Authentication
+section in [Cooldis RPC Control Plane](app-server.md). `cooldis debug bind`
+explains the effective model,
 placement, workspace, runtime, tool, coupling, grant, skill, and context
 envelope strictly from recorded compile and bind receipts. It reads a running
 daemon through `thread/events/list`, or a stopped daemon's SQLite journal with


### PR DESCRIPTION
Closes EMO-505.

The v0.2.0 fresh-install smoke found that the documented standalone quick start (`cooldis rpc` then `cooldis debug rpc call thread/list`) dead-ends at 401 Unauthorized with no path to a credential. The mechanisms already existed but were invisible: `--state-home` was parsed but undocumented, the default state home is a per-process temp directory, and the `COOLDIS_APP_SERVER_TOKEN` client carrier only appeared in the managed walkthrough.

No authentication change and no new credential surface. This PR makes the existing pieces visible:

- `cooldis rpc --help` documents `--state-home`, `--runtime-home`, `--cwd`, and the temp-dir default.
- Startup output names the served state home and gives listener-matched credential guidance (mint before start for WebSocket clients; same-uid Unix peers need no token).
- `docs/app-server.md` gains a standalone quick start that works verbatim on a fresh install ($HOME-anchored state home so both terminals hit the same store); `docs/cli.md` synchronized.
- Process-level tests pin the startup lines and help text.

Review pass (independent thread) fixed: child process leak on test panic (kill-on-drop), process-test serialization and port-race hardening, cwd-relative state home in the docs (would reproduce the 401 across terminals), and ambiguous credential wording. One pre-existing report-only finding: "listening on" prints before the bind can fail; unchanged here.

Verification: `scripts/verify.sh` green after each commit; manual fresh-install smoke transcript on the Linear issue.
