### PR TITLE
Per-thread kernel-operation dispatch overlays (EMO-550)

### DIFF
--- a/crates/verlet-kernel/src/adapters/agent_loop.rs
+++ b/crates/verlet-kernel/src/adapters/agent_loop.rs
@@ -599,6 +599,8 @@ impl AgentLoop {
         if !had_explicit_router && self.bash_tool_config.is_none() {
             self.strict_tool_router_unknowns = false;
         }
+        let mut kernel_dispatch_overlay =
+            verlet_operations::operation_registry::KernelDispatchOverlay::new();
         if let Some(control) = control.clone() {
             let mut provider = crate::agent::agent_process::KernelThreadOperationProvider::new(
                 control.clone(),
@@ -610,23 +612,10 @@ impl AgentLoop {
             let dispatcher: std::sync::Arc<
                 dyn verlet_operations::operation_registry::KernelOperationDispatcher,
             > = std::sync::Arc::new(provider);
-            let _ = router
-                .operation_registry()
-                .set_kernel_dispatcher(
-                    crate::operations::kernel_packages::VERLET_THREADS_PACKAGE,
-                    std::sync::Arc::clone(&dispatcher),
-                )
-                .await;
-            if let Some(config) = &self.bash_tool_config
-                && let Some(registry) = &config.operation_registry
-            {
-                let _ = registry
-                    .set_kernel_dispatcher(
-                        crate::operations::kernel_packages::VERLET_THREADS_PACKAGE,
-                        std::sync::Arc::clone(&dispatcher),
-                    )
-                    .await;
-            }
+            kernel_dispatch_overlay = kernel_dispatch_overlay.with_dispatcher(
+                crate::operations::kernel_packages::VERLET_THREADS_PACKAGE,
+                dispatcher,
+            );
             let schedule_dispatcher: std::sync::Arc<
                 dyn verlet_operations::operation_registry::KernelOperationDispatcher,
             > = std::sync::Arc::new(
@@ -635,23 +624,10 @@ impl AgentLoop {
                     context.clone(),
                 ),
             );
-            let _ = router
-                .operation_registry()
-                .set_kernel_dispatcher(
-                    crate::operations::kernel_packages::VERLET_SCHEDULE_PACKAGE,
-                    std::sync::Arc::clone(&schedule_dispatcher),
-                )
-                .await;
-            if let Some(config) = &self.bash_tool_config
-                && let Some(registry) = &config.operation_registry
-            {
-                let _ = registry
-                    .set_kernel_dispatcher(
-                        crate::operations::kernel_packages::VERLET_SCHEDULE_PACKAGE,
-                        std::sync::Arc::clone(&schedule_dispatcher),
-                    )
-                    .await;
-            }
+            kernel_dispatch_overlay = kernel_dispatch_overlay.with_dispatcher(
+                crate::operations::kernel_packages::VERLET_SCHEDULE_PACKAGE,
+                schedule_dispatcher,
+            );
         }
         let process_cwd = self
             .bash_tool_config
@@ -676,42 +652,22 @@ impl AgentLoop {
         let process_dispatcher: std::sync::Arc<
             dyn verlet_operations::operation_registry::KernelOperationDispatcher,
         > = std::sync::Arc::new(process_provider);
-        let _ = router
-            .operation_registry()
-            .set_kernel_dispatcher(
-                crate::operations::kernel_packages::VERLET_PROCESS_PACKAGE,
-                std::sync::Arc::clone(&process_dispatcher),
-            )
-            .await;
-        if let Some(config) = &self.bash_tool_config
-            && let Some(registry) = &config.operation_registry
-        {
-            let _ = registry
-                .set_kernel_dispatcher(
-                    crate::operations::kernel_packages::VERLET_PROCESS_PACKAGE,
-                    std::sync::Arc::clone(&process_dispatcher),
-                )
-                .await;
-        }
+        kernel_dispatch_overlay = kernel_dispatch_overlay.with_dispatcher(
+            crate::operations::kernel_packages::VERLET_PROCESS_PACKAGE,
+            process_dispatcher,
+        );
         let notify_dispatcher: std::sync::Arc<
             dyn verlet_operations::operation_registry::KernelOperationDispatcher,
         > = std::sync::Arc::new(crate::agent::agent_process::KernelNotifyOperationProvider);
-        let _ = router
-            .operation_registry()
-            .set_kernel_dispatcher(
-                crate::operations::kernel_packages::VERLET_NOTIFY_PACKAGE,
-                std::sync::Arc::clone(&notify_dispatcher),
-            )
-            .await;
-        if let Some(config) = &self.bash_tool_config
-            && let Some(registry) = &config.operation_registry
-        {
-            let _ = registry
-                .set_kernel_dispatcher(
-                    crate::operations::kernel_packages::VERLET_NOTIFY_PACKAGE,
-                    std::sync::Arc::clone(&notify_dispatcher),
-                )
-                .await;
+        kernel_dispatch_overlay = kernel_dispatch_overlay.with_dispatcher(
+            crate::operations::kernel_packages::VERLET_NOTIFY_PACKAGE,
+            notify_dispatcher,
+        );
+        router = router.with_kernel_dispatch_overlay(kernel_dispatch_overlay.clone());
+        if let Some(config) = &mut self.bash_tool_config {
+            *config = config
+                .clone()
+                .with_kernel_dispatch_overlay(kernel_dispatch_overlay);
         }
         if let Some(config) = &self.bash_tool_config {
             let mut provider =

--- a/crates/verlet-kernel/src/adapters/agent_loop/tests.rs
+++ b/crates/verlet-kernel/src/adapters/agent_loop/tests.rs
@@ -47,6 +47,10 @@ struct StreamingClient {
     events: std::sync::Mutex<std::collections::VecDeque<Vec<verlet_provider::ProviderStreamEvent>>>,
 }
 
+struct BashMandateListClient {
+    barrier: std::sync::Arc<tokio::sync::Barrier>,
+}
+
 struct TurnContextRecordingKernelToolProvider {
     snapshots:
         std::sync::Mutex<Vec<Option<crate::kernel::runtime_host::turn::TurnContextSnapshot>>>,
@@ -1502,6 +1506,34 @@ impl verlet_provider::ProviderClient for RecordingClient {
         self.responses.lock().unwrap().pop().ok_or_else(|| {
             verlet_provider::ProviderError::Decode("no test response queued".to_string())
         })
+    }
+}
+
+#[async_trait::async_trait]
+impl verlet_provider::ProviderClient for BashMandateListClient {
+    async fn complete(
+        &self,
+        request: &verlet_provider::ProviderRequest,
+    ) -> verlet_provider::ProviderResult<verlet_provider::ProviderResponse> {
+        if request
+            .messages
+            .iter()
+            .any(|message| matches!(message, verlet_history::CanonicalMessage::ToolResult { .. }))
+        {
+            Ok(response_text("listed mandates"))
+        } else {
+            self.barrier.wait().await;
+            Ok(response_tool_call_named(
+                verlet_vbash::BASH_TOOL,
+                serde_json::json!({
+                    "command": format!(
+                        "printf '{{}}' | verlet run {} {}",
+                        crate::operations::kernel_packages::VERLET_SCHEDULE_PACKAGE,
+                        crate::operations::kernel_packages::MANDATE_LIST_OPERATION,
+                    ),
+                }),
+            ))
+        }
     }
 }
 
@@ -7422,6 +7454,97 @@ async fn runtime_routes_thread_spawn_operation_through_kernel_dispatch() {
     host.shutdown_all().await.unwrap();
 }
 
+#[tokio::test]
+async fn concurrent_thread_mounts_isolate_bash_kernel_dispatch_on_shared_registry() {
+    let provider_client: std::sync::Arc<dyn verlet_provider::ProviderClient> =
+        std::sync::Arc::new(BashMandateListClient {
+            barrier: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
+        });
+    let mut config = crate::adapters::agent_loop::AgentLoopConfig::new(
+        verlet_history::ProviderApi::OpenAIResponses,
+        "openai",
+        "gpt-test",
+    );
+    config.max_tokens = 128;
+    let registry = kernel_schedule_registry().await;
+    let capability_grants =
+        crate::operations::kernel_packages::verlet_schedule_kernel_package().capability_grants;
+    let factory = crate::adapters::agent_loop::AgentLoopFactory::new(config, provider_client)
+        .with_bash_tool(
+            crate::capabilities::execution::VirtualBashRuntimeConfig::default()
+                .with_operation_registry(registry)
+                .with_capability_grants(capability_grants),
+        );
+    let host = crate::kernel::runtime_host::RuntimeHost::new(std::sync::Arc::new(factory));
+
+    let (thread_a, thread_b) = tokio::join!(
+        host.start_thread(
+            verlet_runtime_contracts::ThreadCoordinates::new("tenant_a", "user_1", "overlay-a",),
+            verlet_runtime_contracts::ThreadTopology::root(),
+        ),
+        host.start_thread(
+            verlet_runtime_contracts::ThreadCoordinates::new("tenant_a", "user_1", "overlay-b",),
+            verlet_runtime_contracts::ThreadTopology::root(),
+        ),
+    );
+    let thread_a = thread_a.unwrap();
+    let thread_b = thread_b.unwrap();
+    let thread_a_id = thread_a.context().coordinates.thread_id.to_string();
+    let thread_b_id = thread_b.context().coordinates.thread_id.to_string();
+    let mut status_a = thread_a.subscribe_status();
+    let mut status_b = thread_b.subscribe_status();
+    tokio::join!(
+        wait_for_status(&mut status_a, verlet_runtime_contracts::ThreadStatus::Idle),
+        wait_for_status(&mut status_b, verlet_runtime_contracts::ThreadStatus::Idle),
+    );
+    let mut events_a = thread_a.subscribe_events();
+    let mut events_b = thread_b.subscribe_events();
+
+    let (submit_a, submit_b) = tokio::join!(
+        host.submit(
+            thread_a.context().coordinates.thread_id,
+            "turn-a",
+            "list mandates",
+        ),
+        host.submit(
+            thread_b.context().coordinates.thread_id,
+            "turn-b",
+            "list mandates",
+        ),
+    );
+    submit_a.unwrap();
+    submit_b.unwrap();
+    let (runtime_events_a, runtime_events_b) = tokio::join!(
+        assert_output_with_runtime_events(&mut events_a, "listed mandates"),
+        assert_output_with_runtime_events(&mut events_b, "listed mandates"),
+    );
+
+    let output_a = successful_tool_output(&runtime_events_a);
+    let output_b = successful_tool_output(&runtime_events_b);
+    assert!(output_a.contains(&thread_a_id));
+    assert!(!output_a.contains(&thread_b_id));
+    assert!(output_b.contains(&thread_b_id));
+    assert!(!output_b.contains(&thread_a_id));
+
+    host.shutdown_all().await.unwrap();
+}
+
+fn successful_tool_output(
+    events: &[crate::kernel::runtime_host::runtime_events::RuntimeEventKind],
+) -> &str {
+    events
+        .iter()
+        .find_map(|event| match event {
+            crate::kernel::runtime_host::runtime_events::RuntimeEventKind::ToolCallResult {
+                output,
+                success: true,
+                ..
+            } => Some(output.as_str()),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("successful tool result in {events:#?}"))
+}
+
 async fn kernel_thread_registry()
 -> std::sync::Arc<verlet_operations::operation_registry::OperationRegistry> {
     let registry =
@@ -7453,6 +7576,26 @@ async fn kernel_thread_router() -> crate::agent::agent_tool_router::AgentToolRou
             operation_name: crate::operations::kernel_packages::THREAD_SPAWN_OPERATION.to_string(),
             grant_expiries: Vec::new(),
         }])
+}
+
+async fn kernel_schedule_registry()
+-> std::sync::Arc<verlet_operations::operation_registry::OperationRegistry> {
+    let registry =
+        std::sync::Arc::new(verlet_operations::operation_registry::OperationRegistry::new());
+    let package = crate::operations::kernel_packages::verlet_schedule_kernel_package();
+    let mut registration = verlet_operations::operation_registry::KernelOperationRegistration::new(
+        crate::operations::kernel_packages::VERLET_SCHEDULE_PACKAGE,
+        package.manifest.clone(),
+    )
+    .with_capability_grants(package.capability_grants.clone());
+    registration.metadata.insert(
+        crate::operations::kernel_packages::OPERATION_METADATA_RUNTIME_KIND.to_string(),
+        serde_json::Value::String(
+            crate::operations::kernel_packages::KERNEL_RUNTIME_KIND.to_string(),
+        ),
+    );
+    registry.register_kernel(registration).await.unwrap();
+    registry
 }
 
 async fn append_tool_controller_bind_receipt(

--- a/crates/verlet-kernel/src/agent/agent_tool_router.rs
+++ b/crates/verlet-kernel/src/agent/agent_tool_router.rs
@@ -1,6 +1,7 @@
 #[derive(Clone)]
 pub struct AgentToolRouter {
     operation_registry: std::sync::Arc<verlet_operations::operation_registry::OperationRegistry>,
+    kernel_dispatch_overlay: verlet_operations::operation_registry::KernelDispatchOverlay,
     kernel_tool_providers: Vec<std::sync::Arc<dyn AgentKernelToolProvider>>,
     capability_grants: std::collections::BTreeSet<String>,
     capability_grant_expiries: Vec<verlet_agent::manifest_schema::AgentManifestGrantExpiry>,
@@ -165,6 +166,8 @@ impl AgentToolRouter {
     ) -> Self {
         Self {
             operation_registry,
+            kernel_dispatch_overlay:
+                verlet_operations::operation_registry::KernelDispatchOverlay::new(),
             kernel_tool_providers: Vec::new(),
             capability_grants: std::collections::BTreeSet::new(),
             capability_grant_expiries: Vec::new(),
@@ -177,6 +180,14 @@ impl AgentToolRouter {
         kernel_tool_provider: std::sync::Arc<dyn AgentKernelToolProvider>,
     ) -> Self {
         self.kernel_tool_providers.push(kernel_tool_provider);
+        self
+    }
+
+    pub fn with_kernel_dispatch_overlay(
+        mut self,
+        overlay: verlet_operations::operation_registry::KernelDispatchOverlay,
+    ) -> Self {
+        self.kernel_dispatch_overlay = overlay;
         self
     }
 
@@ -503,8 +514,12 @@ impl AgentToolRouter {
                 now_ms,
             )?;
             let input = encode_tool_input(call_id, tool_name, &projection, arguments)?;
-            let process = self
-                .operation_registry
+            let operation_registry =
+                verlet_operations::operation_registry::ScopedOperationRegistry::new(
+                    std::sync::Arc::clone(&self.operation_registry),
+                    self.kernel_dispatch_overlay.clone(),
+                );
+            let process = operation_registry
                 .invoke_process_with_kernel_metadata(
                     &projection.registered_name,
                     &projection.operation_name,

--- a/crates/verlet-kernel/src/agent/agent_tool_router/tests.rs
+++ b/crates/verlet-kernel/src/agent/agent_tool_router/tests.rs
@@ -49,6 +49,70 @@ async fn router_invokes_registry_operation_and_returns_tool_result() {
 }
 
 #[tokio::test]
+async fn routers_with_shared_registry_isolate_concurrent_kernel_dispatch_overlays() {
+    let registry =
+        std::sync::Arc::new(verlet_operations::operation_registry::OperationRegistry::new());
+    registry
+        .register_kernel(
+            verlet_operations::operation_registry::KernelOperationRegistration::new(
+                "thread-identity",
+                verlet_abi::WasmOperationManifest {
+                    abi: verlet_wasm::runner::OPERATION_ABI.to_string(),
+                    operations: vec![verlet_abi::WasmOperationDefinition {
+                        id: 1,
+                        name: "identify-thread".to_string(),
+                        input: verlet_abi::WasmOperationValueKind::Bytes,
+                        output: verlet_abi::WasmOperationValueKind::Bytes,
+                        events: verlet_abi::WasmOperationEventKind::None,
+                        mode: verlet_abi::WasmOperationMode::Sync,
+                        required_capabilities: Vec::new(),
+                    }],
+                },
+            ),
+        )
+        .await
+        .unwrap();
+
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+    let router_a = kernel_identity_router(
+        std::sync::Arc::clone(&registry),
+        "thread-a",
+        std::sync::Arc::clone(&barrier),
+    );
+    let router_b = kernel_identity_router(registry, "thread-b", barrier);
+
+    let (thread_a, thread_b) = tokio::join!(
+        router_a.invoke_tool_call(
+            "call-a",
+            "identify-thread",
+            serde_json::json!({"input": ""}),
+        ),
+        router_b.invoke_tool_call(
+            "call-b",
+            "identify-thread",
+            serde_json::json!({"input": ""}),
+        ),
+    );
+
+    assert!(matches!(
+        thread_a,
+        verlet_history::CanonicalMessage::ToolResult {
+            is_error: false,
+            content,
+            ..
+        } if tool_result_text(&content) == "thread-a"
+    ));
+    assert!(matches!(
+        thread_b,
+        verlet_history::CanonicalMessage::ToolResult {
+            is_error: false,
+            content,
+            ..
+        } if tool_result_text(&content) == "thread-b"
+    ));
+}
+
+#[tokio::test]
 async fn router_invokes_kernel_tool_provider() {
     let router = crate::agent::agent_tool_router::AgentToolRouter::new(std::sync::Arc::new(
         verlet_operations::operation_registry::OperationRegistry::new(),
@@ -865,6 +929,46 @@ fn wat_bytes(bytes: &[u8]) -> String {
             _ => format!("\\{byte:02x}"),
         })
         .collect()
+}
+
+fn kernel_identity_router(
+    registry: std::sync::Arc<verlet_operations::operation_registry::OperationRegistry>,
+    thread_id: &'static str,
+    barrier: std::sync::Arc<tokio::sync::Barrier>,
+) -> crate::agent::agent_tool_router::AgentToolRouter {
+    let dispatcher: std::sync::Arc<
+        dyn verlet_operations::operation_registry::KernelOperationDispatcher,
+    > = std::sync::Arc::new(ThreadIdentityKernelDispatcher { thread_id, barrier });
+    crate::agent::agent_tool_router::AgentToolRouter::new(registry)
+        .with_kernel_dispatch_overlay(
+            verlet_operations::operation_registry::KernelDispatchOverlay::new()
+                .with_dispatcher("thread-identity", dispatcher),
+        )
+        .with_tool_aliases(vec![crate::agent::agent_tool_router::OperationToolAlias {
+            tool_name: "identify-thread".to_string(),
+            registered_name: "thread-identity".to_string(),
+            operation_name: "identify-thread".to_string(),
+            grant_expiries: Vec::new(),
+        }])
+}
+
+struct ThreadIdentityKernelDispatcher {
+    thread_id: &'static str,
+    barrier: std::sync::Arc<tokio::sync::Barrier>,
+}
+
+#[async_trait::async_trait]
+impl verlet_operations::operation_registry::KernelOperationDispatcher
+    for ThreadIdentityKernelDispatcher
+{
+    async fn invoke_kernel_operation(
+        &self,
+        _operation_name: &str,
+        _input: Vec<u8>,
+    ) -> verlet_operations::VerletResult<Vec<u8>> {
+        self.barrier.wait().await;
+        Ok(self.thread_id.as_bytes().to_vec())
+    }
 }
 
 struct FakeKernelToolProvider;

--- a/crates/verlet-kernel/src/capabilities/execution.rs
+++ b/crates/verlet-kernel/src/capabilities/execution.rs
@@ -49,6 +49,8 @@ pub struct VirtualBashRuntimeConfig {
     pub mounts: Vec<verlet_vbash::VirtualMount>,
     pub operation_registry:
         Option<std::sync::Arc<verlet_operations::operation_registry::OperationRegistry>>,
+    /// Per-caller kernel dispatchers applied when the registry is projected into bash.
+    pub kernel_dispatch_overlay: verlet_operations::operation_registry::KernelDispatchOverlay,
     /// Thread workspace VFS shared with catalog-loaded operations when both surfaces
     /// must re-present one filesystem tree.
     pub workspace_vfs: Option<std::sync::Arc<verlet_vfs::VerletVfs>>,
@@ -75,6 +77,14 @@ impl std::fmt::Debug for VirtualBashRuntimeConfig {
                     .operation_registry
                     .as_ref()
                     .map(|_| "<OperationRegistry>"),
+            )
+            .field(
+                "kernel_dispatch_overlay",
+                &if self.kernel_dispatch_overlay.is_empty() {
+                    "<empty>"
+                } else {
+                    "<configured>"
+                },
             )
             .field(
                 "workspace_vfs",
@@ -105,6 +115,8 @@ impl Default for VirtualBashRuntimeConfig {
             max_output_bytes: 1_048_576,
             mounts: verlet_vbash::default_virtual_mounts(),
             operation_registry: None,
+            kernel_dispatch_overlay:
+                verlet_operations::operation_registry::KernelDispatchOverlay::new(),
             workspace_vfs: None,
             capability_grants: std::collections::BTreeSet::new(),
             capability_grant_expiries: Vec::new(),
@@ -183,6 +195,14 @@ impl VirtualBashRuntimeConfig {
         self
     }
 
+    pub fn with_kernel_dispatch_overlay(
+        mut self,
+        overlay: verlet_operations::operation_registry::KernelDispatchOverlay,
+    ) -> Self {
+        self.kernel_dispatch_overlay = overlay;
+        self
+    }
+
     /// Reuse a thread workspace VFS instead of constructing a private bash tree.
     pub fn with_workspace_vfs(mut self, vfs: std::sync::Arc<verlet_vfs::VerletVfs>) -> Self {
         self.workspace_vfs = Some(vfs);
@@ -242,6 +262,10 @@ impl From<VirtualBashRuntimeConfig> for verlet_vbash::harness::BashkitExecutionC
             max_output_bytes: config.max_output_bytes,
             mounts: config.mounts,
             operation_registry: config.operation_registry.map(|registry| {
+                let registry = verlet_operations::operation_registry::ScopedOperationRegistry::new(
+                    registry,
+                    config.kernel_dispatch_overlay.clone(),
+                );
                 std::sync::Arc::new(KernelVbashOperationRegistry::new(registry))
                     as std::sync::Arc<dyn verlet_vbash::harness::VbashOperationRegistry>
             }),
@@ -256,11 +280,11 @@ impl From<VirtualBashRuntimeConfig> for verlet_vbash::harness::BashkitExecutionC
 #[async_trait::async_trait]
 impl verlet_vbash::harness::VbashOperationRegistry for KernelVbashOperationRegistry {
     async fn describe(&self, name: &str) -> Option<verlet_operations::RegisteredOperation> {
-        self.registry.describe(name).await
+        self.registry.registry().describe(name).await
     }
 
     async fn list(&self) -> Vec<verlet_operations::RegisteredOperation> {
-        self.registry.list().await
+        self.registry.registry().list().await
     }
 
     async fn invoke_process_output(
@@ -281,13 +305,11 @@ impl verlet_vbash::harness::VbashOperationRegistry for KernelVbashOperationRegis
 }
 
 struct KernelVbashOperationRegistry {
-    registry: std::sync::Arc<verlet_operations::operation_registry::OperationRegistry>,
+    registry: verlet_operations::operation_registry::ScopedOperationRegistry,
 }
 
 impl KernelVbashOperationRegistry {
-    fn new(
-        registry: std::sync::Arc<verlet_operations::operation_registry::OperationRegistry>,
-    ) -> Self {
+    fn new(registry: verlet_operations::operation_registry::ScopedOperationRegistry) -> Self {
         Self { registry }
     }
 }
@@ -332,8 +354,12 @@ impl crate::agent::agent_tool_router::AgentKernelToolProvider for BashToolProvid
         if let Some(registry) = &self.config.operation_registry {
             let reserved_commands =
                 verlet_vbash::operation_shell_reserved_commands(&self.config.execution_policy);
-            let registry_adapter =
-                KernelVbashOperationRegistry::new(std::sync::Arc::clone(registry));
+            let registry_adapter = KernelVbashOperationRegistry::new(
+                verlet_operations::operation_registry::ScopedOperationRegistry::new(
+                    std::sync::Arc::clone(registry),
+                    self.config.kernel_dispatch_overlay.clone(),
+                ),
+            );
             let shell_commands = verlet_vbash::harness::operation_shell_command_names(
                 &registry_adapter,
                 &reserved_commands,

--- a/crates/verlet-kernel/src/capabilities/execution/tests.rs
+++ b/crates/verlet-kernel/src/capabilities/execution/tests.rs
@@ -353,6 +353,36 @@ async fn named_echo_operation_registry_with_required(
     registry
 }
 
+struct FixedKernelDispatcher(&'static str);
+
+#[async_trait::async_trait]
+impl verlet_operations::operation_registry::KernelOperationDispatcher for FixedKernelDispatcher {
+    async fn invoke_kernel_operation(
+        &self,
+        _operation_name: &str,
+        _input: Vec<u8>,
+    ) -> verlet_operations::VerletResult<Vec<u8>> {
+        Ok(self.0.as_bytes().to_vec())
+    }
+}
+
+struct BarrierKernelDispatcher {
+    output: &'static str,
+    barrier: std::sync::Arc<tokio::sync::Barrier>,
+}
+
+#[async_trait::async_trait]
+impl verlet_operations::operation_registry::KernelOperationDispatcher for BarrierKernelDispatcher {
+    async fn invoke_kernel_operation(
+        &self,
+        _operation_name: &str,
+        _input: Vec<u8>,
+    ) -> verlet_operations::VerletResult<Vec<u8>> {
+        self.barrier.wait().await;
+        Ok(self.output.as_bytes().to_vec())
+    }
+}
+
 #[tokio::test]
 async fn harness_runs_virtual_file_commands_pipes_and_patch() {
     let mut harness = verlet_vbash::harness::BashkitExecutionHarness::new(
@@ -454,6 +484,127 @@ async fn virtual_bash_verlet_run_invokes_registered_operation_from_pipe() {
 }
 
 #[tokio::test]
+async fn virtual_bash_kernel_operation_uses_dispatch_overlay() {
+    let registry = kernel_identity_operation_registry().await;
+    let config = crate::capabilities::execution::VirtualBashRuntimeConfig::default()
+        .with_operation_registry(registry)
+        .with_kernel_dispatch_overlay(
+            verlet_operations::operation_registry::KernelDispatchOverlay::new().with_dispatcher(
+                "thread-identity",
+                std::sync::Arc::new(FixedKernelDispatcher("bash-thread")),
+            ),
+        );
+    let mut harness = verlet_vbash::harness::BashkitExecutionHarness::new(config)
+        .await
+        .unwrap();
+
+    let output = harness
+        .execute("printf ignored | verlet run thread-identity identify-thread")
+        .await
+        .unwrap();
+
+    assert!(output.success(), "{output:?}");
+    assert_eq!(output.stdout, "bash-thread");
+}
+
+#[tokio::test]
+async fn virtual_bash_dispatch_overlay_builder_is_order_independent() {
+    let registry = kernel_identity_operation_registry().await;
+    let config = crate::capabilities::execution::VirtualBashRuntimeConfig::default()
+        .with_kernel_dispatch_overlay(
+            verlet_operations::operation_registry::KernelDispatchOverlay::new().with_dispatcher(
+                "thread-identity",
+                std::sync::Arc::new(FixedKernelDispatcher("overlay-first")),
+            ),
+        )
+        .with_operation_registry(registry);
+    let mut harness = verlet_vbash::harness::BashkitExecutionHarness::new(config)
+        .await
+        .unwrap();
+
+    let output = harness
+        .execute("printf ignored | verlet run thread-identity identify-thread")
+        .await
+        .unwrap();
+
+    assert!(output.success(), "{output:?}");
+    assert_eq!(output.stdout, "overlay-first");
+}
+
+#[tokio::test]
+async fn virtual_bash_shared_registry_isolates_concurrent_kernel_dispatch_overlays() {
+    let registry = kernel_identity_operation_registry().await;
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+    let config_a = crate::capabilities::execution::VirtualBashRuntimeConfig::default()
+        .with_operation_registry(std::sync::Arc::clone(&registry))
+        .with_kernel_dispatch_overlay(
+            verlet_operations::operation_registry::KernelDispatchOverlay::new().with_dispatcher(
+                "thread-identity",
+                std::sync::Arc::new(BarrierKernelDispatcher {
+                    output: "bash-thread-a",
+                    barrier: std::sync::Arc::clone(&barrier),
+                }),
+            ),
+        );
+    let config_b = crate::capabilities::execution::VirtualBashRuntimeConfig::default()
+        .with_operation_registry(registry)
+        .with_kernel_dispatch_overlay(
+            verlet_operations::operation_registry::KernelDispatchOverlay::new().with_dispatcher(
+                "thread-identity",
+                std::sync::Arc::new(BarrierKernelDispatcher {
+                    output: "bash-thread-b",
+                    barrier,
+                }),
+            ),
+        );
+    let (harness_a, harness_b) = tokio::join!(
+        verlet_vbash::harness::BashkitExecutionHarness::new(config_a),
+        verlet_vbash::harness::BashkitExecutionHarness::new(config_b),
+    );
+    let mut harness_a = harness_a.unwrap();
+    let mut harness_b = harness_b.unwrap();
+
+    let (output_a, output_b) = tokio::join!(
+        harness_a.execute("printf ignored | verlet run thread-identity identify-thread"),
+        harness_b.execute("printf ignored | verlet run thread-identity identify-thread"),
+    );
+    let output_a = output_a.unwrap();
+    let output_b = output_b.unwrap();
+
+    assert!(output_a.success(), "{output_a:?}");
+    assert!(output_b.success(), "{output_b:?}");
+    assert_eq!(output_a.stdout, "bash-thread-a");
+    assert_eq!(output_b.stdout, "bash-thread-b");
+}
+
+async fn kernel_identity_operation_registry()
+-> std::sync::Arc<verlet_operations::operation_registry::OperationRegistry> {
+    let registry =
+        std::sync::Arc::new(verlet_operations::operation_registry::OperationRegistry::new());
+    registry
+        .register_kernel(
+            verlet_operations::operation_registry::KernelOperationRegistration::new(
+                "thread-identity",
+                verlet_abi::WasmOperationManifest {
+                    abi: verlet_wasm::runner::OPERATION_ABI.to_string(),
+                    operations: vec![verlet_abi::WasmOperationDefinition {
+                        id: 1,
+                        name: "identify-thread".to_string(),
+                        input: verlet_abi::WasmOperationValueKind::Bytes,
+                        output: verlet_abi::WasmOperationValueKind::Bytes,
+                        events: verlet_abi::WasmOperationEventKind::None,
+                        mode: verlet_abi::WasmOperationMode::Sync,
+                        required_capabilities: Vec::new(),
+                    }],
+                },
+            ),
+        )
+        .await
+        .unwrap();
+    registry
+}
+
+#[tokio::test]
 async fn virtual_bash_projects_registry_operations_as_host_builtins() {
     let config = crate::capabilities::execution::VirtualBashRuntimeConfig::default()
         .with_operation_registry(named_echo_operation_registry("search", "search").await);
@@ -536,7 +687,10 @@ async fn virtual_bash_host_builtins_reflect_registry_add_and_remove_without_rebu
 async fn virtual_bash_reserved_operation_names_are_not_projected_as_shell_commands() {
     let registry = named_echo_operation_registry("capsule", "type").await;
     let registry_adapter = crate::capabilities::execution::KernelVbashOperationRegistry::new(
-        std::sync::Arc::clone(&registry),
+        verlet_operations::operation_registry::ScopedOperationRegistry::new(
+            std::sync::Arc::clone(&registry),
+            verlet_operations::operation_registry::KernelDispatchOverlay::new(),
+        ),
     );
     let shell_commands = verlet_vbash::harness::operation_shell_command_names(
         &registry_adapter,

--- a/crates/verlet-operations/src/operation_registry.rs
+++ b/crates/verlet-operations/src/operation_registry.rs
@@ -97,6 +97,8 @@ impl KernelOperationRegistration {
         self
     }
 
+    /// Set an immutable fallback dispatcher shared by every caller. Dispatchers
+    /// that capture a thread or caller belong in [`KernelDispatchOverlay`].
     pub fn with_dispatcher(
         mut self,
         dispatcher: std::sync::Arc<dyn KernelOperationDispatcher>,
@@ -141,7 +143,7 @@ enum OperationRegistryEntryRuntime {
         factory: std::sync::Arc<verlet_wasm::runner::WasmRuntimeFactory>,
     },
     Kernel {
-        dispatcher: tokio::sync::RwLock<Option<std::sync::Arc<dyn KernelOperationDispatcher>>>,
+        dispatcher: Option<std::sync::Arc<dyn KernelOperationDispatcher>>,
     },
 }
 
@@ -225,7 +227,7 @@ impl OperationRegistry {
         let entry = std::sync::Arc::new(OperationRegistryEntry {
             record: record.clone(),
             runtime: OperationRegistryEntryRuntime::Kernel {
-                dispatcher: tokio::sync::RwLock::new(registration.dispatcher),
+                dispatcher: registration.dispatcher,
             },
         });
         self.entries
@@ -233,32 +235,6 @@ impl OperationRegistry {
             .await
             .insert(record.name.clone(), entry);
         Ok(record)
-    }
-
-    pub async fn set_kernel_dispatcher(
-        &self,
-        name: &str,
-        dispatcher: std::sync::Arc<dyn KernelOperationDispatcher>,
-    ) -> crate::VerletResult<bool> {
-        let name = normalize_registration_name(name)?;
-        let entry = {
-            let entries = self.entries.read().await;
-            entries.get(&name).cloned()
-        };
-        let Some(entry) = entry else {
-            return Ok(false);
-        };
-        match &entry.runtime {
-            OperationRegistryEntryRuntime::Kernel { dispatcher: slot } => {
-                *slot.write().await = Some(dispatcher);
-                Ok(true)
-            }
-            OperationRegistryEntryRuntime::Wasm { .. } => {
-                Err(crate::VerletOperationsError::RuntimeFactory(format!(
-                    "registered operation {name:?} is not kernel-native"
-                )))
-            }
-        }
     }
 
     pub async fn describe(&self, name: &str) -> Option<crate::RegisteredOperation> {
@@ -308,6 +284,24 @@ impl OperationRegistry {
         input: impl Into<Vec<u8>>,
         kernel_metadata: std::collections::BTreeMap<String, serde_json::Value>,
     ) -> crate::VerletResult<verlet_process::process::WasmOperationOutput> {
+        self.invoke_entry_bytes_with_kernel_metadata(
+            registered_name,
+            operation_name,
+            input.into(),
+            kernel_metadata,
+            None,
+        )
+        .await
+    }
+
+    async fn invoke_entry_bytes_with_kernel_metadata(
+        &self,
+        registered_name: &str,
+        operation_name: &str,
+        input: Vec<u8>,
+        kernel_metadata: std::collections::BTreeMap<String, serde_json::Value>,
+        overlay_dispatcher: Option<std::sync::Arc<dyn KernelOperationDispatcher>>,
+    ) -> crate::VerletResult<verlet_process::process::WasmOperationOutput> {
         let entry = self
             .entries
             .read()
@@ -326,20 +320,18 @@ impl OperationRegistry {
         }
         match &entry.runtime {
             OperationRegistryEntryRuntime::Wasm { factory } => Ok(factory
-                .invoke_operation_bytes(operation_name, input.into())
+                .invoke_operation_bytes(operation_name, input)
                 .await?),
             OperationRegistryEntryRuntime::Kernel { dispatcher } => {
-                let dispatcher = dispatcher.read().await.clone().ok_or_else(|| {
-                    crate::VerletOperationsError::RuntimeExecution(format!(
-                        "kernel operation {registered_name:?}/{operation_name:?} has no dispatcher in this runtime"
-                    ))
-                })?;
+                let dispatcher = overlay_dispatcher
+                    .or_else(|| dispatcher.clone())
+                    .ok_or_else(|| {
+                        crate::VerletOperationsError::RuntimeExecution(format!(
+                            "kernel operation {registered_name:?}/{operation_name:?} has no dispatcher in this runtime"
+                        ))
+                    })?;
                 let output = dispatcher
-                    .invoke_kernel_operation_with_metadata(
-                        operation_name,
-                        input.into(),
-                        kernel_metadata,
-                    )
+                    .invoke_kernel_operation_with_metadata(operation_name, input, kernel_metadata)
                     .await?;
                 let operation = entry
                     .record
@@ -477,7 +469,8 @@ pub fn filter_manifest_operations(
 /// every other thread's kernel operations. The overlay rides with the
 /// invoking side instead (agent tool router, bash execution config) and is
 /// consulted per invocation, before the dispatcher optionally supplied at
-/// registration time (immutable after registration, safe to share).
+/// registration time (immutable after registration and required to be safe to
+/// share across callers).
 #[derive(Clone, Default)]
 pub struct KernelDispatchOverlay {
     dispatchers: std::collections::BTreeMap<String, std::sync::Arc<dyn KernelOperationDispatcher>>,
@@ -488,8 +481,8 @@ impl KernelDispatchOverlay {
         Self::default()
     }
 
-    /// Set the dispatcher for a kernel package name (normalized like
-    /// registration names); replaces any previous overlay entry.
+    /// Set the dispatcher for an exact registered kernel package name; replaces
+    /// any previous overlay entry.
     pub fn with_dispatcher(
         mut self,
         package: impl Into<String>,
@@ -514,9 +507,9 @@ impl KernelDispatchOverlay {
 /// An operation-registry view scoped to one invoking context (EMO-550):
 /// the shared registration state plus this caller's dispatch overlay.
 ///
-/// All kernel-operation invocation goes through this view. Kernel dispatch
-/// resolves from the overlay first, then from the dispatcher supplied at
-/// registration, and fails with the existing "has no dispatcher in this
+/// Caller-scoped kernel-operation invocation goes through this view. Kernel
+/// dispatch resolves from the overlay first, then from the dispatcher supplied
+/// at registration, and fails with the existing "has no dispatcher in this
 /// runtime" error when neither exists. Wasm entries are unaffected by the
 /// overlay. Registration, listing, and describe stay on the underlying
 /// [`OperationRegistry`].
@@ -565,13 +558,15 @@ impl ScopedOperationRegistry {
         input: impl Into<Vec<u8>>,
         kernel_metadata: std::collections::BTreeMap<String, serde_json::Value>,
     ) -> crate::VerletResult<verlet_process::process::WasmOperationOutput> {
-        let _ = (
-            registered_name,
-            operation_name,
-            input.into(),
-            kernel_metadata,
-        );
-        unimplemented!("EMO-550: overlay-first kernel dispatch")
+        self.registry
+            .invoke_entry_bytes_with_kernel_metadata(
+                registered_name,
+                operation_name,
+                input.into(),
+                kernel_metadata,
+                self.overlay.dispatcher(registered_name),
+            )
+            .await
     }
 
     pub async fn invoke_process(
@@ -610,5 +605,147 @@ impl ScopedOperationRegistry {
                 output,
             ),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    struct ThreadDispatcher {
+        thread_id: &'static str,
+        barrier: std::sync::Arc<std::sync::Barrier>,
+    }
+
+    #[async_trait::async_trait]
+    impl super::KernelOperationDispatcher for ThreadDispatcher {
+        async fn invoke_kernel_operation(
+            &self,
+            _operation_name: &str,
+            _input: Vec<u8>,
+        ) -> crate::VerletResult<Vec<u8>> {
+            self.barrier.wait();
+            Ok(self.thread_id.as_bytes().to_vec())
+        }
+    }
+
+    #[test]
+    fn scoped_registries_isolate_concurrent_kernel_dispatch() {
+        let registry = std::sync::Arc::new(super::OperationRegistry::new());
+        block_on(
+            registry.register_kernel(super::KernelOperationRegistration::new(
+                "kernel-package",
+                kernel_manifest(),
+            )),
+        )
+        .unwrap();
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let thread_a = super::ScopedOperationRegistry::new(
+            std::sync::Arc::clone(&registry),
+            super::KernelDispatchOverlay::new().with_dispatcher(
+                "kernel-package",
+                std::sync::Arc::new(ThreadDispatcher {
+                    thread_id: "thread-a",
+                    barrier: std::sync::Arc::clone(&barrier),
+                }),
+            ),
+        );
+        let thread_b = super::ScopedOperationRegistry::new(
+            registry,
+            super::KernelDispatchOverlay::new().with_dispatcher(
+                "kernel-package",
+                std::sync::Arc::new(ThreadDispatcher {
+                    thread_id: "thread-b",
+                    barrier,
+                }),
+            ),
+        );
+
+        let thread_a = std::thread::spawn(move || {
+            block_on(thread_a.invoke_bytes("kernel-package", "identify-thread", Vec::new()))
+                .unwrap()
+                .output
+        });
+        let thread_b = std::thread::spawn(move || {
+            block_on(thread_b.invoke_bytes("kernel-package", "identify-thread", Vec::new()))
+                .unwrap()
+                .output
+        });
+
+        assert_eq!(thread_a.join().unwrap(), b"thread-a");
+        assert_eq!(thread_b.join().unwrap(), b"thread-b");
+    }
+
+    #[test]
+    fn scoped_registry_prefers_overlay_then_falls_back_to_registration_dispatcher() {
+        let registry = std::sync::Arc::new(super::OperationRegistry::new());
+        block_on(
+            registry.register_kernel(
+                super::KernelOperationRegistration::new("kernel-package", kernel_manifest())
+                    .with_dispatcher(std::sync::Arc::new(ThreadDispatcher {
+                        thread_id: "registration",
+                        barrier: std::sync::Arc::new(std::sync::Barrier::new(1)),
+                    })),
+            ),
+        )
+        .unwrap();
+        let scoped = super::ScopedOperationRegistry::new(
+            std::sync::Arc::clone(&registry),
+            super::KernelDispatchOverlay::new().with_dispatcher(
+                "kernel-package",
+                std::sync::Arc::new(ThreadDispatcher {
+                    thread_id: "overlay",
+                    barrier: std::sync::Arc::new(std::sync::Barrier::new(1)),
+                }),
+            ),
+        );
+
+        let overlay_output =
+            block_on(scoped.invoke_bytes("kernel-package", "identify-thread", Vec::new())).unwrap();
+        let registration_output =
+            block_on(registry.invoke_bytes("kernel-package", "identify-thread", Vec::new()))
+                .unwrap();
+
+        assert_eq!(overlay_output.output, b"overlay");
+        assert_eq!(registration_output.output, b"registration");
+    }
+
+    fn kernel_manifest() -> verlet_abi::WasmOperationManifest {
+        verlet_abi::WasmOperationManifest {
+            abi: verlet_wasm::runner::OPERATION_ABI.to_string(),
+            operations: vec![verlet_abi::WasmOperationDefinition {
+                id: 1,
+                name: "identify-thread".to_string(),
+                input: verlet_abi::WasmOperationValueKind::Bytes,
+                output: verlet_abi::WasmOperationValueKind::Bytes,
+                events: verlet_abi::WasmOperationEventKind::None,
+                mode: verlet_abi::WasmOperationMode::Sync,
+                required_capabilities: Vec::new(),
+            }],
+        }
+    }
+
+    fn block_on<F: std::future::Future>(future: F) -> F::Output {
+        struct ThreadWaker(std::thread::Thread);
+
+        impl std::task::Wake for ThreadWaker {
+            fn wake(self: std::sync::Arc<Self>) {
+                self.0.unpark();
+            }
+
+            fn wake_by_ref(self: &std::sync::Arc<Self>) {
+                self.0.unpark();
+            }
+        }
+
+        let waker =
+            std::task::Waker::from(std::sync::Arc::new(ThreadWaker(std::thread::current())));
+        let mut context = std::task::Context::from_waker(&waker);
+        let mut future = std::pin::pin!(future);
+        loop {
+            match future.as_mut().poll(&mut context) {
+                std::task::Poll::Ready(output) => return output,
+                std::task::Poll::Pending => std::thread::park(),
+            }
+        }
     }
 }

--- a/crates/verlet-operations/src/operation_registry.rs
+++ b/crates/verlet-operations/src/operation_registry.rs
@@ -467,3 +467,148 @@ pub fn filter_manifest_operations(
         .retain(|operation| operation_names.contains(&operation.name));
     Ok(manifest)
 }
+
+/// Per-caller overlay of kernel-operation dispatchers (EMO-550).
+///
+/// A dynamic kernel dispatcher captures one thread's control and context.
+/// Registries are shared — across threads today, across instances on the
+/// multi-tenant host — so such a dispatcher must never be written into a
+/// registry slot after registration: the last writer silently redirects
+/// every other thread's kernel operations. The overlay rides with the
+/// invoking side instead (agent tool router, bash execution config) and is
+/// consulted per invocation, before the dispatcher optionally supplied at
+/// registration time (immutable after registration, safe to share).
+#[derive(Clone, Default)]
+pub struct KernelDispatchOverlay {
+    dispatchers: std::collections::BTreeMap<String, std::sync::Arc<dyn KernelOperationDispatcher>>,
+}
+
+impl KernelDispatchOverlay {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the dispatcher for a kernel package name (normalized like
+    /// registration names); replaces any previous overlay entry.
+    pub fn with_dispatcher(
+        mut self,
+        package: impl Into<String>,
+        dispatcher: std::sync::Arc<dyn KernelOperationDispatcher>,
+    ) -> Self {
+        self.dispatchers.insert(package.into(), dispatcher);
+        self
+    }
+
+    pub fn dispatcher(
+        &self,
+        package: &str,
+    ) -> Option<std::sync::Arc<dyn KernelOperationDispatcher>> {
+        self.dispatchers.get(package).cloned()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.dispatchers.is_empty()
+    }
+}
+
+/// An operation-registry view scoped to one invoking context (EMO-550):
+/// the shared registration state plus this caller's dispatch overlay.
+///
+/// All kernel-operation invocation goes through this view. Kernel dispatch
+/// resolves from the overlay first, then from the dispatcher supplied at
+/// registration, and fails with the existing "has no dispatcher in this
+/// runtime" error when neither exists. Wasm entries are unaffected by the
+/// overlay. Registration, listing, and describe stay on the underlying
+/// [`OperationRegistry`].
+#[derive(Clone)]
+pub struct ScopedOperationRegistry {
+    registry: std::sync::Arc<OperationRegistry>,
+    overlay: KernelDispatchOverlay,
+}
+
+impl ScopedOperationRegistry {
+    pub fn new(
+        registry: std::sync::Arc<OperationRegistry>,
+        overlay: KernelDispatchOverlay,
+    ) -> Self {
+        Self { registry, overlay }
+    }
+
+    /// The shared registration state (register/list/describe surfaces).
+    pub fn registry(&self) -> &std::sync::Arc<OperationRegistry> {
+        &self.registry
+    }
+
+    pub fn overlay(&self) -> &KernelDispatchOverlay {
+        &self.overlay
+    }
+
+    pub async fn invoke_bytes(
+        &self,
+        registered_name: &str,
+        operation_name: &str,
+        input: impl Into<Vec<u8>>,
+    ) -> crate::VerletResult<verlet_process::process::WasmOperationOutput> {
+        self.invoke_bytes_with_kernel_metadata(
+            registered_name,
+            operation_name,
+            input,
+            std::collections::BTreeMap::new(),
+        )
+        .await
+    }
+
+    pub async fn invoke_bytes_with_kernel_metadata(
+        &self,
+        registered_name: &str,
+        operation_name: &str,
+        input: impl Into<Vec<u8>>,
+        kernel_metadata: std::collections::BTreeMap<String, serde_json::Value>,
+    ) -> crate::VerletResult<verlet_process::process::WasmOperationOutput> {
+        let _ = (
+            registered_name,
+            operation_name,
+            input.into(),
+            kernel_metadata,
+        );
+        unimplemented!("EMO-550: overlay-first kernel dispatch")
+    }
+
+    pub async fn invoke_process(
+        &self,
+        registered_name: &str,
+        operation_name: &str,
+        input: impl Into<Vec<u8>>,
+    ) -> crate::VerletResult<verlet_process::process::VerletProcessHandle> {
+        self.invoke_process_with_kernel_metadata(
+            registered_name,
+            operation_name,
+            input,
+            std::collections::BTreeMap::new(),
+        )
+        .await
+    }
+
+    pub async fn invoke_process_with_kernel_metadata(
+        &self,
+        registered_name: &str,
+        operation_name: &str,
+        input: impl Into<Vec<u8>>,
+        kernel_metadata: std::collections::BTreeMap<String, serde_json::Value>,
+    ) -> crate::VerletResult<verlet_process::process::VerletProcessHandle> {
+        let output = self
+            .invoke_bytes_with_kernel_metadata(
+                registered_name,
+                operation_name,
+                input,
+                kernel_metadata,
+            )
+            .await?;
+        Ok(
+            verlet_process::process::VerletProcessHandle::from_wasm_operation_output(
+                Some(registered_name.to_string()),
+                output,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Kernel dispatchers move out of the shared OperationRegistry: the mutable per-package slot and set_kernel_dispatcher are gone; registration-time dispatchers are immutable and caller-independent. Each thread mount builds one KernelDispatchOverlay carried by the agent tool router and the virtual-bash config, resolved per invocation through ScopedOperationRegistry (overlay first, then registration).

Host v0 stage A under EMO-549. Verified locally: scripts/verify.sh green (1048 kernel tests) and scripts/verify-linux.sh green. Review-and-fix pass findings (builder order dependence, vbash-path concurrency coverage) fixed in-branch; receipts on the Linear issue.

https://linear.app/emotionscientific/issue/EMO-550