### PR TITLE
EMO-511: bump bashkit 0.9.0 to 0.14.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,9 +281,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.9.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b002f2afbf0b4e846d31fe984b278585ca93cfcf97058a32b7a06719a44ea554"
+checksum = "3189734e07ea68a23e008c486d9f3cdb1a7eea74a8a32122ec750ade99620014"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -311,6 +311,7 @@ dependencies = [
  "tower",
  "unit-prefix",
  "url",
+ "web-time",
 ]
 
 [[package]]

--- a/crates/cooldis-kernel/Cargo.toml
+++ b/crates/cooldis-kernel/Cargo.toml
@@ -8,7 +8,7 @@ autobins = false
 [dependencies]
 async-trait = "0.1"
 base64 = "0.22"
-bashkit = { version = "0.9.0", features = ["realfs"] }
+bashkit = { version = "0.14.3", features = ["realfs"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 chrono-tz = "0.10"
 cooldis-agent = { path = "../cooldis-agent" }

--- a/crates/cooldis-vbash/Cargo.toml
+++ b/crates/cooldis-vbash/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
-bashkit = { version = "0.9.0", features = ["realfs"] }
+bashkit = { version = "0.14.3", features = ["realfs"] }
 cooldis-abi = { path = "../cooldis-abi" }
 cooldis-operations = { path = "../cooldis-operations" }
 cooldis-process = { path = "../cooldis-process" }

--- a/crates/cooldis-vfs/Cargo.toml
+++ b/crates/cooldis-vfs/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
-bashkit = { version = "0.9.0", features = ["realfs"] }
+bashkit = { version = "0.14.3", features = ["realfs"] }
 futures-util = "0.3.32"
 object_store = { version = "0.13.2", features = ["aws"] }
 

--- a/crates/cooldis-wasm/Cargo.toml
+++ b/crates/cooldis-wasm/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-bashkit = { version = "0.9.0", features = ["realfs"] }
+bashkit = { version = "0.14.3", features = ["realfs"] }
 cooldis-abi = { path = "../cooldis-abi" }
 cooldis-process = { path = "../cooldis-process" }
 cooldis-runtime-contracts = { path = "../cooldis-runtime-contracts" }

--- a/crates/cooldis-wasm/src/runner.rs
+++ b/crates/cooldis-wasm/src/runner.rs
@@ -1599,6 +1599,7 @@ fn vfs_error_status(err: BashkitError) -> i32 {
         BashkitError::ResourceLimit(_) => STATUS_TRANSPORT_ERROR,
         BashkitError::Parse { .. }
         | BashkitError::Execution(_)
+        | BashkitError::CommandFailure(_)
         | BashkitError::Network(_)
         | BashkitError::Regex(_)
         | BashkitError::Internal(_) => STATUS_TRANSPORT_ERROR,


### PR DESCRIPTION
Closes EMO-511.

Bumps bashkit from 0.9.0 to 0.14.3 across the four consuming crates. The 0.10.0 release hardened the interpreter, parser, builtins, and VFS against DoS and panic classes, and 0.13.0/0.14.0 added linear-time glob matching; that hardening is the main value of staying current for a kernel that executes agent-supplied bash.

The only compile breakage across the five releases: `bashkit::Error` gained a `CommandFailure(String)` variant, which hit the exhaustive match in `vfs_error_status` (cooldis-wasm). It now maps to `STATUS_TRANSPORT_ERROR`, grouped with `Execution`, since it is a bash-interpreter control-flow error with no more specific ABI status. Review confirmed the only other match site (apply_patch retry classification) handles the new variant correctly by falling through.

Behavior note: 0.14.3 rejects unknown builtin options with a diagnostic and non-zero exit instead of silently ignoring them (real-Bash parity). A fixture sweep found no test or scenario relying on the old lenient behavior, and negative tests still fail for their intended reasons. Lockfile delta is limited to a wasm32-only `web-time` dependency edge (package already present via object_store); no network stack enters the tree because `http_client` stays disabled.

Verification: full `scripts/verify.sh` green on macOS and full `scripts/verify-linux.sh` green in the container, plus focused consumer-crate test lanes rerun during review. Full receipts on the Linear issue.
