### PR TITLE
EMO-509: local Linux verify lane via Docker with a warm cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,31 @@ scripts/verify.sh
 cargo test --workspace --all-targets --locked
 ```
 
+### Local Linux verification
+
+Run the same full verification suite in a pinned Debian Linux container before
+shipping a change that may behave differently across operating systems:
+
+```sh
+scripts/verify-linux.sh
+```
+
+The default is native `linux/arm64` on Apple Silicon. It covers the Linux OS
+class of path, filesystem, glibc, epoll, signal, and timing bugs; CI's x86_64
+leg remains the architecture authority. Use `scripts/verify-linux.sh --amd64`
+only when reproducing an architecture-specific failure because emulation is
+substantially slower.
+
+The first run downloads the Rust 1.97.1 Bookworm image (the stable toolchain
+used by CI when this lane was added), installs its toolchain, and builds the
+full workspace. Later runs reuse Cargo, Rustup, and architecture-specific
+Cargo-lane state from the `cooldis-verify-linux` Docker volume, but still
+execute every verification step. Concurrent wrapper runs serialize access to
+that shared volume. Docker Desktop should have at least 12 GB of memory under
+Settings > Resources; the wrapper warns and reduces Cargo to two build jobs
+below that limit. If cache corruption is suspected, reset it with
+`docker volume rm cooldis-verify-linux`; the next run will be cold.
+
 For the first local path, see [docs/getting-started.md](docs/getting-started.md).
 For release packaging, tag checks, and async release publishing, see
 [RELEASE.md](RELEASE.md).

--- a/scripts/verify-linux-test.sh
+++ b/scripts/verify-linux-test.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+VERIFY_LINUX_SCRIPT="$SCRIPT_DIR/verify-linux.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/verify-linux-test.XXXXXX")" || exit 1
+TMP_DIR="$(cd "$TMP_DIR" && pwd -P)"
+FAKE_BIN="$TMP_DIR/bin"
+DOCKER_RECORD="$TMP_DIR/docker-record"
+FAILURES=0
+RUN_STATUS=0
+MAIN_REPO="$TMP_DIR/repo"
+LINKED_WORKTREE="$MAIN_REPO/.wt/feature"
+COMMA_REPO="$TMP_DIR/repo,comma"
+COMMA_WORKTREE="$TMP_DIR/comma-common-worktree"
+SPACE_REPO="$TMP_DIR/repo with space=ok"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+assert_eq() {
+  local expected=$1
+  local actual=$2
+  local name=$3
+
+  if [[ "$actual" != "$expected" ]]; then
+    fail "$name (expected '$expected', got '$actual')"
+  fi
+}
+
+assert_file_contains() {
+  local file=$1
+  local needle=$2
+  local name=$3
+
+  if [[ ! -f "$file" ]] || ! grep -Fq -- "$needle" "$file"; then
+    fail "$name"
+    if [[ -f "$file" ]]; then
+      printf 'file: %s\ncontents:\n%s\n' "$file" "$(<"$file")" >&2
+    fi
+  fi
+}
+
+assert_file_excludes() {
+  local file=$1
+  local needle=$2
+  local name=$3
+
+  if [[ -f "$file" ]] && grep -Fq -- "$needle" "$file"; then
+    fail "$name"
+    printf 'unexpected: %s\nfile: %s\ncontents:\n%s\n' \
+      "$needle" "$file" "$(<"$file")" >&2
+  fi
+}
+
+run_wrapper() {
+  local cwd=$1
+  local name=$2
+  shift 2
+
+  (
+    cd "$cwd" || exit 1
+    PATH="$FAKE_BIN:/usr/bin:/bin" \
+      FAKE_DOCKER_RECORD="$DOCKER_RECORD" \
+      FAKE_DOCKER_MEMORY="${FAKE_DOCKER_MEMORY:-17179869184}" \
+      FAKE_DOCKER_RUN_EXIT="${FAKE_DOCKER_RUN_EXIT:-0}" \
+      "$cwd/scripts/verify-linux.sh" "$@"
+  ) >"$TMP_DIR/$name.out" 2>"$TMP_DIR/$name.err"
+  RUN_STATUS=$?
+}
+
+if [[ ! -x "$VERIFY_LINUX_SCRIPT" ]]; then
+  printf 'verify-linux-test: missing executable %s\n' "$VERIFY_LINUX_SCRIPT" >&2
+  exit 1
+fi
+
+mkdir -p "$FAKE_BIN" "$MAIN_REPO/scripts"
+cp "$VERIFY_LINUX_SCRIPT" "$MAIN_REPO/scripts/verify-linux.sh"
+chmod +x "$MAIN_REPO/scripts/verify-linux.sh"
+
+cat >"$FAKE_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+set -u
+
+die() {
+  printf 'fake docker: %s\n' "$1" >&2
+  exit 64
+}
+
+record_args() {
+  local arg
+
+  printf 'call' >>"$FAKE_DOCKER_RECORD"
+  for arg in "$@"; do
+    printf ' <%s>' "$arg" >>"$FAKE_DOCKER_RECORD"
+  done
+  printf '\n' >>"$FAKE_DOCKER_RECORD"
+}
+
+expect_arg() {
+  local expected=$1
+  local actual=${2-}
+
+  [[ "$actual" == "$expected" ]] \
+    || die "expected argument '$expected', got '$actual'"
+}
+
+record_args "$@"
+case "${1:-}" in
+  info)
+    if (($# == 1)); then
+      exit 0
+    fi
+    if (($# == 3)) \
+      && [[ "$2" == "--format" && "$3" == '{{.MemTotal}}' ]]; then
+      printf '%s\n' "${FAKE_DOCKER_MEMORY:-17179869184}"
+      exit 0
+    fi
+    die 'unexpected docker info arguments'
+    ;;
+  run)
+    shift
+    expect_arg --rm "${1-}"
+    shift
+    expect_arg --platform "${1-}"
+    shift
+    platform=${1-}
+    case "$platform" in
+      linux/arm64) host_triple=aarch64-unknown-linux-gnu ;;
+      linux/amd64) host_triple=x86_64-unknown-linux-gnu ;;
+      *) die "unexpected platform '$platform'" ;;
+    esac
+    shift
+    expect_arg --mount "${1-}"
+    shift
+    [[ "${1-}" == type=bind,src=*,dst=/workspace ]] \
+      || die 'workspace mount does not use Docker long syntax'
+    shift
+    expect_arg --mount "${1-}"
+    shift
+    [[ "${1-}" == type=bind,src=*,dst=*,readonly ]] \
+      || die 'Git mount does not use read-only Docker long syntax'
+    shift
+    expect_arg --mount "${1-}"
+    shift
+    expect_arg 'type=volume,src=cooldis-verify-linux,dst=/cooldis-cache' "${1-}"
+    shift
+    expect_arg --env "${1-}"
+    shift
+    expect_arg CARGO_HOME=/cooldis-cache/cargo "${1-}"
+    shift
+    expect_arg --env "${1-}"
+    shift
+    expect_arg RUSTUP_HOME=/cooldis-cache/rustup "${1-}"
+    shift
+    expect_arg --env "${1-}"
+    shift
+    expect_arg RUSTUP_TOOLCHAIN=1.97.1 "${1-}"
+    shift
+    expect_arg --env "${1-}"
+    shift
+    expect_arg \
+      "COOLDIS_CARGO_LANE_ROOT=/cooldis-cache/cargo-lanes/$host_triple" \
+      "${1-}"
+    shift
+    expect_arg --env "${1-}"
+    shift
+    expect_arg COOLDIS_VERIFY_MANAGED_CARGO=1 "${1-}"
+    shift
+    if [[ "${1-}" == --env && "${2-}" == CARGO_BUILD_JOBS=2 ]]; then
+      shift 2
+    fi
+    expect_arg --workdir "${1-}"
+    shift
+    expect_arg /workspace "${1-}"
+    shift
+    expect_arg rust:1.97.1-bookworm "${1-}"
+    shift
+    expect_arg bash "${1-}"
+    shift
+    expect_arg -c "${1-}"
+    shift
+    (($# == 1)) || die 'container command must be one bash -c argument'
+    [[ "$1" == *"trap 'exit 130' INT"* ]] \
+      || die 'container command does not map Ctrl-C to status 130'
+    [[ "$1" == *"trap 'exit 143' TERM"* ]] \
+      || die 'container command does not map termination to status 143'
+    [[ "$1" == *'exec 9>/cooldis-cache/verify.lock'* ]] \
+      || die 'container command does not open the volume lock'
+    [[ "$1" == *'flock -n 9'* ]] \
+      || die 'container command does not serialize volume users'
+    [[ "$1" == *"/cooldis-cache/cargo-lanes/$host_triple/*.lock"* ]] \
+      || die 'container command does not settle platform-specific lane locks'
+    [[ "$1" == *'bash scripts/verify.sh'* ]] \
+      || die 'container command does not run the full verifier'
+    [[ "$1" == *'exit "$verify_status"'* ]] \
+      || die 'container command does not preserve the verifier status'
+    exit "${FAKE_DOCKER_RUN_EXIT:-0}"
+    ;;
+esac
+die "unexpected docker command '${1:-}'"
+EOF
+chmod +x "$FAKE_BIN/docker"
+
+git -C "$MAIN_REPO" init -q -b main
+git -C "$MAIN_REPO" config user.name 'Verify Linux Test'
+git -C "$MAIN_REPO" config user.email verify-linux-test@example.invalid
+git -C "$MAIN_REPO" add scripts/verify-linux.sh
+git -C "$MAIN_REPO" commit --no-gpg-sign -qm 'fixture'
+mkdir -p "$MAIN_REPO/.wt"
+git -C "$MAIN_REPO" worktree add -q -b feature "$LINKED_WORKTREE"
+
+run_wrapper "$MAIN_REPO" help --help
+assert_eq 0 "$RUN_STATUS" '--help succeeded'
+assert_file_contains "$TMP_DIR/help.out" \
+  'usage: scripts/verify-linux.sh [--amd64] [--dry-run]' \
+  '--help printed usage'
+
+run_wrapper "$MAIN_REPO" unknown --not-a-flag
+assert_eq 2 "$RUN_STATUS" 'unknown argument failed with usage status'
+assert_file_contains "$TMP_DIR/unknown.err" \
+  'error: unknown argument: --not-a-flag' \
+  'unknown argument explained the failure'
+
+run_wrapper "$MAIN_REPO" main-dry --dry-run
+assert_eq 0 "$RUN_STATUS" 'main-checkout dry run succeeded'
+assert_file_contains "$TMP_DIR/main-dry.out" 'docker run --rm' \
+  'dry run printed the docker invocation'
+assert_file_contains "$TMP_DIR/main-dry.out" '--platform linux/arm64' \
+  'arm64 is the default platform'
+assert_file_contains "$TMP_DIR/main-dry.out" \
+  "type=bind\\,src=$MAIN_REPO\\,dst=/workspace" \
+  'main checkout is mounted at the fixed workspace path'
+assert_file_contains "$TMP_DIR/main-dry.out" \
+  "type=bind\\,src=$MAIN_REPO/.git\\,dst=/workspace/.git\\,readonly" \
+  'main checkout Git directory is over-mounted read-only'
+assert_file_contains "$TMP_DIR/main-dry.out" \
+  'type=volume\,src=cooldis-verify-linux\,dst=/cooldis-cache' \
+  'named volume is mounted at the cache root'
+assert_file_contains "$TMP_DIR/main-dry.out" \
+  'COOLDIS_CARGO_LANE_ROOT=/cooldis-cache/cargo-lanes/aarch64-unknown-linux-gnu' \
+  'arm64 Cargo lanes use a platform-specific root inside the named volume'
+assert_file_contains "$TMP_DIR/main-dry.out" \
+  'CARGO_HOME=/cooldis-cache/cargo' \
+  'Cargo home resolves inside the named volume'
+assert_file_contains "$TMP_DIR/main-dry.out" \
+  'RUSTUP_HOME=/cooldis-cache/rustup' \
+  'Rustup home resolves inside the named volume'
+assert_file_contains "$TMP_DIR/main-dry.out" 'rust:1.97.1-bookworm' \
+  'the Linux image pins the workspace Rust version and Debian variant'
+assert_file_contains "$TMP_DIR/main-dry.out" 'bash -c ' \
+  'container bootstrap preserves the official image tool path'
+assert_file_excludes "$TMP_DIR/main-dry.out" 'bash -lc ' \
+  'container bootstrap does not let a login shell hide the image rustup shim'
+assert_file_contains "$TMP_DIR/main-dry.out" \
+  'ln -sf /usr/local/cargo/bin/rustup /cooldis-cache/cargo/bin/rustup' \
+  'container bootstrap installs the rustup proxy in persistent Cargo home'
+assert_file_contains "$TMP_DIR/main-dry.out" '--component clippy' \
+  'container bootstrap installs every component used by the full verify suite'
+assert_file_contains "$TMP_DIR/main-dry.out" 'stable-aarch64-unknown-linux-gnu' \
+  'container bootstrap exposes the pinned toolchain under the stable name'
+assert_file_contains "$TMP_DIR/main-dry.out" \
+  'reset with docker volume rm cooldis-verify-linux' \
+  'poisoned toolchain cache fails closed with the documented reset command'
+assert_file_contains "$TMP_DIR/main-dry.out" 'verify_status=' \
+  'container shutdown preserves the verify status while locks settle'
+assert_file_contains "$TMP_DIR/main-dry.out" "trap \\'exit 130\\' INT" \
+  'container bootstrap maps Ctrl-C to status 130 while blocked'
+assert_file_contains "$TMP_DIR/main-dry.out" "trap \\'exit 143\\' TERM" \
+  'container bootstrap maps termination to status 143 while blocked'
+assert_file_contains "$TMP_DIR/main-dry.out" \
+  'exec 9>/cooldis-cache/verify.lock' \
+  'container bootstrap opens the volume-wide verification lock'
+assert_file_contains "$TMP_DIR/main-dry.out" 'flock -n 9' \
+  'container bootstrap serializes users of shared PID-based lane locks'
+assert_file_contains "$TMP_DIR/main-dry.out" \
+  'cargo-lanes/aarch64-unknown-linux-gnu/*.lock' \
+  'container shutdown checks the arm64 lane root for unsettled locks'
+assert_file_contains "$TMP_DIR/main-dry.out" \
+  'Cargo lane locks did not settle' \
+  'unsettled lane locks turn a successful verification into a failure'
+assert_file_excludes "$TMP_DIR/main-dry.out" \
+  "$MAIN_REPO/.git/cargo-lanes" \
+  'dry run does not target the host Cargo lane root'
+
+run_wrapper "$LINKED_WORKTREE" worktree-dry --dry-run
+assert_eq 0 "$RUN_STATUS" 'linked-worktree dry run succeeded'
+assert_file_contains "$TMP_DIR/worktree-dry.out" \
+  "type=bind\\,src=$LINKED_WORKTREE\\,dst=/workspace" \
+  'linked worktree is mounted at the fixed workspace path'
+assert_file_contains "$TMP_DIR/worktree-dry.out" \
+  "type=bind\\,src=$MAIN_REPO/.git\\,dst=$MAIN_REPO/.git\\,readonly" \
+  'linked worktree common Git directory remains reachable and read-only'
+assert_file_excludes "$TMP_DIR/worktree-dry.out" \
+  "$MAIN_REPO/.git/cargo-lanes" \
+  'linked-worktree dry run does not target the host Cargo lane root'
+
+run_wrapper "$MAIN_REPO" amd64-dry --amd64 --dry-run
+assert_eq 0 "$RUN_STATUS" 'amd64 dry run succeeded'
+assert_file_contains "$TMP_DIR/amd64-dry.out" '--platform linux/amd64' \
+  '--amd64 selected the emulated architecture'
+assert_file_contains "$TMP_DIR/amd64-dry.out" \
+  'stable-x86_64-unknown-linux-gnu' \
+  '--amd64 selects the matching pinned stable toolchain alias'
+assert_file_contains "$TMP_DIR/amd64-dry.out" \
+  'COOLDIS_CARGO_LANE_ROOT=/cooldis-cache/cargo-lanes/x86_64-unknown-linux-gnu' \
+  '--amd64 uses a target lane distinct from arm64'
+assert_file_contains "$TMP_DIR/amd64-dry.out" \
+  'cargo-lanes/x86_64-unknown-linux-gnu/*.lock' \
+  '--amd64 settles only its platform-specific lane root'
+
+FAKE_DOCKER_MEMORY=8320671744 run_wrapper "$MAIN_REPO" low-memory-dry --dry-run
+assert_eq 0 "$RUN_STATUS" 'low-memory dry run succeeded'
+assert_file_contains "$TMP_DIR/low-memory-dry.err" \
+  'warning: Docker has less than 12 GB of memory' \
+  'low-memory Docker VM emitted the resource warning'
+assert_file_contains "$TMP_DIR/low-memory-dry.out" \
+  'CARGO_BUILD_JOBS=2' \
+  'low-memory Docker VM bounds concurrent compilation'
+
+PATH=/usr/bin:/bin "$MAIN_REPO/scripts/verify-linux.sh" \
+  >"$TMP_DIR/docker-missing.out" 2>"$TMP_DIR/docker-missing.err"
+RUN_STATUS=$?
+assert_eq 1 "$RUN_STATUS" 'missing Docker failed'
+assert_file_contains "$TMP_DIR/docker-missing.err" \
+  'error: Docker is unavailable; start Docker Desktop and try again' \
+  'missing Docker points at Docker Desktop'
+
+FAKE_DOCKER_RUN_EXIT=37 run_wrapper "$MAIN_REPO" exit-code
+assert_eq 37 "$RUN_STATUS" 'docker run exit status passed through unchanged'
+
+mkdir -p "$COMMA_REPO/scripts"
+cp "$VERIFY_LINUX_SCRIPT" "$COMMA_REPO/scripts/verify-linux.sh"
+chmod +x "$COMMA_REPO/scripts/verify-linux.sh"
+git -C "$COMMA_REPO" init -q -b main
+git -C "$COMMA_REPO" config user.name 'Verify Linux Test'
+git -C "$COMMA_REPO" config user.email verify-linux-test@example.invalid
+git -C "$COMMA_REPO" add scripts/verify-linux.sh
+git -C "$COMMA_REPO" commit --no-gpg-sign -qm 'fixture'
+git -C "$COMMA_REPO" worktree add -q -b feature/comma "$COMMA_WORKTREE"
+
+run_wrapper "$COMMA_REPO" comma-root --dry-run
+assert_eq 1 "$RUN_STATUS" 'comma in worktree root failed clearly'
+assert_file_contains "$TMP_DIR/comma-root.err" \
+  'Git worktree root contains a comma, which Docker --mount cannot represent' \
+  'comma in worktree root explained the mount limitation'
+
+run_wrapper "$COMMA_WORKTREE" comma-common --dry-run
+assert_eq 1 "$RUN_STATUS" 'comma in Git common directory failed clearly'
+assert_file_contains "$TMP_DIR/comma-common.err" \
+  'Git common directory contains a comma, which Docker --mount cannot represent' \
+  'comma in Git common directory explained the mount limitation'
+
+mkdir -p "$SPACE_REPO/scripts"
+cp "$VERIFY_LINUX_SCRIPT" "$SPACE_REPO/scripts/verify-linux.sh"
+chmod +x "$SPACE_REPO/scripts/verify-linux.sh"
+git -C "$SPACE_REPO" init -q -b main
+git -C "$SPACE_REPO" config user.name 'Verify Linux Test'
+git -C "$SPACE_REPO" config user.email verify-linux-test@example.invalid
+git -C "$SPACE_REPO" add scripts/verify-linux.sh
+git -C "$SPACE_REPO" commit --no-gpg-sign -qm 'fixture'
+
+run_wrapper "$SPACE_REPO" space-equals --dry-run
+assert_eq 0 "$RUN_STATUS" 'spaces and equals in mount sources remained supported'
+printf -v space_mount '%q' "type=bind,src=$SPACE_REPO,dst=/workspace"
+assert_file_contains "$TMP_DIR/space-equals.out" "$space_mount" \
+  'spaces and equals remained one quoted Docker mount argument'
+
+if ((FAILURES > 0)); then
+  printf 'verify-linux-test: %s failure(s)\n' "$FAILURES" >&2
+  exit 1
+fi
+
+printf 'verify-linux-test: ok\n'

--- a/scripts/verify-linux.sh
+++ b/scripts/verify-linux.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+IMAGE=rust:1.97.1-bookworm
+RUST_TOOLCHAIN=1.97.1
+PLATFORM=linux/arm64
+HOST_TRIPLE=aarch64-unknown-linux-gnu
+VOLUME=cooldis-verify-linux
+CACHE_ROOT=/cooldis-cache
+CONTAINER_WORKSPACE=/workspace
+DRY_RUN=0
+LOW_MEMORY=0
+
+usage() {
+  printf 'usage: scripts/verify-linux.sh [--amd64] [--dry-run]\n'
+}
+
+die() {
+  printf 'error: %s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+print_command() {
+  local arg
+
+  for arg in "$@"; do
+    printf '%q ' "$arg"
+  done
+  printf '\n'
+}
+
+validate_mount_source() {
+  local path=$1
+  local label=$2
+
+  if [[ "$path" == *','* ]]; then
+    die "$label contains a comma, which Docker --mount cannot represent: $path"
+  fi
+  if [[ "$path" == *$'\n'* || "$path" == *$'\r'* ]]; then
+    die "$label contains a line break, which Docker --mount cannot represent"
+  fi
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --amd64)
+      PLATFORM=linux/amd64
+      HOST_TRIPLE=x86_64-unknown-linux-gnu
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      die "unknown argument: $1" 2
+      ;;
+  esac
+  shift
+done
+
+if ! command -v docker >/dev/null 2>&1; then
+  die 'Docker is unavailable; start Docker Desktop and try again'
+fi
+if ! docker info >/dev/null 2>&1; then
+  die 'cannot reach the Docker daemon; start Docker Desktop and try again'
+fi
+
+docker_memory=$(docker info --format '{{.MemTotal}}' 2>/dev/null || true)
+if [[ "$docker_memory" =~ ^[0-9]+$ ]] \
+  && ((docker_memory < 12 * 1024 * 1024 * 1024)); then
+  LOW_MEMORY=1
+  printf '%s\n' \
+    'warning: Docker has less than 12 GB of memory; the full suite may fail.' \
+    'Increase the memory limit in Docker Desktop Settings > Resources.' >&2
+fi
+
+if ! git_top=$(git -C "$ROOT" rev-parse --show-toplevel 2>/dev/null); then
+  die 'verify-linux must run from inside a Git worktree'
+fi
+if ! git_top=$(cd "$git_top" && pwd -P); then
+  die "could not resolve Git worktree root: $git_top"
+fi
+if [[ "$git_top" != "$ROOT" ]]; then
+  die "script directory is not in the Git worktree root: $ROOT"
+fi
+validate_mount_source "$ROOT" 'Git worktree root'
+
+if ! git_common=$(git -C "$ROOT" rev-parse --git-common-dir 2>/dev/null); then
+  die 'could not resolve the Git common directory'
+fi
+if [[ "$git_common" != /* ]]; then
+  git_common="$ROOT/$git_common"
+fi
+if ! git_common=$(cd "$git_common" && pwd -P); then
+  die "could not resolve Git common directory: $git_common"
+fi
+validate_mount_source "$git_common" 'Git common directory'
+
+CARGO_LANE_ROOT="$CACHE_ROOT/cargo-lanes/$HOST_TRIPLE"
+
+if [[ -d "$ROOT/.git" ]]; then
+  git_mount="type=bind,src=$git_common,dst=$CONTAINER_WORKSPACE/.git,readonly"
+elif [[ -f "$ROOT/.git" ]]; then
+  # Linked-worktree .git files contain an absolute host path. Preserve that
+  # path in the container so Git can follow it to the read-only common gitdir.
+  git_mount="type=bind,src=$git_common,dst=$git_common,readonly"
+else
+  die "unsupported Git metadata at $ROOT/.git"
+fi
+
+container_command="set -euo pipefail
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 131' QUIT
+trap 'exit 143' TERM
+git config --global --add safe.directory $CONTAINER_WORKSPACE
+exec 9>$CACHE_ROOT/verify.lock
+if ! flock -n 9; then
+  printf 'waiting for another Linux verification to release the shared cache\n' >&2
+  while ! flock -n 9; do
+    sleep 0.1
+  done
+fi
+mkdir -p $CACHE_ROOT/cargo/bin
+ln -sf /usr/local/cargo/bin/rustup $CACHE_ROOT/cargo/bin/rustup
+for proxy in cargo cargo-clippy cargo-fmt clippy-driver rustc rustdoc rustfmt; do
+  ln -sf rustup $CACHE_ROOT/cargo/bin/\$proxy
+done
+export PATH=$CACHE_ROOT/cargo/bin:\$PATH
+rustup toolchain install $RUST_TOOLCHAIN --profile minimal --component rustfmt --component clippy --target wasm32-unknown-unknown
+pinned_toolchain=$CACHE_ROOT/rustup/toolchains/$RUST_TOOLCHAIN-$HOST_TRIPLE
+stable_toolchain=$CACHE_ROOT/rustup/toolchains/stable-$HOST_TRIPLE
+if [[ -L \"\$stable_toolchain\" ]]; then
+  if [[ ! \"\$stable_toolchain\" -ef \"\$pinned_toolchain\" ]]; then
+    printf 'error: cached stable toolchain does not point at pinned Rust $RUST_TOOLCHAIN; reset with docker volume rm $VOLUME\\n' >&2
+    exit 1
+  fi
+elif [[ -e \"\$stable_toolchain\" ]]; then
+  printf 'error: cached stable toolchain is not the pinned alias; reset with docker volume rm $VOLUME\\n' >&2
+  exit 1
+else
+  ln -s \"\$pinned_toolchain\" \"\$stable_toolchain\"
+fi
+rustup target list --installed --toolchain stable | grep -Fx wasm32-unknown-unknown >/dev/null
+set +e
+bash scripts/verify.sh
+verify_status=\$?
+set -e
+for attempt in 1 2 3 4 5 6 7 8 9 10; do
+  if ! compgen -G '$CARGO_LANE_ROOT/*.lock' >/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+if compgen -G '$CARGO_LANE_ROOT/*.lock' >/dev/null; then
+  printf 'error: Cargo lane locks did not settle under $CARGO_LANE_ROOT\n' >&2
+  if ((verify_status == 0)); then
+    verify_status=1
+  fi
+fi
+exit \"\$verify_status\""
+
+docker_run=(
+  docker run --rm
+  --platform "$PLATFORM"
+  --mount "type=bind,src=$ROOT,dst=$CONTAINER_WORKSPACE"
+  --mount "$git_mount"
+  --mount "type=volume,src=$VOLUME,dst=$CACHE_ROOT"
+  --env "CARGO_HOME=$CACHE_ROOT/cargo"
+  --env "RUSTUP_HOME=$CACHE_ROOT/rustup"
+  --env "RUSTUP_TOOLCHAIN=$RUST_TOOLCHAIN"
+  --env "COOLDIS_CARGO_LANE_ROOT=$CARGO_LANE_ROOT"
+  --env COOLDIS_VERIFY_MANAGED_CARGO=1
+)
+if ((LOW_MEMORY)); then
+  docker_run+=(--env CARGO_BUILD_JOBS=2)
+fi
+docker_run+=(
+  --workdir "$CONTAINER_WORKSPACE"
+  "$IMAGE"
+  bash -c "$container_command"
+)
+
+if ((DRY_RUN)); then
+  print_command "${docker_run[@]}"
+  exit 0
+fi
+
+"${docker_run[@]}"


### PR DESCRIPTION
Closes EMO-509.

Local verification previously covered macOS only; Linux coverage existed only in CI, so Linux-only failures surfaced ~20 minutes into a PR or as post-merge flakes. This adds a local Linux lane so a merge can be validated on both platforms before push.

`scripts/verify-linux.sh` runs the full `scripts/verify.sh` inside a pinned `rust:1.97.1-bookworm` container: native linux/arm64 by default, `--amd64` opt-in for emulated exact-arch repro. A named Docker volume holds CARGO_HOME, RUSTUP_HOME, and architecture-scoped cargo-lane targets via the pre-existing `COOLDIS_CARGO_LANE_ROOT` seam, so container builds can never write into the host's `.git/cargo-lanes`. The git common directory is additionally mounted read-only as a fail-closed barrier. Works from the main checkout and from `.wt/` worktrees.

Measured on the dev machine: cold first build ~23 min (one-time), warm full verify 71 to 79 seconds.

An independent review pass hardened the initial implementation: architecture-scoped lane roots (arm64 and amd64 previously shared one target root), signal traps so Ctrl-C cannot hang the wrapper or orphan a container (probed: exit 130, no residual container), cross-container serialization via a volume-wide flock (PID-based lane locks alias across container namespaces), fail-closed validation of mount-source paths, unsettled lane locks convert success to failure, and a strict fake-docker contract in the self-test.

`scripts/verify-linux-test.sh` covers parsing, missing docker, both checkout shapes, both platforms, low-memory behavior, cache isolation, and exit-code passthrough without needing a build.

Verification: self-test and shellcheck clean; full host `scripts/verify.sh` green (81s); warm container run green (71s); host lane snapshots byte-identical before and after container runs from both checkout shapes. Full receipts on the Linear issue.
