### PR TITLE
EMO-523: fix CI rename regressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ target/
 **/.cooldis/
 _site/
 dist/
+verify-output.log
 scratch/
 notes/
 .claude/

--- a/scripts/guard-rails-test.sh
+++ b/scripts/guard-rails-test.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 GUARD_SCRIPT="$SCRIPT_DIR/guard-rails.sh"
+ENV_COMPAT_SCRIPT="$SCRIPT_DIR/env-compat.sh"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/guard-rails-test.XXXXXX")" || exit 1
 TMP_DIR="$(cd "$TMP_DIR" && pwd -P)"
 GIT_TEMPLATE_DIR="$TMP_DIR/git-template"
@@ -62,6 +63,7 @@ init_repo() {
   REPO="$TMP_DIR/$name"
   mkdir -p "$REPO/scripts" "$REPO/crates/verlet-kernel/src"
   cp "$GUARD_SCRIPT" "$REPO/scripts/guard-rails.sh"
+  cp "$ENV_COMPAT_SCRIPT" "$REPO/scripts/env-compat.sh"
   printf 'pub const runtime_value: &str = "base";\n' >"$REPO/crates/verlet-kernel/src/lib.rs"
   git -C "$REPO" init -q -b current
   git -C "$REPO" config user.name 'Guard Rails Test'

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -37,6 +37,7 @@ cd "$ROOT"
 run "$ROOT/scripts/threat-model-lint.sh"
 run "$ROOT/scripts/verlet-name-lint.sh"
 run "$ROOT/scripts/test-timeout-lint.sh"
+run "$ROOT/scripts/guard-rails-test.sh"
 run_cargo fmt --all -- --check
 # Same lint set as scripts/release-v1-candidate.sh so the everyday lane
 # cannot drift green while the release gate fails (EMO-459).


### PR DESCRIPTION
Fixes the two EMO-520 rename regressions that turned Verify red on all PRs:

- gitignore verify-output.log so the name lint no longer scans the CI log artifact
- guard-rails-test fixtures now copy scripts/env-compat.sh alongside guard-rails.sh (mirrors the script's runtime dependency)
- ratchet: verify.sh now runs scripts/guard-rails-test.sh so this class of regression is caught locally

Verified: guard-rails-test clean, name lint passes with a simulated stray verify-output.log, full verify green on macOS (1047s) and Linux (791s).

Linear: EMO-523