### PR TITLE
EMO-515: trim CI debuginfo to line tables so the build fits every runner

### DIFF
--- a/.github/workflows/scenario-nightly.yml
+++ b/.github/workflows/scenario-nightly.yml
@@ -35,6 +35,11 @@ jobs:
         id: sweep
         continue-on-error: true
         env:
+          # Same heterogeneous-disk fleet as the Verify workspace job
+          # (EMO-515): line tables keep the debug test build inside the
+          # small-root runners' free space.
+          CARGO_PROFILE_DEV_DEBUG: line-tables-only
+          CARGO_PROFILE_TEST_DEBUG: line-tables-only
           RUST_MIN_STACK: "16777216"
           COOLDIS_SCENARIO_SWEEP_BASE_SEED: ${{ github.run_id }}
           COOLDIS_SCENARIO_SWEEP_COUNT: "24"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -57,6 +57,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2.9.1
       - name: Verify workspace
         shell: bash
+        env:
+          # Hosted ubuntu runners come with heterogeneous disks (72G and 145G
+          # roots observed); full debuginfo does not fit the small ones even
+          # after the cleanup above. Line tables keep file:line backtraces and
+          # cut the target dir by more than half (EMO-515).
+          CARGO_PROFILE_DEV_DEBUG: line-tables-only
+          CARGO_PROFILE_TEST_DEBUG: line-tables-only
         run: scripts/verify.sh 2>&1 | tee verify-output.log
       - name: Upload witnessed verify output
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Follow-up hardening to #50. The green run exposed why cleanup alone was not deterministic: the ubuntu-latest fleet serves heterogeneous VMs (72G and 145G roots observed today), and the full-debuginfo test build does not fit a 72G machine even with 38G freed. Line-tables-only debuginfo keeps file:line backtraces for CI failures while cutting the target dir by more than half, which clears the small-disk runners with room to spare. CI-only; local builds keep full debuginfo.

Linear: EMO-515