### PR TITLE
release: fix mangled tap-dispatch workflow name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,4 +126,4 @@ jobs:
             echo "TAP_DISPATCH_TOKEN not configured; skipping tap dispatch"
             exit 0
           fi
-          gh workflow run update-EMO520LEGACYDOTyml --repo emotionscientific/homebrew-tap
+          gh workflow run update-verlet.yml --repo emotionscientific/homebrew-tap


### PR DESCRIPTION
The EMO-520 rename sweep replaced the literal 'cooldis.' inside the tap workflow filename with the lint placeholder, so the Trigger Homebrew tap update step dispatched a nonexistent workflow and failed the v0.3.0 Publish job (assets were already published; only the tap notification broke). Point it at update-verlet.yml, the tap workflow's name after the EMO-525 tap rename.

Full local verify green (pre-push hook).