### PR TITLE
docs: point README badges at verlet-kernel repo slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Verlet
 
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/emotionscientific/cooldis-kernel)
-[![Verify](https://github.com/emotionscientific/cooldis-kernel/actions/workflows/verify.yml/badge.svg)](https://github.com/emotionscientific/cooldis-kernel/actions/workflows/verify.yml)
-[![Release](https://github.com/emotionscientific/cooldis-kernel/actions/workflows/release.yml/badge.svg)](https://github.com/emotionscientific/cooldis-kernel/actions/workflows/release.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/emotionscientific/verlet-kernel)
+[![Verify](https://github.com/emotionscientific/verlet-kernel/actions/workflows/verify.yml/badge.svg)](https://github.com/emotionscientific/verlet-kernel/actions/workflows/verify.yml)
+[![Release](https://github.com/emotionscientific/verlet-kernel/actions/workflows/release.yml/badge.svg)](https://github.com/emotionscientific/verlet-kernel/actions/workflows/release.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Status: experimental](https://img.shields.io/badge/status-experimental-yellow.svg)](README.md)
 

--- a/scripts/verlet-name-allowlist.tsv
+++ b/scripts/verlet-name-allowlist.tsv
@@ -3,7 +3,6 @@
 .github/ISSUE_TEMPLATE/config.yml	Repository remote site or external workflow identity is out of scope for EMO-520.
 .gitignore	Legacy state directory remains ignored during the compatibility window.
 CHANGELOG.md	Rename and deprecation-window receipt for v0.3.0.
-README.md	Repository remote site or external workflow identity is out of scope for EMO-520.
 RELEASE.md	Repository remote site or external workflow identity is out of scope for EMO-520.
 apps/console/src/App.svelte	Stable persisted storage ABI or wire identifier remains unchanged for compatibility.
 apps/console/src/lib/app.svelte.ts	Stable persisted storage ABI or wire identifier remains unchanged for compatibility.


### PR DESCRIPTION
The DeepWiki, Verify, and Release badges still linked the pre-rename cooldis-kernel slug (GitHub redirected; DeepWiki did not). Points all three at emotionscientific/verlet-kernel and drops README.md from the rename-lint allowlist now that its last legacy token is gone.