### PR TITLE
EMO-513: settle fork ingress claims across ambiguous store append faults

### DIFF
--- a/crates/cooldis-kernel/src/kernel/runtime_host.rs
+++ b/crates/cooldis-kernel/src/kernel/runtime_host.rs
@@ -545,6 +545,7 @@ impl RuntimeHost {
             metadata,
             start_reservation,
             record_start_identity,
+            false,
             true,
         )
         .await
@@ -633,6 +634,7 @@ impl RuntimeHost {
         metadata: BTreeMap<String, String>,
         mut start_reservation: ThreadStartReservation<'_>,
         record_start_identity: bool,
+        reconcile_start_identity_append: bool,
         notify_lifecycle_sink: bool,
     ) -> CooldisResult<RuntimeThreadHandle> {
         let thread_id = context.coordinates.thread_id;
@@ -746,12 +748,21 @@ impl RuntimeHost {
         let handle = RuntimeThreadHandle {
             thread: Arc::clone(&thread),
         };
-        if record_start_identity && let Err(err) = handle.record_thread_start_identity().await {
-            thread.cancellation.cancel();
-            handle.abort().await;
-            self.remove_thread_if_current(&thread).await;
-            published_start.disarm();
-            return Err(err);
+        if record_start_identity {
+            let start_identity = if reconcile_start_identity_append {
+                handle
+                    .record_thread_start_identity_with_reconciliation()
+                    .await
+            } else {
+                handle.record_thread_start_identity().await.map(|_| ())
+            };
+            if let Err(err) = start_identity {
+                thread.cancellation.cancel();
+                handle.abort().await;
+                self.remove_thread_if_current(&thread).await;
+                published_start.disarm();
+                return Err(err);
+            }
         }
         let _ = runtime_start_tx.send(());
         if notify_lifecycle_sink
@@ -1528,7 +1539,7 @@ impl RuntimeHost {
             .lock()
             .await
             .insert(checkpoint.id, checkpoint);
-        self.start_reserved_thread(context, metadata, start_reservation, false, true)
+        self.start_reserved_thread(context, metadata, start_reservation, false, false, true)
             .await
     }
 
@@ -1611,7 +1622,6 @@ impl RuntimeHost {
             topology,
             metadata.clone(),
         );
-
         loop {
             match self.get_thread(child_thread_id).await {
                 Ok(handle) => {
@@ -1784,6 +1794,7 @@ impl RuntimeHost {
                     start_metadata,
                     start_reservation,
                     !has_start_identity,
+                    true,
                     notify_lifecycle_sink,
                 )
                 .await;

--- a/crates/cooldis-kernel/src/kernel/runtime_host/tests.rs
+++ b/crates/cooldis-kernel/src/kernel/runtime_host/tests.rs
@@ -1600,6 +1600,23 @@ impl ThreadLifecycleSink for FailingAfterRuntimeStartsSink {
     }
 }
 
+struct HistoryFailingChildLifecycleSink {
+    child_calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl ThreadLifecycleSink for HistoryFailingChildLifecycleSink {
+    async fn thread_started(&self, handle: RuntimeThreadHandle) -> CooldisResult<()> {
+        if handle.context().parent_thread_id.is_some() {
+            self.child_calls.fetch_add(1, Ordering::SeqCst);
+            return Err(CooldisError::History(
+                "controlled child lifecycle history failure".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
 struct ExitRuntimeFactory;
 
 #[async_trait]
@@ -3710,6 +3727,299 @@ async fn reserved_fork_adopts_a_cloned_branch_without_start_history() {
             .count(),
         1,
         "recovery must append one child start identity over the existing clone"
+    );
+    host.shutdown_all().await.unwrap();
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn fork_checkpoint_reconciles_one_shot_append_failures() {
+    for fail_after_commit in [false, true] {
+        let inner = Arc::new(InMemorySessionStore::new());
+        let faulting = if fail_after_commit {
+            FaultingRuntimeStore::new(inner.clone()).fail_nth_after(
+                "append",
+                2,
+                "fork checkpoint append committed before disconnect",
+            )
+        } else {
+            FaultingRuntimeStore::new(inner.clone()).fail_nth(
+                "append",
+                2,
+                "fork checkpoint append failed before commit",
+            )
+        };
+        let store = Arc::new(faulting);
+        let host = RuntimeHost::with_session_store(Arc::new(EchoRuntimeFactory), store.clone());
+        let parent = host
+            .start_thread(
+                coords("tenant_a", "user_1", "fork-checkpoint-append-fault"),
+                ThreadTopology::root(),
+            )
+            .await
+            .unwrap();
+
+        let checkpoint = host
+            .create_checkpoint(
+                parent.context().coordinates.thread_id,
+                None,
+                Some("fork cut".to_string()),
+                BTreeMap::new(),
+            )
+            .await
+            .expect("a one-shot checkpoint append fault must be reconciled");
+
+        let events = inner
+            .read_events(
+                &EventStreamId::for_thread(&parent.context().coordinates),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| {
+                    event.kind == EventKind::SessionEntryAppended
+                        && event.payload["runtime_kind"].as_str() == Some("thread_checkpoint")
+                        && event.payload["runtime_payload"]["checkpoint_id"].as_str()
+                            == Some(checkpoint.id.to_string().as_str())
+                })
+                .count(),
+            1,
+            "checkpoint reconciliation must not duplicate an after-fault commit"
+        );
+        host.shutdown_all().await.unwrap();
+    }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn checkpoint_reconciliation_reads_authoritative_event_history() {
+    let inner = Arc::new(InMemorySessionStore::new());
+    let store = Arc::new(
+        FaultingRuntimeStore::new(inner)
+            .fail_nth_after(
+                "append",
+                2,
+                "fork checkpoint append committed before disconnect",
+            )
+            .fail_nth(
+                "build_context",
+                1,
+                "selected branch projection is temporarily unavailable",
+            ),
+    );
+    let host = RuntimeHost::with_session_store(Arc::new(EchoRuntimeFactory), store.clone());
+    let parent = host
+        .start_thread(
+            coords(
+                "tenant_a",
+                "user_1",
+                "checkpoint-authoritative-reconciliation",
+            ),
+            ThreadTopology::root(),
+        )
+        .await
+        .unwrap();
+
+    host.create_checkpoint(
+        parent.context().coordinates.thread_id,
+        None,
+        Some("fork cut".to_string()),
+        BTreeMap::new(),
+    )
+    .await
+    .expect("reconciliation must use the durable event stream, not a branch projection");
+
+    assert_eq!(store.call_count("read_events"), 1);
+    assert_eq!(store.call_count("build_context"), 0);
+    host.shutdown_all().await.unwrap();
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn checkpoint_reconciliation_reports_append_and_read_failures() {
+    for fail_after_commit in [false, true] {
+        let inner = Arc::new(InMemorySessionStore::new());
+        let faulting = if fail_after_commit {
+            FaultingRuntimeStore::new(inner.clone()).fail_nth_after(
+                "append",
+                2,
+                "checkpoint append committed before disconnect",
+            )
+        } else {
+            FaultingRuntimeStore::new(inner.clone()).fail_nth(
+                "append",
+                2,
+                "checkpoint append failed before commit",
+            )
+        };
+        let store =
+            Arc::new(faulting.fail_nth("read_events", 1, "checkpoint reconciliation read failed"));
+        let host = RuntimeHost::with_session_store(Arc::new(EchoRuntimeFactory), store);
+        let parent = host
+            .start_thread(
+                coords(
+                    "tenant_a",
+                    "user_1",
+                    "checkpoint-reconciliation-read-failure",
+                ),
+                ThreadTopology::root(),
+            )
+            .await
+            .unwrap();
+
+        let error = host
+            .create_checkpoint(
+                parent.context().coordinates.thread_id,
+                None,
+                Some("fork cut".to_string()),
+                BTreeMap::new(),
+            )
+            .await
+            .expect_err("a failed reconciliation read cannot prove append success");
+        let message = error.to_string();
+        assert!(
+            message.contains(if fail_after_commit {
+                "checkpoint append committed before disconnect"
+            } else {
+                "checkpoint append failed before commit"
+            }),
+            "the primary append failure must remain visible: {message}"
+        );
+        assert!(
+            message.contains("checkpoint reconciliation read failed"),
+            "the reconciliation read failure must be included: {message}"
+        );
+
+        let events = inner
+            .read_events(
+                &EventStreamId::for_thread(&parent.context().coordinates),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| {
+                    event.kind == EventKind::SessionEntryAppended
+                        && event.payload["runtime_kind"].as_str() == Some("thread_checkpoint")
+                })
+                .count(),
+            usize::from(fail_after_commit),
+            "a reconciliation read failure must not add a second durable effect"
+        );
+        host.shutdown_all().await.unwrap();
+    }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn reserved_fork_child_start_reconciles_one_shot_append_failures() {
+    for fail_after_commit in [false, true] {
+        let inner = Arc::new(InMemorySessionStore::new());
+        let faulting = if fail_after_commit {
+            FaultingRuntimeStore::new(inner.clone()).fail_nth_after(
+                "append",
+                3,
+                "fork child start append committed before disconnect",
+            )
+        } else {
+            FaultingRuntimeStore::new(inner.clone()).fail_nth(
+                "append",
+                3,
+                "fork child start append failed before commit",
+            )
+        };
+        let store = Arc::new(faulting);
+        let host = RuntimeHost::with_session_store(Arc::new(EchoRuntimeFactory), store.clone());
+        let parent = host
+            .start_thread(
+                coords("tenant_a", "user_1", "fork-child-start-append-fault"),
+                ThreadTopology::root(),
+            )
+            .await
+            .unwrap();
+        let checkpoint = host
+            .create_checkpoint(
+                parent.context().coordinates.thread_id,
+                None,
+                Some("fork cut".to_string()),
+                BTreeMap::new(),
+            )
+            .await
+            .unwrap();
+        let child_thread_id = ThreadId::new();
+
+        let child = host
+            .fork_thread_from_checkpoint_with_id(checkpoint, child_thread_id)
+            .await
+            .expect("a one-shot reserved child identity append fault must be reconciled");
+
+        assert_eq!(child.context().coordinates.thread_id, child_thread_id);
+        let events = inner
+            .read_events(
+                &EventStreamId::for_thread(&child.context().coordinates),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| {
+                    event.kind == EventKind::SessionEntryAppended
+                        && event.payload["runtime_kind"].as_str() == Some("thread_started")
+                        && event.payload["runtime_payload"]["metadata"]["forked_from_thread_id"]
+                            .as_str()
+                            .is_some_and(|id| {
+                                id == parent.context().coordinates.thread_id.to_string()
+                            })
+                })
+                .count(),
+            1,
+            "reserved child recovery must keep one durable start identity"
+        );
+        host.shutdown_all().await.unwrap();
+    }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn reserved_fork_child_does_not_retry_lifecycle_history_errors() {
+    let host = RuntimeHost::new(Arc::new(EchoRuntimeFactory));
+    let child_calls = Arc::new(AtomicUsize::new(0));
+    host.set_lifecycle_sink(Some(Arc::new(HistoryFailingChildLifecycleSink {
+        child_calls: Arc::clone(&child_calls),
+    })))
+    .await;
+    let parent = host
+        .start_thread(
+            coords("tenant_a", "user_1", "fork-child-lifecycle-history-error"),
+            ThreadTopology::root(),
+        )
+        .await
+        .unwrap();
+    let checkpoint = host
+        .create_checkpoint(
+            parent.context().coordinates.thread_id,
+            None,
+            Some("fork cut".to_string()),
+            BTreeMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let error = match host.fork_thread_from_checkpoint(checkpoint).await {
+        Ok(_) => panic!("the controlled lifecycle sink failure must surface"),
+        Err(error) => error,
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("controlled child lifecycle history failure")
+    );
+    assert_eq!(
+        child_calls.load(Ordering::SeqCst),
+        1,
+        "a lifecycle history error is not an identity-append retry signal"
     );
     host.shutdown_all().await.unwrap();
 }

--- a/crates/cooldis-kernel/src/kernel/runtime_host/thread_handle.rs
+++ b/crates/cooldis-kernel/src/kernel/runtime_host/thread_handle.rs
@@ -12,16 +12,18 @@ use crate::agent::manifest_bind::{
 use crate::kernel::control_decision::{PlacementDecisionPayload, PlacementSubject};
 use crate::kernel::history::{
     EventKind, EventProvenance, EventRecord, EventSequence, EventStreamId, NewEventRecord,
-    PolicyBoundPayload, PolicyKind, SessionContext, SessionEntry, SessionEntryKind, StreamCursorV1,
+    PolicyBoundPayload, PolicyKind, SessionContext, SessionEntry, SessionEntryId, SessionEntryKind,
+    StreamCursorV1,
 };
 use crate::kernel::runtime_host::THREAD_BOUND_COUPLING_SET_METADATA;
 use cooldis_runtime_contracts::{
     ThreadCheckpointId, ThreadContext, ThreadLifecycleRecord, ThreadLifecycleStatus, ThreadSignal,
-    ThreadSignalKind, ThreadStatus,
+    ThreadSignalKind, ThreadStatus, ThreadTopology,
 };
 use std::collections::BTreeMap;
 use std::time::Duration;
 use tokio::sync::mpsc;
+use uuid::Uuid;
 
 impl RuntimeThreadHandle {
     pub fn context(&self) -> &ThreadContext {
@@ -251,6 +253,40 @@ impl RuntimeThreadHandle {
         .await
     }
 
+    /// Reconciles the reserved fork child's identity append before the host
+    /// publishes lifecycle side effects. Only the append is retried: an
+    /// unrelated history-shaped factory or lifecycle error must not re-enter
+    /// the whole child start.
+    pub(super) async fn record_thread_start_identity_with_reconciliation(
+        &self,
+    ) -> CooldisResult<()> {
+        let mut first_error = None;
+        for attempt in 0..2 {
+            match self.record_thread_start_identity().await {
+                Ok(_) => return Ok(()),
+                Err(error) => {
+                    let events = self.read_thread_events(None).await.map_err(|read_error| {
+                        reconciliation_read_error(
+                            "thread start identity append",
+                            &error,
+                            read_error,
+                        )
+                    })?;
+                    if events.iter().any(|event| {
+                        thread_start_identity_matches_context(event, &self.thread.context)
+                    }) {
+                        return Ok(());
+                    }
+                    if attempt == 1 {
+                        return Err(first_error.unwrap_or(error));
+                    }
+                    first_error = Some(error);
+                }
+            }
+        }
+        unreachable!("thread start identity reconciliation has exactly two attempts")
+    }
+
     pub async fn record_tool_universe_discovery_receipts(
         &self,
         payloads: Vec<serde_json::Value>,
@@ -414,26 +450,21 @@ impl RuntimeThreadHandle {
             metadata,
             created_at_ms: unix_timestamp_ms(),
         };
-        let checkpoint_entry = self
-            .thread
-            .services
-            .append_session_entry(
-                &self.thread.context.coordinates,
-                None,
-                SessionEntryKind::Runtime {
-                    kind: "thread_checkpoint".to_string(),
-                    payload: serde_json::json!({
-                        "checkpoint_id": checkpoint.id.to_string(),
-                        "lineage": checkpoint.lineage,
-                        "parent_checkpoint_id": checkpoint.parent_checkpoint_id.map(|id| id.to_string()),
-                        "label": checkpoint.label.clone(),
-                        "metadata": checkpoint.metadata.clone(),
-                    }),
-                },
-            )
+        let checkpoint_kind = SessionEntryKind::Runtime {
+            kind: "thread_checkpoint".to_string(),
+            payload: serde_json::json!({
+                "checkpoint_id": checkpoint.id.to_string(),
+                "lineage": checkpoint.lineage,
+                "parent_checkpoint_id": checkpoint.parent_checkpoint_id.map(|id| id.to_string()),
+                "label": checkpoint.label.clone(),
+                "metadata": checkpoint.metadata.clone(),
+            }),
+        };
+        let checkpoint_entry_id = self
+            .append_checkpoint_entry_with_reconciliation(checkpoint.id, checkpoint_kind)
             .await?;
         let checkpoint = ThreadCheckpoint {
-            active_entry_id: Some(checkpoint_entry.entry_id),
+            active_entry_id: Some(checkpoint_entry_id),
             ..checkpoint
         };
         self.thread
@@ -456,6 +487,78 @@ impl RuntimeThreadHandle {
             label: checkpoint.label.clone(),
         });
         Ok(checkpoint)
+    }
+
+    /// Makes the checkpoint prerequisite of a claimed fork survive one planned
+    /// store append fault. An append error is ambiguous, so the exact
+    /// checkpoint id is folded from the authoritative event stream before one
+    /// bounded retry; this both advances a before-fault and adopts an
+    /// after-fault without a selected-branch projection hiding the commit.
+    async fn append_checkpoint_entry_with_reconciliation(
+        &self,
+        checkpoint_id: ThreadCheckpointId,
+        checkpoint_kind: SessionEntryKind,
+    ) -> CooldisResult<SessionEntryId> {
+        let checkpoint_id = checkpoint_id.to_string();
+        let mut first_error = None;
+        for attempt in 0..2 {
+            match self
+                .thread
+                .services
+                .append_session_entry(
+                    &self.thread.context.coordinates,
+                    None,
+                    checkpoint_kind.clone(),
+                )
+                .await
+            {
+                Ok(entry) => return Ok(entry.entry_id),
+                Err(error) => {
+                    let events = self.read_thread_events(None).await.map_err(|read_error| {
+                        reconciliation_read_error("checkpoint append", &error, read_error)
+                    })?;
+                    if let Some(event) = events.iter().rev().find(|event| {
+                        event.kind == EventKind::SessionEntryAppended
+                            && event
+                                .payload
+                                .get("runtime_kind")
+                                .and_then(serde_json::Value::as_str)
+                                == Some("thread_checkpoint")
+                            && event
+                                .payload
+                                .get("runtime_payload")
+                                .and_then(|payload| payload.get("checkpoint_id"))
+                                .and_then(serde_json::Value::as_str)
+                                == Some(checkpoint_id.as_str())
+                    }) {
+                        let entry_id = event
+                            .payload
+                            .get("entry_id")
+                            .and_then(serde_json::Value::as_str)
+                            .ok_or_else(|| {
+                                CooldisError::History(format!(
+                                    "checkpoint {checkpoint_id} reconciliation event is missing entry_id"
+                                ))
+                            })
+                            .and_then(|entry_id| {
+                                Uuid::parse_str(entry_id)
+                                    .map(SessionEntryId::from_uuid)
+                                    .map_err(|parse_error| {
+                                        CooldisError::History(format!(
+                                            "checkpoint {checkpoint_id} reconciliation entry_id is invalid: {parse_error}"
+                                        ))
+                                    })
+                            })?;
+                        return Ok(entry_id);
+                    }
+                    if attempt == 1 {
+                        return Err(first_error.unwrap_or(error));
+                    }
+                    first_error = Some(error);
+                }
+            }
+        }
+        unreachable!("checkpoint append reconciliation has exactly two attempts")
     }
 
     pub fn emit_runtime(&self, kind: RuntimeEventKind) {
@@ -503,4 +606,42 @@ impl RuntimeThreadHandle {
             let _ = join_handle.await;
         }
     }
+}
+
+fn thread_start_identity_matches_context(event: &EventRecord, context: &ThreadContext) -> bool {
+    if event.kind != EventKind::SessionEntryAppended
+        || event
+            .payload
+            .get("runtime_kind")
+            .and_then(serde_json::Value::as_str)
+            != Some("thread_started")
+    {
+        return false;
+    }
+    let Some(payload) = event
+        .payload
+        .get("runtime_payload")
+        .and_then(serde_json::Value::as_object)
+    else {
+        return false;
+    };
+    let Ok(topology) = serde_json::from_value::<ThreadTopology>(payload["topology"].clone()) else {
+        return false;
+    };
+    let Ok(metadata) =
+        serde_json::from_value::<BTreeMap<String, String>>(payload["metadata"].clone())
+    else {
+        return false;
+    };
+    topology == context.topology && metadata == context.metadata
+}
+
+fn reconciliation_read_error(
+    operation: &str,
+    append_error: &CooldisError,
+    read_error: CooldisError,
+) -> CooldisError {
+    CooldisError::History(format!(
+        "{operation} failed ambiguously: {append_error}; reconciliation read failed: {read_error}"
+    ))
 }

--- a/crates/cooldis-kernel/tests/fixtures/scenarios/corpus.json
+++ b/crates/cooldis-kernel/tests/fixtures/scenarios/corpus.json
@@ -11,5 +11,6 @@
   {"seed": 4286450925398396449, "vocabulary_version": 1, "max_ops": 8, "intensity": "sparse", "pins": "EMO-408: base 777 sweep index 0 (count 3, sparse rotation) completed-lease inv3 false positive"},
   {"seed": 3697674979352012850, "vocabulary_version": 1, "max_ops": 8, "intensity": "hostile", "pins": "EMO-405: base 40520260711 sweep index 2 exposed invalid fork settlement, orphaned child routing, false queue remainder, vacuous inv5, and a suppressed nightly receipt"},
   {"seed": 12756048029454721330, "vocabulary_version": 1, "max_ops": 8, "intensity": "hostile", "pins": "EMO-405: base 40520260711 sweep index 14 exposed nondeterministic context output hashes from an unpinned event timestamp"},
-  {"seed": 4861954629787943465, "vocabulary_version": 1, "max_ops": 8, "intensity": "hostile", "pins": "EMO-405: base 40520260711 sweep index 23 exposed nondeterministic context output hashes from an unpinned event timestamp"}
+  {"seed": 4861954629787943465, "vocabulary_version": 1, "max_ops": 8, "intensity": "hostile", "pins": "EMO-405: base 40520260711 sweep index 23 exposed nondeterministic context output hashes from an unpinned event timestamp"},
+  {"seed": 2427668802218700699, "vocabulary_version": 1, "max_ops": 8, "intensity": "hostile", "pins": "EMO-513: fork claim unsettled at quiescence under store append fault"}
 ]


### PR DESCRIPTION
One failed raw store append during the fork path left the fork's io.ingress.claimed durably orphaned at global quiescence (inv6-claims-settle, scenario seed 2427668802218700699 hostile, the Jul 18 nightly rotation): create_checkpoint and the reserved child's start-identity append both propagated the one-shot error without learning whether the append had committed, so thread.spawned and io.ingress.settled were never written.

Checkpoint creation and the reserved child identity append now reconcile an ambiguous append error against the authoritative event stream by exact effect id, then retry once only when no durable record exists. The retry is append-local: runtime construction and lifecycle notification are never re-entered, and a failed reconciliation read surfaces both the append and read errors without risking a duplicate effect. The seed is pinned in the scenario corpus.

A second independent Codex review pass found and fixed three holes in the first implementation (projection-based reconciliation reads, whole-start retry double-notifying lifecycle, masked append errors); the deeper store-contract question it surfaced is filed as EMO-516.

Verification: minimized repro green, 14-entry corpus green, both new neighbor-fault tests green, full scripts/verify.sh (macOS, 1017 tests) and scripts/verify-linux.sh green on the final diff, and the base-29639789669 container sweep shows no scenario-failure for the pinned seed (only EMO-514's known runner-panic remains).

Linear: EMO-513