### PR TITLE
EMO-524: observe delayed scenario provider cuts

### DIFF
--- a/crates/verlet-kernel/tests/fixtures/scenarios/corpus.json
+++ b/crates/verlet-kernel/tests/fixtures/scenarios/corpus.json
@@ -13,5 +13,6 @@
   {"seed": 12756048029454721330, "vocabulary_version": 1, "max_ops": 8, "intensity": "hostile", "pins": "EMO-405: base 40520260711 sweep index 14 exposed nondeterministic context output hashes from an unpinned event timestamp"},
   {"seed": 4861954629787943465, "vocabulary_version": 1, "max_ops": 8, "intensity": "hostile", "pins": "EMO-405: base 40520260711 sweep index 23 exposed nondeterministic context output hashes from an unpinned event timestamp"},
   {"seed": 2427668802218700699, "vocabulary_version": 1, "max_ops": 8, "intensity": "hostile", "pins": "EMO-513: fork claim unsettled at quiescence under store append fault"},
-  {"seed": 13970258769908900442, "vocabulary_version": 1, "max_ops": 8, "intensity": "moderate", "pins": "EMO-514: crash-cut setup submit faulted by plan must not panic the runner"}
+  {"seed": 13970258769908900442, "vocabulary_version": 1, "max_ops": 8, "intensity": "moderate", "pins": "EMO-514: crash-cut setup submit faulted by plan must not panic the runner"},
+  {"seed": 2695179588511443457, "vocabulary_version": 1, "max_ops": 8, "intensity": "hostile", "pins": "EMO-524: delayed provider crash cut notification must not be mistaken for a quiescence hang"}
 ]

--- a/crates/verlet-kernel/tests/support/scenario.rs
+++ b/crates/verlet-kernel/tests/support/scenario.rs
@@ -1886,24 +1886,13 @@ impl CrashCutHost for ScenarioHarness {
                         coordinates = self.fresh_active_root("provider-cut-retry").await;
                         continue;
                     }
-                    for _ in 0..512 {
-                        if !self
-                            .provider
-                            .pause_next_complete
-                            .load(std::sync::atomic::Ordering::SeqCst)
-                        {
-                            break;
-                        }
-                        tokio::task::yield_now().await;
+                    let complete_started = self.provider.complete_started.notified();
+                    tokio::pin!(complete_started);
+                    tokio::select! {
+                        biased;
+                        _ = &mut complete_started => break,
+                        _ = self.wait_for_idle(&coordinates) => {}
                     }
-                    if !self
-                        .provider
-                        .pause_next_complete
-                        .load(std::sync::atomic::Ordering::SeqCst)
-                    {
-                        break;
-                    }
-                    self.wait_for_idle(&coordinates).await;
                 }
                 assert!(
                     !self
@@ -3261,6 +3250,48 @@ mod tests {
                 .all(|item| item.label != "scenario.crash_cut"),
             "a faulted setup submit must not claim that its registered seam was reached"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn provider_cut_delay_does_not_hide_cut_notification_emo_524() {
+        if !super::super::scenario_unit_harness() {
+            return;
+        }
+        let seed = 0x5240_0001;
+        let scenario = Scenario {
+            seed,
+            ops: vec![ScenarioOp::Restart],
+            plan: FaultPlan {
+                seed,
+                vocabulary_version: FAULT_VOCABULARY_VERSION,
+                intensity: Intensity::Sparse,
+                directives: vec![
+                    FaultDirective {
+                        component: FaultComponent::Provider,
+                        operation: "complete",
+                        nth: 1,
+                        timing: FaultTiming::Before,
+                        action: PlannedAction::Delay(std::time::Duration::from_millis(1)),
+                    },
+                    FaultDirective {
+                        component: FaultComponent::Process,
+                        operation: "queue-input-compile",
+                        nth: 1,
+                        timing: FaultTiming::Before,
+                        action: PlannedAction::Fail,
+                    },
+                ],
+            },
+        };
+
+        let transcript = run_scenario_once(&scenario, &[])
+            .await
+            .expect("a delayed provider cut must still be observed before quiescence");
+        assert!(transcript.items.iter().any(|item| {
+            item.label == "scenario.crash_cut"
+                && item.value.get("seam").and_then(serde_json::Value::as_str)
+                    == Some("PersistedInputRuntimeNotify")
+        }));
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
Fixes the nightly scenario sweep failure on seed 2695179588511443457 (thread never quiescent, status Running with an empty queue, reproduced on both same-seed runs).

Root cause (lost wakeup, in the test harness): the PersistedInputRuntimeNotify crash-cut handoff polled the provider pause flag for a bounded number of scheduler yields, then fell through to waiting for idle without ever awaiting the provider's complete_started notification. Under the seed's injected provider delay, the runtime reached the cut after the polling window closed, so the harness waited for a quiescence that could not arrive while the provider was intentionally held at the cut.

Fix: await complete_started directly (notify_one semantics, so an early signal is never lost), raced against a legitimate idle retry. The 30s hang-detector bound is unchanged. Adds a minimized regression test and pins the hostile seed in the scenario corpus (now 16 entries).

Verified: minimized regression fails before and passes after; the exact nightly selection including the same-seed double run passes; corpus holds; full verify green on macOS and Linux.

Linear: EMO-524