### PR TITLE
EMO-515: free hosted-runner disk before big debug test builds

### DIFF
--- a/.github/workflows/scenario-nightly.yml
+++ b/.github/workflows/scenario-nightly.yml
@@ -15,12 +15,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.0
       # Same headroom problem as the Verify workspace job (EMO-515): the
-      # debug test build is near the hosted runner's free-disk line.
+      # debug test build no longer fits where the work folder lives, so free
+      # bloat and put the cargo target dir on the big root disk.
       - name: Free runner disk
         run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /opt/hostedtoolcache /usr/lib/jvm /opt/microsoft /usr/lib/google-cloud-sdk \
+            /usr/local/share/powershell /usr/share/swift /opt/az
           sudo docker image prune --all --force > /dev/null
-          df -h /
+          sudo mkdir -p /opt/cargo-target
+          sudo chown "$(id -u):$(id -g)" /opt/cargo-target
+          ln -sfn /opt/cargo-target "${GITHUB_WORKSPACE%/*}/.cargo-target"
+          df -h
+          df -i /
+          findmnt -T "${GITHUB_WORKSPACE%/*}" || true
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.9.1
       - name: Run rotating sweep

--- a/.github/workflows/scenario-nightly.yml
+++ b/.github/workflows/scenario-nightly.yml
@@ -14,6 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0
+      # Same headroom problem as the Verify workspace job (EMO-515): the
+      # debug test build is near the hosted runner's free-disk line.
+      - name: Free runner disk
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force > /dev/null
+          df -h /
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.9.1
       - name: Run rotating sweep

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -35,6 +35,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0
+      # The debug --all-targets build no longer fits in the ~14G a hosted
+      # runner leaves free; drop preinstalled bloat first (EMO-515).
+      - name: Free runner disk
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force > /dev/null
+          df -h /
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -35,13 +35,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0
-      # The debug --all-targets build no longer fits in the ~14G a hosted
-      # runner leaves free; drop preinstalled bloat first (EMO-515).
+      # The debug --all-targets build no longer fits in what a hosted runner
+      # leaves free where the work folder lives; drop preinstalled bloat and
+      # put the cargo target dir on the big root disk (EMO-515).
       - name: Free runner disk
         run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /opt/hostedtoolcache /usr/lib/jvm /opt/microsoft /usr/lib/google-cloud-sdk \
+            /usr/local/share/powershell /usr/share/swift /opt/az
           sudo docker image prune --all --force > /dev/null
-          df -h /
+          sudo mkdir -p /opt/cargo-target
+          sudo chown "$(id -u):$(id -g)" /opt/cargo-target
+          ln -sfn /opt/cargo-target "${GITHUB_WORKSPACE%/*}/.cargo-target"
+          df -h
+          df -i /
+          findmnt -T "${GITHUB_WORKSPACE%/*}" || true
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt


### PR DESCRIPTION
The Verify workspace job on main (run 30027097514) failed with 'No space left on device' followed by ld bus errors while linking test binaries: the debug --all-targets build has outgrown the ~14 GB a hosted ubuntu runner leaves free. Re-runs fail identically since every attempt gets the same disk profile.

Fix: a 'Free runner disk' step before the build in the two workflows that do big test builds on hosted runners (Verify workspace tests, Scenario nightly sweep). It removes the preinstalled Android SDK, dotnet, ghc, CodeQL, and docker images (roughly 25-30 GB) and prints df so future disk incidents are readable from the log. The macmini job keeps its own existing disk bounding; restart-smoke links few binaries and is untouched.

This PR's own Verify run is the validation: the change is not locally exercisable.

Linear: EMO-515