### PR TITLE
EMO-528: cache the frozen V1 stream schema registry

### DIFF
--- a/crates/verlet-history/src/lib.rs
+++ b/crates/verlet-history/src/lib.rs
@@ -14,7 +14,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 use tokio::sync::RwLock;
@@ -1252,8 +1252,7 @@ impl EventRecord {
     pub fn validate_stream_record_v1(&self) -> HistoryResult<()> {
         let envelope = serde_json::to_value(self.to_stream_record_v1())
             .map_err(|err| HistoryError::Codec(format!("encode stream record envelope: {err}")))?;
-        let registry =
-            stream_schema_registry_v1().map_err(|err| HistoryError::Codec(err.to_string()))?;
+        let registry = stream_schema_registry_v1();
         registry
             .validate(STREAM_RECORD_SCHEMA_V1, &envelope)
             .map_err(|err| HistoryError::Codec(err.to_string()))?;
@@ -1304,103 +1303,114 @@ impl StreamCursorV1 {
         let cursor = serde_json::to_value(self)
             .map_err(|err| HistoryError::Codec(format!("encode stream cursor envelope: {err}")))?;
         stream_schema_registry_v1()
-            .map_err(|err| HistoryError::Codec(err.to_string()))?
             .validate(STREAM_CURSOR_SCHEMA_V1, &cursor)
             .map_err(|err| HistoryError::Codec(err.to_string()))
     }
 }
 
-pub fn stream_schema_registry_v1() -> Result<SchemaRegistry, JsonSchemaValidationError> {
-    let mut registry = SchemaRegistry::new();
-    registry.register(STREAM_RECORD_SCHEMA_V1, stream_record_schema_v1())?;
-    registry.register(STREAM_CURSOR_SCHEMA_V1, stream_cursor_schema_v1())?;
-    registry.register(
-        STREAM_BACKEND_CAPABILITIES_SCHEMA_V1,
-        stream_backend_capabilities_schema_v1(),
-    )?;
-    registry.register(STREAM_APPEND_ACK_SCHEMA_V1, stream_append_ack_schema_v1())?;
-    registry.register(
-        STREAM_ROUTING_DECISION_SCHEMA_V1,
-        stream_routing_decision_schema_v1(),
-    )?;
-    registry.register(CONTEXT_READ_PLAN_SCHEMA_V1, context_read_plan_schema_v1())?;
-    registry.register(
-        DEBUG_THREAD_EXPORT_SCHEMA_V1,
-        debug_thread_export_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::ContextCompileCompleted.payload_schema_id(),
-        context_compile_completed_payload_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::ContextSummaryCompleted.payload_schema_id(),
-        context_summary_completed_payload_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::ContextReadPlanSet.payload_schema_id(),
-        context_read_plan_set_payload_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::ThreadSpawnRequested.payload_schema_id(),
-        thread_spawn_requested_payload_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::ThreadSpawned.payload_schema_id(),
-        thread_spawned_payload_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::ThreadJoined.payload_schema_id(),
-        thread_joined_payload_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::ThreadBranchSelected.payload_schema_id(),
-        thread_branch_selected_payload_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::ThreadReloadDegraded.payload_schema_id(),
-        thread_reload_degraded_payload_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::PolicyBound.payload_schema_id(),
-        policy_bound_payload_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::GrantPetitioned.payload_schema_id(),
-        grant_petitioned_payload_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::TimerFired.payload_schema_id(),
-        timer_fired_payload_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::IoIngressReceived.payload_schema_id(),
-        io_ingress_received_payload_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::IoIngressClaimed.payload_schema_id(),
-        io_ingress_claimed_payload_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::IoIngressSettled.payload_schema_id(),
-        io_ingress_settled_payload_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::IoEgressRequested.payload_schema_id(),
-        io_egress_requested_payload_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::IoEgressDelivered.payload_schema_id(),
-        io_egress_delivered_payload_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::IoEgressFailed.payload_schema_id(),
-        io_egress_failed_payload_schema_v1(),
-    )?;
-    registry.register(
-        EventKind::AdmissionDecided.payload_schema_id(),
-        admission_decided_payload_schema_v1(),
-    )?;
-    Ok(registry)
+/// Returns the frozen V1 stream schema registry, cached once per process.
+///
+/// # Panics
+///
+/// Panics on first use if any frozen schema is malformed.
+pub fn stream_schema_registry_v1() -> &'static SchemaRegistry {
+    static REGISTRY: LazyLock<SchemaRegistry> = LazyLock::new(|| {
+        (|| -> Result<SchemaRegistry, JsonSchemaValidationError> {
+            let mut registry = SchemaRegistry::new();
+            registry.register(STREAM_RECORD_SCHEMA_V1, stream_record_schema_v1())?;
+            registry.register(STREAM_CURSOR_SCHEMA_V1, stream_cursor_schema_v1())?;
+            registry.register(
+                STREAM_BACKEND_CAPABILITIES_SCHEMA_V1,
+                stream_backend_capabilities_schema_v1(),
+            )?;
+            registry.register(STREAM_APPEND_ACK_SCHEMA_V1, stream_append_ack_schema_v1())?;
+            registry.register(
+                STREAM_ROUTING_DECISION_SCHEMA_V1,
+                stream_routing_decision_schema_v1(),
+            )?;
+            registry.register(CONTEXT_READ_PLAN_SCHEMA_V1, context_read_plan_schema_v1())?;
+            registry.register(
+                DEBUG_THREAD_EXPORT_SCHEMA_V1,
+                debug_thread_export_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::ContextCompileCompleted.payload_schema_id(),
+                context_compile_completed_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::ContextSummaryCompleted.payload_schema_id(),
+                context_summary_completed_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::ContextReadPlanSet.payload_schema_id(),
+                context_read_plan_set_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::ThreadSpawnRequested.payload_schema_id(),
+                thread_spawn_requested_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::ThreadSpawned.payload_schema_id(),
+                thread_spawned_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::ThreadJoined.payload_schema_id(),
+                thread_joined_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::ThreadBranchSelected.payload_schema_id(),
+                thread_branch_selected_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::ThreadReloadDegraded.payload_schema_id(),
+                thread_reload_degraded_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::PolicyBound.payload_schema_id(),
+                policy_bound_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::GrantPetitioned.payload_schema_id(),
+                grant_petitioned_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::TimerFired.payload_schema_id(),
+                timer_fired_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::IoIngressReceived.payload_schema_id(),
+                io_ingress_received_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::IoIngressClaimed.payload_schema_id(),
+                io_ingress_claimed_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::IoIngressSettled.payload_schema_id(),
+                io_ingress_settled_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::IoEgressRequested.payload_schema_id(),
+                io_egress_requested_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::IoEgressDelivered.payload_schema_id(),
+                io_egress_delivered_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::IoEgressFailed.payload_schema_id(),
+                io_egress_failed_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::AdmissionDecided.payload_schema_id(),
+                admission_decided_payload_schema_v1(),
+            )?;
+            Ok(registry)
+        })()
+        .expect("frozen V1 stream schema registry must contain only valid schemas")
+    });
+
+    &REGISTRY
 }
 
 fn event_kind_routes_to_model_trace(kind: EventKind) -> bool {
@@ -1490,7 +1500,7 @@ pub fn validate_context_payload_schema_v1(
     kind: EventKind,
     payload: &Value,
 ) -> Result<(), JsonSchemaValidationError> {
-    stream_schema_registry_v1()?.validate(kind.payload_schema_id(), payload)
+    stream_schema_registry_v1().validate(kind.payload_schema_id(), payload)
 }
 
 fn stream_record_schema_v1() -> Value {

--- a/crates/verlet-history/src/tests.rs
+++ b/crates/verlet-history/src/tests.rs
@@ -669,7 +669,6 @@ fn thread_reload_degraded_payload_schema_is_registered() {
     .unwrap();
 
     stream_schema_registry_v1()
-        .unwrap()
         .validate(
             EventKind::ThreadReloadDegraded.payload_schema_id(),
             &payload,
@@ -709,7 +708,7 @@ fn ingress_outcome_payloads_round_trip_whole_and_validate() {
     };
     let claim_value = serde_json::to_value(&claim).unwrap();
     let settle_value = serde_json::to_value(&settle).unwrap();
-    let registry = stream_schema_registry_v1().unwrap();
+    let registry = stream_schema_registry_v1();
 
     registry
         .validate(
@@ -752,7 +751,7 @@ fn events_0_3_payload_fixtures_round_trip_and_validate() {
     let ingress_event_id = EventRecordId::from_uuid(
         uuid::Uuid::parse_str("018f0000-0000-7000-8000-000000000005").unwrap(),
     );
-    let registry = stream_schema_registry_v1().unwrap();
+    let registry = stream_schema_registry_v1();
 
     let cases = [
         (
@@ -1061,7 +1060,6 @@ fn events_0_1_style_stream_record_still_parses_and_unknown_kind_fails_closed() {
         EventKind::TurnCompleted
     );
     stream_schema_registry_v1()
-        .unwrap()
         .validate(
             STREAM_RECORD_SCHEMA_V1,
             &serde_json::to_value(parsed).unwrap(),
@@ -1220,7 +1218,6 @@ fn stream_routing_decision_v1_uses_envelope_fields_not_payload() {
     assert_eq!(baited.route_decision_v1(), decision);
 
     stream_schema_registry_v1()
-        .unwrap()
         .validate(
             STREAM_ROUTING_DECISION_SCHEMA_V1,
             &serde_json::to_value(decision).unwrap(),
@@ -1312,7 +1309,6 @@ fn stream_append_ack_v1_freezes_ack_classes_and_tail_identity() {
     );
 
     stream_schema_registry_v1()
-        .unwrap()
         .validate(
             STREAM_APPEND_ACK_SCHEMA_V1,
             &serde_json::to_value(ack).unwrap(),
@@ -1361,12 +1357,19 @@ fn stream_backend_capabilities_v1_freezes_sqlite_reference_shape() {
     );
 
     stream_schema_registry_v1()
-        .unwrap()
         .validate(
             STREAM_BACKEND_CAPABILITIES_SCHEMA_V1,
             &serde_json::to_value(capabilities).unwrap(),
         )
         .unwrap();
+}
+
+#[test]
+fn stream_schema_registry_v1_is_cached_once_per_process() {
+    let first = stream_schema_registry_v1();
+    let second = stream_schema_registry_v1();
+
+    assert!(std::ptr::eq(first, second));
 }
 
 #[test]
@@ -1483,7 +1486,7 @@ fn stream_schema_registry_v1_validates_envelopes_and_context_payloads() {
         ),
     );
 
-    let registry = stream_schema_registry_v1().unwrap();
+    let registry = stream_schema_registry_v1();
     for record in [&compile, &summary, &read_plan_set] {
         record.validate_stream_record_v1().unwrap();
         validate_context_payload_schema_v1(record.kind, &record.payload).unwrap();

--- a/crates/verlet-kernel/src/adapters/app_server/connection.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/connection.rs
@@ -2556,11 +2556,6 @@ impl VerletAppServer {
             "receipts": receipts,
         });
         stream_schema_registry_v1()
-            .map_err(|err| {
-                internal_error(VerletError::RuntimeFactory(format!(
-                    "debug export schema registry failed: {err}"
-                )))
-            })?
             .validate(DEBUG_THREAD_EXPORT_SCHEMA_V1, &bundle)
             .map_err(|err| {
                 internal_error(VerletError::RuntimeFactory(format!(

--- a/crates/verlet-kernel/tests/contract_fixtures.rs
+++ b/crates/verlet-kernel/tests/contract_fixtures.rs
@@ -275,7 +275,7 @@ fn ingress_outcome_protocol_contract_matches_fixture() {
     };
     let claim_value = serde_json::to_value(&claim).unwrap();
     let settle_value = serde_json::to_value(&settle).unwrap();
-    let registry = stream_schema_registry_v1().unwrap();
+    let registry = stream_schema_registry_v1();
     registry
         .validate(
             EventKind::IoIngressClaimed.payload_schema_id(),
@@ -547,7 +547,7 @@ fn stream_schema_v1_contract_matches_fixture() {
         branch_selection.clone(),
         reload_degraded,
     ];
-    let schema_registry = stream_schema_registry_v1().unwrap();
+    let schema_registry = stream_schema_registry_v1();
     for record in &records {
         record.validate_stream_record_v1().unwrap();
         validate_context_payload_schema_v1(record.kind, &record.payload).unwrap();
@@ -734,7 +734,6 @@ fn debug_thread_export_v1_contract_matches_fixture() {
     });
 
     stream_schema_registry_v1()
-        .unwrap()
         .validate(DEBUG_THREAD_EXPORT_SCHEMA_V1, &bundle)
         .unwrap();
     support::assert_json_fixture("contracts/debug_thread_export_v1.json", bundle);


### PR DESCRIPTION
The frozen V1 stream schema registry was rebuilt and re-self-validated (~25 schemas) on every event validation, which burned a full core in the idle daemon under the 250ms egress poll. This caches it in a LazyLock, returns &'static SchemaRegistry, and migrates all callers (4 production + 14 test/fixture sites).

Read-side validation coverage is unchanged (ADR 0001 fail-closed posture kept). Guard: a pointer-equality test pins once-per-process construction.

Verification: scripts/verify.sh green (macOS), scripts/verify-linux.sh green, plus an independent Codex review-and-fix pass over the diff with no findings (report trail on EMO-528).

Linear: EMO-528