### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Changelog
 
-## v0.3.0 (Unreleased)
+## v0.3.0 (2026-08-04)
 
 - Renamed the Cooldis kernel, crates, and primary binary to Verlet. The
   `cooldis` binary name, `COOLDIS_*` environment variables, old config
   filenames, and old state-directory names remain compatible in v0.3.0 with
-  deprecation warnings; removal is no earlier than v0.4.0.
+  deprecation warnings; removal is no earlier than v0.4.0. Release archives,
+  installer, and the Homebrew formula now use the `verlet` name.
+- Fork ingress claims now settle correctly when a store append fails
+  ambiguously: reconciliation reads the authoritative event stream, adopts
+  the entry if the write landed, and retries once only when no durable
+  record exists. Previously a single failed append could leave a fork claim
+  durably orphaned so the child thread never started.
+- RPC client errors from the standalone credential path render without
+  internal component naming, and the credential setup is documented.
+- Bumped bashkit from 0.9.0 to 0.14.3.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5788,7 +5788,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "verlet"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/crates/verlet-kernel/Cargo.toml
+++ b/crates/verlet-kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verlet"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 publish = false
 autobins = false


### PR DESCRIPTION
Version bump to 0.3.0 plus CHANGELOG for the Verlet rename release (epic EMO-519).

- crates/verlet-kernel version 0.2.0 -> 0.3.0, Cargo.lock refreshed
- CHANGELOG v0.3.0 entry: rename + compat window, EMO-513 fork-claim fix, EMO-505/506 polish, bashkit bump

Full local verify green on this tree (pre-push hook).