### PR TITLE
EMO-506: render rpc client errors without internal naming

### DIFF
--- a/crates/cooldis-kernel/src/adapters/codex_tui.rs
+++ b/crates/cooldis-kernel/src/adapters/codex_tui.rs
@@ -118,11 +118,11 @@ impl CodexTuiTestClient<UnixStream> {
         let endpoint = format!("unix://{}", socket_path.display());
         let mut request = CODEX_TUI_UDS_WEBSOCKET_HANDSHAKE_URL
             .into_client_request()
-            .map_err(|err| tui_error(format!("invalid UDS websocket handshake URL: {err}")))?;
+            .map_err(|err| tui_error(format!("invalid Cooldis RPC handshake URL: {err}")))?;
         set_bearer_token(&mut request, config.bearer_token.as_deref())?;
         let stream = UnixStream::connect(&socket_path).await.map_err(|err| {
             tui_error(format!(
-                "failed to connect Codex TUI test client to `{endpoint}`: {err}"
+                "failed to connect to the Cooldis RPC endpoint `{endpoint}`: {err}"
             ))
         })?;
         let (websocket, _) =
@@ -130,7 +130,7 @@ impl CodexTuiTestClient<UnixStream> {
                 .await
                 .map_err(|err| {
                     tui_error(format!(
-                        "failed to upgrade Codex TUI test client at `{endpoint}`: {err}"
+                        "failed to connect to the Cooldis RPC endpoint `{endpoint}`: {err}"
                     ))
                 })?;
         Self::connect_with_websocket(websocket, endpoint, config).await
@@ -146,11 +146,11 @@ impl CodexTuiTestClient<TcpStream> {
         let authority = websocket_tcp_authority(url)?;
         let mut request = url
             .into_client_request()
-            .map_err(|err| tui_error(format!("invalid TCP websocket URL `{endpoint}`: {err}")))?;
+            .map_err(|err| tui_error(format!("invalid Cooldis RPC URL `{endpoint}`: {err}")))?;
         set_bearer_token(&mut request, config.bearer_token.as_deref())?;
         let stream = TcpStream::connect(authority).await.map_err(|err| {
             tui_error(format!(
-                "failed to connect Codex TUI test client to `{endpoint}`: {err}"
+                "failed to connect to the Cooldis RPC endpoint `{endpoint}`: {err}"
             ))
         })?;
         let (websocket, _) =
@@ -158,7 +158,7 @@ impl CodexTuiTestClient<TcpStream> {
                 .await
                 .map_err(|err| {
                     tui_error(format!(
-                        "failed to upgrade Codex TUI test client at `{endpoint}`: {err}"
+                        "failed to connect to the Cooldis RPC endpoint `{endpoint}`: {err}"
                     ))
                 })?;
         Self::connect_with_websocket(websocket, endpoint, config).await
@@ -377,7 +377,7 @@ where
             tokio::select! {
                 _ = &mut deadline => {
                     return Err(tui_error(format!(
-                        "timed out waiting for Codex TUI turn `{turn_id}` to complete"
+                        "timed out waiting for Cooldis RPC turn `{turn_id}` to complete"
                     )));
                 }
                 event = self.next_event() => {
@@ -414,7 +414,7 @@ where
                         }
                         CodexTuiEvent::Error(error) => {
                             return Err(tui_error(format!(
-                                "Codex TUI test client received JSON-RPC error {}: {}",
+                                "Cooldis RPC client received JSON-RPC error {}: {}",
                                 error.error.code,
                                 error.error.message
                             )));
@@ -456,7 +456,7 @@ where
                 }
                 CodexTuiEvent::Error(error) if error.id == id => {
                     return Err(tui_error(format!(
-                        "Codex TUI request `{method}` failed: {}",
+                        "request `{method}` was refused: {}",
                         error.error.message
                     )));
                 }
@@ -489,8 +489,8 @@ where
                 .websocket
                 .next()
                 .await
-                .ok_or_else(|| tui_error("Codex TUI websocket closed"))?
-                .map_err(|err| tui_error(format!("Codex TUI websocket read failed: {err}")))?;
+                .ok_or_else(|| tui_error("Cooldis RPC connection closed"))?
+                .map_err(|err| tui_error(format!("Cooldis RPC connection read failed: {err}")))?;
             match message {
                 Message::Text(text) => return jsonrpc_event_from_text(&text),
                 Message::Close(frame) => {
@@ -500,7 +500,7 @@ where
                         .filter(|reason| !reason.is_empty())
                         .unwrap_or_else(|| "connection closed".to_string());
                     return Err(tui_error(format!(
-                        "Codex TUI websocket closed by remote: {reason}"
+                        "Cooldis RPC connection was closed by the endpoint: {reason}"
                     )));
                 }
                 Message::Binary(_) | Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {}
@@ -512,7 +512,7 @@ where
         self.websocket
             .close(None)
             .await
-            .map_err(|err| tui_error(format!("failed to close Codex TUI websocket: {err}")))
+            .map_err(|err| tui_error(format!("failed to close Cooldis RPC connection: {err}")))
     }
 }
 
@@ -560,7 +560,7 @@ where
                 }
                 CodexTuiEvent::Error(error) if error.id == initialize_request_id => {
                     break Err(tui_error(format!(
-                        "remote app server at `{endpoint}` rejected initialize: {}",
+                        "Cooldis RPC endpoint `{endpoint}` refused initialization: {}",
                         error.error.message
                     )));
                 }
@@ -595,15 +595,11 @@ where
     S: AsyncRead + AsyncWrite + Unpin,
 {
     let payload = serde_json::to_string(&message)
-        .map_err(|err| tui_error(format!("failed to encode Codex TUI JSON-RPC: {err}")))?;
+        .map_err(|err| tui_error(format!("failed to encode Cooldis RPC message: {err}")))?;
     websocket
         .send(Message::Text(payload.into()))
         .await
-        .map_err(|err| {
-            tui_error(format!(
-                "failed to write Codex TUI websocket message: {err}"
-            ))
-        })
+        .map_err(|err| tui_error(format!("failed to write Cooldis RPC message: {err}")))
 }
 
 async fn read_jsonrpc_event<S>(websocket: &mut WebSocketStream<S>) -> CooldisResult<CodexTuiEvent>
@@ -614,8 +610,8 @@ where
         let message = websocket
             .next()
             .await
-            .ok_or_else(|| tui_error("Codex TUI websocket closed"))?
-            .map_err(|err| tui_error(format!("Codex TUI websocket read failed: {err}")))?;
+            .ok_or_else(|| tui_error("Cooldis RPC connection closed"))?
+            .map_err(|err| tui_error(format!("Cooldis RPC connection read failed: {err}")))?;
         match message {
             Message::Text(text) => return jsonrpc_event_from_text(&text),
             Message::Close(frame) => {
@@ -625,7 +621,7 @@ where
                     .filter(|reason| !reason.is_empty())
                     .unwrap_or_else(|| "connection closed".to_string());
                 return Err(tui_error(format!(
-                    "Codex TUI websocket closed by remote: {reason}"
+                    "Cooldis RPC connection was closed by the endpoint: {reason}"
                 )));
             }
             Message::Binary(_) | Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {}
@@ -635,7 +631,7 @@ where
 
 fn jsonrpc_event_from_text(text: &str) -> CooldisResult<CodexTuiEvent> {
     match serde_json::from_str::<JsonRpcMessage>(text)
-        .map_err(|err| tui_error(format!("invalid Codex TUI JSON-RPC message: {err}")))?
+        .map_err(|err| tui_error(format!("invalid Cooldis RPC message: {err}")))?
     {
         JsonRpcMessage::Notification(notification) => Ok(CodexTuiEvent::Notification(notification)),
         JsonRpcMessage::Request(request) => Ok(CodexTuiEvent::Request(request)),
@@ -678,19 +674,19 @@ fn codex_tui_websocket_config() -> WebSocketConfig {
 fn websocket_tcp_authority(url: &str) -> CooldisResult<&str> {
     let rest = url
         .strip_prefix("ws://")
-        .ok_or_else(|| tui_error(format!("TCP websocket URL must start with ws://: {url:?}")))?;
+        .ok_or_else(|| tui_error(format!("Cooldis RPC URL must start with ws://: {url:?}")))?;
     let authority = rest
         .split_once('/')
         .map(|(authority, _)| authority)
         .unwrap_or(rest);
     if authority.is_empty() {
-        return Err(tui_error("TCP websocket URL requires host:port"));
+        return Err(tui_error("Cooldis RPC URL requires host:port"));
     }
     Ok(authority)
 }
 
 fn tui_error(message: impl Into<String>) -> CooldisError {
-    CooldisError::RuntimeFactory(message.into())
+    CooldisError::RpcClient(message.into())
 }
 
 #[cfg(test)]

--- a/crates/cooldis-kernel/src/adapters/codex_tui/tests.rs
+++ b/crates/cooldis-kernel/src/adapters/codex_tui/tests.rs
@@ -14,6 +14,19 @@ fn codex_tui_connect_config_redacts_bearer_token() {
 }
 
 #[test]
+fn rpc_client_errors_render_without_the_runtime_factory_prefix() {
+    assert_eq!(
+        tui_error("failed to connect to the Cooldis RPC endpoint `ws://127.0.0.1:1/rpc`")
+            .to_string(),
+        "failed to connect to the Cooldis RPC endpoint `ws://127.0.0.1:1/rpc`"
+    );
+    assert_eq!(
+        CooldisError::RuntimeFactory("fixture failure".to_string()).to_string(),
+        "runtime factory failed: fixture failure"
+    );
+}
+
+#[test]
 fn codex_tui_initialize_request_uses_codex_remote_shape() {
     let message = JsonRpcMessage::Request(JsonRpcRequest {
         id: RequestId::String("initialize".to_string()),

--- a/crates/cooldis-kernel/src/cli/debug_rpc.rs
+++ b/crates/cooldis-kernel/src/cli/debug_rpc.rs
@@ -179,10 +179,19 @@ pub(super) async fn run_debug_rpc_tail(args: Vec<OsString>) -> CooldisResult<()>
                 )));
             }
             Ok(CodexTuiEvent::Request(_) | CodexTuiEvent::Response(_)) => {}
-            Err(err) if err.to_string().contains("websocket closed") => return Ok(()),
+            Err(err) if rpc_connection_was_closed(&err) => return Ok(()),
             Err(err) => return Err(err),
         }
     }
+}
+
+fn rpc_connection_was_closed(err: &CooldisError) -> bool {
+    matches!(
+        err,
+        CooldisError::RpcClient(message)
+            if message == "Cooldis RPC connection closed"
+                || message.starts_with("Cooldis RPC connection was closed by the endpoint:")
+    )
 }
 
 pub(super) fn print_debug_rpc_help() {

--- a/crates/cooldis-kernel/src/cli/debug_rpc/tests.rs
+++ b/crates/cooldis-kernel/src/cli/debug_rpc/tests.rs
@@ -128,3 +128,19 @@ fn notification_error_detection_handles_failed_completed_turn() {
         "provider failed"
     );
 }
+
+#[test]
+fn rpc_tail_treats_remote_connection_close_as_success() {
+    assert!(rpc_connection_was_closed(&CooldisError::RpcClient(
+        "Cooldis RPC connection closed".to_string()
+    )));
+    assert!(rpc_connection_was_closed(&CooldisError::RpcClient(
+        "Cooldis RPC connection was closed by the endpoint: going away".to_string()
+    )));
+    assert!(!rpc_connection_was_closed(&CooldisError::RpcClient(
+        "Cooldis RPC connection read failed: reset".to_string()
+    )));
+    assert!(!rpc_connection_was_closed(&CooldisError::RuntimeFactory(
+        "Cooldis RPC connection closed".to_string()
+    )));
+}

--- a/crates/cooldis-kernel/src/kernel/runtime_host.rs
+++ b/crates/cooldis-kernel/src/kernel/runtime_host.rs
@@ -109,6 +109,8 @@ pub enum CooldisError {
     ThreadClosed(ThreadId),
     #[error("runtime factory failed: {0}")]
     RuntimeFactory(String),
+    #[error("{0}")]
+    RpcClient(String),
     #[error("runtime execution failed: {0}")]
     RuntimeExecution(String),
     #[error("history store failed: {0}")]

--- a/crates/cooldis-kernel/tests/cooldis_debug_rpc.rs
+++ b/crates/cooldis-kernel/tests/cooldis_debug_rpc.rs
@@ -7,7 +7,7 @@ use cooldis::{
     SystemDaemonClock,
 };
 use serde_json::Value;
-use std::net::{SocketAddr, TcpListener};
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::{Output, Stdio};
 use std::sync::Arc;
@@ -18,12 +18,11 @@ use uuid::Uuid;
 
 #[tokio::test]
 async fn debug_rpc_cli_calls_and_streams_turns_over_websocket() {
-    let root = PathBuf::from("/tmp").join(format!("cdis-debug-rpc-{}", Uuid::now_v7().simple()));
-    let workspace = root.join("workspace");
+    let root = TestRoot::new("cdis-debug-rpc");
+    let workspace = root.path().join("workspace");
     std::fs::create_dir_all(&workspace).unwrap();
-    let addr = unused_loopback_addr();
-    let url = format!("ws://{addr}/rpc");
-    let server = DebugRpcServer::start(&root, &workspace, addr).await;
+    let server = DebugRpcServer::start(root.path(), &workspace).await;
+    let url = server.url();
 
     let call = run_cooldis(
         ["debug", "rpc", "call", "thread/list", "--url", url.as_str()],
@@ -126,7 +125,7 @@ async fn debug_rpc_cli_calls_and_streams_turns_over_websocket() {
         resumed_stdout.contains("second debug rpc turn"),
         "resumed turn output did not include prompt: {resumed_stdout:?}"
     );
-    let store = SqliteSessionStore::open(root.join("state/session_history.sqlite3"))
+    let store = SqliteSessionStore::open(root.path().join("state/session_history.sqlite3"))
         .await
         .unwrap();
     let control_events = store
@@ -141,7 +140,7 @@ async fn debug_rpc_cli_calls_and_streams_turns_over_websocket() {
     drop(store);
 
     server.stop().await;
-    let journal = root.join("state/session_history.sqlite3");
+    let journal = root.path().join("state/session_history.sqlite3");
     let offline_bind = run_cooldis(
         [
             "debug",
@@ -157,22 +156,13 @@ async fn debug_rpc_cli_calls_and_streams_turns_over_websocket() {
     assert_success(&offline_bind);
     let offline_explanation: Value = serde_json::from_slice(&offline_bind.stdout).unwrap();
     assert_eq!(offline_explanation, live_explanation);
-    let _ = std::fs::remove_dir_all(root);
 }
 
 #[tokio::test]
 async fn debug_rpc_cli_renders_rpc_client_errors_without_internal_names() {
-    let closed_addr = unused_loopback_addr();
-    let closed_url = format!("ws://{closed_addr}/rpc");
+    let closed_url = "ws://127.0.0.1:0/rpc";
     let closed = run_cooldis(
-        [
-            "debug",
-            "rpc",
-            "call",
-            "thread/list",
-            "--url",
-            closed_url.as_str(),
-        ],
+        ["debug", "rpc", "call", "thread/list", "--url", closed_url],
         None,
     )
     .await;
@@ -187,13 +177,11 @@ async fn debug_rpc_cli_renders_rpc_client_errors_without_internal_names() {
     assert!(!closed_error.contains("runtime factory failed"));
     assert!(!closed_error.contains("Codex TUI"));
 
-    let root =
-        PathBuf::from("/tmp").join(format!("cdis-debug-rpc-errors-{}", Uuid::now_v7().simple()));
-    let workspace = root.join("workspace");
+    let root = TestRoot::new("cdis-debug-rpc-errors");
+    let workspace = root.path().join("workspace");
     std::fs::create_dir_all(&workspace).unwrap();
-    let addr = unused_loopback_addr();
-    let url = format!("ws://{addr}/rpc");
-    let server = DebugRpcServer::start(&root, &workspace, addr).await;
+    let server = DebugRpcServer::start(root.path(), &workspace).await;
+    let url = server.url();
 
     let unauthorized = run_cooldis(
         ["debug", "rpc", "call", "thread/list", "--url", url.as_str()],
@@ -202,11 +190,15 @@ async fn debug_rpc_cli_renders_rpc_client_errors_without_internal_names() {
     .await;
     assert!(!unauthorized.status.success());
     let unauthorized_error = String::from_utf8(unauthorized.stderr).unwrap();
-    assert_eq!(
-        unauthorized_error,
-        format!(
-            "cooldis: failed to connect to the Cooldis RPC endpoint `{url}`: HTTP error: 401 Unauthorized\n"
-        )
+    assert!(
+        unauthorized_error.starts_with(&format!(
+            "cooldis: failed to connect to the Cooldis RPC endpoint `{url}`:"
+        )),
+        "unexpected unauthorized error: {unauthorized_error:?}"
+    );
+    assert!(
+        unauthorized_error.contains("401"),
+        "unauthorized error did not preserve HTTP status: {unauthorized_error:?}"
     );
 
     let refused = run_cooldis(
@@ -222,7 +214,6 @@ async fn debug_rpc_cli_renders_rpc_client_errors_without_internal_names() {
     );
 
     server.stop().await;
-    let _ = std::fs::remove_dir_all(root);
 }
 
 fn assert_admission_precedes_execution(
@@ -260,15 +251,18 @@ fn assert_admission_precedes_execution(
 }
 
 struct DebugRpcServer {
+    addr: SocketAddr,
     token: String,
     adapter_token: String,
-    task: JoinHandle<cooldis::CooldisResult<()>>,
+    task: Option<JoinHandle<cooldis::CooldisResult<()>>>,
 }
 
 impl DebugRpcServer {
-    async fn start(root: &Path, workspace: &Path, addr: SocketAddr) -> Self {
+    async fn start(root: &Path, workspace: &Path) -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
         let listen = AppServerListenAddr::WebSocket(addr);
-        let mut config = CooldisAppServerConfig::local(listen.clone(), workspace);
+        let mut config = CooldisAppServerConfig::local(listen, workspace);
         config.runtime_home = root.join("runtime");
         config.state_home = root.join("state");
         let app = CooldisAppServer::new_local(config).await.unwrap();
@@ -299,18 +293,51 @@ impl DebugRpcServer {
             .await
             .unwrap()
             .1;
-        let task = tokio::spawn(async move { app.serve(listen).await });
-        wait_for_websocket(&format!("ws://{addr}/rpc"), &token).await;
-        Self {
+        let task = tokio::spawn(async move { app.serve_websocket_listener(listener).await });
+        let server = Self {
+            addr,
             token,
             adapter_token,
-            task,
-        }
+            task: Some(task),
+        };
+        wait_for_websocket(&format!("ws://{addr}/rpc"), &server.token).await;
+        server
     }
 
-    async fn stop(self) {
-        self.task.abort();
-        let _ = self.task.await;
+    fn url(&self) -> String {
+        format!("ws://{}/rpc", self.addr)
+    }
+
+    async fn stop(mut self) {
+        let task = self.task.take().expect("debug RPC server task missing");
+        task.abort();
+        let _ = task.await;
+    }
+}
+
+impl Drop for DebugRpcServer {
+    fn drop(&mut self) {
+        if let Some(task) = &self.task {
+            task.abort();
+        }
+    }
+}
+
+struct TestRoot(PathBuf);
+
+impl TestRoot {
+    fn new(prefix: &str) -> Self {
+        Self(PathBuf::from("/tmp").join(format!("{prefix}-{}", Uuid::now_v7().simple())))
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TestRoot {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
     }
 }
 
@@ -401,11 +428,4 @@ fn item_text(item: &Value) -> Option<&str> {
             .and_then(|content| content.get("text"))
             .and_then(Value::as_str)
     })
-}
-
-fn unused_loopback_addr() -> SocketAddr {
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
-    addr
 }

--- a/crates/cooldis-kernel/tests/cooldis_debug_rpc.rs
+++ b/crates/cooldis-kernel/tests/cooldis_debug_rpc.rs
@@ -1,4 +1,6 @@
-use cooldis::daemon::identity::{IdentityAuthority, PrincipalId, SqliteIdentityAuthority};
+use cooldis::daemon::identity::{
+    IdentityAuthority, PrincipalId, PrincipalKind, SqliteIdentityAuthority,
+};
 use cooldis::{
     AppServerListenAddr, CodexTuiConnectConfig, CodexTuiTestClient, CooldisAppServer,
     CooldisAppServerConfig, EventKind, EventStore, EventStreamId, SqliteSessionStore,
@@ -158,6 +160,71 @@ async fn debug_rpc_cli_calls_and_streams_turns_over_websocket() {
     let _ = std::fs::remove_dir_all(root);
 }
 
+#[tokio::test]
+async fn debug_rpc_cli_renders_rpc_client_errors_without_internal_names() {
+    let closed_addr = unused_loopback_addr();
+    let closed_url = format!("ws://{closed_addr}/rpc");
+    let closed = run_cooldis(
+        [
+            "debug",
+            "rpc",
+            "call",
+            "thread/list",
+            "--url",
+            closed_url.as_str(),
+        ],
+        None,
+    )
+    .await;
+    assert!(!closed.status.success());
+    let closed_error = String::from_utf8(closed.stderr).unwrap();
+    assert!(
+        closed_error.starts_with(&format!(
+            "cooldis: failed to connect to the Cooldis RPC endpoint `{closed_url}`:"
+        )),
+        "unexpected closed-port error: {closed_error:?}"
+    );
+    assert!(!closed_error.contains("runtime factory failed"));
+    assert!(!closed_error.contains("Codex TUI"));
+
+    let root =
+        PathBuf::from("/tmp").join(format!("cdis-debug-rpc-errors-{}", Uuid::now_v7().simple()));
+    let workspace = root.join("workspace");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let addr = unused_loopback_addr();
+    let url = format!("ws://{addr}/rpc");
+    let server = DebugRpcServer::start(&root, &workspace, addr).await;
+
+    let unauthorized = run_cooldis(
+        ["debug", "rpc", "call", "thread/list", "--url", url.as_str()],
+        None,
+    )
+    .await;
+    assert!(!unauthorized.status.success());
+    let unauthorized_error = String::from_utf8(unauthorized.stderr).unwrap();
+    assert_eq!(
+        unauthorized_error,
+        format!(
+            "cooldis: failed to connect to the Cooldis RPC endpoint `{url}`: HTTP error: 401 Unauthorized\n"
+        )
+    );
+
+    let refused = run_cooldis(
+        ["debug", "rpc", "call", "thread/list", "--url", url.as_str()],
+        Some(&server.adapter_token),
+    )
+    .await;
+    assert!(!refused.status.success());
+    let refused_error = String::from_utf8(refused.stderr).unwrap();
+    assert_eq!(
+        refused_error,
+        "cooldis: request `thread/list` was refused: request is not authorized for this principal\n"
+    );
+
+    server.stop().await;
+    let _ = std::fs::remove_dir_all(root);
+}
+
 fn assert_admission_precedes_execution(
     control_events: &[cooldis::EventRecord],
     thread_events: &[cooldis::EventRecord],
@@ -194,6 +261,7 @@ fn assert_admission_precedes_execution(
 
 struct DebugRpcServer {
     token: String,
+    adapter_token: String,
     task: JoinHandle<cooldis::CooldisResult<()>>,
 }
 
@@ -216,9 +284,28 @@ impl DebugRpcServer {
             .await
             .unwrap()
             .1;
+        let adapter = PrincipalId::new("adapter:debug-rpc-error-test");
+        authority
+            .declare_principal(
+                &principal,
+                &adapter,
+                PrincipalKind::Adapter,
+                "Debug RPC error test adapter",
+            )
+            .await
+            .unwrap();
+        let adapter_token = authority
+            .mint_credential(&principal, &adapter, None)
+            .await
+            .unwrap()
+            .1;
         let task = tokio::spawn(async move { app.serve(listen).await });
         wait_for_websocket(&format!("ws://{addr}/rpc"), &token).await;
-        Self { token, task }
+        Self {
+            token,
+            adapter_token,
+            task,
+        }
     }
 
     async fn stop(self) {
@@ -261,6 +348,8 @@ async fn run_cooldis<const N: usize>(args: [&str; N], token: Option<&str>) -> Ou
     command.args(args).stdin(Stdio::null());
     if let Some(token) = token {
         command.env("COOLDIS_APP_SERVER_TOKEN", token);
+    } else {
+        command.env_remove("COOLDIS_APP_SERVER_TOKEN");
     }
     command.output().await.unwrap()
 }


### PR DESCRIPTION
Closes EMO-506.

The v0.2.0 fresh-install smoke found user-facing CLI errors leaking internal vocabulary: "runtime factory failed" and "Codex TUI test client" for what is simply a refused RPC connection.

The misleading prefix was the error variant, not the message text: every client-side error borrowed `CooldisError::RuntimeFactory`'s Display. This PR adds a dedicated `CooldisError::RpcClient` variant with plain rendering and rewords all client-side strings to Cooldis RPC vocabulary. Before and after:

- `cooldis: runtime factory failed: failed to upgrade Codex TUI test client at ...: HTTP error: 401 Unauthorized` becomes `cooldis: failed to connect to the Cooldis RPC endpoint ...: HTTP error: 401 Unauthorized`
- `cooldis: runtime factory failed: Codex TUI request ... failed: request is not authorized for this principal` becomes `cooldis: request ... was refused: request is not authorized for this principal`

No change to error semantics, exit codes, wire bodies, the uniform 401, or the -32003 refusal. Genuine runtime-factory failures keep their existing rendering. Internal type and module names stay.

Review pass (independent thread) caught a real regression before it shipped: `debug rpc tail` classified an orderly remote close by searching the old "websocket closed" wording, so the rewording would have turned normal closes into exit 1. Now classified on the typed variant with a regression test. It also loosened a third-party error-phrasing pin and hardened test cleanup.

The merge commit unifies the two review passes' independent hardenings of the shared debug-rpc test harness (process-test lock, RAII temp roots, pre-bound listener, kill-on-drop).

Verification: `scripts/verify.sh` green on each commit and on the merge; before/after transcripts on the Linear issue.
