### PR TITLE
EMO-546: rename codex_tui adapter to operator_client

### DIFF
--- a/crates/verlet-kernel/src/adapters/acp_agent.rs
+++ b/crates/verlet-kernel/src/adapters/acp_agent.rs
@@ -121,7 +121,7 @@ struct VerletAcpAgent {
     state: std::sync::Arc<tokio::sync::Mutex<AcpAgentState>>,
     outbound: tokio::sync::mpsc::UnboundedSender<serde_json::Value>,
     #[cfg(unix)]
-    daemon_client: Option<crate::adapters::codex_tui::CodexTuiTestClient<tokio::net::UnixStream>>,
+    daemon_client: Option<crate::adapters::operator_client::OperatorClient<tokio::net::UnixStream>>,
 }
 
 impl VerletAcpAgent {
@@ -532,7 +532,7 @@ impl VerletAcpAgent {
     #[cfg(unix)]
     async fn client(
         &mut self,
-    ) -> Result<&mut crate::adapters::codex_tui::CodexTuiTestClient<tokio::net::UnixStream>, String>
+    ) -> Result<&mut crate::adapters::operator_client::OperatorClient<tokio::net::UnixStream>, String>
     {
         if self.daemon_client.is_none() {
             self.daemon_client = Some(connect_acp_client(&self.config).await?);
@@ -544,12 +544,12 @@ impl VerletAcpAgent {
 #[cfg(unix)]
 async fn connect_acp_client(
     config: &VerletAcpAgentConfig,
-) -> Result<crate::adapters::codex_tui::CodexTuiTestClient<tokio::net::UnixStream>, String> {
-    let mut client = crate::adapters::codex_tui::CodexTuiTestClient::connect_unix(
+) -> Result<crate::adapters::operator_client::OperatorClient<tokio::net::UnixStream>, String> {
+    let mut client = crate::adapters::operator_client::OperatorClient::connect_unix(
         config.daemon_socket.clone(),
-        crate::adapters::codex_tui::CodexTuiConnectConfig {
+        crate::adapters::operator_client::OperatorConnectConfig {
             client_name: "verlet-acp-agent".to_string(),
-            ..crate::adapters::codex_tui::CodexTuiConnectConfig::default()
+            ..crate::adapters::operator_client::OperatorConnectConfig::default()
         },
     )
     .await
@@ -564,11 +564,11 @@ async fn connect_acp_client(
 }
 
 async fn turn_start_text_with_config<S>(
-    client: &mut crate::adapters::codex_tui::CodexTuiTestClient<S>,
+    client: &mut crate::adapters::operator_client::OperatorClient<S>,
     thread_id: &str,
     text: &str,
     config: &AcpSessionConfig,
-) -> crate::kernel::runtime_host::VerletResult<crate::adapters::codex_tui::CodexTuiTurn>
+) -> crate::kernel::runtime_host::VerletResult<crate::adapters::operator_client::OperatorTurn>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
@@ -599,7 +599,7 @@ where
             )
         })?
         .to_string();
-    Ok(crate::adapters::codex_tui::CodexTuiTurn { id, raw: turn })
+    Ok(crate::adapters::operator_client::OperatorTurn { id, raw: turn })
 }
 
 async fn clear_active_turn(
@@ -618,7 +618,7 @@ async fn clear_active_turn(
 fn prompt_completed_responses(
     request_id: serde_json::Value,
     session_id: &str,
-    completed: crate::adapters::codex_tui::CodexTuiCompletedTurn,
+    completed: crate::adapters::operator_client::OperatorCompletedTurn,
     turn: serde_json::Value,
 ) -> Vec<serde_json::Value> {
     let completed_thread_id = completed.thread_id.clone();
@@ -1434,11 +1434,11 @@ mod tests {
         assert_eq!(session["result"]["verlet"]["threadId"], session_id);
         assert_eq!(session["result"]["verlet"]["thread"]["id"], session_id);
 
-        let mut inspector = crate::adapters::codex_tui::CodexTuiTestClient::connect_unix(
+        let mut inspector = crate::adapters::operator_client::OperatorClient::connect_unix(
             socket.clone(),
-            crate::adapters::codex_tui::CodexTuiConnectConfig {
+            crate::adapters::operator_client::OperatorConnectConfig {
                 client_name: "verlet-acp-agent-test-inspector".to_string(),
-                ..crate::adapters::codex_tui::CodexTuiConnectConfig::default()
+                ..crate::adapters::operator_client::OperatorConnectConfig::default()
             },
         )
         .await

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -11543,7 +11543,7 @@ async fn app_server_unix_socket_restart_loads_saved_session_and_continues_thread
         .await;
         let server = app.clone();
         let server_task = tokio::spawn(async move { server.serve(listen).await });
-        let mut client = connect_tui_test_client(&socket, "socket-load-first").await;
+        let mut client = connect_operator_client(&socket, "socket-load-first").await;
 
         let thread = client
             .thread_start(serde_json::json!({ "cwd": crate::adapters::app_server::connection::cwd_string(&first_cwd), "ephemeral": true }))
@@ -11583,7 +11583,7 @@ async fn app_server_unix_socket_restart_loads_saved_session_and_continues_thread
     .await;
     let server = restarted.clone();
     let server_task = tokio::spawn(async move { server.serve(listen).await });
-    let mut client = connect_tui_test_client(&socket, "socket-load-second").await;
+    let mut client = connect_operator_client(&socket, "socket-load-second").await;
 
     let loaded = client.loaded_thread_list().await.unwrap();
     let loaded_ids = loaded["data"]
@@ -11640,7 +11640,7 @@ async fn app_server_unix_socket_restart_loads_saved_session_and_continues_thread
 }
 
 #[tokio::test]
-async fn app_server_websocket_listen_accepts_codex_tui_client() {
+async fn app_server_websocket_listen_accepts_operator_client() {
     let root = unique_test_root("app-server-websocket-listen");
     let addr = unused_loopback_addr();
     let listen =
@@ -11660,7 +11660,7 @@ async fn app_server_websocket_listen_accepts_codex_tui_client() {
     let token = mint_app_server_test_token(&app).await;
     let server = app.clone();
     let server_task = tokio::spawn(async move { server.serve(listen).await });
-    let mut client = connect_ws_tui_test_client(&format!("ws://{addr}/rpc"), &token).await;
+    let mut client = connect_ws_operator_client(&format!("ws://{addr}/rpc"), &token).await;
 
     assert_eq!(
         client.initialize_result()["userAgent"],
@@ -11715,7 +11715,7 @@ async fn app_server_websocket_query_methods_are_callable() {
     let token = mint_app_server_test_token(&app).await;
     let server = app.clone();
     let server_task = tokio::spawn(async move { server.serve(listen).await });
-    let mut client = connect_ws_tui_test_client(&format!("ws://{addr}/rpc"), &token).await;
+    let mut client = connect_ws_operator_client(&format!("ws://{addr}/rpc"), &token).await;
 
     let agents = client
         .request("agent/list", serde_json::json!({}))
@@ -11946,7 +11946,7 @@ async fn app_server_websocket_listen_requires_console_session_token() {
         "unexpected wrong-token response: {wrong:?}"
     );
 
-    let mut client = connect_ws_tui_test_client(&format!("ws://{addr}/rpc"), &session_token).await;
+    let mut client = connect_ws_operator_client(&format!("ws://{addr}/rpc"), &session_token).await;
     assert_eq!(
         client.initialize_result()["userAgent"],
         "verlet-app-server/0.1"
@@ -15526,17 +15526,17 @@ fn item_text(item: &serde_json::Value) -> Option<String> {
 }
 
 #[cfg(unix)]
-async fn connect_tui_test_client(
+async fn connect_operator_client(
     socket: &std::path::Path,
     client_name: &str,
-) -> crate::adapters::codex_tui::CodexTuiTestClient<tokio::net::UnixStream> {
+) -> crate::adapters::operator_client::OperatorClient<tokio::net::UnixStream> {
     let mut last_error = None;
     for _ in 0..1_500 {
-        match crate::adapters::codex_tui::CodexTuiTestClient::connect_unix(
+        match crate::adapters::operator_client::OperatorClient::connect_unix(
             socket,
-            crate::adapters::codex_tui::CodexTuiConnectConfig {
+            crate::adapters::operator_client::OperatorConnectConfig {
                 client_name: client_name.to_string(),
-                ..crate::adapters::codex_tui::CodexTuiConnectConfig::default()
+                ..crate::adapters::operator_client::OperatorConnectConfig::default()
             },
         )
         .await
@@ -15555,18 +15555,18 @@ async fn connect_tui_test_client(
     );
 }
 
-async fn connect_ws_tui_test_client(
+async fn connect_ws_operator_client(
     url: &str,
     token: &str,
-) -> crate::adapters::codex_tui::CodexTuiTestClient<tokio::net::TcpStream> {
+) -> crate::adapters::operator_client::OperatorClient<tokio::net::TcpStream> {
     let mut last_error = None;
     for _ in 0..1_500 {
-        match crate::adapters::codex_tui::CodexTuiTestClient::connect_websocket(
+        match crate::adapters::operator_client::OperatorClient::connect_websocket(
             url,
-            crate::adapters::codex_tui::CodexTuiConnectConfig {
+            crate::adapters::operator_client::OperatorConnectConfig {
                 client_name: "websocket-listen-test".to_string(),
                 bearer_token: Some(token.to_string()),
-                ..crate::adapters::codex_tui::CodexTuiConnectConfig::default()
+                ..crate::adapters::operator_client::OperatorConnectConfig::default()
             },
         )
         .await

--- a/crates/verlet-kernel/src/adapters/mcp_server.rs
+++ b/crates/verlet-kernel/src/adapters/mcp_server.rs
@@ -68,7 +68,7 @@ struct VerletMcpServer {
     initialized_seen: bool,
     client_info: Option<serde_json::Value>,
     #[cfg(unix)]
-    daemon_client: Option<crate::adapters::codex_tui::CodexTuiTestClient<tokio::net::UnixStream>>,
+    daemon_client: Option<crate::adapters::operator_client::OperatorClient<tokio::net::UnixStream>>,
 }
 
 impl VerletMcpServer {
@@ -399,14 +399,14 @@ impl VerletMcpServer {
     #[cfg(unix)]
     async fn client(
         &mut self,
-    ) -> Result<&mut crate::adapters::codex_tui::CodexTuiTestClient<tokio::net::UnixStream>, String>
+    ) -> Result<&mut crate::adapters::operator_client::OperatorClient<tokio::net::UnixStream>, String>
     {
         if self.daemon_client.is_none() {
-            let mut client = crate::adapters::codex_tui::CodexTuiTestClient::connect_unix(
+            let mut client = crate::adapters::operator_client::OperatorClient::connect_unix(
                 self.config.daemon_socket.clone(),
-                crate::adapters::codex_tui::CodexTuiConnectConfig {
+                crate::adapters::operator_client::OperatorConnectConfig {
                     client_name: "verlet-mcp-server".to_string(),
-                    ..crate::adapters::codex_tui::CodexTuiConnectConfig::default()
+                    ..crate::adapters::operator_client::OperatorConnectConfig::default()
                 },
             )
             .await
@@ -563,7 +563,7 @@ fn timeout_from_ms(timeout_ms: Option<u64>, default: std::time::Duration) -> std
 }
 
 fn completed_turn_json(
-    completed: crate::adapters::codex_tui::CodexTuiCompletedTurn,
+    completed: crate::adapters::operator_client::OperatorCompletedTurn,
     submitted_turn: Option<serde_json::Value>,
 ) -> serde_json::Value {
     serde_json::json!({

--- a/crates/verlet-kernel/src/adapters/operator_client.rs
+++ b/crates/verlet-kernel/src/adapters/operator_client.rs
@@ -2,16 +2,16 @@ use futures_util::SinkExt as _;
 use futures_util::StreamExt as _;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest as _;
 
-pub const CODEX_TUI_UDS_WEBSOCKET_HANDSHAKE_URL: &str = "ws://localhost/rpc";
-pub const CODEX_TUI_TEST_CLIENT_NAME: &str = "verlet-codex-tui-test";
+pub const OPERATOR_CLIENT_UDS_WEBSOCKET_HANDSHAKE_URL: &str = "ws://localhost/rpc";
+pub const OPERATOR_CLIENT_NAME: &str = "verlet-codex-tui-test";
 
-const CODEX_TUI_MAX_WEBSOCKET_MESSAGE_SIZE: usize = 128 << 20;
-const CODEX_TUI_INITIALIZE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const OPERATOR_CLIENT_MAX_WEBSOCKET_MESSAGE_SIZE: usize = 128 << 20;
+const OPERATOR_CLIENT_INITIALIZE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
-/// Verlet-owned copy of the Codex TUI remote-client path, trimmed to a
-/// headless driver for app-server tests.
+/// Verlet-owned operator client, trimmed to a headless driver for app-server
+/// tests.
 #[derive(Clone)]
-pub struct CodexTuiConnectConfig {
+pub struct OperatorConnectConfig {
     pub client_name: String,
     pub client_version: String,
     pub experimental_api: bool,
@@ -19,7 +19,7 @@ pub struct CodexTuiConnectConfig {
     pub bearer_token: Option<String>,
 }
 
-impl Default for CodexTuiConnectConfig {
+impl Default for OperatorConnectConfig {
     fn default() -> Self {
         // MCP, ACP, debug RPC, and other daemon clients inherit this config.
         // Managed callers provide their boundary credential via
@@ -28,7 +28,7 @@ impl Default for CodexTuiConnectConfig {
             .ok()
             .filter(|token| !token.trim().is_empty());
         Self {
-            client_name: CODEX_TUI_TEST_CLIENT_NAME.to_string(),
+            client_name: OPERATOR_CLIENT_NAME.to_string(),
             client_version: env!("CARGO_PKG_VERSION").to_string(),
             experimental_api: true,
             opt_out_notification_methods: Vec::new(),
@@ -37,9 +37,9 @@ impl Default for CodexTuiConnectConfig {
     }
 }
 
-impl std::fmt::Debug for CodexTuiConnectConfig {
+impl std::fmt::Debug for OperatorConnectConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CodexTuiConnectConfig")
+        f.debug_struct("OperatorConnectConfig")
             .field("client_name", &self.client_name)
             .field("client_version", &self.client_version)
             .field("experimental_api", &self.experimental_api)
@@ -56,19 +56,19 @@ impl std::fmt::Debug for CodexTuiConnectConfig {
 }
 
 #[derive(Clone, Debug)]
-pub struct CodexTuiThread {
+pub struct OperatorThread {
     pub id: String,
     pub raw: serde_json::Value,
 }
 
 #[derive(Clone, Debug)]
-pub struct CodexTuiTurn {
+pub struct OperatorTurn {
     pub id: String,
     pub raw: serde_json::Value,
 }
 
 #[derive(Clone, Debug)]
-pub struct CodexTuiCompletedTurn {
+pub struct OperatorCompletedTurn {
     pub thread_id: String,
     pub turn_id: String,
     pub assistant_text: String,
@@ -76,31 +76,29 @@ pub struct CodexTuiCompletedTurn {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum CodexTuiEvent {
+pub enum OperatorEvent {
     Notification(crate::adapters::app_server::connection::JsonRpcNotification),
     Request(crate::adapters::app_server::connection::JsonRpcRequest),
     Response(crate::adapters::app_server::connection::JsonRpcResponse),
     Error(crate::adapters::app_server::connection::JsonRpcError),
 }
 
-pub struct CodexTuiTestClient<S> {
+pub struct OperatorClient<S> {
     websocket: tokio_tungstenite::WebSocketStream<S>,
     next_request_id: i64,
-    pending_events: std::collections::VecDeque<CodexTuiEvent>,
+    pending_events: std::collections::VecDeque<OperatorEvent>,
     initialize_result: serde_json::Value,
 }
 
-pub type VerletOperatorClient<S> = CodexTuiTestClient<S>;
-
 #[cfg(unix)]
-impl CodexTuiTestClient<tokio::net::UnixStream> {
+impl OperatorClient<tokio::net::UnixStream> {
     pub async fn connect_unix(
         socket_path: impl Into<std::path::PathBuf>,
-        config: CodexTuiConnectConfig,
+        config: OperatorConnectConfig,
     ) -> crate::kernel::runtime_host::VerletResult<Self> {
         let socket_path = socket_path.into();
         let endpoint = format!("unix://{}", socket_path.display());
-        let mut request = CODEX_TUI_UDS_WEBSOCKET_HANDSHAKE_URL
+        let mut request = OPERATOR_CLIENT_UDS_WEBSOCKET_HANDSHAKE_URL
             .into_client_request()
             .map_err(|err| tui_error(format!("invalid Verlet RPC handshake URL: {err}")))?;
         set_bearer_token(&mut request, config.bearer_token.as_deref())?;
@@ -114,7 +112,7 @@ impl CodexTuiTestClient<tokio::net::UnixStream> {
         let (websocket, _) = tokio_tungstenite::client_async_with_config(
             request,
             stream,
-            Some(codex_tui_websocket_config()),
+            Some(operator_client_websocket_config()),
         )
         .await
         .map_err(|err| {
@@ -126,10 +124,10 @@ impl CodexTuiTestClient<tokio::net::UnixStream> {
     }
 }
 
-impl CodexTuiTestClient<tokio::net::TcpStream> {
+impl OperatorClient<tokio::net::TcpStream> {
     pub async fn connect_websocket(
         url: &str,
-        config: CodexTuiConnectConfig,
+        config: OperatorConnectConfig,
     ) -> crate::kernel::runtime_host::VerletResult<Self> {
         let endpoint = url.to_string();
         let authority = websocket_tcp_authority(url)?;
@@ -147,7 +145,7 @@ impl CodexTuiTestClient<tokio::net::TcpStream> {
         let (websocket, _) = tokio_tungstenite::client_async_with_config(
             request,
             stream,
-            Some(codex_tui_websocket_config()),
+            Some(operator_client_websocket_config()),
         )
         .await
         .map_err(|err| {
@@ -176,14 +174,14 @@ fn set_bearer_token(
     Ok(())
 }
 
-impl<S> CodexTuiTestClient<S>
+impl<S> OperatorClient<S>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
     pub async fn connect_with_websocket(
         mut websocket: tokio_tungstenite::WebSocketStream<S>,
         endpoint: impl Into<String>,
-        config: CodexTuiConnectConfig,
+        config: OperatorConnectConfig,
     ) -> crate::kernel::runtime_host::VerletResult<Self> {
         let endpoint = endpoint.into();
         let (initialize_result, pending_events) =
@@ -229,7 +227,7 @@ where
     pub async fn thread_start(
         &mut self,
         params: serde_json::Value,
-    ) -> crate::kernel::runtime_host::VerletResult<CodexTuiThread> {
+    ) -> crate::kernel::runtime_host::VerletResult<OperatorThread> {
         let result = self.request("thread/start", params).await?;
         thread_from_result(result, "thread/start")
     }
@@ -238,7 +236,7 @@ where
         &mut self,
         thread_id: &str,
         include_turns: bool,
-    ) -> crate::kernel::runtime_host::VerletResult<CodexTuiThread> {
+    ) -> crate::kernel::runtime_host::VerletResult<OperatorThread> {
         let result = self
             .request(
                 "thread/resume",
@@ -254,7 +252,7 @@ where
     pub async fn thread_fork(
         &mut self,
         thread_id: &str,
-    ) -> crate::kernel::runtime_host::VerletResult<CodexTuiThread> {
+    ) -> crate::kernel::runtime_host::VerletResult<OperatorThread> {
         let result = self
             .request(
                 "thread/fork",
@@ -338,7 +336,7 @@ where
         &mut self,
         thread_id: &str,
         text: &str,
-    ) -> crate::kernel::runtime_host::VerletResult<CodexTuiTurn> {
+    ) -> crate::kernel::runtime_host::VerletResult<OperatorTurn> {
         let result = self
             .request(
                 "turn/start",
@@ -353,7 +351,7 @@ where
             .cloned()
             .ok_or_else(|| tui_error("turn/start response missing turn"))?;
         let id = string_field(&turn, "id", "turn/start turn")?;
-        Ok(CodexTuiTurn { id, raw: turn })
+        Ok(OperatorTurn { id, raw: turn })
     }
 
     pub async fn turn_steer_text(
@@ -392,7 +390,7 @@ where
         &mut self,
         prompt: &str,
         timeout: std::time::Duration,
-    ) -> crate::kernel::runtime_host::VerletResult<CodexTuiCompletedTurn> {
+    ) -> crate::kernel::runtime_host::VerletResult<OperatorCompletedTurn> {
         let thread = self.thread_start(serde_json::json!({})).await?;
         let turn = self.turn_start_text(&thread.id, prompt).await?;
         self.wait_for_turn_completed(&thread.id, &turn.id, timeout)
@@ -404,7 +402,7 @@ where
         thread_id: &str,
         turn_id: &str,
         timeout_duration: std::time::Duration,
-    ) -> crate::kernel::runtime_host::VerletResult<CodexTuiCompletedTurn> {
+    ) -> crate::kernel::runtime_host::VerletResult<OperatorCompletedTurn> {
         let deadline = tokio::time::sleep(timeout_duration);
         tokio::pin!(deadline);
         let mut assistant_text = String::new();
@@ -418,7 +416,7 @@ where
                 }
                 event = self.next_event() => {
                     match event? {
-                        CodexTuiEvent::Notification(notification) => {
+                        OperatorEvent::Notification(notification) => {
                             if notification.method == "item/agentMessage/delta"
                                 && notification.params.as_ref()
                                     .and_then(|params| params.get("threadId"))
@@ -440,7 +438,7 @@ where
                                     .and_then(serde_json::Value::as_str) == Some(turn_id);
                             notifications.push(notification);
                             if completed {
-                                return Ok(CodexTuiCompletedTurn {
+                                return Ok(OperatorCompletedTurn {
                                     thread_id: thread_id.to_string(),
                                     turn_id: turn_id.to_string(),
                                     assistant_text,
@@ -448,14 +446,14 @@ where
                                 });
                             }
                         }
-                        CodexTuiEvent::Error(error) => {
+                        OperatorEvent::Error(error) => {
                             return Err(tui_error(format!(
                                 "Verlet RPC client received JSON-RPC error {}: {}",
                                 error.error.code,
                                 error.error.message
                             )));
                         }
-                        CodexTuiEvent::Request(_) | CodexTuiEvent::Response(_) => {}
+                        OperatorEvent::Request(_) | OperatorEvent::Response(_) => {}
                     }
                 }
             }
@@ -493,10 +491,10 @@ where
 
         loop {
             match self.read_event().await? {
-                CodexTuiEvent::Response(response) if response.id == id => {
+                OperatorEvent::Response(response) if response.id == id => {
                     return Ok(response.result);
                 }
-                CodexTuiEvent::Error(error) if error.id == id => {
+                OperatorEvent::Error(error) if error.id == id => {
                     return Err(tui_error(format!(
                         "request `{method}` was refused: {}",
                         error.error.message
@@ -524,14 +522,14 @@ where
         .await
     }
 
-    pub async fn next_event(&mut self) -> crate::kernel::runtime_host::VerletResult<CodexTuiEvent> {
+    pub async fn next_event(&mut self) -> crate::kernel::runtime_host::VerletResult<OperatorEvent> {
         if let Some(event) = self.pending_events.pop_front() {
             return Ok(event);
         }
         self.read_event().await
     }
 
-    async fn read_event(&mut self) -> crate::kernel::runtime_host::VerletResult<CodexTuiEvent> {
+    async fn read_event(&mut self) -> crate::kernel::runtime_host::VerletResult<OperatorEvent> {
         loop {
             let message = self
                 .websocket
@@ -572,10 +570,10 @@ where
 async fn initialize_remote_connection<S>(
     websocket: &mut tokio_tungstenite::WebSocketStream<S>,
     endpoint: &str,
-    config: CodexTuiConnectConfig,
+    config: OperatorConnectConfig,
 ) -> crate::kernel::runtime_host::VerletResult<(
     serde_json::Value,
-    std::collections::VecDeque<CodexTuiEvent>,
+    std::collections::VecDeque<OperatorEvent>,
 )>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
@@ -609,13 +607,13 @@ where
     .await?;
 
     let mut pending_events = std::collections::VecDeque::new();
-    let initialize_result = tokio::time::timeout(CODEX_TUI_INITIALIZE_TIMEOUT, async {
+    let initialize_result = tokio::time::timeout(OPERATOR_CLIENT_INITIALIZE_TIMEOUT, async {
         loop {
             match read_jsonrpc_event(websocket).await? {
-                CodexTuiEvent::Response(response) if response.id == initialize_request_id => {
+                OperatorEvent::Response(response) if response.id == initialize_request_id => {
                     break Ok(response.result);
                 }
-                CodexTuiEvent::Error(error) if error.id == initialize_request_id => {
+                OperatorEvent::Error(error) if error.id == initialize_request_id => {
                     break Err(tui_error(format!(
                         "Verlet RPC endpoint `{endpoint}` refused initialization: {}",
                         error.error.message
@@ -665,7 +663,7 @@ where
 
 async fn read_jsonrpc_event<S>(
     websocket: &mut tokio_tungstenite::WebSocketStream<S>,
-) -> crate::kernel::runtime_host::VerletResult<CodexTuiEvent>
+) -> crate::kernel::runtime_host::VerletResult<OperatorEvent>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
@@ -697,21 +695,21 @@ where
     }
 }
 
-fn jsonrpc_event_from_text(text: &str) -> crate::kernel::runtime_host::VerletResult<CodexTuiEvent> {
+fn jsonrpc_event_from_text(text: &str) -> crate::kernel::runtime_host::VerletResult<OperatorEvent> {
     match serde_json::from_str::<crate::adapters::app_server::connection::JsonRpcMessage>(text)
         .map_err(|err| tui_error(format!("invalid Verlet RPC message: {err}")))?
     {
         crate::adapters::app_server::connection::JsonRpcMessage::Notification(notification) => {
-            Ok(CodexTuiEvent::Notification(notification))
+            Ok(OperatorEvent::Notification(notification))
         }
         crate::adapters::app_server::connection::JsonRpcMessage::Request(request) => {
-            Ok(CodexTuiEvent::Request(request))
+            Ok(OperatorEvent::Request(request))
         }
         crate::adapters::app_server::connection::JsonRpcMessage::Response(response) => {
-            Ok(CodexTuiEvent::Response(response))
+            Ok(OperatorEvent::Response(response))
         }
         crate::adapters::app_server::connection::JsonRpcMessage::Error(error) => {
-            Ok(CodexTuiEvent::Error(error))
+            Ok(OperatorEvent::Error(error))
         }
     }
 }
@@ -739,19 +737,19 @@ fn string_field(
 fn thread_from_result(
     result: serde_json::Value,
     method: &str,
-) -> crate::kernel::runtime_host::VerletResult<CodexTuiThread> {
+) -> crate::kernel::runtime_host::VerletResult<OperatorThread> {
     let thread = result
         .get("thread")
         .cloned()
         .ok_or_else(|| tui_error(format!("{method} response missing thread")))?;
     let id = string_field(&thread, "id", &format!("{method} thread"))?;
-    Ok(CodexTuiThread { id, raw: thread })
+    Ok(OperatorThread { id, raw: thread })
 }
 
-fn codex_tui_websocket_config() -> tokio_tungstenite::tungstenite::protocol::WebSocketConfig {
+fn operator_client_websocket_config() -> tokio_tungstenite::tungstenite::protocol::WebSocketConfig {
     tokio_tungstenite::tungstenite::protocol::WebSocketConfig::default()
-        .max_frame_size(Some(CODEX_TUI_MAX_WEBSOCKET_MESSAGE_SIZE))
-        .max_message_size(Some(CODEX_TUI_MAX_WEBSOCKET_MESSAGE_SIZE))
+        .max_frame_size(Some(OPERATOR_CLIENT_MAX_WEBSOCKET_MESSAGE_SIZE))
+        .max_message_size(Some(OPERATOR_CLIENT_MAX_WEBSOCKET_MESSAGE_SIZE))
 }
 
 fn websocket_tcp_authority(url: &str) -> crate::kernel::runtime_host::VerletResult<&str> {

--- a/crates/verlet-kernel/src/adapters/operator_client/tests.rs
+++ b/crates/verlet-kernel/src/adapters/operator_client/tests.rs
@@ -1,8 +1,8 @@
 #[test]
-fn codex_tui_connect_config_redacts_bearer_token() {
-    let config = crate::adapters::codex_tui::CodexTuiConnectConfig {
+fn operator_client_connect_config_redacts_bearer_token() {
+    let config = crate::adapters::operator_client::OperatorConnectConfig {
         bearer_token: Some("do-not-log-this-token".to_string()),
-        ..crate::adapters::codex_tui::CodexTuiConnectConfig::default()
+        ..crate::adapters::operator_client::OperatorConnectConfig::default()
     };
     let debug = format!("{config:?}");
     assert!(debug.contains("<redacted>"));
@@ -12,7 +12,7 @@ fn codex_tui_connect_config_redacts_bearer_token() {
 #[test]
 fn rpc_client_errors_render_without_the_runtime_factory_prefix() {
     assert_eq!(
-        crate::adapters::codex_tui::tui_error(
+        crate::adapters::operator_client::tui_error(
             "failed to connect to the Verlet RPC endpoint `ws://127.0.0.1:1/rpc`"
         )
         .to_string(),
@@ -26,7 +26,7 @@ fn rpc_client_errors_render_without_the_runtime_factory_prefix() {
 }
 
 #[test]
-fn codex_tui_initialize_request_uses_codex_remote_shape() {
+fn operator_client_initialize_request_uses_codex_remote_shape() {
     let message = crate::adapters::app_server::connection::JsonRpcMessage::Request(
         crate::adapters::app_server::connection::JsonRpcRequest {
             id: crate::adapters::app_server::connection::RequestId::String(
@@ -72,7 +72,7 @@ fn codex_tui_initialize_request_uses_codex_remote_shape() {
 
 #[cfg(unix)]
 #[tokio::test]
-async fn codex_tui_driver_runs_prompt_against_app_server() {
+async fn operator_client_driver_runs_prompt_against_app_server() {
     let root = std::path::PathBuf::from("/tmp")
         .join(format!("cdis-tui-{}", uuid::Uuid::now_v7().simple()));
     let socket = root.join("app.sock");
@@ -91,9 +91,9 @@ async fn codex_tui_driver_runs_prompt_against_app_server() {
 
     wait_for_socket(&socket).await.unwrap();
 
-    let mut client = crate::adapters::codex_tui::CodexTuiTestClient::connect_unix(
+    let mut client = crate::adapters::operator_client::OperatorClient::connect_unix(
         &socket,
-        crate::adapters::codex_tui::CodexTuiConnectConfig::default(),
+        crate::adapters::operator_client::OperatorConnectConfig::default(),
     )
     .await
     .unwrap();
@@ -160,7 +160,7 @@ async fn codex_tui_driver_runs_prompt_against_app_server() {
 
 #[cfg(unix)]
 #[tokio::test]
-async fn codex_tui_operator_client_covers_thread_lifecycle_methods() {
+async fn operator_client_covers_thread_lifecycle_methods() {
     let root = std::path::PathBuf::from("/tmp")
         .join(format!("cdis-operator-{}", uuid::Uuid::now_v7().simple()));
     let socket = root.join("app.sock");
@@ -179,9 +179,9 @@ async fn codex_tui_operator_client_covers_thread_lifecycle_methods() {
 
     wait_for_socket(&socket).await.unwrap();
 
-    let mut client = crate::adapters::codex_tui::VerletOperatorClient::connect_unix(
+    let mut client = crate::adapters::operator_client::OperatorClient::connect_unix(
         &socket,
-        crate::adapters::codex_tui::CodexTuiConnectConfig::default(),
+        crate::adapters::operator_client::OperatorConnectConfig::default(),
     )
     .await
     .unwrap();
@@ -227,7 +227,7 @@ async fn wait_for_socket(
         }
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
     }
-    Err(crate::adapters::codex_tui::tui_error(format!(
+    Err(crate::adapters::operator_client::tui_error(format!(
         "timed out waiting for socket {}",
         path.display()
     )))

--- a/crates/verlet-kernel/src/cli/chat.rs
+++ b/crates/verlet-kernel/src/cli/chat.rs
@@ -64,7 +64,7 @@ async fn run_chat_console(
     let result = async {
         #[cfg(unix)]
         {
-            let client = crate::adapters::codex_tui::VerletOperatorClient::connect_unix(
+            let client = crate::adapters::operator_client::OperatorClient::connect_unix(
                 socket_path,
                 chat_connect_config(invocation),
             )
@@ -99,7 +99,7 @@ async fn run_attached_chat(
             #[cfg(unix)]
             {
                 let label = format!("attach unix://{}", path.display());
-                let client = crate::adapters::codex_tui::VerletOperatorClient::connect_unix(
+                let client = crate::adapters::operator_client::OperatorClient::connect_unix(
                     path,
                     chat_connect_config(invocation),
                 )
@@ -116,7 +116,7 @@ async fn run_attached_chat(
         }
         ChatAttachTarget::WebSocket(url) => {
             let label = format!("attach {url}");
-            let client = crate::adapters::codex_tui::VerletOperatorClient::<tokio::net::TcpStream>::connect_websocket(
+            let client = crate::adapters::operator_client::OperatorClient::<tokio::net::TcpStream>::connect_websocket(
                 &url,
                 chat_connect_config(invocation),
             )
@@ -128,10 +128,10 @@ async fn run_attached_chat(
 
 fn chat_connect_config(
     invocation: ChatInvocation,
-) -> crate::adapters::codex_tui::CodexTuiConnectConfig {
-    crate::adapters::codex_tui::CodexTuiConnectConfig {
+) -> crate::adapters::operator_client::OperatorConnectConfig {
+    crate::adapters::operator_client::OperatorConnectConfig {
         client_name: invocation.client_name().to_string(),
-        ..crate::adapters::codex_tui::CodexTuiConnectConfig::default()
+        ..crate::adapters::operator_client::OperatorConnectConfig::default()
     }
 }
 
@@ -163,7 +163,7 @@ struct ChatSessionInfo {
 }
 
 async fn run_chat_client<S>(
-    mut client: crate::adapters::codex_tui::VerletOperatorClient<S>,
+    mut client: crate::adapters::operator_client::OperatorClient<S>,
     initial_prompt: Option<String>,
     connection_label: String,
 ) -> crate::kernel::runtime_host::VerletResult<()>
@@ -216,7 +216,7 @@ where
 }
 
 async fn bootstrap_chat_client<S>(
-    client: &mut crate::adapters::codex_tui::VerletOperatorClient<S>,
+    client: &mut crate::adapters::operator_client::OperatorClient<S>,
     connection_label: String,
 ) -> crate::kernel::runtime_host::VerletResult<ChatSessionInfo>
 where
@@ -267,7 +267,7 @@ impl ChatDriver {
     /// into the transcript and are not fatal.
     async fn drive<S>(
         &mut self,
-        client: &mut crate::adapters::codex_tui::VerletOperatorClient<S>,
+        client: &mut crate::adapters::operator_client::OperatorClient<S>,
         mut actions: tokio::sync::mpsc::UnboundedReceiver<verlet_chat::Action>,
         events: tokio::sync::mpsc::UnboundedSender<verlet_chat::ChatEvent>,
     ) -> crate::kernel::runtime_host::VerletResult<()>
@@ -296,7 +296,7 @@ impl ChatDriver {
 
     async fn execute<S>(
         &mut self,
-        client: &mut crate::adapters::codex_tui::VerletOperatorClient<S>,
+        client: &mut crate::adapters::operator_client::OperatorClient<S>,
         events: &tokio::sync::mpsc::UnboundedSender<verlet_chat::ChatEvent>,
         action: verlet_chat::Action,
     ) -> crate::kernel::runtime_host::VerletResult<()>
@@ -372,7 +372,7 @@ impl ChatDriver {
     fn switch_thread(
         &mut self,
         events: &tokio::sync::mpsc::UnboundedSender<verlet_chat::ChatEvent>,
-        thread: crate::adapters::codex_tui::CodexTuiThread,
+        thread: crate::adapters::operator_client::OperatorThread,
         reason: &str,
     ) {
         self.thread_id = thread.id.clone();
@@ -388,16 +388,16 @@ impl ChatDriver {
     /// Translate one client event into zero or more UI events.
     fn project(
         &mut self,
-        event: crate::adapters::codex_tui::CodexTuiEvent,
+        event: crate::adapters::operator_client::OperatorEvent,
         events: &tokio::sync::mpsc::UnboundedSender<verlet_chat::ChatEvent>,
     ) {
         match event {
-            crate::adapters::codex_tui::CodexTuiEvent::Notification(notification) => {
+            crate::adapters::operator_client::OperatorEvent::Notification(notification) => {
                 for event in self.project_notification(&notification) {
                     let _ = events.send(event);
                 }
             }
-            crate::adapters::codex_tui::CodexTuiEvent::Error(error) => {
+            crate::adapters::operator_client::OperatorEvent::Error(error) => {
                 self.active_turn_id = None;
                 let _ = events.send(verlet_chat::ChatEvent::Error {
                     title: format!(
@@ -408,8 +408,8 @@ impl ChatDriver {
                 });
                 let _ = events.send(verlet_chat::ChatEvent::TurnCompleted { error: None });
             }
-            crate::adapters::codex_tui::CodexTuiEvent::Request(_)
-            | crate::adapters::codex_tui::CodexTuiEvent::Response(_) => {}
+            crate::adapters::operator_client::OperatorEvent::Request(_)
+            | crate::adapters::operator_client::OperatorEvent::Response(_) => {}
         }
     }
 

--- a/crates/verlet-kernel/src/cli/debug_rpc.rs
+++ b/crates/verlet-kernel/src/cli/debug_rpc.rs
@@ -26,7 +26,7 @@ pub(super) async fn run_debug(
 }
 
 /// `verlet debug rpc` — protocol-level debug client for a RUNNING daemon's
-/// app-server websocket. Connects with `CodexTuiTestClient::connect_websocket`,
+/// app-server websocket. Connects with `OperatorClient::connect_websocket`,
 /// performs the initialize handshake, then dispatches a subcommand.
 pub(super) async fn run_debug_rpc(
     mut args: Vec<std::ffi::OsString>,
@@ -179,18 +179,18 @@ pub(super) async fn run_debug_rpc_tail(
         .await?;
     loop {
         match client.next_event().await {
-            Ok(crate::adapters::codex_tui::CodexTuiEvent::Notification(notification)) => {
+            Ok(crate::adapters::operator_client::OperatorEvent::Notification(notification)) => {
                 print_jsonl_notification(&notification)?;
             }
-            Ok(crate::adapters::codex_tui::CodexTuiEvent::Error(error)) => {
+            Ok(crate::adapters::operator_client::OperatorEvent::Error(error)) => {
                 return Err(crate::cli::usage_error(format!(
                     "JSON-RPC error {}: {}",
                     error.error.code, error.error.message
                 )));
             }
             Ok(
-                crate::adapters::codex_tui::CodexTuiEvent::Request(_)
-                | crate::adapters::codex_tui::CodexTuiEvent::Response(_),
+                crate::adapters::operator_client::OperatorEvent::Request(_)
+                | crate::adapters::operator_client::OperatorEvent::Response(_),
             ) => {}
             Err(err) if rpc_connection_was_closed(&err) => return Ok(()),
             Err(err) => return Err(err),
@@ -419,20 +419,20 @@ pub(super) fn resolve_debug_rpc_endpoint(
 pub(super) async fn connect_debug_rpc_client(
     url: &str,
 ) -> crate::kernel::runtime_host::VerletResult<
-    crate::adapters::codex_tui::CodexTuiTestClient<tokio::net::TcpStream>,
+    crate::adapters::operator_client::OperatorClient<tokio::net::TcpStream>,
 > {
-    crate::adapters::codex_tui::CodexTuiTestClient::connect_websocket(
+    crate::adapters::operator_client::OperatorClient::connect_websocket(
         url,
-        crate::adapters::codex_tui::CodexTuiConnectConfig {
+        crate::adapters::operator_client::OperatorConnectConfig {
             client_name: "verlet-debug-rpc".to_string(),
-            ..crate::adapters::codex_tui::CodexTuiConnectConfig::default()
+            ..crate::adapters::operator_client::OperatorConnectConfig::default()
         },
     )
     .await
 }
 
 pub(super) async fn stream_debug_rpc_turn(
-    client: &mut crate::adapters::codex_tui::CodexTuiTestClient<tokio::net::TcpStream>,
+    client: &mut crate::adapters::operator_client::OperatorClient<tokio::net::TcpStream>,
     thread_id: &str,
     turn_id: &str,
     json_output: bool,
@@ -452,7 +452,7 @@ pub(super) async fn stream_debug_rpc_turn(
             }
             event = client.next_event() => {
                 match event? {
-                    crate::adapters::codex_tui::CodexTuiEvent::Notification(notification) => {
+                    crate::adapters::operator_client::OperatorEvent::Notification(notification) => {
                         if json_output && notification_thread_id(&notification) == Some(thread_id) {
                             print_jsonl_notification(&notification)?;
                         }
@@ -481,7 +481,7 @@ pub(super) async fn stream_debug_rpc_turn(
                             return Ok(DebugRpcTurnStreamResult::Completed);
                         }
                     }
-                    crate::adapters::codex_tui::CodexTuiEvent::Error(error) => {
+                    crate::adapters::operator_client::OperatorEvent::Error(error) => {
                         if !json_output {
                             println!();
                         }
@@ -490,7 +490,7 @@ pub(super) async fn stream_debug_rpc_turn(
                             error.error.code, error.error.message
                         )));
                     }
-                    crate::adapters::codex_tui::CodexTuiEvent::Request(_) | crate::adapters::codex_tui::CodexTuiEvent::Response(_) => {}
+                    crate::adapters::operator_client::OperatorEvent::Request(_) | crate::adapters::operator_client::OperatorEvent::Response(_) => {}
                 }
             }
         }

--- a/crates/verlet-kernel/src/lib.rs
+++ b/crates/verlet-kernel/src/lib.rs
@@ -20,9 +20,9 @@ pub mod adapters {
     pub mod acp_agent;
     pub mod agent_loop;
     pub mod app_server;
-    pub mod codex_tui;
     pub mod mcp_client;
     pub mod mcp_server;
+    pub mod operator_client;
 }
 
 pub mod agent {

--- a/crates/verlet-kernel/tests/boundary_auth.rs
+++ b/crates/verlet-kernel/tests/boundary_auth.rs
@@ -451,11 +451,11 @@ async fn tcp_boundary_authenticates_before_upgrade_and_witnesses_sessions() {
     let server = app.clone();
     let server_task = tokio::spawn(async move { server.serve_websocket_listener(listener).await });
 
-    let mut client = verlet::adapters::codex_tui::CodexTuiTestClient::connect_websocket(
+    let mut client = verlet::adapters::operator_client::OperatorClient::connect_websocket(
         &format!("ws://{addr}/rpc"),
-        verlet::adapters::codex_tui::CodexTuiConnectConfig {
+        verlet::adapters::operator_client::OperatorConnectConfig {
             bearer_token: Some(accepted_token.clone()),
-            ..verlet::adapters::codex_tui::CodexTuiConnectConfig::default()
+            ..verlet::adapters::operator_client::OperatorConnectConfig::default()
         },
     )
     .await
@@ -651,9 +651,9 @@ async fn unix_boundary_maps_same_uid_only_in_local_mode_and_secures_socket() {
         0o600
     );
 
-    let mut local_client = verlet::adapters::codex_tui::CodexTuiTestClient::connect_unix(
+    let mut local_client = verlet::adapters::operator_client::OperatorClient::connect_unix(
         &local_socket,
-        verlet::adapters::codex_tui::CodexTuiConnectConfig::default(),
+        verlet::adapters::operator_client::OperatorConnectConfig::default(),
     )
     .await
     .unwrap();
@@ -742,11 +742,11 @@ async fn unix_boundary_maps_same_uid_only_in_local_mode_and_secures_socket() {
         0o600
     );
 
-    let no_token = verlet::adapters::codex_tui::CodexTuiTestClient::connect_unix(
+    let no_token = verlet::adapters::operator_client::OperatorClient::connect_unix(
         &managed_socket,
-        verlet::adapters::codex_tui::CodexTuiConnectConfig {
+        verlet::adapters::operator_client::OperatorConnectConfig {
             bearer_token: None,
-            ..verlet::adapters::codex_tui::CodexTuiConnectConfig::default()
+            ..verlet::adapters::operator_client::OperatorConnectConfig::default()
         },
     )
     .await;
@@ -756,11 +756,11 @@ async fn unix_boundary_maps_same_uid_only_in_local_mode_and_secures_socket() {
     };
     assert!(no_token.to_string().contains("401"));
 
-    let unknown_token = verlet::adapters::codex_tui::CodexTuiTestClient::connect_unix(
+    let unknown_token = verlet::adapters::operator_client::OperatorClient::connect_unix(
         &managed_socket,
-        verlet::adapters::codex_tui::CodexTuiConnectConfig {
+        verlet::adapters::operator_client::OperatorConnectConfig {
             bearer_token: Some("unknown-token".to_string()),
-            ..verlet::adapters::codex_tui::CodexTuiConnectConfig::default()
+            ..verlet::adapters::operator_client::OperatorConnectConfig::default()
         },
     )
     .await;
@@ -771,11 +771,11 @@ async fn unix_boundary_maps_same_uid_only_in_local_mode_and_secures_socket() {
     assert!(unknown_token.to_string().contains("401"));
 
     for rejected_token in [expired_token, revoked_token, revoked_operator_token] {
-        let rejected = verlet::adapters::codex_tui::CodexTuiTestClient::connect_unix(
+        let rejected = verlet::adapters::operator_client::OperatorClient::connect_unix(
             &managed_socket,
-            verlet::adapters::codex_tui::CodexTuiConnectConfig {
+            verlet::adapters::operator_client::OperatorConnectConfig {
                 bearer_token: Some(rejected_token),
-                ..verlet::adapters::codex_tui::CodexTuiConnectConfig::default()
+                ..verlet::adapters::operator_client::OperatorConnectConfig::default()
             },
         )
         .await;
@@ -786,11 +786,11 @@ async fn unix_boundary_maps_same_uid_only_in_local_mode_and_secures_socket() {
         assert!(rejected.to_string().contains("401"));
     }
 
-    let mut token_client = verlet::adapters::codex_tui::CodexTuiTestClient::connect_unix(
+    let mut token_client = verlet::adapters::operator_client::OperatorClient::connect_unix(
         &managed_socket,
-        verlet::adapters::codex_tui::CodexTuiConnectConfig {
+        verlet::adapters::operator_client::OperatorConnectConfig {
             bearer_token: Some(token.clone()),
-            ..verlet::adapters::codex_tui::CodexTuiConnectConfig::default()
+            ..verlet::adapters::operator_client::OperatorConnectConfig::default()
         },
     )
     .await

--- a/crates/verlet-kernel/tests/daemon_smoke.rs
+++ b/crates/verlet-kernel/tests/daemon_smoke.rs
@@ -73,15 +73,15 @@ fn escape_toml_string(value: &str) -> String {
 
 async fn connect_daemon_client(
     socket: &std::path::Path,
-) -> verlet::adapters::codex_tui::CodexTuiTestClient<tokio::net::UnixStream> {
+) -> verlet::adapters::operator_client::OperatorClient<tokio::net::UnixStream> {
     let mut last_error = None;
     for _ in 0..1_500 {
         if socket.exists() {
-            match verlet::adapters::codex_tui::CodexTuiTestClient::connect_unix(
+            match verlet::adapters::operator_client::OperatorClient::connect_unix(
                 socket,
-                verlet::adapters::codex_tui::CodexTuiConnectConfig {
+                verlet::adapters::operator_client::OperatorConnectConfig {
                     client_name: "verlet-daemon-smoke".to_string(),
-                    ..verlet::adapters::codex_tui::CodexTuiConnectConfig::default()
+                    ..verlet::adapters::operator_client::OperatorConnectConfig::default()
                 },
             )
             .await

--- a/crates/verlet-kernel/tests/remote_store_sync.rs
+++ b/crates/verlet-kernel/tests/remote_store_sync.rs
@@ -1378,15 +1378,15 @@ fn escape_toml(value: &str) -> String {
 
 async fn connect_daemon_client(
     socket: &std::path::Path,
-) -> verlet::adapters::codex_tui::CodexTuiTestClient<tokio::net::UnixStream> {
+) -> verlet::adapters::operator_client::OperatorClient<tokio::net::UnixStream> {
     let mut last_error = None;
     for _ in 0..1_500 {
         if socket.exists() {
-            match verlet::adapters::codex_tui::CodexTuiTestClient::connect_unix(
+            match verlet::adapters::operator_client::OperatorClient::connect_unix(
                 socket,
-                verlet::adapters::codex_tui::CodexTuiConnectConfig {
+                verlet::adapters::operator_client::OperatorConnectConfig {
                     client_name: "verlet-remote-placement-e2e".to_string(),
-                    ..verlet::adapters::codex_tui::CodexTuiConnectConfig::default()
+                    ..verlet::adapters::operator_client::OperatorConnectConfig::default()
                 },
             )
             .await

--- a/crates/verlet-kernel/tests/smokes/verlet-app-server-smoke.rs
+++ b/crates/verlet-kernel/tests/smokes/verlet-app-server-smoke.rs
@@ -176,16 +176,16 @@ async fn connect_client(
     socket: &std::path::Path,
     client_name: &str,
 ) -> Result<
-    verlet::adapters::codex_tui::CodexTuiTestClient<tokio::net::UnixStream>,
+    verlet::adapters::operator_client::OperatorClient<tokio::net::UnixStream>,
     Box<dyn std::error::Error>,
 > {
     let mut last_error = None;
     for _ in 0..1_500 {
-        match verlet::adapters::codex_tui::CodexTuiTestClient::connect_unix(
+        match verlet::adapters::operator_client::OperatorClient::connect_unix(
             socket,
-            verlet::adapters::codex_tui::CodexTuiConnectConfig {
+            verlet::adapters::operator_client::OperatorConnectConfig {
                 client_name: client_name.to_string(),
-                ..verlet::adapters::codex_tui::CodexTuiConnectConfig::default()
+                ..verlet::adapters::operator_client::OperatorConnectConfig::default()
             },
         )
         .await
@@ -210,17 +210,17 @@ async fn connect_tcp_client(
     client_name: &str,
     token: &str,
 ) -> Result<
-    verlet::adapters::codex_tui::CodexTuiTestClient<tokio::net::TcpStream>,
+    verlet::adapters::operator_client::OperatorClient<tokio::net::TcpStream>,
     Box<dyn std::error::Error>,
 > {
     let mut last_error = None;
     for _ in 0..1_500 {
-        match verlet::adapters::codex_tui::CodexTuiTestClient::connect_websocket(
+        match verlet::adapters::operator_client::OperatorClient::connect_websocket(
             url,
-            verlet::adapters::codex_tui::CodexTuiConnectConfig {
+            verlet::adapters::operator_client::OperatorConnectConfig {
                 client_name: client_name.to_string(),
                 bearer_token: Some(token.to_string()),
-                ..verlet::adapters::codex_tui::CodexTuiConnectConfig::default()
+                ..verlet::adapters::operator_client::OperatorConnectConfig::default()
             },
         )
         .await

--- a/crates/verlet-kernel/tests/smokes/verlet-workbench-smoke.rs
+++ b/crates/verlet-kernel/tests/smokes/verlet-workbench-smoke.rs
@@ -172,17 +172,17 @@ async fn connect_client(
     url: &str,
     token: &str,
 ) -> Result<
-    verlet::adapters::codex_tui::CodexTuiTestClient<tokio::net::TcpStream>,
+    verlet::adapters::operator_client::OperatorClient<tokio::net::TcpStream>,
     Box<dyn std::error::Error>,
 > {
     let mut last_error = None;
     for _ in 0..1_500 {
-        match verlet::adapters::codex_tui::CodexTuiTestClient::connect_websocket(
+        match verlet::adapters::operator_client::OperatorClient::connect_websocket(
             url,
-            verlet::adapters::codex_tui::CodexTuiConnectConfig {
+            verlet::adapters::operator_client::OperatorConnectConfig {
                 client_name: "verlet-workbench-smoke".to_string(),
                 bearer_token: Some(token.to_string()),
-                ..verlet::adapters::codex_tui::CodexTuiConnectConfig::default()
+                ..verlet::adapters::operator_client::OperatorConnectConfig::default()
             },
         )
         .await

--- a/crates/verlet-kernel/tests/verlet_debug_rpc.rs
+++ b/crates/verlet-kernel/tests/verlet_debug_rpc.rs
@@ -471,12 +471,12 @@ fn unused_loopback_addr() -> std::net::SocketAddr {
 async fn wait_for_websocket(url: &str, token: &str) {
     let mut last_error = None;
     for _ in 0..1_500 {
-        match verlet::adapters::codex_tui::CodexTuiTestClient::connect_websocket(
+        match verlet::adapters::operator_client::OperatorClient::connect_websocket(
             url,
-            verlet::adapters::codex_tui::CodexTuiConnectConfig {
+            verlet::adapters::operator_client::OperatorConnectConfig {
                 client_name: "verlet-debug-rpc-test-wait".to_string(),
                 bearer_token: Some(token.to_string()),
-                ..verlet::adapters::codex_tui::CodexTuiConnectConfig::default()
+                ..verlet::adapters::operator_client::OperatorConnectConfig::default()
             },
         )
         .await

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -413,7 +413,7 @@ cargo test -p verlet clock_route
 ```
 
 The first smoke starts the real `verlet daemon run` binary on a configured
-Unix socket and drives it with the Verlet-owned Codex TUI remote client. The
+Unix socket and drives it with the Verlet-owned operator client. The
 second queues an ingress envelope into SQLite, drops the first queue/bridge,
 reopens the queue, and proves the restarted worker can submit it into the
 runtime.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -66,7 +66,7 @@ baseline, and repo-relative affected-surface paths that resolve to files.
 - Status: MITIGATED
 - Severity: Medium
 - Threat: The debug client can call an arbitrary JSON-RPC method on a configurable WebSocket endpoint; if the endpoint accepted unauthenticated connections, treating the client as a harmless diagnostic would expose the full control plane.
-- Affected surface: `crates/verlet-kernel/src/cli/debug_rpc.rs`, `crates/verlet-kernel/src/adapters/codex_tui.rs`
+- Affected surface: `crates/verlet-kernel/src/cli/debug_rpc.rs`, `crates/verlet-kernel/src/adapters/operator_client.rs`
 - Mitigation: Existing: the app-server endpoint authenticates every connection, so the debug client succeeds only with a valid credential (supplied via `VERLET_APP_SERVER_TOKEN` or explicit configuration) and acts with exactly that principal's authority under the dispatcher gate.
 - Deterministic guard: `crates/verlet-kernel/tests/boundary_auth.rs` pins the unauthenticated 401 on the WebSocket endpoint the debug client targets.
 


### PR DESCRIPTION
Finishes the EMO-506 leftover: the internal RPC client adapter loses its Codex TUI naming.

- `adapters::codex_tui` -> `adapters::operator_client`; `CodexTuiTestClient` -> `OperatorClient`; `CodexTuiConnectConfig` -> `OperatorConnectConfig`; the `VerletOperatorClient` alias is deleted and call sites name `OperatorClient` directly.
- Pure rename: no behavior, error-string, or wire-format changes. The wire-visible default client name string and the wire-dialect test name keep the word codex deliberately (they describe the protocol shape, not the component).
- `grep -ri "codex_tui|CodexTui" crates/` returns nothing.

Verification: workspace tests green (1048 passed), clippy/fmt clean, full scripts/verify.sh (macOS) and scripts/verify-linux.sh green.

Linear: EMO-546