### PR TITLE
build: add a Nix flake for the dev shell and binary packaging

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+use flake
+
+# Re-evaluate when the toolchain changes. Without this, switching Rust
+# versions in rust-toolchain.toml won't take effect until `direnv reload`.
+nix_direnv_watch_file rust-toolchain.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 target/
 **/target/
 
+result
+result-*
+.direnv/
+
 .tmp/
 .site/
 # Local daemon runtime state (publish records embed absolute home paths).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,13 @@ For the repository's fuller local checks, use:
 scripts/check-pre-push.sh
 ```
 
+Nix users can get the pinned toolchain plus `just`, `bun`, and `sccache` with
+`nix develop` (or `direnv allow`, which uses the checked-in `.envrc`). The
+toolchain comes from `rust-toolchain.toml`, the same file rustup reads, so both
+setups build the same thing. `nix build` produces the `verlet`,
+`verlet-mcp-server`, and `verlet-acp-agent` binaries. The flake is a convenience
+for local work; `.github/workflows/verify.yml` remains the gate.
+
 ## Contribution License
 
 The repository is licensed under the Apache License, Version 2.0. A future

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,106 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1785782307,
+        "narHash": "sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "2c71e194474d13de031d729b729c968ddbe3507f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785967620,
+        "narHash": "sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b7c2ada94fe99c15b0dbcf4d11fd7850b957a436",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785993740,
+        "narHash": "sha256-naSJ+p7zkIT2hHNSJkhxiPZlmVRgE3UdODinMM7rpD8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3d1b34a12a26be073f7ae67165a6b61229ca6025",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785945821,
+        "narHash": "sha256-NLSyTCW4K4ofhNBllt3omPasm6QpralXH1DBZOc91Dw=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "ae7910970dddc408fe6ab1c8e4b277bb21d72dc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "verlet-kernel workspace";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    crane = {
+      url = "github:ipetkov/crane";
+    };
+
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      # The four targets .github/workflows/release.yml packages.
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      imports = [
+        inputs.treefmt-nix.flakeModule
+        ./nix/toolchain.nix
+        ./nix/packages.nix
+        ./nix/devshell.nix
+        ./nix/fmt.nix
+      ];
+    };
+}

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,0 +1,41 @@
+{ ... }:
+{
+  perSystem =
+    {
+      pkgs,
+      rustToolchain,
+      lib,
+      ...
+    }:
+    {
+      devShells.default = pkgs.mkShell {
+        nativeBuildInputs = [
+          rustToolchain
+
+          pkgs.sccache
+          pkgs.clang
+          pkgs.lldb
+
+          # Justfile is the task entrypoint; scripts/build-console-assets.sh
+          # needs bun for apps/console.
+          pkgs.just
+          pkgs.bun
+        ]
+        # mold and wild are ELF-only, so Linux-only.
+        ++ lib.optionals pkgs.stdenv.isLinux [
+          pkgs.mold
+          pkgs.wild
+        ];
+
+        RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+
+        shellHook = ''
+          export RUSTC_WRAPPER=sccache
+        ''
+        + lib.optionalString pkgs.stdenv.isLinux ''
+          # Pick the linker with LINKER=wild (or LINKER=lld, LINKER=bfd, ...).
+          export RUSTFLAGS="''${RUSTFLAGS:-} -C link-arg=-fuse-ld=''${LINKER:-mold}"
+        '';
+      };
+    };
+}

--- a/nix/fmt.nix
+++ b/nix/fmt.nix
@@ -1,0 +1,20 @@
+{ ... }:
+{
+  perSystem =
+    { ... }:
+    {
+      treefmt.config = {
+        projectRootFile = "flake.nix";
+
+        programs = {
+          nixfmt.enable = true;
+          taplo.enable = true;
+        };
+
+        # No rustfmt here. treefmt applies one edition to every file, but
+        # verlet-sqlite is edition 2021 and the rest of the workspace is 2024,
+        # so a single setting always disagrees with somebody. `cargo fmt` reads
+        # each crate's edition and is already gated by scripts/verify.sh.
+      };
+    };
+}

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,0 +1,50 @@
+{ ... }:
+{
+  perSystem =
+    {
+      craneLib,
+      ...
+    }:
+    let
+      # Version tracks the kernel crate, which is what `verlet --version` reports.
+      crateName = craneLib.crateNameFromCargoToml {
+        cargoToml = ../crates/verlet-kernel/Cargo.toml;
+      };
+
+      commonArgs = {
+        src = craneLib.cleanCargoSource ../.;
+        strictDeps = true;
+
+        # Deliberately no pkg-config/openssl: reqwest is rustls-only and
+        # rusqlite is `bundled`, so SQLite compiles from vendored C with the
+        # stdenv compiler. Nothing in the tree links a system library.
+      };
+
+      cargoArtifacts = craneLib.buildDepsOnly (commonArgs // { inherit (crateName) pname version; });
+    in
+    {
+      packages.default = craneLib.buildPackage (
+        commonArgs
+        // {
+          inherit cargoArtifacts;
+          inherit (crateName) pname version;
+
+          # The kernel crate also declares smoke and support-binary targets that
+          # only make sense inside `scripts/verify.sh`; ship the runtime ones.
+          cargoExtraArgs = "--locked --package verlet --bin verlet --bin verlet-mcp-server --bin verlet-acp-agent";
+
+          # The suite wants fixtures that cleanCargoSource strips, a
+          # wasm32-unknown-unknown cargo build, and network. CI owns it.
+          doCheck = false;
+
+          meta.mainProgram = "verlet";
+        }
+      );
+
+      # `nix flake check` runs treefmt (added by the treefmt-nix module).
+      # Clippy and the workspace test suite are intentionally not mirrored here:
+      # both need `--all-targets`, which pulls in the JSON/wasm/sqlite fixtures
+      # that cleanCargoSource drops, and the tests shell out to cargo and the
+      # network. .github/workflows/verify.yml is the gate for those.
+    };
+}

--- a/nix/toolchain.nix
+++ b/nix/toolchain.nix
@@ -1,0 +1,24 @@
+{ inputs, ... }:
+{
+  perSystem =
+    {
+      system,
+      lib,
+      ...
+    }:
+    let
+      pkgs = import inputs.nixpkgs {
+        inherit system;
+        overlays = [ inputs.rust-overlay.overlays.default ];
+      };
+
+      rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ../rust-toolchain.toml;
+
+      craneLib = (inputs.crane.mkLib pkgs).overrideToolchain (_: rustToolchain);
+    in
+    {
+      _module.args = {
+        inherit pkgs rustToolchain craneLib;
+      };
+    };
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,19 @@
+# rust-toolchain.toml — Single source of truth for the Rust toolchain.
+#
+# Consumed by: Cargo, rust-analyzer, rustup, and rust-overlay (via Nix).
+# Non-Nix developers can use this same file with rustup.
+
+[toolchain]
+channel = "stable"
+# For nightly, pin a specific date:
+# channel = "nightly-2026-04-01"
+
+profile = "default"
+
+# rust-src is CRITICAL on NixOS: without it, rust-analyzer cannot find
+# the standard library sources.
+components = ["rust-src", "rust-analyzer", "clippy", "rustfmt"]
+
+# The wasm smoke tests (`verlet-wasm-smoke`, the tests/fixtures/wasm-* guest
+# crates) build for wasm32, which is why every CI job installs it too.
+targets = ["wasm32-unknown-unknown"]

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,3 @@
+[formatting]
+column_width = 140
+indent_string = "    "

--- a/tools/trace-ab/Cargo.toml
+++ b/tools/trace-ab/Cargo.toml
@@ -7,4 +7,3 @@ publish = false
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
-


### PR DESCRIPTION
## Maintainer Summary

Adds a Nix flake so `nix develop` gives the pinned toolchain and `nix build`
produces the runtime binaries. Nothing about how CI or rustup users build the
workspace changes.

- **`rust-toolchain.toml` stays the single source of truth.** `nix develop` and
  `rustup` resolve the same compiler. It now also requests
  `wasm32-unknown-unknown`, which every job in `verify.yml` and `release.yml`
  already installs by hand for the wasm smokes.
- **`nix build` packages `verlet`, `verlet-mcp-server`, and
  `verlet-acp-agent`** via crane. Nothing in the tree links a system library
  (reqwest is rustls-only, rusqlite is `bundled`), so there are no pkg-config
  or openssl inputs. The v0.3.0 compatibility wrapper is skipped — there are no
  legacy Nix installs to be compatible with.
- **`nix flake check` runs treefmt over Nix and TOML only.** Three things are
  deliberately *not* mirrored from CI:
  - Clippy and the workspace suite both need `--all-targets`, which pulls in
    the JSON/wasm/sqlite fixtures that crane's source filter strips, and the
    tests shell out to cargo and the network.
  - Rust formatting stays with `cargo fmt`, which reads each crate's own
    edition. treefmt can only apply one edition to every file, and
    `verlet-sqlite` is edition 2021 while the other 18 crates are 2024 — any
    single setting disagrees with somebody. (Confirmed empirically: a
    `--edition 2024` treefmt pass wanted to rewrite
    `crates/verlet-sqlite/src/lib.rs`, which `cargo fmt --all -- --check`
    considers clean.)

  `verify.yml` remains the gate for all three.
- **`taplo.toml` matches the workspace's existing TOML style**
  (`column_width = 140`, four-space indent), so taplo is a no-op rather than a
  reformat of 20 hand-maintained `Cargo.toml`s.
- `flake.nix` covers the four systems `release.yml` packages.

The only non-Nix content change is a stray trailing blank line removed from
`tools/trace-ab/Cargo.toml`.

## Verification

All run locally on aarch64-darwin:

- `nix build .#default` — builds and installs the three binaries;
  `./bin/verlet --version` reports `verlet 0.3.1`.
- `nix flake check` — green (treefmt, 299 files, no changes).
- `nix flake show` — evaluates clean on all four systems.
- `cargo fmt --all -- --check` — still clean, unaffected by the flake.
- `scripts/verlet-name-lint.sh`, `scripts/threat-model-lint.sh`,
  `scripts/test-timeout-lint.sh`, `scripts/check-remote-ci.sh` — all pass.

The workspace test suite was not run under Nix by design; see above.

## Risk

Low. The flake is additive and optional; no workflow, script, or crate consumes
it. The one behavior change reaching non-Nix contributors is the
`wasm32-unknown-unknown` entry in `rust-toolchain.toml`, which makes rustup
install a target CI already installs explicitly.

## Checklist

- [x] I understand the change and can explain it.
- [x] This is a maintainer-owned pull request.
- [x] I kept the pull request scoped and reviewable.
- [x] I did not include secrets, private credentials, local machine paths, or scratch artifacts.
- [x] I updated docs or tests where the behavior changed.
