### PR TITLE
Instance-owned lifecycle for the kernel app server (EMO-551)

### DIFF
--- a/crates/verlet-kernel/src/adapters/app_server.rs
+++ b/crates/verlet-kernel/src/adapters/app_server.rs
@@ -9,6 +9,7 @@ use tokio::io::AsyncWriteExt as _;
 use verlet_metadata::provider_store::LlmProviderCatalogStore as _;
 pub mod connection;
 mod default_manifest;
+pub mod lifecycle;
 mod orchestrator_boundary;
 mod subscriptions;
 #[cfg(test)]
@@ -995,6 +996,37 @@ impl VerletAppServer {
             AppServerListenAddr::Unix(path) => self.serve_unix(path).await,
             AppServerListenAddr::WebSocket(addr) => self.serve_websocket(addr).await,
         }
+    }
+
+    /// Transport-independent RPC dispatch (EMO-551): serve one JSON-RPC
+    /// request for an already-authenticated principal, without a socket,
+    /// session witness derivation from process identity, or listener. This
+    /// is the seam the multi-tenant host facade routes into (EMO-553): the
+    /// facade authenticates the connection, resolves exactly one instance,
+    /// and calls this per request. Session open/close witnessing happens
+    /// here against the supplied principal — never from process UID (that
+    /// derivation stays in `local_json_rpc_request`, which remains the
+    /// standalone local-operator path).
+    pub async fn dispatch_authenticated_json_rpc(
+        &self,
+        principal: crate::daemon::identity::ResolvedPrincipal,
+        method: &str,
+        params: serde_json::Value,
+    ) -> crate::kernel::runtime_host::VerletResult<serde_json::Value> {
+        let _ = (principal, method, params);
+        unimplemented!("EMO-551: transport-independent authenticated dispatch")
+    }
+
+    /// Instance-owned async shutdown (EMO-551). Cancels and awaits every
+    /// background task this instance spawned (subscription watchers,
+    /// recovery/daemon-I/O workers, connection tasks when this instance
+    /// owns a listener), retires the console credential (moving that work
+    /// out of `VerletAppServerInner::drop`, which stops constructing a
+    /// runtime), and shuts down + unregisters the supervisor tenant so the
+    /// id can be reused. Idempotent; after it resolves, dropping the
+    /// instance is inert and a co-resident instance is unaffected.
+    pub async fn shutdown(&self) -> crate::kernel::runtime_host::VerletResult<()> {
+        unimplemented!("EMO-551: instance-owned shutdown")
     }
 
     pub fn supervisor(&self) -> crate::kernel::supervisor::VerletSupervisor {

--- a/crates/verlet-kernel/src/adapters/app_server.rs
+++ b/crates/verlet-kernel/src/adapters/app_server.rs
@@ -475,6 +475,9 @@ pub struct VerletAppServer {
 
 struct VerletAppServerInner {
     supervisor: crate::kernel::supervisor::VerletSupervisor,
+    tasks: std::sync::Arc<crate::adapters::app_server::lifecycle::InstanceTaskSet>,
+    shutdown: tokio::sync::Mutex<bool>,
+    dispatch_gate: tokio::sync::RwLock<()>,
     tenant_id: String,
     user_id: String,
     identity_mode: crate::daemon::identity::IdentityMode,
@@ -492,7 +495,7 @@ struct VerletAppServerInner {
     console_assets: Option<ConsoleAssetConfig>,
     identity_authority: std::sync::Arc<dyn crate::daemon::identity::IdentityAuthority>,
     identity_clock: std::sync::Arc<dyn crate::daemon::clock_route::DaemonClock>,
-    console_credential: Option<ConsoleCredentialLease>,
+    console_credential: tokio::sync::Mutex<Option<ConsoleCredentialLease>>,
     cwd: std::path::PathBuf,
     codex_home: std::path::PathBuf,
     metadata_store_path: std::path::PathBuf,
@@ -518,6 +521,7 @@ struct ConsoleCredentialLease {
 struct SessionCloseWitness {
     authority: std::sync::Arc<dyn crate::daemon::identity::IdentityAuthority>,
     clock: std::sync::Arc<dyn crate::daemon::clock_route::DaemonClock>,
+    tasks: std::sync::Arc<crate::adapters::app_server::lifecycle::InstanceTaskSet>,
     session_id: String,
     armed: bool,
 }
@@ -526,11 +530,13 @@ impl SessionCloseWitness {
     fn new(
         authority: std::sync::Arc<dyn crate::daemon::identity::IdentityAuthority>,
         clock: std::sync::Arc<dyn crate::daemon::clock_route::DaemonClock>,
+        tasks: std::sync::Arc<crate::adapters::app_server::lifecycle::InstanceTaskSet>,
         session_id: String,
     ) -> Self {
         Self {
             authority,
             clock,
+            tasks,
             session_id,
             armed: true,
         }
@@ -560,46 +566,30 @@ impl Drop for SessionCloseWitness {
         let authority = std::sync::Arc::clone(&self.authority);
         let session_id = self.session_id.clone();
         let closed_at_ms = self.clock.now().timestamp_millis();
-        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
-            runtime.spawn(async move {
-                if let Err(error) = authority
-                    .witness_session_closed(&session_id, closed_at_ms)
-                    .await
-                {
-                    eprintln!("failed to witness aborted Verlet app-server session: {error}");
-                }
-            });
+        if !self.tasks.spawn_from_drop(async move {
+            if let Err(error) = authority
+                .witness_session_closed(&session_id, closed_at_ms)
+                .await
+            {
+                eprintln!("failed to witness aborted Verlet app-server session: {error}");
+            }
+        }) {
+            eprintln!(
+                "could not schedule aborted Verlet app-server session cleanup after instance shutdown"
+            );
         }
     }
 }
 
 impl Drop for VerletAppServerInner {
     fn drop(&mut self) {
-        let Some(credential) = self.console_credential.take() else {
+        let Some(credential) = self.console_credential.get_mut().take() else {
             return;
         };
-        let authority = std::sync::Arc::clone(&self.identity_authority);
-        let cleanup = std::thread::Builder::new()
-            .name("verlet-console-credential-cleanup".to_string())
-            .spawn(move || {
-                let runtime = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .map_err(|error| error.to_string())?;
-                runtime
-                    .block_on(retire_console_credential(authority, &credential))
-                    .map_err(|error| error.to_string())
-            });
-        match cleanup {
-            Ok(cleanup) => match cleanup.join() {
-                Ok(Ok(())) => {}
-                Ok(Err(error)) => {
-                    eprintln!("failed to retire Verlet console credential: {error}")
-                }
-                Err(_) => eprintln!("Verlet console credential cleanup thread panicked"),
-            },
-            Err(error) => eprintln!("failed to start Verlet console credential cleanup: {error}"),
-        }
+        eprintln!(
+            "Verlet app-server dropped before shutdown completed; console credential {} cleanup may be incomplete",
+            credential.credential_id
+        );
     }
 }
 
@@ -885,6 +875,11 @@ impl VerletAppServer {
         let app = Self {
             inner: std::sync::Arc::new(VerletAppServerInner {
                 supervisor,
+                tasks: std::sync::Arc::new(
+                    crate::adapters::app_server::lifecycle::InstanceTaskSet::new(),
+                ),
+                shutdown: tokio::sync::Mutex::new(false),
+                dispatch_gate: tokio::sync::RwLock::new(()),
                 tenant_id: config.tenant_id,
                 user_id: config.user_id,
                 identity_mode: config.identity_mode,
@@ -902,7 +897,7 @@ impl VerletAppServer {
                 console_assets: config.console_assets,
                 identity_authority,
                 identity_clock,
-                console_credential,
+                console_credential: tokio::sync::Mutex::new(console_credential),
                 cwd: config.cwd,
                 codex_home,
                 metadata_store_path,
@@ -921,64 +916,89 @@ impl VerletAppServer {
                 ),
             }),
         };
-        let process_ingress: std::sync::Arc<
-            dyn crate::kernel::runtime_host::runtime_api::ProcessHandleIngressSink,
-        > = std::sync::Arc::new(AppServerProcessHandleIngress {
-            app: std::sync::Arc::downgrade(&app.inner),
-        });
-        let runtime_store = app
-            .inner
-            .supervisor
-            .runtime_store(&app.inner.tenant_id)
-            .await?;
-        let process_dispatcher =
-            crate::kernel::process_handle_dispatch::ProcessHandleDispatcher::new(
+        let initialization = async {
+            let process_ingress: std::sync::Arc<
+                dyn crate::kernel::runtime_host::runtime_api::ProcessHandleIngressSink,
+            > = std::sync::Arc::new(AppServerProcessHandleIngress {
+                app: std::sync::Arc::downgrade(&app.inner),
+            });
+            let runtime_store = app
+                .inner
+                .supervisor
+                .runtime_store(&app.inner.tenant_id)
+                .await?;
+            let process_tasks = std::sync::Arc::downgrade(&app.inner.tasks);
+            let process_dispatcher = crate::kernel::process_handle_dispatch::ProcessHandleDispatcher::new_with_task_owner(
                 runtime_store,
                 std::sync::Arc::clone(&process_ingress),
+                app.inner.tasks.cancellation(),
+                std::sync::Arc::new(move |task| {
+                    process_tasks
+                        .upgrade()
+                        .is_some_and(|tasks| tasks.spawn(task))
+                }),
             );
-        app.inner
-            .process_dispatcher
-            .set(process_dispatcher.clone())
-            .map_err(|_| {
-                crate::kernel::runtime_host::VerletError::RuntimeFactory(
-                    "app-server process dispatcher initialized twice".to_string(),
+            app.inner
+                .process_dispatcher
+                .set(process_dispatcher.clone())
+                .map_err(|_| {
+                    crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                        "app-server process dispatcher initialized twice".to_string(),
+                    )
+                })?;
+            app.inner
+                .supervisor
+                .set_process_handle_ingress(&app.inner.tenant_id, Some(process_ingress))
+                .await?;
+            app.inner
+                .supervisor
+                .set_process_handle_dispatcher(
+                    &app.inner.tenant_id,
+                    Some(process_dispatcher.clone()),
                 )
-            })?;
-        app.inner
-            .supervisor
-            .set_process_handle_ingress(&app.inner.tenant_id, Some(process_ingress))
-            .await?;
-        app.inner
-            .supervisor
-            .set_process_handle_dispatcher(&app.inner.tenant_id, Some(process_dispatcher.clone()))
-            .await?;
-        app.inner
-            .supervisor
-            .set_thread_lifecycle_sink(
+                .await?;
+            app.inner
+                .supervisor
+                .set_thread_lifecycle_sink(
+                    &app.inner.tenant_id,
+                    Some(std::sync::Arc::new(
+                        threads::AppServerThreadLifecycleSink::new(&app),
+                    )),
+                )
+                .await?;
+            app.load_threads_from_metadata().await?;
+            // Construction is the earliest common boundary for daemon listeners,
+            // standalone app-server serving, and in-process/local JSON-RPC users.
+            // Run recovery before returning the first callable surface.
+            process_dispatcher.assert_startup_registry_empty().await?;
+            let recovery_store =
+                verlet_history_sqlite::SqliteSessionStore::open(&app.inner.session_store_path)
+                    .await
+                    .map_err(|err| {
+                        crate::kernel::runtime_host::VerletError::History(err.to_string())
+                    })?
+                    .with_lease_epoch(app.inner.lease_epoch);
+            crate::daemon::recovery_sweep::StartupRecoverySweep::new(
+                recovery_store,
+                process_dispatcher,
                 &app.inner.tenant_id,
-                Some(std::sync::Arc::new(
-                    threads::AppServerThreadLifecycleSink::new(&app),
-                )),
+                &app.inner.user_id,
             )
-            .await?;
-        app.load_threads_from_metadata().await?;
-        // Construction is the earliest common boundary for daemon listeners,
-        // standalone app-server serving, and in-process/local JSON-RPC users.
-        // Run recovery before returning the first callable surface.
-        process_dispatcher.assert_startup_registry_empty().await?;
-        let recovery_store =
-            verlet_history_sqlite::SqliteSessionStore::open(&app.inner.session_store_path)
-                .await
-                .map_err(|err| crate::kernel::runtime_host::VerletError::History(err.to_string()))?
-                .with_lease_epoch(app.inner.lease_epoch);
-        let recovery = crate::daemon::recovery_sweep::StartupRecoverySweep::new(
-            recovery_store,
-            process_dispatcher,
-            &app.inner.tenant_id,
-            &app.inner.user_id,
-        )
-        .run_once()
-        .await?;
+            .run_once()
+            .await
+        }
+        .await;
+        let recovery = match initialization {
+            Ok(recovery) => recovery,
+            Err(error) => {
+                if let Err(shutdown_error) = app.shutdown().await {
+                    eprintln!(
+                        "failed to shut down partially initialized Verlet app-server after {error}: {shutdown_error}"
+                    );
+                }
+                return Err(error);
+            }
+        };
         if recovery.thread_joins > 0 || recovery.process_outcomes > 0 {
             eprintln!(
                 "verlet startup recovery appended {} thread join(s) and submitted {} process outcome(s)",
@@ -1013,20 +1033,49 @@ impl VerletAppServer {
         method: &str,
         params: serde_json::Value,
     ) -> crate::kernel::runtime_host::VerletResult<serde_json::Value> {
-        let _ = (principal, method, params);
-        unimplemented!("EMO-551: transport-independent authenticated dispatch")
+        self.authenticated_json_rpc_request(
+            principal,
+            crate::daemon::identity::BoundarySurface::Console,
+            "in-process-host",
+            method,
+            params,
+        )
+        .await
     }
 
     /// Instance-owned async shutdown (EMO-551). Cancels and awaits every
     /// background task this instance spawned (subscription watchers,
-    /// recovery/daemon-I/O workers, connection tasks when this instance
-    /// owns a listener), retires the console credential (moving that work
-    /// out of `VerletAppServerInner::drop`, which stops constructing a
-    /// runtime), and shuts down + unregisters the supervisor tenant so the
-    /// id can be reused. Idempotent; after it resolves, dropping the
-    /// instance is inert and a co-resident instance is unaffected.
+    /// connection tasks, websocket writers, process-settlement monitors, and
+    /// persistence one-shots),
+    /// retires the console credential (moving that work out of
+    /// `VerletAppServerInner::drop`, which stops constructing a runtime), and
+    /// shuts down + unregisters the supervisor tenant so the id can be
+    /// reused. Idempotent; after it resolves, dropping the instance is inert
+    /// and a co-resident instance is unaffected.
     pub async fn shutdown(&self) -> crate::kernel::runtime_host::VerletResult<()> {
-        unimplemented!("EMO-551: instance-owned shutdown")
+        let mut shutdown = self.inner.shutdown.lock().await;
+        if *shutdown {
+            return Ok(());
+        }
+
+        let _dispatch = self.inner.dispatch_gate.write().await;
+        self.inner.tasks.shutdown().await;
+        let mut console_credential = self.inner.console_credential.lock().await;
+        if let Some(credential) = console_credential.as_ref() {
+            retire_console_credential(
+                std::sync::Arc::clone(&self.inner.identity_authority),
+                credential,
+            )
+            .await?;
+        }
+        console_credential.take();
+        drop(console_credential);
+        self.inner
+            .supervisor
+            .shutdown_and_unregister_tenant(&self.inner.tenant_id)
+            .await?;
+        *shutdown = true;
+        Ok(())
     }
 
     pub fn supervisor(&self) -> crate::kernel::supervisor::VerletSupervisor {
@@ -1107,8 +1156,13 @@ impl VerletAppServer {
             ))
         })?;
 
+        let cancellation = self.inner.tasks.cancellation();
         loop {
-            let (stream, _) = listener.accept().await.map_err(|err| {
+            let accepted = tokio::select! {
+                _ = cancellation.cancelled() => return Ok(()),
+                accepted = listener.accept() => accepted,
+            };
+            let (stream, _) = accepted.map_err(|err| {
                 crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
                     "failed to accept Verlet app-server connection: {err}"
                 ))
@@ -1122,7 +1176,7 @@ impl VerletAppServer {
                 })?
                 .uid();
             let app = self.clone();
-            tokio::spawn(async move {
+            self.inner.tasks.spawn(async move {
                 if let Err(err) = app.handle_unix_stream(stream, peer_uid).await {
                     eprintln!("verlet app-server connection failed: {err}");
                 }
@@ -1165,14 +1219,19 @@ impl VerletAppServer {
             ));
         }
 
+        let cancellation = self.inner.tasks.cancellation();
         loop {
-            let (stream, peer) = listener.accept().await.map_err(|err| {
+            let accepted = tokio::select! {
+                _ = cancellation.cancelled() => return Ok(()),
+                accepted = listener.accept() => accepted,
+            };
+            let (stream, peer) = accepted.map_err(|err| {
                 crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
                     "failed to accept Verlet app-server websocket connection: {err}"
                 ))
             })?;
             let app = self.clone();
-            tokio::spawn(async move {
+            self.inner.tasks.spawn(async move {
                 if let Err(err) = app.handle_tcp_stream(stream).await {
                     eprintln!("verlet app-server websocket connection from {peer} failed: {err}");
                 }
@@ -1186,19 +1245,30 @@ impl VerletAppServer {
         mut stream: tokio::net::UnixStream,
         peer_uid: u32,
     ) -> crate::kernel::runtime_host::VerletResult<()> {
-        let Some(resolved_principal) = self
-            .authenticate_unix_websocket(&mut stream, peer_uid)
-            .await?
-        else {
+        let authentication = async {
+            let Some(resolved_principal) = self
+                .authenticate_unix_websocket(&mut stream, peer_uid)
+                .await?
+            else {
+                return Ok(None);
+            };
+            let websocket = accept_authenticated_websocket(stream)
+                .await
+                .map_err(|err| {
+                    crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
+                        "failed to upgrade Verlet app-server unix socket websocket: {err}"
+                    ))
+                })?;
+            Ok::<_, crate::kernel::runtime_host::VerletError>(Some((websocket, resolved_principal)))
+        };
+        let cancellation = self.inner.tasks.cancellation();
+        let authenticated = tokio::select! {
+            _ = cancellation.cancelled() => return Ok(()),
+            authenticated = authentication => authenticated?,
+        };
+        let Some((websocket, resolved_principal)) = authenticated else {
             return Ok(());
         };
-        let websocket = accept_authenticated_websocket(stream)
-            .await
-            .map_err(|err| {
-                crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
-                    "failed to upgrade Verlet app-server unix socket websocket: {err}"
-                ))
-            })?;
         self.handle_websocket(
             websocket,
             resolved_principal,
@@ -1212,21 +1282,36 @@ impl VerletAppServer {
         stream: tokio::net::TcpStream,
     ) -> crate::kernel::runtime_host::VerletResult<()> {
         let mut stream = stream;
-        if self.handle_http_request(&mut stream).await? {
-            return Ok(());
-        }
-        let Some((resolved_principal, surface)) =
-            self.authenticate_tcp_websocket(&mut stream).await?
-        else {
+        let authentication = async {
+            if self.handle_http_request(&mut stream).await? {
+                return Ok(None);
+            }
+            let Some((resolved_principal, surface)) =
+                self.authenticate_tcp_websocket(&mut stream).await?
+            else {
+                return Ok(None);
+            };
+            let websocket = accept_authenticated_websocket(stream)
+                .await
+                .map_err(|err| {
+                    crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
+                        "failed to upgrade Verlet app-server tcp websocket: {err}"
+                    ))
+                })?;
+            Ok::<_, crate::kernel::runtime_host::VerletError>(Some((
+                websocket,
+                resolved_principal,
+                surface,
+            )))
+        };
+        let cancellation = self.inner.tasks.cancellation();
+        let authenticated = tokio::select! {
+            _ = cancellation.cancelled() => return Ok(()),
+            authenticated = authentication => authenticated?,
+        };
+        let Some((websocket, resolved_principal, surface)) = authenticated else {
             return Ok(());
         };
-        let websocket = accept_authenticated_websocket(stream)
-            .await
-            .map_err(|err| {
-                crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
-                    "failed to upgrade Verlet app-server tcp websocket: {err}"
-                ))
-            })?;
         self.handle_websocket(websocket, resolved_principal, surface)
             .await
     }

--- a/crates/verlet-kernel/src/adapters/app_server/connection.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/connection.rs
@@ -1137,8 +1137,31 @@ impl crate::adapters::app_server::VerletAppServer {
                     "local JSON-RPC requires the local-mode operator principal".to_string(),
                 )
             })?;
+        self.authenticated_json_rpc_request(
+            resolved_principal,
+            crate::daemon::identity::BoundarySurface::UnixSocket,
+            "local-json-rpc",
+            method,
+            params,
+        )
+        .await
+    }
+
+    pub(super) async fn authenticated_json_rpc_request(
+        &self,
+        resolved_principal: crate::daemon::identity::ResolvedPrincipal,
+        surface: crate::daemon::identity::BoundarySurface,
+        client_name: &str,
+        method: &str,
+        params: serde_json::Value,
+    ) -> crate::kernel::runtime_host::VerletResult<serde_json::Value> {
+        let _dispatch = self.inner.dispatch_gate.read().await;
+        if self.inner.tasks.is_shutdown() {
+            return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                "Verlet app-server instance is shut down".to_string(),
+            ));
+        }
         let session_id = format!("session_{}", uuid::Uuid::now_v7());
-        let surface = crate::daemon::identity::BoundarySurface::UnixSocket;
         self.inner
             .identity_authority
             .witness_session_opened(&crate::daemon::identity::IdentitySessionV1 {
@@ -1157,6 +1180,7 @@ impl crate::adapters::app_server::VerletAppServer {
         let mut close_witness = crate::adapters::app_server::SessionCloseWitness::new(
             std::sync::Arc::clone(&self.inner.identity_authority),
             std::sync::Arc::clone(&self.inner.identity_clock),
+            std::sync::Arc::clone(&self.inner.tasks),
             session_id.clone(),
         );
         let (outbound, _rx) = tokio::sync::mpsc::unbounded_channel::<JsonRpcMessage>();
@@ -1180,7 +1204,7 @@ impl crate::adapters::app_server::VerletAppServer {
         connection
             .handle_initialize(Some(serde_json::json!({
                 "clientInfo": {
-                    "name": "local-json-rpc",
+                    "name": client_name,
                     "title": null,
                     "version": env!("CARGO_PKG_VERSION"),
                 },
@@ -1196,7 +1220,7 @@ impl crate::adapters::app_server::VerletAppServer {
         match (dispatch_result, close_result) {
             (Err(error), Err(close_error)) => {
                 eprintln!(
-                    "failed to witness closing a failed local JSON-RPC session: {close_error}"
+                    "failed to witness closing a failed authenticated JSON-RPC session: {close_error}"
                 );
                 Err(error)
             }
@@ -1234,30 +1258,39 @@ impl crate::adapters::app_server::VerletAppServer {
         let mut close_witness = crate::adapters::app_server::SessionCloseWitness::new(
             std::sync::Arc::clone(&self.inner.identity_authority),
             std::sync::Arc::clone(&self.inner.identity_clock),
+            std::sync::Arc::clone(&self.inner.tasks),
             session_id.clone(),
         );
         let (mut sink, mut stream) = websocket.split();
         let (outbound, mut outbound_rx) = tokio::sync::mpsc::unbounded_channel::<JsonRpcMessage>();
-        let writer = tokio::spawn(async move {
-            while let Some(message) = outbound_rx.recv().await {
-                let payload = match serde_json::to_string(&message) {
-                    Ok(payload) => payload,
-                    Err(err) => {
-                        eprintln!("failed to encode Verlet app-server JSON-RPC message: {err}");
-                        continue;
+        let tasks = std::sync::Arc::clone(&self.inner.tasks);
+        let writer_cancellation = tasks.cancellation();
+        tasks.spawn(async move {
+                loop {
+                    let message = tokio::select! {
+                        _ = writer_cancellation.cancelled() => break,
+                        message = outbound_rx.recv() => message,
+                    };
+                    let Some(message) = message else {
+                        break;
+                    };
+                    let payload = match serde_json::to_string(&message) {
+                        Ok(payload) => payload,
+                        Err(err) => {
+                            eprintln!("failed to encode Verlet app-server JSON-RPC message: {err}");
+                            continue;
+                        }
+                    };
+                    let sent = tokio::select! {
+                        _ = writer_cancellation.cancelled() => break,
+                        sent = sink.send(tokio_tungstenite::tungstenite::Message::Text(payload.into())) => sent,
+                    };
+                    if let Err(err) = sent {
+                        eprintln!("failed to write Verlet app-server websocket message: {err}");
+                        break;
                     }
-                };
-                if let Err(err) = sink
-                    .send(tokio_tungstenite::tungstenite::Message::Text(
-                        payload.into(),
-                    ))
-                    .await
-                {
-                    eprintln!("failed to write Verlet app-server websocket message: {err}");
-                    break;
                 }
-            }
-        });
+            });
 
         let connection = ConnectionState {
             app: self.clone(),
@@ -1278,7 +1311,15 @@ impl crate::adapters::app_server::VerletAppServer {
         };
 
         let mut read_result = Ok(());
-        while let Some(message) = stream.next().await {
+        let cancellation = self.inner.tasks.cancellation();
+        loop {
+            let message = tokio::select! {
+                _ = cancellation.cancelled() => break,
+                message = stream.next() => message,
+            };
+            let Some(message) = message else {
+                break;
+            };
             match message {
                 Ok(tokio_tungstenite::tungstenite::Message::Text(text)) => {
                     if let Err(err) = handle_inbound_text(&connection, &text).await {
@@ -1300,7 +1341,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }
 
         connection.abort_subscriptions().await;
-        writer.abort();
+        drop(connection);
         let close_result = close_witness.close().await;
         finish_websocket_session(read_result, close_result)
     }
@@ -2207,29 +2248,40 @@ impl crate::adapters::app_server::VerletAppServer {
         let metadata_store = self.inner.metadata_store.clone();
         let user_metadata_store = self.inner.user_metadata_store.clone();
         let delete_provider_id = provider_id.clone();
-        tokio::spawn(async move {
-            metadata_store
-                .delete_provider(&delete_provider_id)
-                .await
-                .map_err(|err| {
-                    internal_error(crate::adapters::app_server::provider_store_error(err))
-                })?;
-            user_metadata_store
-                .delete_credential(&delete_provider_id)
-                .await
-                .map_err(|err| {
-                    internal_error(crate::adapters::app_server::provider_store_error(err))
-                })?;
-            metadata_store
-                .delete_credential(&delete_provider_id)
-                .await
-                .map_err(|err| {
-                    internal_error(crate::adapters::app_server::provider_store_error(err))
-                })?;
-            Ok::<(), JsonRpcErrorError>(())
-        })
-        .await
-        .map_err(|error| {
+        let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
+        if !self.inner.tasks.spawn(async move {
+            let result = async {
+                metadata_store
+                    .delete_provider(&delete_provider_id)
+                    .await
+                    .map_err(|err| {
+                        internal_error(crate::adapters::app_server::provider_store_error(err))
+                    })?;
+                user_metadata_store
+                    .delete_credential(&delete_provider_id)
+                    .await
+                    .map_err(|err| {
+                        internal_error(crate::adapters::app_server::provider_store_error(err))
+                    })?;
+                metadata_store
+                    .delete_credential(&delete_provider_id)
+                    .await
+                    .map_err(|err| {
+                        internal_error(crate::adapters::app_server::provider_store_error(err))
+                    })?;
+                Ok::<(), JsonRpcErrorError>(())
+            }
+            .await;
+            let _ = completion_tx.send(result);
+        }) {
+            return Err(internal_error(
+                crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                    "Verlet app-server instance shut down before model provider deletion started"
+                        .to_string(),
+                ),
+            ));
+        }
+        completion_rx.await.map_err(|error| {
             internal_error(crate::kernel::runtime_host::VerletError::RuntimeFactory(
                 format!("model provider deletion task failed: {error}"),
             ))
@@ -4088,7 +4140,7 @@ impl crate::adapters::app_server::VerletAppServer {
                 .map(|thread| thread.cwd.clone())
                 .unwrap_or_else(|| self.inner.cwd.clone())
         };
-        tokio::spawn(async move {
+        if !self.inner.tasks.spawn_cancellable(
             crate::adapters::app_server::subscriptions::complete_shell_command(
                 connection,
                 params.thread_id,
@@ -4096,9 +4148,15 @@ impl crate::adapters::app_server::VerletAppServer {
                 item_id,
                 command,
                 cwd,
-            )
-            .await;
-        });
+            ),
+        ) {
+            return Err(internal_error(
+                crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                    "Verlet app-server instance shut down before shell command execution started"
+                        .to_string(),
+                ),
+            ));
+        }
 
         Ok(serde_json::json!({}))
     }
@@ -4892,8 +4950,22 @@ impl crate::adapters::app_server::VerletAppServer {
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
         let source = absolute_path(params.source_path)?;
         let destination = absolute_path(params.destination_path)?;
-        tokio::task::spawn_blocking(move || copy_path(&source, &destination, params.recursive))
+        let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
+        if !self.inner.tasks.spawn(async move {
+            let result = tokio::task::spawn_blocking(move || {
+                copy_path(&source, &destination, params.recursive)
+            })
+            .await;
+            let _ = completion_tx.send(result);
+        }) {
+            return Err(jsonrpc_error(
+                -32000,
+                "Verlet app-server instance shut down before fs/copy started",
+            ));
+        }
+        completion_rx
             .await
+            .map_err(|err| jsonrpc_error(-32000, format!("fs/copy task failed: {err}")))?
             .map_err(|err| jsonrpc_error(-32000, format!("fs/copy task failed: {err}")))?
             .map_err(fs_error)?;
         Ok(serde_json::json!({}))

--- a/crates/verlet-kernel/src/adapters/app_server/lifecycle.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/lifecycle.rs
@@ -3,11 +3,13 @@
 //! instances independently.
 //!
 //! Today background work an instance starts (subscription watchers,
-//! daemon-I/O workers, connection tasks) is spawned detached: dropping the
-//! instance leaks the tasks, and a live watcher holding an app clone keeps
-//! the whole instance alive. Every such spawn moves into an
-//! [`InstanceTaskSet`] owned by the instance; `VerletAppServer::shutdown`
-//! cancels the set and awaits every task before releasing the instance.
+//! connection tasks, websocket writers, process-settlement monitors, and
+//! persistence one-shots) is
+//! spawned detached: dropping the instance leaks the tasks, and a live
+//! watcher holding an app clone keeps the whole instance alive. Every such
+//! spawn moves into an [`InstanceTaskSet`] owned by the instance;
+//! `VerletAppServer::shutdown` cancels the set and awaits every task before
+//! releasing the instance.
 //! `Drop` never constructs a runtime (the console-credential retirement in
 //! `VerletAppServerInner::drop` moves here; the Drop impl becomes a
 //! best-effort warning for instances dropped without shutdown).
@@ -18,7 +20,8 @@
 /// nothing an instance starts may outlive it.
 pub struct InstanceTaskSet {
     cancellation: tokio_util::sync::CancellationToken,
-    tasks: tokio::sync::Mutex<tokio::task::JoinSet<()>>,
+    tasks: std::sync::Mutex<Option<tokio::task::JoinSet<()>>>,
+    shutdown_drain: tokio::sync::Mutex<()>,
 }
 
 impl Default for InstanceTaskSet {
@@ -31,7 +34,8 @@ impl InstanceTaskSet {
     pub fn new() -> Self {
         Self {
             cancellation: tokio_util::sync::CancellationToken::new(),
-            tasks: tokio::sync::Mutex::new(tokio::task::JoinSet::new()),
+            tasks: std::sync::Mutex::new(Some(tokio::task::JoinSet::new())),
+            shutdown_drain: tokio::sync::Mutex::new(()),
         }
     }
 
@@ -41,19 +45,187 @@ impl InstanceTaskSet {
         self.cancellation.child_token()
     }
 
-    /// Spawn a task owned by this instance. The future must exit promptly
-    /// once the cancellation token fires; shutdown awaits it.
-    pub async fn spawn<F>(&self, task: F)
+    /// Spawn a task owned by this instance. Long-lived work must exit promptly
+    /// once the cancellation token fires; bounded atomic one-shots may run to
+    /// completion because shutdown awaits them. A spawn after shutdown has
+    /// begun drops the supplied future without polling it. Returns whether the
+    /// task was accepted.
+    pub fn spawn<F>(&self, task: F) -> bool
     where
         F: std::future::Future<Output = ()> + Send + 'static,
     {
-        let _ = task;
-        unimplemented!("EMO-551: instance-owned task spawn")
+        let mut tasks = self.tasks.lock().unwrap_or_else(|error| error.into_inner());
+        if self.cancellation.is_cancelled() {
+            return false;
+        }
+        let Some(tasks) = tasks.as_mut() else {
+            return false;
+        };
+        while let Some(result) = tasks.try_join_next() {
+            log_task_result(result);
+        }
+        tasks.spawn(task);
+        true
+    }
+
+    /// Spawn work that may be abandoned at the instance cancellation
+    /// boundary. Use [`InstanceTaskSet::spawn`] directly for atomic one-shots
+    /// that must run to completion once they have started.
+    pub fn spawn_cancellable<F>(&self, task: F) -> bool
+    where
+        F: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let cancellation = self.cancellation();
+        self.spawn(async move {
+            tokio::select! {
+                _ = cancellation.cancelled() => {},
+                _ = task => {},
+            }
+        })
     }
 
     /// Cancel every owned task and await them all. Idempotent; concurrent
     /// callers all observe completion.
     pub async fn shutdown(&self) {
-        unimplemented!("EMO-551: instance-owned task shutdown")
+        self.cancellation.cancel();
+        let _drain = self.shutdown_drain.lock().await;
+        loop {
+            let result = std::future::poll_fn(|context| {
+                let mut tasks = self.tasks.lock().unwrap_or_else(|error| error.into_inner());
+                let Some(tasks) = tasks.as_mut() else {
+                    return std::task::Poll::Ready(None);
+                };
+                tasks.poll_join_next(context)
+            })
+            .await;
+            let Some(result) = result else {
+                break;
+            };
+            log_task_result(result);
+        }
+        self.tasks
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .take();
+    }
+
+    pub(crate) fn is_shutdown(&self) -> bool {
+        self.cancellation.is_cancelled()
+    }
+
+    pub(crate) fn spawn_from_drop<F>(&self, task: F) -> bool
+    where
+        F: std::future::Future<Output = ()> + Send + 'static,
+    {
+        if tokio::runtime::Handle::try_current().is_err() || self.cancellation.is_cancelled() {
+            return false;
+        }
+        self.spawn(task)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn task_count(&self) -> usize {
+        self.tasks
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .as_ref()
+            .map(tokio::task::JoinSet::len)
+            .unwrap_or(0)
+    }
+}
+
+fn log_task_result(result: Result<(), tokio::task::JoinError>) {
+    if let Err(error) = result {
+        eprintln!("instance-owned Verlet app-server task failed: {error}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn finished_tasks_are_reaped_before_the_next_spawn() {
+        let tasks = super::InstanceTaskSet::new();
+        let (finished_tx, finished_rx) = tokio::sync::oneshot::channel();
+        tasks.spawn(async move {
+            let _ = finished_tx.send(());
+        });
+        finished_rx.await.unwrap();
+        tokio::task::yield_now().await;
+
+        let cancellation = tasks.cancellation();
+        tasks.spawn(async move {
+            cancellation.cancelled().await;
+        });
+
+        assert_eq!(tasks.task_count(), 1);
+        tasks.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_can_resume_after_the_draining_caller_is_cancelled() {
+        let tasks = std::sync::Arc::new(super::InstanceTaskSet::new());
+        let started = std::sync::Arc::new(tokio::sync::Notify::new());
+        let release = std::sync::Arc::new(tokio::sync::Notify::new());
+        let task_started = std::sync::Arc::clone(&started);
+        let task_release = std::sync::Arc::clone(&release);
+        tasks.spawn(async move {
+            task_started.notify_one();
+            task_release.notified().await;
+        });
+        started.notified().await;
+
+        let first = {
+            let tasks = std::sync::Arc::clone(&tasks);
+            tokio::spawn(async move { tasks.shutdown().await })
+        };
+        while !tasks.is_shutdown() {
+            tokio::task::yield_now().await;
+        }
+        for _ in 0..16 {
+            tokio::task::yield_now().await;
+        }
+        first.abort();
+        assert!(first.await.unwrap_err().is_cancelled());
+        release.notify_one();
+
+        // tight-timeout: a retry must not wait for the abandoned shutdown caller
+        tokio::time::timeout(std::time::Duration::from_secs(1), tasks.shutdown())
+            .await
+            .expect("shutdown retry remained stuck after its first caller was cancelled");
+        assert_eq!(tasks.task_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn concurrent_shutdown_cancels_and_drains_every_owned_task() {
+        let tasks = std::sync::Arc::new(super::InstanceTaskSet::new());
+        let started = std::sync::Arc::new(tokio::sync::Notify::new());
+        let task_started = std::sync::Arc::clone(&started);
+        let cancellation = tasks.cancellation();
+        tasks.spawn(async move {
+            task_started.notify_one();
+            cancellation.cancelled().await;
+        });
+        started.notified().await;
+
+        let first = {
+            let tasks = std::sync::Arc::clone(&tasks);
+            async move { tasks.shutdown().await }
+        };
+        let second = {
+            let tasks = std::sync::Arc::clone(&tasks);
+            async move { tasks.shutdown().await }
+        };
+        tokio::join!(first, second);
+
+        assert_eq!(tasks.task_count(), 0);
+        tasks.shutdown().await;
+
+        let polled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let task_polled = std::sync::Arc::clone(&polled);
+        tasks.spawn(async move {
+            task_polled.store(true, std::sync::atomic::Ordering::Release);
+        });
+        assert!(!polled.load(std::sync::atomic::Ordering::Acquire));
+        assert_eq!(tasks.task_count(), 0);
     }
 }

--- a/crates/verlet-kernel/src/adapters/app_server/lifecycle.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/lifecycle.rs
@@ -1,0 +1,59 @@
+//! Instance-owned lifecycle (EMO-551): the cancellation and task-ownership
+//! boundary that lets one process construct, run, and tear down N kernel
+//! instances independently.
+//!
+//! Today background work an instance starts (subscription watchers,
+//! daemon-I/O workers, connection tasks) is spawned detached: dropping the
+//! instance leaks the tasks, and a live watcher holding an app clone keeps
+//! the whole instance alive. Every such spawn moves into an
+//! [`InstanceTaskSet`] owned by the instance; `VerletAppServer::shutdown`
+//! cancels the set and awaits every task before releasing the instance.
+//! `Drop` never constructs a runtime (the console-credential retirement in
+//! `VerletAppServerInner::drop` moves here; the Drop impl becomes a
+//! best-effort warning for instances dropped without shutdown).
+
+/// The background tasks and cancellation token owned by one kernel
+/// instance. Tasks spawned through this set observe the instance's
+/// cancellation token and are awaited by [`InstanceTaskSet::shutdown`];
+/// nothing an instance starts may outlive it.
+pub struct InstanceTaskSet {
+    cancellation: tokio_util::sync::CancellationToken,
+    tasks: tokio::sync::Mutex<tokio::task::JoinSet<()>>,
+}
+
+impl Default for InstanceTaskSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InstanceTaskSet {
+    pub fn new() -> Self {
+        Self {
+            cancellation: tokio_util::sync::CancellationToken::new(),
+            tasks: tokio::sync::Mutex::new(tokio::task::JoinSet::new()),
+        }
+    }
+
+    /// A child token for a task that needs to select on cancellation
+    /// alongside its own work (watchers, accept loops).
+    pub fn cancellation(&self) -> tokio_util::sync::CancellationToken {
+        self.cancellation.child_token()
+    }
+
+    /// Spawn a task owned by this instance. The future must exit promptly
+    /// once the cancellation token fires; shutdown awaits it.
+    pub async fn spawn<F>(&self, task: F)
+    where
+        F: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let _ = task;
+        unimplemented!("EMO-551: instance-owned task spawn")
+    }
+
+    /// Cancel every owned task and await them all. Idempotent; concurrent
+    /// callers all observe completion.
+    pub async fn shutdown(&self) {
+        unimplemented!("EMO-551: instance-owned task shutdown")
+    }
+}

--- a/crates/verlet-kernel/src/adapters/app_server/subscriptions.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/subscriptions.rs
@@ -20,7 +20,7 @@ pub(super) struct AppServerSubscriber {
 
 pub(super) struct AppServerThreadWatcher {
     pub(super) id: u64,
-    pub(super) handle: tokio::task::JoinHandle<()>,
+    pub(super) cancellation: tokio_util::sync::CancellationToken,
 }
 
 enum ResyncedTurnItem {
@@ -121,25 +121,28 @@ impl crate::adapters::app_server::VerletAppServer {
         let should_spawn = subscriptions
             .watchers
             .get(&thread_id)
-            .is_none_or(|watcher| watcher.handle.is_finished());
+            .is_none_or(|watcher| watcher.cancellation.is_cancelled());
         if should_spawn {
             subscriptions.watchers.remove(&thread_id);
             let watcher_id = subscriptions.next_watcher_id;
             subscriptions.next_watcher_id = subscriptions.next_watcher_id.saturating_add(1);
             let app = self.clone();
             let watcher_thread_id = thread_id.clone();
-            let watcher = tokio::spawn(async move {
-                watch_thread(app.clone(), handle).await;
+            let watcher_cancellation = self.inner.tasks.cancellation();
+            let task_cancellation = watcher_cancellation.clone();
+            if self.inner.tasks.spawn(async move {
+                watch_thread(app.clone(), handle, task_cancellation).await;
                 app.finish_thread_watcher(&watcher_thread_id, watcher_id)
                     .await;
-            });
-            subscriptions.watchers.insert(
-                thread_id,
-                AppServerThreadWatcher {
-                    id: watcher_id,
-                    handle: watcher,
-                },
-            );
+            }) {
+                subscriptions.watchers.insert(
+                    thread_id,
+                    AppServerThreadWatcher {
+                        id: watcher_id,
+                        cancellation: watcher_cancellation,
+                    },
+                );
+            }
         }
         subscriber_id
     }
@@ -168,7 +171,7 @@ impl crate::adapters::app_server::VerletAppServer {
             }
         };
         if let Some(watcher) = watcher {
-            watcher.handle.abort();
+            watcher.cancellation.cancel();
         }
     }
 
@@ -208,7 +211,7 @@ impl crate::adapters::app_server::VerletAppServer {
             }
         };
         if let Some(watcher) = watcher {
-            watcher.handle.abort();
+            watcher.cancellation.cancel();
         }
     }
 
@@ -251,6 +254,7 @@ impl AppServerSubscriber {
 pub(super) async fn watch_thread(
     app: crate::adapters::app_server::VerletAppServer,
     handle: crate::kernel::runtime_host::RuntimeThreadHandle,
+    cancellation: tokio_util::sync::CancellationToken,
 ) {
     let thread_id = handle.context().coordinates.thread_id.to_string();
     let mut events = handle.subscribe_events();
@@ -263,6 +267,7 @@ pub(super) async fn watch_thread(
     loop {
         tokio::select! {
             biased;
+            _ = cancellation.cancelled() => break,
             event = events.recv() => {
                 match event {
                     Ok(event) => {
@@ -885,10 +890,9 @@ pub(super) async fn handle_thread_status(
 
     if let Some(turn_id) = completion_to_schedule {
         let app = app.clone();
+        let tasks = std::sync::Arc::clone(&app.inner.tasks);
         let thread_id = thread_id.to_string();
-        tokio::spawn(async move {
-            complete_turn_after_settle(app, thread_id, turn_id).await;
-        });
+        tasks.spawn_cancellable(complete_turn_after_settle(app, thread_id, turn_id));
     }
     if matches!(
         status,

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -12096,6 +12096,555 @@ async fn local_dispatch_error_still_witnesses_its_session_close() {
 }
 
 #[tokio::test]
+async fn unbound_instances_dispatch_and_shutdown_independently() {
+    let first = test_app_at_root(&unique_test_root("app-server-instance-first")).await;
+    let second = test_app_at_root(&unique_test_root("app-server-instance-second")).await;
+    let first_principal = operator_principal(&first);
+    let second_principal = operator_principal(&second);
+
+    assert_eq!(
+        first
+            .dispatch_authenticated_json_rpc(
+                first_principal.clone(),
+                "account/read",
+                serde_json::json!({}),
+            )
+            .await
+            .unwrap()["requiresOpenaiAuth"],
+        false
+    );
+    assert_eq!(
+        second
+            .dispatch_authenticated_json_rpc(
+                second_principal.clone(),
+                "account/read",
+                serde_json::json!({}),
+            )
+            .await
+            .unwrap()["requiresOpenaiAuth"],
+        false
+    );
+
+    let (second_connection, mut second_outbound) = test_connection(second.clone()).await;
+    initialize_for_test(&second_connection).await;
+    let thread = second
+        .dispatch_request(
+            &second_connection,
+            "thread/start",
+            Some(serde_json::json!({})),
+        )
+        .await
+        .unwrap();
+    let thread_id = thread["thread"]["id"].as_str().unwrap().to_string();
+    assert!(second.inner.tasks.task_count() > 0);
+
+    first.shutdown().await.unwrap();
+    assert_eq!(first.inner.tasks.task_count(), 0);
+    let error = first
+        .dispatch_authenticated_json_rpc(first_principal, "account/read", serde_json::json!({}))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("shut down"));
+
+    let turn = second
+        .dispatch_request(
+            &second_connection,
+            "turn/start",
+            Some(serde_json::json!({
+                "threadId": thread_id.clone(),
+                "input": [{
+                    "type": "text",
+                    "text": "second instance remains live",
+                    "text_elements": [],
+                }],
+            })),
+        )
+        .await
+        .unwrap();
+    let turn_id = turn["turn"]["id"].as_str().unwrap().to_string();
+    wait_for_turn_completed_notification(&mut second_outbound, &thread_id, &turn_id).await;
+    assert_eq!(
+        second
+            .dispatch_authenticated_json_rpc(
+                second_principal.clone(),
+                "account/read",
+                serde_json::json!({}),
+            )
+            .await
+            .unwrap()["requiresOpenaiAuth"],
+        false
+    );
+    assert!(second.inner.tasks.task_count() > 0);
+
+    let watcher_cancellation = second
+        .inner
+        .subscriptions
+        .lock()
+        .await
+        .watchers
+        .get(&thread_id)
+        .unwrap()
+        .cancellation
+        .clone();
+    watcher_cancellation.cancel();
+    for _ in 0..10_000 {
+        if !second
+            .inner
+            .subscriptions
+            .lock()
+            .await
+            .watchers
+            .contains_key(&thread_id)
+        {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        !second
+            .inner
+            .subscriptions
+            .lock()
+            .await
+            .watchers
+            .contains_key(&thread_id),
+        "cancelled thread watcher did not remove its map entry"
+    );
+    assert!(!second.inner.tasks.is_shutdown());
+    second
+        .dispatch_authenticated_json_rpc(second_principal, "account/read", serde_json::json!({}))
+        .await
+        .unwrap();
+
+    first.shutdown().await.unwrap();
+    second.shutdown().await.unwrap();
+    assert_eq!(second.inner.tasks.task_count(), 0);
+}
+
+#[tokio::test]
+async fn shutdown_then_drop_inside_runtime_is_inert() {
+    let root = unique_test_root("app-server-shutdown-drop");
+    let config = test_config_at_root(&root)
+        .with_console_assets(root.join("console"), "initial-console-token");
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    assert!(app.inner.console_credential.lock().await.is_some());
+
+    app.shutdown().await.unwrap();
+    app.shutdown().await.unwrap();
+    drop(app);
+}
+
+#[tokio::test]
+async fn failed_console_retirement_can_be_retried_to_completion() {
+    let root = unique_test_root("app-server-shutdown-retry");
+    let config = test_config_at_root(&root)
+        .with_console_assets(root.join("console"), "initial-console-token");
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let record_path = app
+        .inner
+        .console_credential
+        .lock()
+        .await
+        .as_ref()
+        .unwrap()
+        .record_path
+        .clone();
+    std::fs::remove_file(&record_path).unwrap();
+    std::fs::create_dir(&record_path).unwrap();
+
+    let error = app.shutdown().await.unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("failed to read Verlet console credential record")
+    );
+    assert!(app.inner.tasks.is_shutdown());
+    assert!(app.inner.console_credential.lock().await.is_some());
+    assert!(
+        app.inner
+            .supervisor
+            .runtime_store(app.tenant_id())
+            .await
+            .is_ok(),
+        "a retirement failure must leave the tenant registered for retry"
+    );
+
+    std::fs::remove_dir(&record_path).unwrap();
+    app.shutdown().await.unwrap();
+    app.shutdown().await.unwrap();
+    assert!(app.inner.console_credential.lock().await.is_none());
+    assert!(
+        app.inner
+            .supervisor
+            .runtime_store(app.tenant_id())
+            .await
+            .is_err(),
+        "a successful retry must unregister the tenant"
+    );
+}
+
+#[tokio::test]
+async fn cancelled_console_retirement_preserves_the_lease_for_retry() {
+    let root = unique_test_root("app-server-shutdown-cancelled-retirement");
+    let config = test_config_at_root(&root)
+        .with_console_assets(root.join("console"), "initial-console-token");
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let database =
+        verlet_sqlite::Db::open(app.session_store_path(), verlet_sqlite::DbConfig::default())
+            .await
+            .unwrap();
+    let mut database_connection = database.connect().await.unwrap();
+    let blocker = database_connection
+        .transaction_with_behavior(verlet_sqlite::TransactionBehavior::Immediate)
+        .await
+        .unwrap();
+
+    let shutdown_app = app.clone();
+    let shutdown = tokio::spawn(async move { shutdown_app.shutdown().await });
+    while !app.inner.tasks.is_shutdown() {
+        tokio::task::yield_now().await;
+    }
+    for _ in 0..128 {
+        tokio::task::yield_now().await;
+    }
+    shutdown.abort();
+    assert!(shutdown.await.unwrap_err().is_cancelled());
+    assert!(
+        app.inner.console_credential.lock().await.is_some(),
+        "cancelled retirement lost the credential lease needed by a retry"
+    );
+
+    blocker.rollback().await.unwrap();
+    app.shutdown().await.unwrap();
+    assert!(app.inner.console_credential.lock().await.is_none());
+}
+
+#[tokio::test]
+async fn shutdown_waits_for_in_flight_authenticated_dispatch_and_closes_its_session() {
+    let root = unique_test_root("app-server-dispatch-shutdown-race");
+    let config = test_config_at_root(&root);
+    let metadata_path = config.metadata_store_path();
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let store_path = app.session_store_path().to_path_buf();
+    let principal = operator_principal(&app);
+    let expected_principal_id = principal.principal_id.to_string();
+    let database = verlet_sqlite::Db::open(&metadata_path, verlet_sqlite::DbConfig::default())
+        .await
+        .unwrap();
+    let mut database_connection = database.connect().await.unwrap();
+    let blocker = database_connection
+        .transaction_with_behavior(verlet_sqlite::TransactionBehavior::Immediate)
+        .await
+        .unwrap();
+
+    let dispatch_app = app.clone();
+    let dispatch = tokio::spawn(async move {
+        dispatch_app
+            .dispatch_authenticated_json_rpc(
+                principal,
+                "modelProvider/upsert",
+                serde_json::json!({
+                    "provider": {
+                        "providerId": "blocked-upsert",
+                        "api": "open_ai_chat_completions",
+                        "baseUrl": "https://example.invalid/v1"
+                    }
+                }),
+            )
+            .await
+    });
+    wait_for_identity_sql_count(
+        &store_path,
+        "SELECT COUNT(*) FROM cooldis_identity_sessions WHERE closed_at_ms IS NULL",
+        1,
+    )
+    .await;
+
+    let shutdown_app = app.clone();
+    let shutdown = tokio::spawn(async move { shutdown_app.shutdown().await });
+    for _ in 0..128 {
+        if shutdown.is_finished() {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        !shutdown.is_finished(),
+        "shutdown completed while authenticated dispatch still held an in-flight request"
+    );
+
+    blocker.rollback().await.unwrap();
+    dispatch.await.unwrap().unwrap();
+    shutdown.await.unwrap().unwrap();
+    assert_eq!(
+        identity_sql_count(
+            &store_path,
+            "SELECT COUNT(*) FROM cooldis_identity_sessions WHERE closed_at_ms IS NOT NULL",
+        )
+        .await,
+        1
+    );
+    let store = verlet_history_sqlite::SqliteSessionStore::open(&store_path)
+        .await
+        .unwrap();
+    let connection = store.sqlite_database().connect().await.unwrap();
+    let mut rows = connection
+        .query(
+            "SELECT principal_id FROM cooldis_identity_sessions ORDER BY opened_at_ms DESC LIMIT 1",
+            (),
+        )
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<String>(0).unwrap(), expected_principal_id);
+}
+
+struct FailingReloadRuntimeFactory;
+
+#[async_trait::async_trait]
+impl crate::kernel::runtime_host::runtime_api::AgentRuntimeFactory for FailingReloadRuntimeFactory {
+    async fn build(
+        &self,
+        _context: &verlet_runtime_contracts::ThreadContext,
+    ) -> crate::kernel::runtime_host::VerletResult<
+        Box<dyn crate::kernel::runtime_host::runtime_api::AgentRuntime>,
+    > {
+        Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+            "injected constructor reload failure".to_string(),
+        ))
+    }
+}
+
+#[tokio::test]
+async fn constructor_failure_after_console_mint_retires_the_credential() {
+    let root = unique_test_root("app-server-constructor-cleanup");
+    let first = test_app_at_root(&root).await;
+    let (connection, _outbound_rx) = test_connection(first.clone()).await;
+    initialize_for_test(&connection).await;
+    let started = first
+        .dispatch_request(&connection, "thread/start", Some(serde_json::json!({})))
+        .await
+        .unwrap();
+    let thread_id =
+        verlet_runtime_contracts::ThreadId::parse_str(started["thread"]["id"].as_str().unwrap())
+            .unwrap();
+    let mut lifecycle = first
+        .inner
+        .metadata_store
+        .get_thread_lifecycle(thread_id)
+        .await
+        .unwrap()
+        .unwrap();
+    first.shutdown().await.unwrap();
+    lifecycle.status = verlet_runtime_contracts::ThreadLifecycleStatus::Idle;
+    first
+        .inner
+        .metadata_store
+        .upsert_thread_lifecycle(lifecycle)
+        .await
+        .unwrap();
+    assert!(first.inner.console_credential.lock().await.is_none());
+    let session_store_path = first.session_store_path().to_path_buf();
+    let active_credentials_before = identity_sql_count(
+        &session_store_path,
+        "SELECT COUNT(*) FROM cooldis_identity_credentials WHERE revoked_at_ms IS NULL",
+    )
+    .await;
+    let revoked_credentials_before = identity_sql_count(
+        &session_store_path,
+        "SELECT COUNT(*) FROM cooldis_identity_credentials WHERE revoked_at_ms IS NOT NULL",
+    )
+    .await;
+    let metadata_store = first.inner.metadata_store.clone();
+    drop(first);
+
+    let config = test_config_at_root(&root)
+        .with_console_assets(root.join("console"), "initial-console-token");
+    let error =
+        match crate::adapters::app_server::VerletAppServer::with_runtime_factory_and_metadata_store(
+            config,
+            std::sync::Arc::new(FailingReloadRuntimeFactory),
+            metadata_store,
+        )
+        .await
+        {
+            Ok(_) => panic!("constructor unexpectedly succeeded"),
+            Err(error) => error,
+        };
+    assert!(
+        error
+            .to_string()
+            .contains("injected constructor reload failure")
+    );
+    assert_eq!(
+        identity_sql_count(
+            &session_store_path,
+            "SELECT COUNT(*) FROM cooldis_identity_credentials WHERE revoked_at_ms IS NULL",
+        )
+        .await,
+        active_credentials_before
+    );
+    assert_eq!(
+        identity_sql_count(
+            &session_store_path,
+            "SELECT COUNT(*) FROM cooldis_identity_credentials WHERE revoked_at_ms IS NOT NULL",
+        )
+        .await,
+        revoked_credentials_before + 1
+    );
+    assert!(
+        !root
+            .join("state")
+            .join(crate::adapters::app_server::CONSOLE_CREDENTIAL_ID_FILE)
+            .exists()
+    );
+}
+
+#[tokio::test]
+async fn post_shutdown_one_shots_are_rejected_without_polling_or_partial_delete() {
+    let app = test_app().await;
+    let provider_id = "post-shutdown-provider";
+    app.inner
+        .metadata_store
+        .upsert_provider(verlet_metadata::provider_store::LlmProviderRecord::new(
+            provider_id,
+            verlet_history::ProviderApi::OpenAIChatCompletions,
+            "https://example.invalid/v1",
+        ))
+        .await
+        .unwrap();
+    app.inner
+        .metadata_store
+        .set_credential(
+            provider_id,
+            verlet_metadata::provider_store::LlmProviderCredential::ApiKey {
+                key: "project-key".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    app.inner
+        .user_metadata_store
+        .set_credential(
+            provider_id,
+            verlet_metadata::provider_store::LlmProviderCredential::ApiKey {
+                key: "user-key".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    let started = app
+        .dispatch_request(&connection, "thread/start", Some(serde_json::json!({})))
+        .await
+        .unwrap();
+    let thread_id =
+        verlet_runtime_contracts::ThreadId::parse_str(started["thread"]["id"].as_str().unwrap())
+            .unwrap();
+    let handle = app
+        .inner
+        .supervisor
+        .get_thread(app.tenant_id(), thread_id)
+        .await
+        .unwrap();
+    app.shutdown().await.unwrap();
+
+    let delete_error = app
+        .model_provider_delete(
+            crate::adapters::app_server::connection::ModelProviderDeleteParams {
+                provider_id: provider_id.to_string(),
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(delete_error.message.contains("instance shut down"));
+    assert!(
+        app.inner
+            .metadata_store
+            .get_provider(provider_id)
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        app.inner
+            .metadata_store
+            .get_credential(provider_id)
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        app.inner
+            .user_metadata_store
+            .get_credential(provider_id)
+            .await
+            .unwrap()
+            .is_some()
+    );
+
+    let polled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let operation_polled = std::sync::Arc::clone(&polled);
+    let witness_error = app
+        .witness_and_persist_lifecycle(handle, move |_| async move {
+            operation_polled.store(true, std::sync::atomic::Ordering::Release);
+            Ok(())
+        })
+        .await
+        .unwrap_err();
+    assert!(witness_error.message.contains("instance shut down"));
+    assert!(!polled.load(std::sync::atomic::Ordering::Acquire));
+}
+
+#[tokio::test]
+async fn shutdown_stops_an_instance_owned_listener() {
+    let app = test_app().await;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = app.clone();
+    let serve = tokio::spawn(async move { server.serve_websocket_listener(listener).await });
+    let mut client = tokio::net::TcpStream::connect(address).await.unwrap();
+    for _ in 0..10_000 {
+        if app.inner.tasks.task_count() > 0 {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    assert!(app.inner.tasks.task_count() > 0);
+
+    app.shutdown().await.unwrap();
+
+    tokio::time::timeout(std::time::Duration::from_secs(30), serve)
+        .await
+        .expect("listener did not stop after instance shutdown")
+        .unwrap()
+        .unwrap();
+    let mut byte = [0_u8; 1];
+    let read = tokio::time::timeout(std::time::Duration::from_secs(30), client.read(&mut byte))
+        .await
+        .expect("mid-handshake connection remained open after shutdown");
+    match read {
+        Ok(0) => {}
+        Ok(len) => panic!("mid-handshake connection emitted {len} unexpected byte(s)"),
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::BrokenPipe
+            ) => {}
+        Err(error) => panic!("mid-handshake connection closed unexpectedly: {error}"),
+    }
+}
+
+#[tokio::test]
 async fn failed_session_close_rearms_the_drop_witness() {
     let app = test_app().await;
     let store_path = app.session_store_path().to_path_buf();
@@ -12103,6 +12652,7 @@ async fn failed_session_close_rearms_the_drop_witness() {
     let mut close_witness = crate::adapters::app_server::SessionCloseWitness::new(
         std::sync::Arc::clone(&app.inner.identity_authority),
         std::sync::Arc::clone(&app.inner.identity_clock),
+        std::sync::Arc::clone(&app.inner.tasks),
         connection_state.witnessed_session_id.clone(),
     );
     let store = verlet_history_sqlite::SqliteSessionStore::open(&store_path)
@@ -12605,6 +13155,47 @@ async fn command_exec_streaming_start_returns_running_process_id_then_poll_compl
     assert_eq!(completed["processId"].as_str(), Some(process_id.as_str()));
     assert_eq!(completed["stdout"].as_str(), Some("done"));
     assert_eq!(completed["exitCode"].as_i64(), Some(0));
+}
+
+#[tokio::test]
+async fn process_terminal_monitor_is_owned_by_the_app_server_instance() {
+    let app = test_app().await;
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    let thread = app
+        .dispatch_request(&connection, "thread/start", Some(serde_json::json!({})))
+        .await
+        .unwrap();
+    let thread_id = thread["thread"]["id"].as_str().unwrap().to_string();
+    let task_count_before = app.inner.tasks.task_count();
+
+    let started = app
+        .dispatch_request(
+            &connection,
+            "command/exec",
+            Some(serde_json::json!({
+                "command": ["/bin/sh", "-c", "sleep 30"],
+                "streamStdoutStderr": true,
+                "yieldTimeMs": 1,
+                "timeoutMs": 60_000,
+                "threadId": thread_id,
+            })),
+        )
+        .await
+        .unwrap();
+    assert_eq!(started["status"].as_str(), Some("running"));
+    let task_count_with_monitor = app.inner.tasks.task_count();
+
+    // tight-timeout: shutdown must cancel and join the monitor before returning
+    tokio::time::timeout(std::time::Duration::from_secs(5), app.shutdown())
+        .await
+        .expect("shutdown left the process terminal monitor detached")
+        .unwrap();
+    assert!(
+        task_count_with_monitor > task_count_before,
+        "the process terminal monitor was not registered with the instance task set"
+    );
+    assert_eq!(app.inner.tasks.task_count(), 0);
 }
 
 #[tokio::test]
@@ -13358,6 +13949,15 @@ async fn test_app() -> crate::adapters::app_server::VerletAppServer {
 }
 
 async fn test_app_at_root(root: &std::path::Path) -> crate::adapters::app_server::VerletAppServer {
+    let config = test_config_at_root(root);
+    crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap()
+}
+
+fn test_config_at_root(
+    root: &std::path::Path,
+) -> crate::adapters::app_server::VerletAppServerConfig {
     let listen =
         crate::adapters::app_server::AppServerListenAddr::Unix(root.join("app-server.sock"));
     let mut config = crate::adapters::app_server::VerletAppServerConfig::local(
@@ -13372,9 +13972,7 @@ async fn test_app_at_root(root: &std::path::Path) -> crate::adapters::app_server
     config.agent_registry_root = root.join("agents");
     config.blob_registry_root = root.join("blobs");
     config.skill_registry_root = root.join("skills");
-    crate::adapters::app_server::VerletAppServer::new_local(config)
-        .await
-        .unwrap()
+    config
 }
 
 async fn test_connection(
@@ -13386,13 +13984,7 @@ async fn test_connection(
     let (outbound, rx) = tokio::sync::mpsc::unbounded_channel::<
         crate::adapters::app_server::connection::JsonRpcMessage,
     >();
-    let resolved_principal = crate::daemon::identity::ResolvedPrincipal {
-        principal_id: crate::daemon::identity::PrincipalId::new(app.user_id()),
-        kind: crate::daemon::identity::PrincipalKind::Operator,
-        auth: crate::daemon::identity::AuthenticationPath::PeerUid {
-            uid: crate::adapters::app_server::current_effective_uid(),
-        },
-    };
+    let resolved_principal = operator_principal(&app);
     let witnessed_session_id = format!("test-session-{}", uuid::Uuid::now_v7());
     app.inner
         .identity_authority
@@ -13430,6 +14022,18 @@ async fn test_connection(
         },
         rx,
     )
+}
+
+fn operator_principal(
+    app: &crate::adapters::app_server::VerletAppServer,
+) -> crate::daemon::identity::ResolvedPrincipal {
+    crate::daemon::identity::ResolvedPrincipal {
+        principal_id: crate::daemon::identity::PrincipalId::new(app.user_id()),
+        kind: crate::daemon::identity::PrincipalKind::Operator,
+        auth: crate::daemon::identity::AuthenticationPath::PeerUid {
+            uid: crate::adapters::app_server::current_effective_uid(),
+        },
+    }
 }
 
 async fn initialize_for_test(

--- a/crates/verlet-kernel/src/adapters/app_server/threads.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/threads.rs
@@ -685,7 +685,8 @@ impl crate::adapters::app_server::VerletAppServer {
         handle: crate::kernel::runtime_host::RuntimeThreadHandle,
     ) {
         let app = self.clone();
-        tokio::spawn(async move {
+        let tasks = std::sync::Arc::clone(&self.inner.tasks);
+        tasks.spawn_cancellable(async move {
             let mut status = handle.subscribe_status();
             let _ = status.borrow_and_update();
             loop {
@@ -709,7 +710,8 @@ impl crate::adapters::app_server::VerletAppServer {
                     let mut state = app.inner.state.write().await;
                     if let Some(thread) = state.threads.get_mut(&thread_id) {
                         thread.status = status_value;
-                        thread.updated_at_ms = crate::adapters::app_server::connection::now_ms();
+                        thread.updated_at_ms =
+                            crate::adapters::app_server::connection::now_ms();
                     }
                 }
                 if matches!(
@@ -1826,15 +1828,24 @@ impl crate::adapters::app_server::VerletAppServer {
     {
         let supervisor = self.inner.supervisor.clone();
         let coordinates = handle.context().coordinates.clone();
-        tokio::spawn(async move {
-            if let Err(err) = operation(handle.clone()).await {
+        let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
+        if !self.inner.tasks.spawn(async move {
+            let result = if let Err(err) = operation(handle.clone()).await {
                 let _ = supervisor.shutdown_thread_at(&coordinates).await;
-                return Err(crate::adapters::app_server::connection::internal_error(err));
-            }
-            Ok(())
-        })
-        .await
-        .map_err(|err| {
+                Err(crate::adapters::app_server::connection::internal_error(err))
+            } else {
+                Ok(())
+            };
+            let _ = completion_tx.send(result);
+        }) {
+            return Err(crate::adapters::app_server::connection::internal_error(
+                crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                    "Verlet app-server instance shut down before manifest lifecycle witnessing started"
+                        .to_string(),
+                ),
+            ));
+        }
+        completion_rx.await.map_err(|err| {
             crate::adapters::app_server::connection::internal_error(
                 crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
                     "manifest lifecycle witness task failed: {err}"

--- a/crates/verlet-kernel/src/cli/daemon/tests.rs
+++ b/crates/verlet-kernel/src/cli/daemon/tests.rs
@@ -224,6 +224,7 @@ agents = "agents"
         "console initialization did not mint for the configured managed principal"
     );
 
+    app.shutdown().await.unwrap();
     drop(app);
     assert_eq!(
         authority

--- a/crates/verlet-kernel/src/kernel/process_handle_dispatch.rs
+++ b/crates/verlet-kernel/src/kernel/process_handle_dispatch.rs
@@ -17,6 +17,11 @@
 const TERMINAL_MONITOR_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
 const SETUP_FAILURE_MAX_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
 
+pub(crate) type ProcessHandleTask =
+    std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>;
+pub(crate) type ProcessHandleTaskSpawner =
+    std::sync::Arc<dyn Fn(ProcessHandleTask) -> bool + Send + Sync>;
+
 #[derive(Clone)]
 pub struct ProcessHandleDispatcher {
     inner: std::sync::Arc<ProcessHandleDispatcherInner>,
@@ -36,6 +41,13 @@ struct ProcessHandleDispatcherInner {
             verlet_runtime_contracts::handle::HandleDispatchEnvelope,
         >,
     >,
+    task_owner: Option<ProcessHandleTaskOwner>,
+}
+
+#[derive(Clone)]
+struct ProcessHandleTaskOwner {
+    cancellation: tokio_util::sync::CancellationToken,
+    spawn: ProcessHandleTaskSpawner,
 }
 
 impl ProcessHandleDispatcher {
@@ -45,6 +57,34 @@ impl ProcessHandleDispatcher {
             dyn crate::kernel::runtime_host::runtime_api::ProcessHandleIngressSink,
         >,
     ) -> Self {
+        Self::new_inner(store, ingress, None)
+    }
+
+    pub(crate) fn new_with_task_owner(
+        store: std::sync::Arc<dyn verlet_history::RuntimeStore>,
+        ingress: std::sync::Arc<
+            dyn crate::kernel::runtime_host::runtime_api::ProcessHandleIngressSink,
+        >,
+        cancellation: tokio_util::sync::CancellationToken,
+        spawn: ProcessHandleTaskSpawner,
+    ) -> Self {
+        Self::new_inner(
+            store,
+            ingress,
+            Some(ProcessHandleTaskOwner {
+                cancellation,
+                spawn,
+            }),
+        )
+    }
+
+    fn new_inner(
+        store: std::sync::Arc<dyn verlet_history::RuntimeStore>,
+        ingress: std::sync::Arc<
+            dyn crate::kernel::runtime_host::runtime_api::ProcessHandleIngressSink,
+        >,
+        task_owner: Option<ProcessHandleTaskOwner>,
+    ) -> Self {
         Self {
             inner: std::sync::Arc::new(ProcessHandleDispatcherInner {
                 store,
@@ -52,7 +92,21 @@ impl ProcessHandleDispatcher {
                 locks: tokio::sync::Mutex::new(std::collections::BTreeMap::new()),
                 terminal_monitors: tokio::sync::Mutex::new(std::collections::HashSet::new()),
                 live_bindings: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+                task_owner,
             }),
+        }
+    }
+
+    async fn await_while_owned<F>(&self, future: F) -> Option<F::Output>
+    where
+        F: std::future::Future,
+    {
+        let Some(owner) = &self.inner.task_owner else {
+            return Some(future.await);
+        };
+        tokio::select! {
+            _ = owner.cancellation.cancelled() => None,
+            output = future => Some(output),
         }
     }
 
@@ -338,9 +392,15 @@ impl ProcessHandleDispatcher {
             return;
         }
         let this = self.clone();
-        tokio::spawn(async move {
+        let monitor = async move {
             loop {
-                match manager.snapshot(process_id, output_cap_bytes).await {
+                let Some(snapshot) = this
+                    .await_while_owned(manager.snapshot(process_id, output_cap_bytes))
+                    .await
+                else {
+                    break;
+                };
+                match snapshot {
                     Ok(outcome)
                         if outcome.snapshot.status
                             != verlet_process::live::ProcessSnapshotStatus::Running =>
@@ -352,7 +412,15 @@ impl ProcessHandleDispatcher {
                                     "verlet process settlement {} encode failed: {err}",
                                     binding.dispatch_id
                                 );
-                                tokio::time::sleep(TERMINAL_MONITOR_INTERVAL).await;
+                                if this
+                                    .await_while_owned(tokio::time::sleep(
+                                        TERMINAL_MONITOR_INTERVAL,
+                                    ))
+                                    .await
+                                    .is_none()
+                                {
+                                    break;
+                                }
                                 continue;
                             }
                         };
@@ -368,7 +436,15 @@ impl ProcessHandleDispatcher {
                                         "verlet process settlement {} could not release terminal entry: {err}",
                                         binding.dispatch_id
                                     );
-                                    tokio::time::sleep(TERMINAL_MONITOR_INTERVAL).await;
+                                    if this
+                                        .await_while_owned(tokio::time::sleep(
+                                            TERMINAL_MONITOR_INTERVAL,
+                                        ))
+                                        .await
+                                        .is_none()
+                                    {
+                                        break;
+                                    }
                                     continue;
                                 }
                                 this.forget_settled_binding(&binding, process_id, &dispatch_lock)
@@ -389,14 +465,34 @@ impl ProcessHandleDispatcher {
                         );
                     }
                 }
-                tokio::time::sleep(TERMINAL_MONITOR_INTERVAL).await;
+                if this
+                    .await_while_owned(tokio::time::sleep(TERMINAL_MONITOR_INTERVAL))
+                    .await
+                    .is_none()
+                {
+                    break;
+                }
             }
             this.inner
                 .terminal_monitors
                 .lock()
                 .await
                 .remove(&process_id);
-        });
+        };
+        let accepted = match &self.inner.task_owner {
+            Some(owner) => (owner.spawn)(Box::pin(monitor)),
+            None => {
+                tokio::spawn(monitor);
+                true
+            }
+        };
+        if !accepted {
+            self.inner
+                .terminal_monitors
+                .lock()
+                .await
+                .remove(&process_id);
+        }
     }
 
     async fn deliver_setup_failure(
@@ -407,12 +503,17 @@ impl ProcessHandleDispatcher {
         let envelope = setup_failure_envelope(binding, reason);
         let mut retry_interval = TERMINAL_MONITOR_INTERVAL;
         loop {
-            match self
-                .inner
-                .ingress
-                .submit_process_handle_envelope(envelope.clone())
+            let Some(delivery) = self
+                .await_while_owned(
+                    self.inner
+                        .ingress
+                        .submit_process_handle_envelope(envelope.clone()),
+                )
                 .await
-            {
+            else {
+                return;
+            };
+            match delivery {
                 Ok(()) => break,
                 Err(err) => eprintln!(
                     "verlet process setup failure {} retrying after ingress failure in {}ms: {err}",
@@ -420,7 +521,13 @@ impl ProcessHandleDispatcher {
                     retry_interval.as_millis()
                 ),
             }
-            tokio::time::sleep(retry_interval).await;
+            if self
+                .await_while_owned(tokio::time::sleep(retry_interval))
+                .await
+                .is_none()
+            {
+                return;
+            }
             retry_interval = retry_interval
                 .saturating_mul(2)
                 .min(SETUP_FAILURE_MAX_RETRY_INTERVAL);

--- a/crates/verlet-kernel/src/kernel/supervisor.rs
+++ b/crates/verlet-kernel/src/kernel/supervisor.rs
@@ -670,6 +670,19 @@ impl VerletSupervisor {
         self.tenant(tenant_id).await?.host.shutdown_all().await
     }
 
+    /// Shut down a tenant's threads AND remove its registration atomically
+    /// (EMO-551), so the tenant id can be re-registered — `shutdown_tenant`
+    /// alone leaves the id claimed and `register_tenant` then rejects it.
+    /// The multi-tenant host uses this to replace or retire one instance
+    /// while co-resident tenants keep running.
+    pub async fn shutdown_and_unregister_tenant(
+        &self,
+        tenant_id: &str,
+    ) -> crate::kernel::runtime_host::VerletResult<Vec<verlet_runtime_contracts::ThreadId>> {
+        let _ = tenant_id;
+        unimplemented!("EMO-551: atomic tenant shutdown-and-unregister")
+    }
+
     pub async fn shutdown_all(
         &self,
     ) -> crate::kernel::runtime_host::VerletResult<

--- a/crates/verlet-kernel/src/kernel/supervisor.rs
+++ b/crates/verlet-kernel/src/kernel/supervisor.rs
@@ -11,6 +11,35 @@ struct TenantRuntime {
     tenant_id: String,
     context: TenantRuntimeContext,
     host: crate::kernel::runtime_host::RuntimeHost,
+    retiring: std::sync::atomic::AtomicBool,
+}
+
+struct TenantRetirementGuard {
+    tenant: std::sync::Arc<TenantRuntime>,
+    armed: bool,
+}
+
+impl TenantRetirementGuard {
+    fn new(tenant: std::sync::Arc<TenantRuntime>) -> Self {
+        Self {
+            tenant,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TenantRetirementGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            self.tenant
+                .retiring
+                .store(false, std::sync::atomic::Ordering::Release);
+        }
+    }
 }
 
 pub struct TenantRegistration {
@@ -228,6 +257,7 @@ impl VerletSupervisor {
                 context.execution_policy().clone(),
             ),
             context,
+            retiring: std::sync::atomic::AtomicBool::new(false),
         };
         tenants.insert(tenant_id, std::sync::Arc::new(tenant));
         Ok(())
@@ -679,8 +709,34 @@ impl VerletSupervisor {
         &self,
         tenant_id: &str,
     ) -> crate::kernel::runtime_host::VerletResult<Vec<verlet_runtime_contracts::ThreadId>> {
-        let _ = tenant_id;
-        unimplemented!("EMO-551: atomic tenant shutdown-and-unregister")
+        let tenant = self.tenant(tenant_id).await?;
+        tenant
+            .retiring
+            .compare_exchange(
+                false,
+                true,
+                std::sync::atomic::Ordering::AcqRel,
+                std::sync::atomic::Ordering::Acquire,
+            )
+            .map_err(|_| {
+                crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
+                    "tenant {tenant_id} is already shutting down"
+                ))
+            })?;
+        let mut retirement = TenantRetirementGuard::new(std::sync::Arc::clone(&tenant));
+        let stopped = tenant.host.shutdown_all().await?;
+        let mut tenants = self.inner.tenants.write().await;
+        if !tenants
+            .get(tenant_id)
+            .is_some_and(|registered| std::sync::Arc::ptr_eq(registered, &tenant))
+        {
+            return Err(crate::kernel::runtime_host::VerletError::TenantNotFound(
+                tenant_id.to_string(),
+            ));
+        }
+        tenants.remove(tenant_id);
+        retirement.disarm();
+        Ok(stopped)
     }
 
     pub async fn shutdown_all(
@@ -887,7 +943,8 @@ impl VerletSupervisor {
         &self,
         tenant_id: &str,
     ) -> crate::kernel::runtime_host::VerletResult<std::sync::Arc<TenantRuntime>> {
-        self.inner
+        let tenant = self
+            .inner
             .tenants
             .read()
             .await
@@ -895,7 +952,13 @@ impl VerletSupervisor {
             .cloned()
             .ok_or_else(|| {
                 crate::kernel::runtime_host::VerletError::TenantNotFound(tenant_id.to_string())
-            })
+            })?;
+        if tenant.retiring.load(std::sync::atomic::Ordering::Acquire) {
+            return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                format!("tenant {tenant_id} is shutting down"),
+            ));
+        }
+        Ok(tenant)
     }
 
     fn validate_thread_scope(

--- a/crates/verlet-kernel/src/kernel/supervisor/tests.rs
+++ b/crates/verlet-kernel/src/kernel/supervisor/tests.rs
@@ -86,6 +86,62 @@ impl crate::kernel::runtime_host::runtime_api::AgentRuntime for EchoRuntime {
     }
 }
 
+#[derive(Default)]
+struct GatedShutdownFactory {
+    shutdown_received: std::sync::Arc<tokio::sync::Notify>,
+    release_shutdown: std::sync::Arc<tokio::sync::Notify>,
+}
+
+#[async_trait::async_trait]
+impl crate::kernel::runtime_host::runtime_api::AgentRuntimeFactory for GatedShutdownFactory {
+    async fn build(
+        &self,
+        _context: &verlet_runtime_contracts::ThreadContext,
+    ) -> crate::kernel::runtime_host::VerletResult<
+        Box<dyn crate::kernel::runtime_host::runtime_api::AgentRuntime>,
+    > {
+        Ok(Box::new(GatedShutdownRuntime {
+            shutdown_received: std::sync::Arc::clone(&self.shutdown_received),
+            release_shutdown: std::sync::Arc::clone(&self.release_shutdown),
+        }))
+    }
+}
+
+struct GatedShutdownRuntime {
+    shutdown_received: std::sync::Arc<tokio::sync::Notify>,
+    release_shutdown: std::sync::Arc<tokio::sync::Notify>,
+}
+
+#[async_trait::async_trait]
+impl crate::kernel::runtime_host::runtime_api::AgentRuntime for GatedShutdownRuntime {
+    async fn run(
+        self: Box<Self>,
+        _context: verlet_runtime_contracts::ThreadContext,
+        _services: crate::kernel::runtime_host::runtime_services::RuntimeServices,
+        mut commands: tokio::sync::mpsc::Receiver<
+            crate::kernel::runtime_host::runtime_api::ThreadCommand,
+        >,
+        _events: tokio::sync::broadcast::Sender<
+            crate::kernel::runtime_host::runtime_api::ThreadEvent,
+        >,
+        status: tokio::sync::watch::Sender<verlet_runtime_contracts::ThreadStatus>,
+        _cancellation: tokio_util::sync::CancellationToken,
+    ) {
+        let _ = status.send(verlet_runtime_contracts::ThreadStatus::Idle);
+        while let Some(command) = commands.recv().await {
+            if matches!(
+                command,
+                crate::kernel::runtime_host::runtime_api::ThreadCommand::Shutdown
+            ) {
+                self.shutdown_received.notify_one();
+                self.release_shutdown.notified().await;
+                let _ = status.send(verlet_runtime_contracts::ThreadStatus::Stopped);
+                return;
+            }
+        }
+    }
+}
+
 async fn supervisor() -> crate::kernel::supervisor::VerletSupervisor {
     supervisor_with_root(&unique_temp_dir("verlet-supervisor")).await
 }
@@ -611,6 +667,92 @@ async fn supervisor_can_shutdown_one_tenant_without_stopping_others() {
             .await
             .is_ok()
     );
+}
+
+#[tokio::test]
+async fn supervisor_only_releases_tenant_id_when_shutdown_unregisters_it() {
+    let root = unique_temp_dir("verlet-supervisor-unregister");
+    let supervisor = supervisor_with_root(&root).await;
+
+    supervisor.shutdown_tenant("tenant_a").await.unwrap();
+    let error = supervisor
+        .register_tenant(crate::kernel::supervisor::TenantRegistration {
+            context: tenant_context(&root, "tenant_a"),
+            runtime_factory: std::sync::Arc::new(EchoRuntimeFactory),
+        })
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        crate::kernel::runtime_host::VerletError::TenantAlreadyExists(tenant_id)
+            if tenant_id == "tenant_a"
+    ));
+
+    supervisor
+        .shutdown_and_unregister_tenant("tenant_a")
+        .await
+        .unwrap();
+    supervisor
+        .register_tenant(crate::kernel::supervisor::TenantRegistration {
+            context: tenant_context(&root, "tenant_a"),
+            runtime_factory: std::sync::Arc::new(EchoRuntimeFactory),
+        })
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn unregistering_one_tenant_does_not_block_co_resident_tenant_work() {
+    let root = unique_temp_dir("verlet-supervisor-unregister-isolation");
+    let supervisor = crate::kernel::supervisor::VerletSupervisor::new();
+    let gated = std::sync::Arc::new(GatedShutdownFactory::default());
+    supervisor
+        .register_tenant(crate::kernel::supervisor::TenantRegistration {
+            context: tenant_context(&root, "tenant_a"),
+            runtime_factory: gated.clone(),
+        })
+        .await
+        .unwrap();
+    supervisor
+        .register_tenant(crate::kernel::supervisor::TenantRegistration {
+            context: tenant_context(&root, "tenant_b"),
+            runtime_factory: std::sync::Arc::new(EchoRuntimeFactory),
+        })
+        .await
+        .unwrap();
+    supervisor
+        .start_thread(start_request("tenant_a"))
+        .await
+        .unwrap();
+
+    let shutdown = {
+        let supervisor = supervisor.clone();
+        tokio::spawn(async move { supervisor.shutdown_and_unregister_tenant("tenant_a").await })
+    };
+    gated.shutdown_received.notified().await;
+
+    let co_resident_start = {
+        let supervisor = supervisor.clone();
+        tokio::spawn(async move { supervisor.start_thread(start_request("tenant_b")).await })
+    };
+    for _ in 0..10_000 {
+        if co_resident_start.is_finished() {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        co_resident_start.is_finished(),
+        "tenant_a shutdown held the supervisor registry lock across runtime teardown"
+    );
+    let tenant_b = co_resident_start.await.unwrap().unwrap();
+
+    gated.release_shutdown.notify_one();
+    shutdown.await.unwrap().unwrap();
+    supervisor
+        .shutdown_thread("tenant_b", tenant_b.context().coordinates.thread_id)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]

--- a/crates/verlet-kernel/tests/boundary_auth.rs
+++ b/crates/verlet-kernel/tests/boundary_auth.rs
@@ -931,7 +931,9 @@ async fn console_credential_lifecycle_keeps_one_active_credential_across_restart
 
     let record_path = root.join("state").join("console-credential-id");
     assert!(record_path.is_file());
-    drop(generations);
+    for app in generations {
+        app.shutdown().await.unwrap();
+    }
     assert_eq!(
         active_credential_count(&store_path, OPERATOR_ID).await,
         baseline,


### PR DESCRIPTION
Host v0 stage B (EMO-549 stage 2). VerletAppServer becomes an embeddable kernel instance.

- Every background task an instance starts (connection tasks, websocket writers, subscription and lifecycle watchers, process-settlement monitors, persistence one-shots) is owned by an InstanceTaskSet with an instance cancellation token; finished tasks are reaped on spawn.
- Explicit idempotent `shutdown()`: gates out new dispatches, drains in-flight requests, cancels and awaits the task set, retires the console credential (retry-safe), and atomically shuts down + unregisters the supervisor tenant. Drop never constructs a runtime.
- `dispatch_authenticated_json_rpc(principal, method, params)`: transport-independent entry sharing the request core with local JSON-RPC, for the coming multi-tenant host facade (EMO-553).
- Constructor failures shut the partial instance down (no leaked console credential); tenant retirement no longer holds the supervisor registry lock across runtime teardown; instance shutdown leaves thread lifecycle records nonterminal so rehomed instances recover from the journal.
- Standalone daemon behavior unchanged.

Verification: full scripts/verify.sh green on macOS (1067 passed / 0 failed, +9 tests), pre-push verify green; Linux lane running, merge gated on it. Review-and-fix pass applied 11 findings (7 High) before commit; receipts on the Linear issue.

Linear: https://linear.app/emotionscientific/issue/EMO-551/kernel-kernelinstance-seam-unbound-constructor-transport-independent