### PR TITLE
EMO-512: raise debug test-thread stack so the scenario sweep reports instead of dying

### DIFF
--- a/.github/workflows/scenario-nightly.yml
+++ b/.github/workflows/scenario-nightly.yml
@@ -20,12 +20,13 @@ jobs:
         id: sweep
         continue-on-error: true
         env:
+          RUST_MIN_STACK: "16777216"
           COOLDIS_SCENARIO_SWEEP_BASE_SEED: ${{ github.run_id }}
           COOLDIS_SCENARIO_SWEEP_COUNT: "24"
           COOLDIS_SCENARIO_SWEEP_MAX_OPS: "8"
           COOLDIS_SCENARIO_SWEEP_COMMIT_SHA: ${{ github.sha }}
           COOLDIS_SCENARIO_SWEEP_RECEIPT_PATH: ${{ runner.temp }}/scenario-nightly-receipt.json
-        run: cargo test -p cooldis --lib scenario_nightly_sweep -- --ignored
+        run: cargo test -p cooldis --lib scenario_nightly_sweep -- --ignored --nocapture
       - name: Witness scenario receipt
         if: always()
         env:

--- a/crates/cooldis-kernel/tests/support/scenario.rs
+++ b/crates/cooldis-kernel/tests/support/scenario.rs
@@ -3001,6 +3001,7 @@ mod tests {
                 _ => ("hostile", Intensity::Hostile),
             };
             *tallies.get_mut(intensity_name).unwrap() += 1;
+            eprintln!("sweep progress: index {index} intensity {intensity_name} seed {seed}");
             let derive = || Scenario::derive(seed, ScenarioBounds { max_ops, intensity });
             let first = catch_scenario_once(&derive()).await;
             let second = catch_scenario_once(&derive()).await;

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# EMO-512: debug-build async poll frames are large, so deeply nested scenarios
+# need more test-thread stack headroom than libtest's default.
+export RUST_MIN_STACK=16777216
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 run() {


### PR DESCRIPTION
The Scenario nightly sweep overflowed the 2 MiB default libtest thread stack on Linux debug builds (fat async poll frames under the deepest restart/recovery scenario shapes) and died with SIGABRT, losing all per-seed detail. It was red 5 of the last 6 nights.

Fix is headroom plus reporting: export RUST_MIN_STACK=16777216 in scripts/verify.sh (covers the macOS gate, the Linux verify lane, and remote CI), add the same env plus --nocapture to the nightly workflow, and keep a per-scenario progress line so any future abort identifies its scenario in the raw log.

Validated in the Linux verify container against all five red nights' base seeds: three now pass end to end; the other two run to completion and report the structured failures the abort was masking (EMO-513, EMO-514). scripts/verify.sh (macOS) and scripts/verify-linux.sh both green locally.

Linear: EMO-512