### PR TITLE
Deslop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,45 @@ members = [
 ]
 default-members = ["crates/verlet-kernel"]
 resolver = "3"
+
+[workspace.dependencies]
+async-trait = "0.1"
+base64 = "0.22"
+bashkit = { version = "0.14.3", features = ["realfs"] }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+chrono-tz = "0.10"
+crc32fast = "1.5"
+croner = "3.0.1"
+crossterm = { version = "0.28.1", features = ["event-stream"] }
+futures-executor = "0.3"
+futures-util = "0.3.32"
+getrandom = "0.3"
+hex = "0.4"
+hmac = "0.13"
+libc = "0.2"
+object_store = { version = "0.13.2", features = ["aws"] }
+pgqrs = { version = "0.15.3", default-features = false }
+proc-macro2 = "1"
+quote = "1"
+ratatui = "=0.30.2"
+regex = "1.13"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+# ADR 0005 decision 8: retained for the ingress IO-state enclave until EMO-409.
+rusqlite = { version = "0.32.1", features = ["bundled"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+# verlet-provider pins sha2 0.11 locally to match hmac 0.13; everything else is on 0.10.
+sha2 = "0.10"
+subtle = "2"
+syn = { version = "2", features = ["full"] }
+tempfile = "3"
+thiserror = "2"
+tokio = "1"
+tokio-tungstenite = "0.28"
+tokio-util = "0.7"
+toml = "0.9"
+turso = "=0.7.0-pre.19"
+turso_core = "=0.7.0-pre.19"
+uuid = "1"
+wasmtime = { version = "44.0.1", default-features = false, features = ["async", "cache", "cranelift", "runtime", "std"] }
+wat = "1"

--- a/crates/verlet-abi/Cargo.toml
+++ b/crates/verlet-abi/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 publish = false
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/verlet-agent/Cargo.toml
+++ b/crates/verlet-agent/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 verlet-abi = { path = "../verlet-abi" }
 verlet-operations = { path = "../verlet-operations" }
 verlet-runtime-contracts = { path = "../verlet-runtime-contracts" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-sha2 = "0.10"
-thiserror = "2"
-toml = "0.9"
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+toml = { workspace = true }

--- a/crates/verlet-guest-sdk-macros/Cargo.toml
+++ b/crates/verlet-guest-sdk-macros/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1"
-quote = "1"
-syn = { version = "2", features = ["full"] }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }

--- a/crates/verlet-guest-sdk/Cargo.toml
+++ b/crates/verlet-guest-sdk/Cargo.toml
@@ -6,5 +6,5 @@ publish = false
 
 [dependencies]
 verlet-guest-sdk-macros = { path = "../verlet-guest-sdk-macros" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/verlet-history-sqlite/Cargo.toml
+++ b/crates/verlet-history-sqlite/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2024"
 publish = false
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }
 verlet-history = { path = "../verlet-history" }
 verlet-runtime-contracts = { path = "../verlet-runtime-contracts" }
 verlet-sqlite = { path = "../verlet-sqlite" }
-serde_json = "1"
-tokio = { version = "1", features = ["rt", "sync"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync"] }
 
 [dev-dependencies]
-base64 = "0.22"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
+base64 = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }

--- a/crates/verlet-history/Cargo.toml
+++ b/crates/verlet-history/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2024"
 publish = false
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }
 verlet-runtime-contracts = { path = "../verlet-runtime-contracts" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
-tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
-uuid = { version = "1", features = ["serde", "v7"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
+uuid = { workspace = true, features = ["serde", "v7"] }

--- a/crates/verlet-io-core/Cargo.toml
+++ b/crates/verlet-io-core/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2024"
 publish = false
 
 [dependencies]
-async-trait = "0.1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
-uuid = { version = "1", features = ["serde", "v7"] }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true, features = ["serde", "v7"] }

--- a/crates/verlet-io-pgqrs/Cargo.toml
+++ b/crates/verlet-io-pgqrs/Cargo.toml
@@ -10,15 +10,15 @@ sqlite = ["pgqrs/sqlite"]
 postgres = ["pgqrs/postgres"]
 
 [dependencies]
-async-trait = "0.1"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
+async-trait = { workspace = true }
+chrono = { workspace = true }
 verlet-io-core = { path = "../verlet-io-core" }
-pgqrs = { version = "0.15.3", default-features = false }
+pgqrs = { workspace = true }
 # ADR 0005 decision 8: retained for the ingress IO-state enclave until EMO-409.
-rusqlite = { version = "0.32.1", features = ["bundled"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
+rusqlite = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/verlet-io-telegram/Cargo.toml
+++ b/crates/verlet-io-telegram/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2024"
 publish = false
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }
 verlet-io-core = { path = "../verlet-io-core" }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/verlet-kernel/Cargo.toml
+++ b/crates/verlet-kernel/Cargo.toml
@@ -6,11 +6,11 @@ publish = false
 autobins = false
 
 [dependencies]
-async-trait = "0.1"
-base64 = "0.22"
-bashkit = { version = "0.14.3", features = ["realfs"] }
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
-chrono-tz = "0.10"
+async-trait = { workspace = true }
+base64 = { workspace = true }
+bashkit = { workspace = true }
+chrono = { workspace = true }
+chrono-tz = { workspace = true }
 verlet-agent = { path = "../verlet-agent" }
 verlet-abi = { path = "../verlet-abi" }
 verlet-history = { path = "../verlet-history" }
@@ -27,32 +27,32 @@ verlet-sqlite = { path = "../verlet-sqlite" }
 verlet-vfs = { path = "../verlet-vfs" }
 verlet-vbash = { path = "../verlet-vbash" }
 verlet-wasm = { path = "../verlet-wasm" }
-croner = "3.0.1"
-crossterm = { version = "0.28.1", features = ["event-stream"] }
-futures-util = "0.3.32"
-getrandom = "0.3"
-libc = "0.2"
-object_store = { version = "0.13.2", features = ["aws"] }
-ratatui = "=0.30.2"
-regex = "1.13"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+croner = { workspace = true }
+crossterm = { workspace = true }
+futures-util = { workspace = true }
+getrandom = { workspace = true }
+libc = { workspace = true }
+object_store = { workspace = true }
+ratatui = { workspace = true }
+regex = { workspace = true }
+reqwest = { workspace = true }
 # ADR 0005 decision 8: retained for the ingress IO-state enclave until EMO-409.
-rusqlite = { version = "0.32.1", features = ["bundled"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-sha2 = "0.10"
-subtle = "2"
-thiserror = "2"
-tokio = { version = "1", features = ["io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
-tokio-tungstenite = "0.28"
-tokio-util = "0.7"
-toml = "0.9"
-uuid = { version = "1", features = ["serde", "v4", "v5", "v7"] }
+rusqlite = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+subtle = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
+tokio-tungstenite = { workspace = true }
+tokio-util = { workspace = true }
+toml = { workspace = true }
+uuid = { workspace = true, features = ["serde", "v4", "v5", "v7"] }
 
 [dev-dependencies]
-futures-executor = "0.3"
-tokio = { version = "1", features = ["io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time", "test-util"] }
-wat = "1"
+futures-executor = { workspace = true }
+tokio = { workspace = true, features = ["io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time", "test-util"] }
+wat = { workspace = true }
 
 [[bin]]
 name = "verlet"

--- a/crates/verlet-metadata/Cargo.toml
+++ b/crates/verlet-metadata/Cargo.toml
@@ -5,17 +5,17 @@ edition = "2024"
 publish = false
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }
 verlet-abi = { path = "../verlet-abi" }
 verlet-history = { path = "../verlet-history" }
 verlet-runtime-contracts = { path = "../verlet-runtime-contracts" }
 verlet-sqlite = { path = "../verlet-sqlite" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
-tokio = { version = "1", features = ["rt"] }
-uuid = { version = "1", features = ["v7"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt"] }
+uuid = { workspace = true, features = ["v7"] }
 
 [dev-dependencies]
-futures-executor = "0.3"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
+futures-executor = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }

--- a/crates/verlet-operations/Cargo.toml
+++ b/crates/verlet-operations/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2024"
 publish = false
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }
 verlet-abi = { path = "../verlet-abi" }
 verlet-process = { path = "../verlet-process" }
 verlet-runtime-contracts = { path = "../verlet-runtime-contracts" }
 verlet-wasm = { path = "../verlet-wasm" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-sha2 = "0.10"
-thiserror = "2"
-tokio = { version = "1", features = ["sync"] }
-toml = "0.9"
-uuid = { version = "1", features = ["v7"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+toml = { workspace = true }
+uuid = { workspace = true, features = ["v7"] }

--- a/crates/verlet-process/Cargo.toml
+++ b/crates/verlet-process/Cargo.toml
@@ -5,19 +5,19 @@ edition = "2024"
 publish = false
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }
 verlet-abi = { path = "../verlet-abi" }
 verlet-runtime-contracts = { path = "../verlet-runtime-contracts" }
-futures-util = "0.3.32"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
-tokio = { version = "1", features = ["io-util", "process", "sync", "time"] }
-tokio-util = "0.7"
-uuid = { version = "1", features = ["serde", "v7"] }
+futures-util = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["io-util", "process", "sync", "time"] }
+tokio-util = { workspace = true }
+uuid = { workspace = true, features = ["serde", "v7"] }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/verlet-provider/Cargo.toml
+++ b/crates/verlet-provider/Cargo.toml
@@ -5,20 +5,21 @@ edition = "2024"
 publish = false
 
 [dependencies]
-async-trait = "0.1"
-base64 = "0.22"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
+async-trait = { workspace = true }
+base64 = { workspace = true }
+chrono = { workspace = true }
 verlet-history = { path = "../verlet-history" }
-crc32fast = "1.5"
-hex = "0.4"
-hmac = "0.13"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+crc32fast = { workspace = true }
+hex = { workspace = true }
+hmac = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+# Not workspace-inherited: hmac 0.13 needs sha2 0.11, the rest of the tree is on 0.10.
 sha2 = "0.11"
-thiserror = "2"
-tokio = { version = "1", features = ["macros"] }
-tokio-util = "0.7"
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
+tokio-util = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "time"] }
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "time"] }

--- a/crates/verlet-runtime-contracts/Cargo.toml
+++ b/crates/verlet-runtime-contracts/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2024"
 publish = false
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-uuid = { version = "1", features = ["serde", "v7"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true, features = ["serde", "v7"] }
 
 [dev-dependencies]

--- a/crates/verlet-sqlite/Cargo.toml
+++ b/crates/verlet-sqlite/Cargo.toml
@@ -6,10 +6,10 @@ license = "Apache-2.0"
 description = "Engine-owner crate for verlet SQLite stores (ADR 0005): configuration, connections, migrations, DST IO hook"
 
 [dependencies]
-turso = "=0.7.0-pre.19"
-turso_core = "=0.7.0-pre.19"
-thiserror = "2"
+turso = { workspace = true }
+turso_core = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
-tempfile = "3"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
+tempfile = { workspace = true }

--- a/crates/verlet-vbash/Cargo.toml
+++ b/crates/verlet-vbash/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2024"
 publish = false
 
 [dependencies]
-async-trait = "0.1"
-bashkit = { version = "0.14.3", features = ["realfs"] }
+async-trait = { workspace = true }
+bashkit = { workspace = true }
 verlet-abi = { path = "../verlet-abi" }
 verlet-operations = { path = "../verlet-operations" }
 verlet-process = { path = "../verlet-process" }
 verlet-vfs = { path = "../verlet-vfs" }
-serde_json = "1"
-thiserror = "2"
-tokio = { version = "1", features = ["rt", "sync"] }
-tokio-util = "0.7"
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync"] }
+tokio-util = { workspace = true }

--- a/crates/verlet-vfs/Cargo.toml
+++ b/crates/verlet-vfs/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2024"
 publish = false
 
 [dependencies]
-async-trait = "0.1"
-bashkit = { version = "0.14.3", features = ["realfs"] }
-futures-util = "0.3.32"
-object_store = { version = "0.13.2", features = ["aws"] }
+async-trait = { workspace = true }
+bashkit = { workspace = true }
+futures-util = { workspace = true }
+object_store = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }

--- a/crates/verlet-wasm/Cargo.toml
+++ b/crates/verlet-wasm/Cargo.toml
@@ -5,14 +5,14 @@ edition = "2024"
 publish = false
 
 [dependencies]
-bashkit = { version = "0.14.3", features = ["realfs"] }
+bashkit = { workspace = true }
 verlet-abi = { path = "../verlet-abi" }
 verlet-process = { path = "../verlet-process" }
 verlet-runtime-contracts = { path = "../verlet-runtime-contracts" }
 verlet-vfs = { path = "../verlet-vfs" }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
-tokio = { version = "1", features = ["fs", "net"] }
-wasmtime = { version = "44.0.1", default-features = false, features = ["async", "cache", "cranelift", "runtime", "std"] }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["fs", "net"] }
+wasmtime = { workspace = true }

--- a/tools/trace-ab/Cargo.toml
+++ b/tools/trace-ab/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2024"
 publish = false
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 


### PR DESCRIPTION
All third-party deps now declared once in the root manifest; members inherit with `{ workspace = true }` and add features only where they diverge (`tokio`, `uuid`).

`verlet-provider` keeps `sha2 = "0.11"` local — `hmac 0.13` requires it, the rest of the tree is on `0.10`.

Verified: `cargo tree --workspace --all-targets --format "{p} {f}"` is byte-identical before/after, and `cargo metadata --locked` passes with `Cargo.lock` untouched.

Supersedes #67 (identical diff; re-opened with the head branch on this repo so follow-up PRs can stack on top of it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)