### PR TITLE
release: bump kernel version to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5788,7 +5788,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "verlet"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "base64",

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Verlet
 
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/emotionscientific/cooldis-kernel)
-[![Verify](https://github.com/emotionscientific/cooldis-kernel/actions/workflows/verify.yml/badge.svg)](https://github.com/emotionscientific/cooldis-kernel/actions/workflows/verify.yml)
-[![Release](https://github.com/emotionscientific/cooldis-kernel/actions/workflows/release.yml/badge.svg)](https://github.com/emotionscientific/cooldis-kernel/actions/workflows/release.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/emotionscientific/verlet-kernel)
+[![Verify](https://github.com/emotionscientific/verlet-kernel/actions/workflows/verify.yml/badge.svg)](https://github.com/emotionscientific/verlet-kernel/actions/workflows/verify.yml)
+[![Release](https://github.com/emotionscientific/verlet-kernel/actions/workflows/release.yml/badge.svg)](https://github.com/emotionscientific/verlet-kernel/actions/workflows/release.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Status: experimental](https://img.shields.io/badge/status-experimental-yellow.svg)](README.md)
 

--- a/crates/verlet-kernel/Cargo.toml
+++ b/crates/verlet-kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verlet"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 publish = false
 autobins = false

--- a/scripts/verlet-name-allowlist.tsv
+++ b/scripts/verlet-name-allowlist.tsv
@@ -3,7 +3,6 @@
 .github/ISSUE_TEMPLATE/config.yml	Repository remote site or external workflow identity is out of scope for EMO-520.
 .gitignore	Legacy state directory remains ignored during the compatibility window.
 CHANGELOG.md	Rename and deprecation-window receipt for v0.3.0.
-README.md	Repository remote site or external workflow identity is out of scope for EMO-520.
 RELEASE.md	Repository remote site or external workflow identity is out of scope for EMO-520.
 apps/console/src/App.svelte	Stable persisted storage ABI or wire identifier remains unchanged for compatibility.
 apps/console/src/lib/app.svelte.ts	Stable persisted storage ABI or wire identifier remains unchanged for compatibility.


### PR DESCRIPTION
Version bump for the v0.3.1 release: first release carrying the orchestrator boundary v0 (EMO-532, ADR 0009) and the incremental egress drain. Needed by the bundled orchestrator deployment, which installs the daemon from tagged release binaries.