### PR TITLE
Hosted instance config hygiene (EMO-552)

### DIFF
--- a/crates/verlet-kernel/src/adapters/agent_loop.rs
+++ b/crates/verlet-kernel/src/adapters/agent_loop.rs
@@ -110,10 +110,6 @@ fn reattach_late_tool_result_entries(
     output
 }
 
-fn default_process_dispatcher_cwd() -> std::path::PathBuf {
-    std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
-}
-
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct AgentLoopConfig {
     pub provider: String,
@@ -236,6 +232,8 @@ pub struct AgentLoopFactory {
     thread_spawn_agent_resolver:
         Option<std::sync::Arc<dyn crate::agent::agent_process::KernelThreadSpawnAgentResolver>>,
     hook_pipeline: Option<std::sync::Arc<crate::agent::hooks::HookPipeline>>,
+    hook_shell: Option<String>,
+    process_dispatcher_cwd: Option<std::path::PathBuf>,
     tool_permission_gate: std::sync::Arc<dyn crate::agent::tool_interceptor::ToolPermissionGate>,
     context_compile_policy: crate::kernel::context_compiler::AgentContextCompilePolicy,
     compaction_policy: crate::kernel::compaction::CompactionPolicy,
@@ -256,6 +254,8 @@ impl AgentLoopFactory {
             bash_tool_config: None,
             thread_spawn_agent_resolver: None,
             hook_pipeline: None,
+            hook_shell: None,
+            process_dispatcher_cwd: None,
             tool_permission_gate: std::sync::Arc::new(
                 crate::agent::tool_interceptor::AllowAllToolPermissionGate,
             ),
@@ -326,6 +326,17 @@ impl AgentLoopFactory {
         self
     }
 
+    // lexicon-allow: hook - existing host debug hook configuration name retained for compatibility.
+    pub(crate) fn with_hook_shell(mut self, hook_shell: Option<String>) -> Self {
+        self.hook_shell = hook_shell;
+        self
+    }
+
+    pub(crate) fn with_process_dispatcher_cwd(mut self, cwd: Option<std::path::PathBuf>) -> Self {
+        self.process_dispatcher_cwd = cwd;
+        self
+    }
+
     pub fn with_tool_permission_gate(
         mut self,
         tool_permission_gate: std::sync::Arc<
@@ -390,7 +401,15 @@ impl crate::kernel::runtime_host::runtime_api::AgentRuntimeFactory for AgentLoop
             tool_router: self.tool_router.clone(),
             bash_tool_config: self.bash_tool_config.clone(),
             thread_spawn_agent_resolver: self.thread_spawn_agent_resolver.clone(),
-            hook_pipeline: self.hook_pipeline.clone(),
+            hook_pipeline: self.hook_pipeline.as_ref().map(|pipeline| {
+                std::sync::Arc::new(
+                    pipeline
+                        .as_ref()
+                        .clone()
+                        .with_shell(self.hook_shell.clone()),
+                )
+            }),
+            process_dispatcher_cwd: self.process_dispatcher_cwd.clone(),
             tool_permission_gate: std::sync::Arc::clone(&self.tool_permission_gate),
             context_compile_policy: self.context_compile_policy.clone(),
             compaction_policy: self.compaction_policy.clone(),
@@ -411,6 +430,7 @@ struct AgentLoop {
     thread_spawn_agent_resolver:
         Option<std::sync::Arc<dyn crate::agent::agent_process::KernelThreadSpawnAgentResolver>>,
     hook_pipeline: Option<std::sync::Arc<crate::agent::hooks::HookPipeline>>,
+    process_dispatcher_cwd: Option<std::path::PathBuf>,
     tool_permission_gate: std::sync::Arc<dyn crate::agent::tool_interceptor::ToolPermissionGate>,
     context_compile_policy: crate::kernel::context_compiler::AgentContextCompilePolicy,
     compaction_policy: crate::kernel::compaction::CompactionPolicy,
@@ -633,7 +653,8 @@ impl AgentLoop {
             .bash_tool_config
             .as_ref()
             .map(|config| config.cwd.clone())
-            .unwrap_or_else(default_process_dispatcher_cwd);
+            .or_else(|| self.process_dispatcher_cwd.clone())
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
         let process_handle_dispatcher = services.process_handle_dispatcher().or_else(|| {
             services.process_handle_ingress().map(|ingress| {
                 crate::kernel::process_handle_dispatch::ProcessHandleDispatcher::new(

--- a/crates/verlet-kernel/src/adapters/app_server.rs
+++ b/crates/verlet-kernel/src/adapters/app_server.rs
@@ -122,7 +122,7 @@ impl AppServerListenAddr {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct VerletAppServerConfig {
     pub listen: AppServerListenAddr,
     pub runtime_home: std::path::PathBuf,
@@ -151,6 +151,7 @@ pub struct VerletAppServerConfig {
     /// configured sync listener has bound successfully.
     pub remote_event_store_served: std::sync::Arc<std::sync::atomic::AtomicBool>,
     pub console_assets: Option<ConsoleAssetConfig>,
+    root_reservation: Option<instance::InstanceRootReservation>,
     /// Per-instance replacements for process-state reads at depth
     /// (EMO-552): provider auth, hook shell, process-id source.
     pub instance_environment: instance::InstanceEnvironment,
@@ -187,6 +188,7 @@ impl VerletAppServerConfig {
             model: APP_SERVER_LOCAL_MODEL.to_string(),
             model_provider: APP_SERVER_LOCAL_PROVIDER.to_string(),
             provider: AppServerProviderConfig::LocalOffline,
+            // lexicon-allow: capsule - existing app-server operation binding field.
             capsule_bindings: CapsuleBindingsConfig::default()
                 .with_registry_root(project_storage_root.join("operations")),
             agent_registry_root: project_storage_root.join("agents"),
@@ -200,6 +202,7 @@ impl VerletAppServerConfig {
                 false,
             )),
             console_assets: None,
+            root_reservation: None,
             instance_environment: instance::InstanceEnvironment::standalone(),
         };
         config.apply_daemon_identity_config(&identity);
@@ -219,8 +222,52 @@ impl VerletAppServerConfig {
         cwd: impl Into<std::path::PathBuf>,
         identity: &crate::daemon::identity::VerletDaemonIdentityConfig,
     ) -> crate::kernel::runtime_host::VerletResult<Self> {
-        let _ = (roots, environment, cwd, identity);
-        unimplemented!("EMO-552: hosted config from explicit roots + injected environment")
+        let cwd = cwd.into();
+        environment.validate_hosted()?;
+        if !cwd.is_absolute() {
+            return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                format!("hosted instance cwd must be absolute: {}", cwd.display()),
+            ));
+        }
+        let reservation = instance::reserve_instance_roots(&roots)?;
+        let canonical_roots = reservation.canonical_roots();
+        let runtime_home = canonical_roots[0].clone();
+        let state_home = canonical_roots[1].clone();
+        let user_state_home = canonical_roots[2].clone();
+        let agent_registry_root = canonical_roots[3].clone();
+        let blob_registry_root = canonical_roots[4].clone();
+        let skill_registry_root = canonical_roots[5].clone();
+        let mut config = Self {
+            listen: AppServerListenAddr::Unix(runtime_home.join("app-server.unbound.sock")),
+            runtime_home: runtime_home.clone(),
+            state_home,
+            user_state_home,
+            cwd,
+            tenant_id: String::new(),
+            user_id: String::new(),
+            identity_mode: crate::daemon::identity::IdentityMode::Local,
+            console_principal: None,
+            model: APP_SERVER_LOCAL_MODEL.to_string(),
+            model_provider: APP_SERVER_LOCAL_PROVIDER.to_string(),
+            provider: AppServerProviderConfig::LocalOffline,
+            capsule_bindings: CapsuleBindingsConfig::default()
+                .with_registry_root(runtime_home.join("operations")),
+            agent_registry_root,
+            blob_registry_root,
+            skill_registry_root,
+            lease_epoch: 0,
+            default_placement: crate::agent::manifest_bind::AgentManifestPlacementBinding::default(
+            ),
+            default_workspace: None,
+            remote_event_store_served: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
+                false,
+            )),
+            console_assets: None,
+            root_reservation: Some(reservation),
+            instance_environment: environment,
+        };
+        config.apply_daemon_identity_config(identity);
+        Ok(config)
     }
 
     /// Project a daemon identity config onto this app-server config. This is
@@ -371,6 +418,61 @@ impl VerletAppServerConfig {
 
     pub fn provider_metadata_store_path(&self) -> std::path::PathBuf {
         self.user_metadata_store_path()
+    }
+
+    fn validate_root_reservation(&self) -> crate::kernel::runtime_host::VerletResult<()> {
+        let Some(reservation) = &self.root_reservation else {
+            return Ok(());
+        };
+        self.instance_environment.validate_hosted()?;
+        if !self.cwd.is_absolute() {
+            return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                format!(
+                    "hosted instance cwd must be absolute: {}",
+                    self.cwd.display()
+                ),
+            ));
+        }
+        let configured_roots = [
+            ("runtime_home", &self.runtime_home),
+            ("state_home", &self.state_home),
+            ("user_state_home", &self.user_state_home),
+            ("agent_registry_root", &self.agent_registry_root),
+            ("blob_registry_root", &self.blob_registry_root),
+            ("skill_registry_root", &self.skill_registry_root),
+        ];
+        for ((name, configured), reserved) in configured_roots
+            .into_iter()
+            .zip(reservation.canonical_roots())
+        {
+            if configured != reserved {
+                return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                    format!(
+                        "hosted instance root {name} changed after reservation: configured {}, reserved {}",
+                        configured.display(),
+                        reserved.display()
+                    ),
+                ));
+            }
+        }
+        let expected_operation_registry_root = self.runtime_home.join("operations");
+        if self.capsule_bindings.registry_root.as_deref()
+            != Some(expected_operation_registry_root.as_path())
+        {
+            let configured = self
+                .capsule_bindings
+                .registry_root
+                .as_deref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "<none>".to_string());
+            return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                format!(
+                    "hosted instance operation registry root changed after reservation: configured {configured}, expected {}",
+                    expected_operation_registry_root.display()
+                ),
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -542,6 +644,13 @@ struct VerletAppServerInner {
     subscriptions:
         tokio::sync::Mutex<crate::adapters::app_server::subscriptions::AppServerSubscriptions>,
     state: tokio::sync::RwLock<crate::adapters::app_server::threads::AppServerState>,
+}
+
+impl VerletAppServerInner {
+    fn agent_registry(&self) -> crate::agent::manifest::LocalAgentRegistry {
+        crate::agent::manifest::LocalAgentRegistry::new(self.agent_registry_root.clone())
+            .with_blob_registry_root(self.blob_registry_root.clone())
+    }
 }
 
 struct ConsoleCredentialLease {
@@ -724,6 +833,7 @@ impl VerletAppServer {
     pub async fn new(
         mut config: VerletAppServerConfig,
     ) -> crate::kernel::runtime_host::VerletResult<Self> {
+        config.validate_root_reservation()?;
         let metadata_store = open_and_seed_metadata_store(config.metadata_store_path()).await?;
         let user_metadata_store =
             open_and_seed_metadata_store(config.user_metadata_store_path()).await?;
@@ -746,6 +856,7 @@ impl VerletAppServer {
             dyn crate::kernel::runtime_host::runtime_api::AgentRuntimeFactory,
         >,
     ) -> crate::kernel::runtime_host::VerletResult<Self> {
+        config.validate_root_reservation()?;
         let metadata_store = verlet_metadata::provider_store::SqliteMetadataStore::in_memory()
             .await
             .map_err(metadata_store_error)?;
@@ -842,6 +953,7 @@ impl VerletAppServer {
             >,
         >,
     ) -> crate::kernel::runtime_host::VerletResult<Self> {
+        config.validate_root_reservation()?;
         crate::adapters::app_server::threads::normalize_registry_roots(&mut config);
         let provider_surface =
             agent_manifest_provider_surface_for_config(&config, &metadata_store).await?;
@@ -904,6 +1016,11 @@ impl VerletAppServer {
             &console_credential_record_path,
         )
         .await?;
+        let process_manager =
+            verlet_process::live::AsyncExecutionManager::new_with_process_id_source(
+                verlet_process::live::AsyncExecutionManagerConfig::default(),
+                std::sync::Arc::clone(&config.instance_environment.process_ids),
+            );
         let app = Self {
             inner: std::sync::Arc::new(VerletAppServerInner {
                 supervisor,
@@ -912,7 +1029,7 @@ impl VerletAppServer {
                 ),
                 shutdown: tokio::sync::Mutex::new(false),
                 dispatch_gate: tokio::sync::RwLock::new(()),
-                root_reservation: None,
+                root_reservation: config.root_reservation,
                 instance_environment: config.instance_environment,
                 tenant_id: config.tenant_id,
                 user_id: config.user_id,
@@ -940,7 +1057,7 @@ impl VerletAppServer {
                 lease_epoch: config.lease_epoch,
                 metadata_store,
                 user_metadata_store,
-                process_manager: verlet_process::live::AsyncExecutionManager::default(),
+                process_manager,
                 process_dispatcher: tokio::sync::OnceCell::new(),
                 subscriptions: tokio::sync::Mutex::new(
                     crate::adapters::app_server::subscriptions::AppServerSubscriptions::default(),
@@ -2269,10 +2386,11 @@ async fn runtime_factory_from_config(
             max_tokens,
             stream,
         } => {
+            let auth_context = config.instance_environment.provider_auth.resolve();
             let resolved = resolve_catalog_openai_chat_completions_provider(
                 provider_store,
                 auth_store,
-                &verlet_metadata::provider_store::LlmProviderAuthContext::from_process_env(),
+                &auth_context,
                 provider_id,
                 model.as_deref(),
                 *max_tokens,
@@ -2306,6 +2424,7 @@ async fn runtime_factory_from_config(
 pub(crate) fn runtime_factory_from_provider_parts(
     runtime_config: crate::adapters::agent_loop::AgentLoopConfig,
     client: std::sync::Arc<dyn verlet_provider::ProviderClient>,
+    // lexicon-allow: capsule - existing app-server config API names
     capsule_bindings: CapsuleBindingsConfig,
 ) -> std::sync::Arc<dyn crate::kernel::runtime_host::runtime_api::AgentRuntimeFactory> {
     runtime_factory_from_provider_parts_with_secret_resolver(
@@ -2341,6 +2460,7 @@ pub(crate) fn runtime_factory_from_provider_parts_with_secret_resolver(
         crate::agent::manifest_bind::AgentManifestPlacementBinding::default(),
         None,
         std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        None,
     )
 }
 
@@ -2369,6 +2489,7 @@ pub(crate) fn runtime_factory_from_provider_parts_with_app_paths(
         config.default_placement.clone(),
         config.default_workspace.clone(),
         std::sync::Arc::clone(&config.remote_event_store_served),
+        config.instance_environment.hook_shell.clone(),
     )
 }
 
@@ -2389,6 +2510,7 @@ fn runtime_factory_from_provider_parts_with_store_paths(
     default_placement: crate::agent::manifest_bind::AgentManifestPlacementBinding,
     default_workspace: Option<crate::agent::manifest_bind::AgentManifestWorkspaceBinding>,
     remote_event_store_served: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    hook_shell: Option<String>,
 ) -> std::sync::Arc<dyn crate::kernel::runtime_host::runtime_api::AgentRuntimeFactory> {
     // lexicon-allow: capsule - existing app-server runtime factory name
     std::sync::Arc::new(threads::CapsuleBindingRuntimeFactory {
@@ -2405,6 +2527,7 @@ fn runtime_factory_from_provider_parts_with_store_paths(
         blob_registry_root,
         skill_registry_root,
         cwd,
+        hook_shell,
         default_placement,
         default_workspace,
         remote_event_store_served,

--- a/crates/verlet-kernel/src/adapters/app_server.rs
+++ b/crates/verlet-kernel/src/adapters/app_server.rs
@@ -9,6 +9,7 @@ use tokio::io::AsyncWriteExt as _;
 use verlet_metadata::provider_store::LlmProviderCatalogStore as _;
 pub mod connection;
 mod default_manifest;
+pub mod instance;
 pub mod lifecycle;
 mod orchestrator_boundary;
 mod subscriptions;
@@ -150,6 +151,9 @@ pub struct VerletAppServerConfig {
     /// configured sync listener has bound successfully.
     pub remote_event_store_served: std::sync::Arc<std::sync::atomic::AtomicBool>,
     pub console_assets: Option<ConsoleAssetConfig>,
+    /// Per-instance replacements for process-state reads at depth
+    /// (EMO-552): provider auth, hook shell, process-id source.
+    pub instance_environment: instance::InstanceEnvironment,
 }
 
 impl VerletAppServerConfig {
@@ -196,9 +200,27 @@ impl VerletAppServerConfig {
                 false,
             )),
             console_assets: None,
+            instance_environment: instance::InstanceEnvironment::standalone(),
         };
         config.apply_daemon_identity_config(&identity);
         config
+    }
+
+    /// Hosted-instance config (EMO-552): explicit absolute roots + fully
+    /// injected environment; no listener (`listen` is set but the host
+    /// never binds it — RPC arrives through
+    /// `dispatch_authenticated_json_rpc`). Construction canonicalizes the
+    /// roots and reserves them process-wide before any store opens;
+    /// overlapping a live instance's roots is a loud error. None of the
+    /// cwd/XDG defaulting of [`VerletAppServerConfig::local`] applies.
+    pub fn hosted(
+        roots: instance::InstanceRoots,
+        environment: instance::InstanceEnvironment,
+        cwd: impl Into<std::path::PathBuf>,
+        identity: &crate::daemon::identity::VerletDaemonIdentityConfig,
+    ) -> crate::kernel::runtime_host::VerletResult<Self> {
+        let _ = (roots, environment, cwd, identity);
+        unimplemented!("EMO-552: hosted config from explicit roots + injected environment")
     }
 
     /// Project a daemon identity config onto this app-server config. This is
@@ -478,6 +500,16 @@ struct VerletAppServerInner {
     tasks: std::sync::Arc<crate::adapters::app_server::lifecycle::InstanceTaskSet>,
     shutdown: tokio::sync::Mutex<bool>,
     dispatch_gate: tokio::sync::RwLock<()>,
+    /// Process-wide claim on this instance's roots (EMO-552). `None` for
+    /// standalone-daemon construction; hosted construction holds it so the
+    /// claim releases when the instance is dropped after shutdown.
+    #[allow(dead_code)]
+    root_reservation: Option<instance::InstanceRootReservation>,
+    /// Injected environment (EMO-552): provider auth, hook shell,
+    /// process-id source. The deep process-state reads resolve through
+    /// this instead of `std::env`/globals.
+    #[allow(dead_code)]
+    instance_environment: instance::InstanceEnvironment,
     tenant_id: String,
     user_id: String,
     identity_mode: crate::daemon::identity::IdentityMode,
@@ -880,6 +912,8 @@ impl VerletAppServer {
                 ),
                 shutdown: tokio::sync::Mutex::new(false),
                 dispatch_gate: tokio::sync::RwLock::new(()),
+                root_reservation: None,
+                instance_environment: config.instance_environment,
                 tenant_id: config.tenant_id,
                 user_id: config.user_id,
                 identity_mode: config.identity_mode,

--- a/crates/verlet-kernel/src/adapters/app_server/connection.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/connection.rs
@@ -2052,8 +2052,7 @@ impl crate::adapters::app_server::VerletAppServer {
         import_id: &str,
         server_ref: &str,
     ) -> Result<Vec<serde_json::Value>, JsonRpcErrorError> {
-        let registry =
-            crate::agent::manifest::LocalAgentRegistry::new(self.inner.agent_registry_root.clone());
+        let registry = self.inner.agent_registry();
         crate::agent::manifest::AgentRecordRef::parse(agent_ref)
             .map_err(|err| malformed_agent_ref(agent_ref, err))?;
         let (record, _) = registry
@@ -2111,8 +2110,7 @@ impl crate::adapters::app_server::VerletAppServer {
     }
 
     pub(super) fn agent_list(&self) -> Result<serde_json::Value, JsonRpcErrorError> {
-        let registry =
-            crate::agent::manifest::LocalAgentRegistry::new(self.inner.agent_registry_root.clone());
+        let registry = self.inner.agent_registry();
         let data = registry
             .list_records()
             .map_err(internal_error)?
@@ -2126,8 +2124,7 @@ impl crate::adapters::app_server::VerletAppServer {
         &self,
         params: AgentReadParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
-        let registry =
-            crate::agent::manifest::LocalAgentRegistry::new(self.inner.agent_registry_root.clone());
+        let registry = self.inner.agent_registry();
         crate::agent::manifest::AgentRecordRef::parse(&params.ref_uri)
             .map_err(|err| malformed_agent_ref(&params.ref_uri, err))?;
         let (record, alias_receipt) = registry
@@ -2145,8 +2142,7 @@ impl crate::adapters::app_server::VerletAppServer {
         &self,
         params: AgentDraftParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
-        let registry =
-            crate::agent::manifest::LocalAgentRegistry::new(self.inner.agent_registry_root.clone());
+        let registry = self.inner.agent_registry();
         let (mut plan, source) = agent_publish_plan_from_draft(&params)?;
         verify_agent_plan_refs(&mut plan, self.agent_publish_operation_registry_root())?;
         let suggested_next_version = suggested_agent_version(&registry, &plan.name, &plan.version)
@@ -2165,8 +2161,7 @@ impl crate::adapters::app_server::VerletAppServer {
         &self,
         params: AgentDraftParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
-        let registry =
-            crate::agent::manifest::LocalAgentRegistry::new(self.inner.agent_registry_root.clone());
+        let registry = self.inner.agent_registry();
         let base = validate_agent_publish_base(&registry, &params)?;
         let (plan, source) = agent_publish_plan_from_draft(&params)?;
         if plan.name != base.name || plan.namespace != base.namespace {
@@ -2382,10 +2377,11 @@ impl crate::adapters::app_server::VerletAppServer {
         &self,
         provider: &verlet_metadata::provider_store::LlmProviderRecord,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
+        let auth_context = self.inner.instance_environment.provider_auth.resolve();
         let status = verlet_metadata::provider_store::llm_provider_auth_status(
             &self.inner.user_metadata_store,
             provider,
-            &verlet_metadata::provider_store::LlmProviderAuthContext::from_process_env(),
+            &auth_context,
         )
         .await
         .map_err(|err| internal_error(crate::adapters::app_server::provider_store_error(err)))?;
@@ -2403,10 +2399,11 @@ impl crate::adapters::app_server::VerletAppServer {
         &self,
         provider: &verlet_metadata::provider_store::LlmProviderRecord,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
+        let auth_context = self.inner.instance_environment.provider_auth.resolve();
         let status = verlet_metadata::provider_store::llm_provider_auth_status(
             &self.inner.user_metadata_store,
             provider,
-            &verlet_metadata::provider_store::LlmProviderAuthContext::from_process_env(),
+            &auth_context,
         )
         .await
         .map_err(|err| internal_error(crate::adapters::app_server::provider_store_error(err)))?;
@@ -3623,11 +3620,11 @@ impl crate::adapters::app_server::VerletAppServer {
                         .to_string(),
                 )));
             }
-            let source_record = crate::agent::manifest::LocalAgentRegistry::new(
-                self.inner.agent_registry_root.clone(),
-            )
-            .load_ref(source_agent_ref)
-            .map_err(internal_error)?;
+            let source_record = self
+                .inner
+                .agent_registry()
+                .load_ref(source_agent_ref)
+                .map_err(internal_error)?;
             if source_record.manifest_hash != *source_manifest_hash {
                 return Err(internal_error(
                     crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(

--- a/crates/verlet-kernel/src/adapters/app_server/default_manifest.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/default_manifest.rs
@@ -28,7 +28,8 @@ pub(super) fn ensure_default_manifest_published(
     supports_streaming: bool,
 ) -> crate::kernel::runtime_host::VerletResult<crate::agent::manifest::PublishedAgentRecord> {
     let registry =
-        crate::agent::manifest::LocalAgentRegistry::new(config.agent_registry_root.clone());
+        crate::agent::manifest::LocalAgentRegistry::new(config.agent_registry_root.clone())
+            .with_blob_registry_root(config.blob_registry_root.clone());
     let _lock = DefaultManifestPublishLock::acquire(&registry)?;
     let existing = load_existing_default_manifest(&registry)?;
     if let Some(record) = existing.record() {
@@ -484,18 +485,15 @@ fn invalid_default_version(version: &str) -> crate::kernel::runtime_host::Verlet
 fn absolute_path_string(
     path: &std::path::Path,
 ) -> crate::kernel::runtime_host::VerletResult<String> {
-    let absolute = if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        std::env::current_dir()
-            .map_err(|err| {
-                crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
-                    "failed to resolve current directory for default manifest cwd: {err}"
-                ))
-            })?
-            .join(path)
-    };
-    Ok(path_string(&absolute))
+    if !path.is_absolute() {
+        return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+            format!(
+                "configured instance cwd must be absolute when resolving default manifest path {}",
+                path.display(),
+            ),
+        ));
+    }
+    Ok(path_string(path))
 }
 
 fn path_string(path: &std::path::Path) -> String {

--- a/crates/verlet-kernel/src/adapters/app_server/default_manifest/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/default_manifest/tests.rs
@@ -32,6 +32,28 @@ fn synthesized_default_manifest_preserves_slash_bearing_model_ids() {
 }
 
 #[test]
+fn synthesized_default_manifest_uses_configured_cwd_without_trailing_separator() {
+    let cwd = std::env::temp_dir().join(format!(
+        "verlet-default-manifest-cwd-{}",
+        uuid::Uuid::now_v7()
+    ));
+    let config = crate::adapters::app_server::VerletAppServerConfig::local(
+        crate::adapters::app_server::AppServerListenAddr::Unix(
+            std::env::temp_dir().join("verlet-test.sock"),
+        ),
+        &cwd,
+    );
+
+    let manifest =
+        crate::adapters::app_server::default_manifest::synthesize_default_manifest_with_version(
+            &config, false, "0.1.0",
+        )
+        .unwrap();
+
+    assert_eq!(manifest.runtime.default_cwd, cwd.to_string_lossy());
+}
+
+#[test]
 fn existing_legacy_default_agent_record_is_migrated_in_place() {
     let root = std::env::temp_dir().join(format!(
         "verlet-default-manifest-legacy-{}",

--- a/crates/verlet-kernel/src/adapters/app_server/instance.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/instance.rs
@@ -1,0 +1,146 @@
+//! Hosted-instance config hygiene (EMO-552): explicit roots with
+//! process-wide overlap rejection, and an injected environment that
+//! replaces process-state reads at depth.
+//!
+//! Two instances sharing a `state_home` silently become one database
+//! namespace, and independently reopened history stores to the same path
+//! bypass the per-store write gate. Hosted construction therefore requires
+//! explicit absolute roots; the constructor canonicalizes them and rejects
+//! any overlap with roots already reserved in this process BEFORE opening
+//! SQLite. Defaults derived from cwd/XDG remain a convenience of the
+//! standalone daemon boundary only.
+//!
+//! Sharing policy (architect decision on the issue): immutable CAS
+//! artifact bytes may be shared; ALL mutable naming (catalog records,
+//! aliases including the default-manifest alias, bindings, default
+//! manifests, secrets, dispatchers) is per instance — separate registry
+//! roots, no alias namespacing scheme.
+
+/// The filesystem roots one kernel instance owns exclusively. All paths
+/// must be absolute; construction of a hosted instance canonicalizes them
+/// (creating the directories first so symlinked parents resolve) and
+/// reserves them process-wide via [`reserve_instance_roots`].
+#[derive(Clone, Debug)]
+pub struct InstanceRoots {
+    pub runtime_home: std::path::PathBuf,
+    pub state_home: std::path::PathBuf,
+    pub user_state_home: std::path::PathBuf,
+    pub agent_registry_root: std::path::PathBuf,
+    pub blob_registry_root: std::path::PathBuf,
+    pub skill_registry_root: std::path::PathBuf,
+}
+
+impl InstanceRoots {
+    /// Standard layout: every root a distinct child of one absolute
+    /// instance directory (`runtime/`, `state/`, `user-state/`, `agents/`,
+    /// `blobs/`, `skills/`).
+    pub fn under(instance_root: impl Into<std::path::PathBuf>) -> Self {
+        let instance_root = instance_root.into();
+        Self {
+            runtime_home: instance_root.join("runtime"),
+            state_home: instance_root.join("state"),
+            user_state_home: instance_root.join("user-state"),
+            agent_registry_root: instance_root.join("agents"),
+            blob_registry_root: instance_root.join("blobs"),
+            skill_registry_root: instance_root.join("skills"),
+        }
+    }
+}
+
+/// A process-wide claim on one instance's canonicalized roots. Held by the
+/// instance for its lifetime; dropping it (instance shutdown or drop)
+/// releases the claim so the roots can be reused by a successor instance.
+pub struct InstanceRootReservation {
+    canonical_roots: Vec<std::path::PathBuf>,
+}
+
+impl Drop for InstanceRootReservation {
+    fn drop(&mut self) {
+        release_reserved_roots(&self.canonical_roots);
+    }
+}
+
+/// Canonicalize every root (creating missing directories first) and claim
+/// them in the process-wide reservation table. Fails loudly — before any
+/// SQLite open — when any pair of the supplied roots overlaps, or when any
+/// supplied root overlaps a root already reserved by a live instance.
+/// Overlap means equality OR one canonical path being a prefix of the
+/// other, so symlinked aliases of the same directory are caught.
+pub fn reserve_instance_roots(
+    roots: &InstanceRoots,
+) -> crate::kernel::runtime_host::VerletResult<InstanceRootReservation> {
+    let _ = roots;
+    unimplemented!("EMO-552: canonicalize + overlap-reject + process-wide root reservation")
+}
+
+fn release_reserved_roots(canonical_roots: &[std::path::PathBuf]) {
+    let _ = canonical_roots;
+    unimplemented!("EMO-552: release reserved roots on reservation drop")
+}
+
+/// Where an instance resolves LLM provider auth from. Hosted instances get
+/// an injected context and never see this process's environment; the
+/// standalone daemon keeps today's process-environment behavior.
+#[derive(Clone)]
+pub enum ProviderAuthSource {
+    /// Snapshot the daemon process environment on demand (standalone
+    /// boundary only; today's `LlmProviderAuthContext::from_process_env`).
+    ProcessEnvironment,
+    /// Use exactly this injected context; process env vars are invisible.
+    Injected(verlet_metadata::provider_store::LlmProviderAuthContext),
+}
+
+impl std::fmt::Debug for ProviderAuthSource {
+    /// The injected context carries credential material; never print it.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ProcessEnvironment => f.write_str("ProviderAuthSource::ProcessEnvironment"),
+            Self::Injected(_) => f.write_str("ProviderAuthSource::Injected(<redacted>)"),
+        }
+    }
+}
+
+impl ProviderAuthSource {
+    /// The auth context this instance dispatches provider calls with.
+    pub fn resolve(&self) -> verlet_metadata::provider_store::LlmProviderAuthContext {
+        unimplemented!("EMO-552: resolve provider auth from the configured source")
+    }
+}
+
+/// Per-instance replacements for state that library code currently reads
+/// from the process at depth (env vars, cwd, global switches). The three
+/// deep reads this retires: provider auth env snapshots, the hook shell
+/// from `COMSPEC`/`SHELL`, and the process-global deterministic-ID switch
+/// in verlet-process.
+#[derive(Clone)]
+pub struct InstanceEnvironment {
+    pub provider_auth: ProviderAuthSource,
+    /// Shell for agent hooks. `None` = today's `COMSPEC`/`SHELL` lookup
+    /// (standalone boundary only); hosted instances inject a shell path.
+    pub hook_shell: Option<String>,
+    /// Source of process ids for this instance's process manager. Random
+    /// in production; a per-instance deterministic source is what lets the
+    /// EMO-553 two-instance DST run one harness per instance.
+    pub process_ids: std::sync::Arc<dyn verlet_process::process::ProcessIdSource>,
+}
+
+impl InstanceEnvironment {
+    /// Standalone-daemon behavior: process env for provider auth,
+    /// `COMSPEC`/`SHELL` for hooks, random process ids.
+    pub fn standalone() -> Self {
+        Self {
+            provider_auth: ProviderAuthSource::ProcessEnvironment,
+            hook_shell: None,
+            process_ids: std::sync::Arc::new(verlet_process::process::RandomProcessIds),
+        }
+    }
+}
+
+impl std::fmt::Debug for InstanceEnvironment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InstanceEnvironment")
+            .field("provider_auth", &self.provider_auth)
+            .field("hook_shell", &self.hook_shell)
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/verlet-kernel/src/adapters/app_server/instance.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/instance.rs
@@ -10,11 +10,13 @@
 //! SQLite. Defaults derived from cwd/XDG remain a convenience of the
 //! standalone daemon boundary only.
 //!
-//! Sharing policy (architect decision on the issue): immutable CAS
-//! artifact bytes may be shared; ALL mutable naming (catalog records,
-//! aliases including the default-manifest alias, bindings, default
-//! manifests, secrets, dispatchers) is per instance — separate registry
-//! roots, no alias namespacing scheme.
+//! Sharing policy (architect decision on the issue): ALL mutable naming
+//! (catalog records, aliases including the default-manifest alias,
+//! bindings, default manifests, secrets, dispatchers) is per instance —
+//! separate registry roots, no alias namespacing scheme. Immutable CAS
+//! artifact bytes may be shared in principle, but host v0 reserves every
+//! root exclusively, blob store included; a shared dedup CAS store is a
+//! future optimization with its own design.
 
 /// The filesystem roots one kernel instance owns exclusively. All paths
 /// must be absolute; construction of a hosted instance canonicalizes them
@@ -47,11 +49,18 @@ impl InstanceRoots {
     }
 }
 
-/// A process-wide claim on one instance's canonicalized roots. Held by the
-/// instance for its lifetime; dropping it (instance shutdown or drop)
+/// A process-wide claim on one instance's canonicalized roots. Held first by
+/// the hosted config and then by the instance; dropping the current owner
 /// releases the claim so the roots can be reused by a successor instance.
+#[derive(Debug)]
 pub struct InstanceRootReservation {
     canonical_roots: Vec<std::path::PathBuf>,
+}
+
+impl InstanceRootReservation {
+    pub(super) fn canonical_roots(&self) -> &[std::path::PathBuf] {
+        &self.canonical_roots
+    }
 }
 
 impl Drop for InstanceRootReservation {
@@ -69,13 +78,107 @@ impl Drop for InstanceRootReservation {
 pub fn reserve_instance_roots(
     roots: &InstanceRoots,
 ) -> crate::kernel::runtime_host::VerletResult<InstanceRootReservation> {
-    let _ = roots;
-    unimplemented!("EMO-552: canonicalize + overlap-reject + process-wide root reservation")
+    let named_roots = [
+        ("runtime_home", &roots.runtime_home),
+        ("state_home", &roots.state_home),
+        ("user_state_home", &roots.user_state_home),
+        ("agent_registry_root", &roots.agent_registry_root),
+        ("blob_registry_root", &roots.blob_registry_root),
+        ("skill_registry_root", &roots.skill_registry_root),
+    ];
+    for (name, path) in named_roots {
+        if !path.is_absolute() {
+            return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                format!(
+                    "hosted instance root {name} must be absolute: {}",
+                    path.display()
+                ),
+            ));
+        }
+    }
+
+    let mut canonical_roots = Vec::with_capacity(named_roots.len());
+    for (name, path) in named_roots {
+        std::fs::create_dir_all(path).map_err(|error| {
+            crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
+                "failed to create hosted instance root {name} {}: {error}",
+                path.display()
+            ))
+        })?;
+        let canonical = std::fs::canonicalize(path).map_err(|error| {
+            crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
+                "failed to canonicalize hosted instance root {name} {}: {error}",
+                path.display()
+            ))
+        })?;
+        canonical_roots.push((name, path, canonical));
+    }
+
+    for first_index in 0..canonical_roots.len() {
+        for second_index in (first_index + 1)..canonical_roots.len() {
+            let (first_name, first_original, first) = &canonical_roots[first_index];
+            let (second_name, second_original, second) = &canonical_roots[second_index];
+            if roots_overlap(first, second) {
+                return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                    format!(
+                        "hosted instance roots overlap: {first_name} {} (canonical {}) and {second_name} {} (canonical {})",
+                        first_original.display(),
+                        first.display(),
+                        second_original.display(),
+                        second.display()
+                    ),
+                ));
+            }
+        }
+    }
+
+    let mut reserved = reserved_instance_roots()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    for (name, original, canonical) in &canonical_roots {
+        if let Some(existing) = reserved
+            .iter()
+            .find(|existing| roots_overlap(canonical, existing))
+        {
+            return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                format!(
+                    "hosted instance root {name} {} (canonical {}) overlaps reserved root {}",
+                    original.display(),
+                    canonical.display(),
+                    existing.display()
+                ),
+            ));
+        }
+    }
+    let canonical_roots = canonical_roots
+        .into_iter()
+        .map(|(_, _, canonical)| canonical)
+        .collect::<Vec<_>>();
+    reserved.extend(canonical_roots.iter().cloned());
+    drop(reserved);
+
+    Ok(InstanceRootReservation { canonical_roots })
 }
 
 fn release_reserved_roots(canonical_roots: &[std::path::PathBuf]) {
-    let _ = canonical_roots;
-    unimplemented!("EMO-552: release reserved roots on reservation drop")
+    let mut reserved = reserved_instance_roots()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    for root in canonical_roots {
+        reserved.remove(root);
+    }
+}
+
+fn reserved_instance_roots()
+-> &'static std::sync::Mutex<std::collections::HashSet<std::path::PathBuf>> {
+    static RESERVED_ROOTS: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashSet<std::path::PathBuf>>,
+    > = std::sync::OnceLock::new();
+    RESERVED_ROOTS.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+}
+
+fn roots_overlap(first: &std::path::Path, second: &std::path::Path) -> bool {
+    first.starts_with(second) || second.starts_with(first)
 }
 
 /// Where an instance resolves LLM provider auth from. Hosted instances get
@@ -103,7 +206,12 @@ impl std::fmt::Debug for ProviderAuthSource {
 impl ProviderAuthSource {
     /// The auth context this instance dispatches provider calls with.
     pub fn resolve(&self) -> verlet_metadata::provider_store::LlmProviderAuthContext {
-        unimplemented!("EMO-552: resolve provider auth from the configured source")
+        match self {
+            Self::ProcessEnvironment => {
+                verlet_metadata::provider_store::LlmProviderAuthContext::from_process_env()
+            }
+            Self::Injected(context) => context.clone(),
+        }
     }
 }
 
@@ -133,6 +241,29 @@ impl InstanceEnvironment {
             hook_shell: None,
             process_ids: std::sync::Arc::new(verlet_process::process::RandomProcessIds),
         }
+    }
+
+    pub(super) fn validate_hosted(&self) -> crate::kernel::runtime_host::VerletResult<()> {
+        if matches!(&self.provider_auth, ProviderAuthSource::ProcessEnvironment) {
+            return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                "hosted instance provider auth must be injected".to_string(),
+            ));
+        }
+        let Some(hook_shell) = self
+            .hook_shell
+            .as_deref()
+            .filter(|shell| !shell.trim().is_empty())
+        else {
+            return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                "hosted instance hook shell must be injected".to_string(),
+            ));
+        };
+        if !std::path::Path::new(hook_shell).is_absolute() {
+            return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                format!("hosted instance hook shell must be absolute: {hook_shell}"),
+            ));
+        }
+        Ok(())
     }
 }
 

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -9,6 +9,35 @@ use verlet_metadata::provider_store::LlmProviderCatalogStore as _;
 use verlet_metadata::provider_store::ThreadMetadataStore as _;
 use verlet_metadata::secret_store::SecretResolver as _;
 
+static PROCESS_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+struct ProcessEnvGuard {
+    name: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl ProcessEnvGuard {
+    fn set(name: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(name);
+        // SAFETY: env-mutating tests in this module serialize through
+        // `PROCESS_ENV_LOCK`, and the guard restores the prior value.
+        unsafe { std::env::set_var(name, value) };
+        Self { name, previous }
+    }
+}
+
+impl Drop for ProcessEnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: see `ProcessEnvGuard::set`.
+        unsafe {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
+    }
+}
+
 #[test]
 fn dispatcher_method_authority_classes_are_exhaustive_and_explicit() {
     const EXPECTED: &[(&str, crate::daemon::identity::AuthorityClass)] = &[
@@ -1016,7 +1045,7 @@ async fn model_provider_auth_methods_store_redacted_credentials() {
         .unwrap();
     drop(metadata_store);
 
-    let app = crate::adapters::app_server::VerletAppServer::new_local(config.clone())
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
         .await
         .unwrap();
     let (connection, _outbound_rx) = test_connection(app.clone()).await;
@@ -1249,7 +1278,7 @@ async fn model_provider_upsert_creates_and_updates_endpoint_records() {
     config.state_home = root.join("state");
     config.agent_registry_root = root.join("agents");
     let metadata_path = config.metadata_store_path();
-    let app = crate::adapters::app_server::VerletAppServer::new_local(config.clone())
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
         .await
         .unwrap();
     let (connection, _outbound_rx) = test_connection(app.clone()).await;
@@ -3479,13 +3508,20 @@ async fn default_manifest_publish_is_idempotent_and_patch_bumps_on_model_change(
     let listen = crate::adapters::app_server::AppServerListenAddr::Unix(std::env::temp_dir().join(
         format!("verlet-default-manifest-idem-{}.sock", uuid::Uuid::now_v7()),
     ));
-    let mut config = crate::adapters::app_server::VerletAppServerConfig::local(listen, &workspace);
-    config.runtime_home = root.join("runtime");
-    config.state_home = root.join("state");
-    config.agent_registry_root = agent_registry_root.clone();
-    let _ = crate::adapters::app_server::VerletAppServer::new_local(config.clone())
-        .await
-        .unwrap();
+    let config = |model: &str| {
+        let mut config =
+            crate::adapters::app_server::VerletAppServerConfig::local(listen.clone(), &workspace);
+        config.runtime_home = root.join("runtime");
+        config.state_home = root.join("state");
+        config.agent_registry_root = agent_registry_root.clone();
+        config.model = model.to_string();
+        config
+    };
+    let _ = crate::adapters::app_server::VerletAppServer::new_local(config(
+        crate::adapters::app_server::APP_SERVER_LOCAL_MODEL,
+    ))
+    .await
+    .unwrap();
 
     let registry = crate::agent::manifest::LocalAgentRegistry::new(&agent_registry_root);
     let first = registry
@@ -3500,9 +3536,11 @@ async fn default_manifest_publish_is_idempotent_and_patch_bumps_on_model_change(
     );
     assert_eq!(default_agent_version_count(&agent_registry_root), 1);
 
-    let _ = crate::adapters::app_server::VerletAppServer::new_local(config.clone())
-        .await
-        .unwrap();
+    let _ = crate::adapters::app_server::VerletAppServer::new_local(config(
+        crate::adapters::app_server::APP_SERVER_LOCAL_MODEL,
+    ))
+    .await
+    .unwrap();
     let second = registry
         .load_ref(crate::adapters::app_server::default_manifest::DEFAULT_AGENT_REF)
         .unwrap();
@@ -3510,8 +3548,7 @@ async fn default_manifest_publish_is_idempotent_and_patch_bumps_on_model_change(
     assert_eq!(second.manifest_hash, first.manifest_hash);
     assert_eq!(default_agent_version_count(&agent_registry_root), 1);
 
-    config.model = "echo-v2".to_string();
-    let _ = crate::adapters::app_server::VerletAppServer::new_local(config)
+    let _ = crate::adapters::app_server::VerletAppServer::new_local(config("echo-v2"))
         .await
         .unwrap();
     let third = registry
@@ -12221,6 +12258,756 @@ async fn unbound_instances_dispatch_and_shutdown_independently() {
     assert_eq!(second.inner.tasks.task_count(), 0);
 }
 
+#[test]
+fn hosted_roots_reject_duplicate_and_nested_paths_before_sqlite_open() {
+    let duplicate_root = unique_test_root("hosted-duplicate-roots");
+    let mut duplicate =
+        crate::adapters::app_server::instance::InstanceRoots::under(&duplicate_root);
+    duplicate.state_home = duplicate.runtime_home.clone();
+    let duplicate_db = duplicate.state_home.join("metadata.sqlite3");
+    let duplicate_path = duplicate.runtime_home.display().to_string();
+
+    let error = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        duplicate,
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .err()
+    .expect("duplicate roots must fail");
+    assert!(error.to_string().contains("runtime_home"));
+    assert!(error.to_string().contains("state_home"));
+    assert!(error.to_string().contains(&duplicate_path));
+    assert!(!duplicate_db.exists());
+
+    let reclaim = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        crate::adapters::app_server::instance::InstanceRoots::under(&duplicate_root),
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .expect("a failed reservation must not leave any root claimed");
+    drop(reclaim);
+
+    let nested_root = unique_test_root("hosted-nested-roots");
+    let mut nested = crate::adapters::app_server::instance::InstanceRoots::under(&nested_root);
+    nested.state_home = nested.runtime_home.join("nested-state");
+    let nested_db = nested.state_home.join("metadata.sqlite3");
+    let runtime_path = nested.runtime_home.display().to_string();
+    let state_path = nested.state_home.display().to_string();
+    let error = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        nested,
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .err()
+    .expect("nested roots must fail");
+    assert!(error.to_string().contains(&runtime_path));
+    assert!(error.to_string().contains(&state_path));
+    assert!(!nested_db.exists());
+
+    let _ = std::fs::remove_dir_all(duplicate_root);
+    let _ = std::fs::remove_dir_all(nested_root);
+}
+
+#[test]
+fn hosted_roots_reject_relative_paths_without_creating_them() {
+    let relative_root =
+        std::path::PathBuf::from(format!("verlet-relative-instance-{}", uuid::Uuid::now_v7()));
+    let relative = crate::adapters::app_server::instance::InstanceRoots::under(&relative_root);
+
+    let error = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        relative,
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .err()
+    .expect("relative roots must fail");
+
+    assert!(error.to_string().contains("absolute"));
+    assert!(
+        error
+            .to_string()
+            .contains(&relative_root.display().to_string())
+    );
+    assert!(!relative_root.exists());
+}
+
+#[test]
+fn hosted_config_rejects_ambient_environment_before_creating_roots() {
+    let provider_root = unique_test_root("hosted-ambient-provider-environment");
+    let provider_error = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        crate::adapters::app_server::instance::InstanceRoots::under(&provider_root),
+        crate::adapters::app_server::instance::InstanceEnvironment::standalone(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .err()
+    .expect("hosted provider auth must not resolve from process env");
+    assert!(provider_error.to_string().contains("provider auth"));
+    assert!(!provider_root.exists());
+
+    let shell_root = unique_test_root("hosted-ambient-shell-environment");
+    let shell_error = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        crate::adapters::app_server::instance::InstanceRoots::under(&shell_root),
+        crate::adapters::app_server::instance::InstanceEnvironment {
+            provider_auth: crate::adapters::app_server::instance::ProviderAuthSource::Injected(
+                verlet_metadata::provider_store::LlmProviderAuthContext::new(),
+            ),
+            hook_shell: None,
+            process_ids: std::sync::Arc::new(verlet_process::process::RandomProcessIds),
+        },
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .err()
+    .expect("hosted hook execution must not resolve its shell from process env");
+    assert!(shell_error.to_string().contains("hook shell"));
+    assert!(!shell_root.exists());
+}
+
+#[test]
+fn hosted_config_rejects_relative_cwd_before_creating_roots() {
+    let root = unique_test_root("hosted-relative-cwd");
+    let relative_cwd = std::path::PathBuf::from("relative-hosted-cwd");
+    let error = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        crate::adapters::app_server::instance::InstanceRoots::under(&root),
+        hosted_test_environment(),
+        &relative_cwd,
+        &hosted_test_identity(),
+    )
+    .err()
+    .expect("hosted cwd must be absolute");
+    assert!(error.to_string().contains("cwd must be absolute"));
+    assert!(
+        error
+            .to_string()
+            .contains(&relative_cwd.display().to_string())
+    );
+    assert!(!root.exists());
+}
+
+#[tokio::test]
+async fn hosted_config_rejects_environment_mutation_before_sqlite_open() {
+    let environment_root = unique_test_root("hosted-mutated-environment");
+    let environment_roots =
+        crate::adapters::app_server::instance::InstanceRoots::under(&environment_root);
+    let environment_db = environment_roots.state_home.join("metadata.sqlite3");
+    let mut config = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        environment_roots,
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .unwrap();
+    config.instance_environment =
+        crate::adapters::app_server::instance::InstanceEnvironment::standalone();
+    let error = crate::adapters::app_server::VerletAppServer::new(config)
+        .await
+        .err()
+        .expect("hosted environment mutation must fail");
+    assert!(error.to_string().contains("provider auth"));
+    assert!(!environment_db.exists());
+
+    let cwd_root = unique_test_root("hosted-mutated-cwd");
+    let cwd_roots = crate::adapters::app_server::instance::InstanceRoots::under(&cwd_root);
+    let cwd_db = cwd_roots.state_home.join("metadata.sqlite3");
+    let mut config = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        cwd_roots,
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .unwrap();
+    config.cwd = std::path::PathBuf::from("mutated-relative-cwd");
+    let error = crate::adapters::app_server::VerletAppServer::new(config)
+        .await
+        .err()
+        .expect("hosted cwd mutation must fail");
+    assert!(error.to_string().contains("cwd must be absolute"));
+    assert!(!cwd_db.exists());
+
+    let _ = std::fs::remove_dir_all(environment_root);
+    let _ = std::fs::remove_dir_all(cwd_root);
+}
+
+#[test]
+fn dropping_unconsumed_hosted_config_releases_its_roots() {
+    let root = unique_test_root("hosted-config-drop");
+    let roots = crate::adapters::app_server::instance::InstanceRoots::under(&root);
+    let config = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        roots.clone(),
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .unwrap();
+    let error = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        roots.clone(),
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .err()
+    .expect("an unconsumed config must retain its reservation");
+    assert!(error.to_string().contains("overlaps reserved root"));
+
+    drop(config);
+
+    let successor = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        roots,
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .expect("dropping an unconsumed config must release its reservation");
+    drop(successor);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn concurrent_overlapping_root_reservations_admit_exactly_one_owner() {
+    let root = unique_test_root("hosted-concurrent-reservation");
+    let first_roots =
+        crate::adapters::app_server::instance::InstanceRoots::under(root.join("first"));
+    let mut second_roots =
+        crate::adapters::app_server::instance::InstanceRoots::under(root.join("second"));
+    second_roots.skill_registry_root = first_roots.runtime_home.clone();
+    let start = std::sync::Arc::new(std::sync::Barrier::new(3));
+    let finish = std::sync::Arc::new(std::sync::Barrier::new(3));
+    let spawn_reserver = |roots| {
+        let start = std::sync::Arc::clone(&start);
+        let finish = std::sync::Arc::clone(&finish);
+        std::thread::spawn(move || {
+            start.wait();
+            let reservation = crate::adapters::app_server::VerletAppServerConfig::hosted(
+                roots,
+                hosted_test_environment(),
+                std::env::temp_dir(),
+                &hosted_test_identity(),
+            );
+            let admitted = reservation.is_ok();
+            finish.wait();
+            drop(reservation);
+            admitted
+        })
+    };
+    let first = spawn_reserver(first_roots.clone());
+    let second = spawn_reserver(second_roots.clone());
+
+    start.wait();
+    finish.wait();
+
+    let admitted = usize::from(first.join().unwrap()) + usize::from(second.join().unwrap());
+    assert_eq!(admitted, 1);
+    let first_successor = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        first_roots,
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .expect("the concurrent winner must release its roots on drop");
+    drop(first_successor);
+    let second_successor = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        second_roots,
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .expect("the concurrent loser must not leave a partial reservation");
+    drop(second_successor);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn hosted_config_rejects_root_mutation_before_sqlite_open() {
+    let root = unique_test_root("hosted-mutated-root");
+    let roots = crate::adapters::app_server::instance::InstanceRoots::under(&root);
+    let reserved_state = roots.state_home.clone();
+    let configured_state = root.join("changed-state");
+    let mut config = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        roots,
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .unwrap();
+    config.state_home = configured_state.clone();
+
+    let error = crate::adapters::app_server::VerletAppServer::new(config)
+        .await
+        .err()
+        .expect("a hosted root changed after reservation must fail");
+
+    assert!(error.to_string().contains("state_home"));
+    assert!(
+        error
+            .to_string()
+            .contains(&configured_state.display().to_string())
+    );
+    assert!(
+        error
+            .to_string()
+            .contains(&reserved_state.display().to_string())
+    );
+    assert!(!configured_state.join("metadata.sqlite3").exists());
+    assert!(!reserved_state.join("metadata.sqlite3").exists());
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn hosted_config_rejects_operation_registry_escape_before_writing() {
+    let root = unique_test_root("hosted-mutated-operation-root");
+    let roots = crate::adapters::app_server::instance::InstanceRoots::under(root.join("instance"));
+    let escaped_operation_root = root.join("escaped-operations");
+    let mut config = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        roots,
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .unwrap();
+    // lexicon-allow: capsule - existing app-server operation binding field.
+    config.capsule_bindings.registry_root = Some(escaped_operation_root.clone());
+
+    let error = crate::adapters::app_server::VerletAppServer::new(config)
+        .await
+        .err()
+        .expect("a hosted operation registry outside runtime_home must fail");
+
+    assert!(error.to_string().contains("operation registry root"));
+    assert!(
+        error
+            .to_string()
+            .contains(&escaped_operation_root.display().to_string())
+    );
+    assert!(!escaped_operation_root.exists());
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn live_hosted_instance_rejects_overlapping_root_and_releases_on_drop() {
+    let first_root = unique_test_root("hosted-live-first");
+    let second_root = unique_test_root("hosted-live-second");
+    let first_roots = crate::adapters::app_server::instance::InstanceRoots::under(&first_root);
+    let first_config = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        first_roots.clone(),
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .unwrap();
+    let first = crate::adapters::app_server::VerletAppServer::new(first_config)
+        .await
+        .unwrap();
+
+    for (index, reserved_root) in [
+        &first_roots.runtime_home,
+        &first_roots.state_home,
+        &first_roots.user_state_home,
+        &first_roots.agent_registry_root,
+        &first_roots.blob_registry_root,
+        &first_roots.skill_registry_root,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let mut second_roots = crate::adapters::app_server::instance::InstanceRoots::under(
+            second_root.join(index.to_string()),
+        );
+        second_roots.skill_registry_root = reserved_root.clone();
+        let second_db = second_roots.state_home.join("metadata.sqlite3");
+        let error = crate::adapters::app_server::VerletAppServerConfig::hosted(
+            second_roots,
+            hosted_test_environment(),
+            std::env::temp_dir(),
+            &hosted_test_identity(),
+        )
+        .err()
+        .expect("a live instance must keep every root reserved");
+        assert!(
+            error
+                .to_string()
+                .contains(&reserved_root.display().to_string())
+        );
+        assert!(!second_db.exists());
+    }
+
+    first.shutdown().await.unwrap();
+    drop(first);
+
+    let successor = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        first_roots,
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .expect("dropping the first instance must release its roots");
+    drop(successor);
+
+    let _ = std::fs::remove_dir_all(first_root);
+    let _ = std::fs::remove_dir_all(second_root);
+}
+
+#[tokio::test]
+async fn panicking_hosted_instance_owner_releases_its_roots() {
+    let root = unique_test_root("hosted-panicking-owner");
+    let roots = crate::adapters::app_server::instance::InstanceRoots::under(&root);
+    let app = crate::adapters::app_server::VerletAppServer::new(
+        crate::adapters::app_server::VerletAppServerConfig::hosted(
+            roots.clone(),
+            hosted_test_environment(),
+            std::env::temp_dir(),
+            &hosted_test_identity(),
+        )
+        .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let panic = tokio::spawn(async move {
+        let _app = app;
+        panic!("injected hosted-instance owner panic");
+    })
+    .await
+    .expect_err("the owner task must panic");
+    assert!(panic.is_panic());
+
+    let successor = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        roots,
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .expect("unwinding the only instance owner must release its roots");
+    drop(successor);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn live_hosted_instance_rejects_symlinked_root_alias_before_sqlite_open() {
+    let root = unique_test_root("hosted-symlink-overlap");
+    let first_root = root.join("first");
+    let second_root = root.join("second");
+    let alias_root = root.join("first-alias");
+    let first_roots = crate::adapters::app_server::instance::InstanceRoots::under(&first_root);
+    let first = crate::adapters::app_server::VerletAppServer::new(
+        crate::adapters::app_server::VerletAppServerConfig::hosted(
+            first_roots.clone(),
+            hosted_test_environment(),
+            std::env::temp_dir(),
+            &hosted_test_identity(),
+        )
+        .unwrap(),
+    )
+    .await
+    .unwrap();
+    std::os::unix::fs::symlink(&first_root, &alias_root).unwrap();
+
+    let mut second_roots =
+        crate::adapters::app_server::instance::InstanceRoots::under(&second_root);
+    second_roots.blob_registry_root = alias_root.join("blobs");
+    let second_db = second_roots.state_home.join("metadata.sqlite3");
+    let alias_path = second_roots.blob_registry_root.display().to_string();
+    let reserved_path = first_roots.blob_registry_root.display().to_string();
+    let error = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        second_roots,
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .err()
+    .expect("a symlinked alias of a live root must fail");
+    assert!(error.to_string().contains(&alias_path));
+    assert!(error.to_string().contains(&reserved_path));
+    assert!(!second_db.exists());
+
+    first.shutdown().await.unwrap();
+    drop(first);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn hosted_instance_keeps_mutable_registries_out_of_cwd_defaults() {
+    let root = unique_test_root("hosted-no-cwd-defaults");
+    let cwd = root.join("cwd");
+    let cwd_defaults = cwd.join(".verlet");
+    std::fs::create_dir_all(&cwd_defaults).unwrap();
+    std::fs::write(cwd_defaults.join("sentinel"), "unchanged").unwrap();
+    let mut roots =
+        crate::adapters::app_server::instance::InstanceRoots::under(root.join("instance"));
+    roots.blob_registry_root = root.join("instance-artifacts");
+    let config = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        roots.clone(),
+        hosted_test_environment(),
+        &cwd,
+        &hosted_test_identity(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        config.agent_registry_root,
+        std::fs::canonicalize(&roots.agent_registry_root).unwrap()
+    );
+    assert_eq!(
+        config.blob_registry_root,
+        std::fs::canonicalize(&roots.blob_registry_root).unwrap()
+    );
+    assert_eq!(
+        config.skill_registry_root,
+        std::fs::canonicalize(&roots.skill_registry_root).unwrap()
+    );
+    assert_eq!(
+        // lexicon-allow: capsule - existing app-server operation binding field.
+        config.capsule_bindings.registry_root.as_deref(),
+        Some(
+            std::fs::canonicalize(&roots.runtime_home)
+                .unwrap()
+                .join("operations")
+                .as_path()
+        )
+    );
+
+    let app = crate::adapters::app_server::VerletAppServer::new(config)
+        .await
+        .unwrap();
+    assert_eq!(
+        app.inner.agent_registry().blob_registry_root(),
+        std::fs::canonicalize(&roots.blob_registry_root)
+            .unwrap()
+            .as_path()
+    );
+    assert!(
+        !roots
+            .agent_registry_root
+            .parent()
+            .unwrap()
+            .join("blobs")
+            .exists()
+    );
+    assert_eq!(
+        std::fs::read_to_string(cwd_defaults.join("sentinel")).unwrap(),
+        "unchanged"
+    );
+    assert_eq!(std::fs::read_dir(&cwd_defaults).unwrap().count(), 1);
+
+    app.shutdown().await.unwrap();
+    drop(app);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn hosted_provider_auth_uses_injected_context_and_ignores_process_env() {
+    const AMBIENT_NAME: &str = "VERLET_EMO_552_AMBIENT_PROVIDER_AUTH";
+    const INJECTED_NAME: &str = "VERLET_EMO_552_INJECTED_PROVIDER_AUTH";
+    const PROVIDER_ID: &str = "emo_552_injected_provider";
+    const AMBIENT_PROVIDER_ID: &str = "emo_552_ambient_provider";
+
+    let _env_lock = PROCESS_ENV_LOCK.lock().await;
+    let _env = ProcessEnvGuard::set(AMBIENT_NAME, "ambient-secret-must-be-invisible");
+    let root = unique_test_root("hosted-injected-provider-auth");
+    let environment = crate::adapters::app_server::instance::InstanceEnvironment {
+        provider_auth: crate::adapters::app_server::instance::ProviderAuthSource::Injected(
+            verlet_metadata::provider_store::LlmProviderAuthContext::new()
+                .with_env(INJECTED_NAME, "injected-secret"),
+        ),
+        hook_shell: Some(hosted_test_hook_shell()),
+        process_ids: std::sync::Arc::new(verlet_process::process::RandomProcessIds),
+    };
+    let config = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        crate::adapters::app_server::instance::InstanceRoots::under(root.join("instance")),
+        environment,
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .unwrap()
+    .with_catalog_openai_chat_completions(PROVIDER_ID, Some("fixture-model".to_string()));
+    assert!(!format!("{:?}", config.instance_environment).contains("injected-secret"));
+
+    let metadata_store =
+        verlet_metadata::provider_store::SqliteMetadataStore::open(config.metadata_store_path())
+            .await
+            .unwrap();
+    for (provider_id, env_name) in [
+        (PROVIDER_ID, INJECTED_NAME),
+        (AMBIENT_PROVIDER_ID, AMBIENT_NAME),
+    ] {
+        metadata_store
+            .upsert_provider(
+                verlet_metadata::provider_store::LlmProviderRecord::new(
+                    provider_id,
+                    verlet_history::ProviderApi::OpenAIChatCompletions,
+                    "https://example.invalid/v1",
+                )
+                .with_auth(
+                    verlet_metadata::provider_store::LlmProviderAuthConfig::Env {
+                        name: env_name.to_string(),
+                    },
+                )
+                .with_auth_header(true)
+                .with_model(
+                    verlet_metadata::provider_store::LlmProviderModelRecord::new("fixture-model")
+                        .with_metadata("default", "true"),
+                ),
+            )
+            .await
+            .unwrap();
+    }
+    drop(metadata_store);
+
+    let app = crate::adapters::app_server::VerletAppServer::new(config)
+        .await
+        .expect("catalog provider dispatch must resolve the injected API key");
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    let injected = app
+        .dispatch_request(
+            &connection,
+            "modelProvider/auth/status",
+            Some(serde_json::json!({ "providerId": PROVIDER_ID })),
+        )
+        .await
+        .unwrap();
+    let ambient = app
+        .dispatch_request(
+            &connection,
+            "modelProvider/auth/status",
+            Some(serde_json::json!({ "providerId": AMBIENT_PROVIDER_ID })),
+        )
+        .await
+        .unwrap();
+    assert_eq!(injected["auth"]["configured"], true);
+    assert_eq!(injected["auth"]["source"], "environment");
+    assert_eq!(ambient["auth"]["configured"], false);
+
+    app.shutdown().await.unwrap();
+    drop(connection);
+    drop(app);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn hosted_process_managers_use_independent_injected_id_sources() {
+    let root = unique_test_root("hosted-process-id-sources");
+    let first = hosted_test_app_with_process_ids(
+        root.join("first"),
+        std::sync::Arc::new(verlet_process::process::DeterministicProcessIds::new()),
+    )
+    .await;
+    let second = hosted_test_app_with_process_ids(
+        root.join("second"),
+        std::sync::Arc::new(verlet_process::process::DeterministicProcessIds::new()),
+    )
+    .await;
+    let backend = std::sync::Arc::new(verlet_process::live::HostBashLiveBackend);
+    let request = || {
+        verlet_process::live::AsyncProcessStartRequest::host_command(
+            vec!["/bin/sh".to_string(), "-c".to_string(), "true".to_string()],
+            std::env::temp_dir(),
+        )
+    };
+
+    let first_outcome = first
+        .inner
+        .process_manager
+        .start(backend.clone(), request())
+        .await
+        .unwrap();
+    let second_outcome = second
+        .inner
+        .process_manager
+        .start(backend, request())
+        .await
+        .unwrap();
+    assert_eq!(
+        first_outcome.snapshot.process_id,
+        second_outcome.snapshot.process_id
+    );
+    assert_eq!(
+        first_outcome.snapshot.process_id.unwrap().to_string(),
+        "00000000-0000-0000-0000-000000000001"
+    );
+
+    first.shutdown().await.unwrap();
+    second.shutdown().await.unwrap();
+    drop(first);
+    drop(second);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn hosted_default_manifest_aliases_are_isolated_by_instance_registry() {
+    let root = unique_test_root("hosted-default-alias-isolation");
+    let cwd = root.join("workspace");
+    std::fs::create_dir_all(&cwd).unwrap();
+    let first_roots =
+        crate::adapters::app_server::instance::InstanceRoots::under(root.join("first"));
+    let second_roots =
+        crate::adapters::app_server::instance::InstanceRoots::under(root.join("second"));
+    let first = crate::adapters::app_server::VerletAppServer::new(
+        crate::adapters::app_server::VerletAppServerConfig::hosted(
+            first_roots.clone(),
+            hosted_test_environment(),
+            &cwd,
+            &hosted_test_identity(),
+        )
+        .unwrap(),
+    )
+    .await
+    .unwrap();
+    let second = crate::adapters::app_server::VerletAppServer::new(
+        crate::adapters::app_server::VerletAppServerConfig::hosted(
+            second_roots.clone(),
+            hosted_test_environment(),
+            &cwd,
+            &hosted_test_identity(),
+        )
+        .unwrap(),
+    )
+    .await
+    .unwrap();
+    let first_registry =
+        crate::agent::manifest::LocalAgentRegistry::new(&first_roots.agent_registry_root);
+    let second_registry =
+        crate::agent::manifest::LocalAgentRegistry::new(&second_roots.agent_registry_root);
+    let second_before = second_registry
+        .load_ref(crate::adapters::app_server::default_manifest::DEFAULT_AGENT_REF)
+        .unwrap();
+
+    let mut overwrite = crate::adapters::app_server::VerletAppServerConfig::local(
+        crate::adapters::app_server::AppServerListenAddr::Unix(root.join("overwrite.sock")),
+        &cwd,
+    );
+    // lexicon-allow: capsule - existing app-server operation binding field.
+    overwrite.capsule_bindings.registry_root = Some(first_roots.runtime_home.join("operations"));
+    overwrite.agent_registry_root = first_roots.agent_registry_root.clone();
+    overwrite.model = "instance-a-overwrite".to_string();
+    crate::adapters::app_server::default_manifest::ensure_default_manifest_published(
+        &overwrite, false,
+    )
+    .unwrap();
+
+    let first_after = first_registry
+        .load_ref(crate::adapters::app_server::default_manifest::DEFAULT_AGENT_REF)
+        .unwrap();
+    let second_after = second_registry
+        .load_ref(crate::adapters::app_server::default_manifest::DEFAULT_AGENT_REF)
+        .unwrap();
+    assert_eq!(first_after.version, "1.0.1");
+    assert_ne!(first_after.manifest_hash, second_after.manifest_hash);
+    assert_eq!(second_after.ref_uri, second_before.ref_uri);
+    assert_eq!(second_after.manifest_hash, second_before.manifest_hash);
+
+    first.shutdown().await.unwrap();
+    second.shutdown().await.unwrap();
+    drop(first);
+    drop(second);
+    let _ = std::fs::remove_dir_all(root);
+}
+
 #[tokio::test]
 async fn shutdown_then_drop_inside_runtime_is_inert() {
     let root = unique_test_root("app-server-shutdown-drop");
@@ -12421,6 +13208,84 @@ impl crate::kernel::runtime_host::runtime_api::AgentRuntimeFactory for FailingRe
             "injected constructor reload failure".to_string(),
         ))
     }
+}
+
+#[tokio::test]
+async fn hosted_constructor_failure_after_inner_build_releases_roots() {
+    let root = unique_test_root("hosted-constructor-cleanup");
+    let roots = crate::adapters::app_server::instance::InstanceRoots::under(root.join("instance"));
+    let first = crate::adapters::app_server::VerletAppServer::new(
+        crate::adapters::app_server::VerletAppServerConfig::hosted(
+            roots.clone(),
+            hosted_test_environment(),
+            std::env::temp_dir(),
+            &hosted_test_identity(),
+        )
+        .unwrap(),
+    )
+    .await
+    .unwrap();
+    let (connection, _outbound_rx) = test_connection(first.clone()).await;
+    initialize_for_test(&connection).await;
+    let started = first
+        .dispatch_request(&connection, "thread/start", Some(serde_json::json!({})))
+        .await
+        .unwrap();
+    let thread_id =
+        verlet_runtime_contracts::ThreadId::parse_str(started["thread"]["id"].as_str().unwrap())
+            .unwrap();
+    let mut lifecycle = first
+        .inner
+        .metadata_store
+        .get_thread_lifecycle(thread_id)
+        .await
+        .unwrap()
+        .unwrap();
+    first.shutdown().await.unwrap();
+    lifecycle.status = verlet_runtime_contracts::ThreadLifecycleStatus::Idle;
+    first
+        .inner
+        .metadata_store
+        .upsert_thread_lifecycle(lifecycle)
+        .await
+        .unwrap();
+    let metadata_store = first.inner.metadata_store.clone();
+    drop(connection);
+    drop(first);
+
+    let failing_config = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        roots.clone(),
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .unwrap();
+    let error =
+        match crate::adapters::app_server::VerletAppServer::with_runtime_factory_and_metadata_store(
+            failing_config,
+            std::sync::Arc::new(FailingReloadRuntimeFactory),
+            metadata_store,
+        )
+        .await
+        {
+            Ok(_) => panic!("constructor unexpectedly succeeded"),
+            Err(error) => error,
+        };
+    assert!(
+        error
+            .to_string()
+            .contains("injected constructor reload failure")
+    );
+
+    let successor = crate::adapters::app_server::VerletAppServerConfig::hosted(
+        roots,
+        hosted_test_environment(),
+        std::env::temp_dir(),
+        &hosted_test_identity(),
+    )
+    .expect("a constructor failure after inner build must release its roots exactly once");
+    drop(successor);
+    let _ = std::fs::remove_dir_all(root);
 }
 
 #[tokio::test]
@@ -13955,6 +14820,49 @@ async fn test_app_at_root(root: &std::path::Path) -> crate::adapters::app_server
         .unwrap()
 }
 
+fn hosted_test_identity() -> crate::daemon::identity::VerletDaemonIdentityConfig {
+    crate::daemon::daemon_config::synthesized_local_daemon_identity_config()
+}
+
+fn hosted_test_environment() -> crate::adapters::app_server::instance::InstanceEnvironment {
+    crate::adapters::app_server::instance::InstanceEnvironment {
+        provider_auth: crate::adapters::app_server::instance::ProviderAuthSource::Injected(
+            verlet_metadata::provider_store::LlmProviderAuthContext::new(),
+        ),
+        hook_shell: Some(hosted_test_hook_shell()),
+        process_ids: std::sync::Arc::new(verlet_process::process::RandomProcessIds),
+    }
+}
+
+fn hosted_test_hook_shell() -> String {
+    if cfg!(windows) {
+        r"C:\Windows\System32\cmd.exe".to_string()
+    } else {
+        "/bin/sh".to_string()
+    }
+}
+
+async fn hosted_test_app_with_process_ids(
+    root: std::path::PathBuf,
+    process_ids: std::sync::Arc<dyn verlet_process::process::ProcessIdSource>,
+) -> crate::adapters::app_server::VerletAppServer {
+    let environment = crate::adapters::app_server::instance::InstanceEnvironment {
+        process_ids,
+        ..hosted_test_environment()
+    };
+    crate::adapters::app_server::VerletAppServer::new(
+        crate::adapters::app_server::VerletAppServerConfig::hosted(
+            crate::adapters::app_server::instance::InstanceRoots::under(&root),
+            environment,
+            std::env::temp_dir(),
+            &hosted_test_identity(),
+        )
+        .unwrap(),
+    )
+    .await
+    .unwrap()
+}
+
 fn test_config_at_root(
     root: &std::path::Path,
 ) -> crate::adapters::app_server::VerletAppServerConfig {
@@ -14424,6 +15332,7 @@ where
         config.default_placement.clone(),
         None,
         std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        None,
     );
     crate::adapters::app_server::VerletAppServer::with_runtime_factory(config, factory)
         .await

--- a/crates/verlet-kernel/src/adapters/app_server/threads.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/threads.rs
@@ -394,8 +394,7 @@ impl crate::adapters::app_server::VerletAppServer {
             }
             (None, None) => {}
         }
-        let registry =
-            crate::agent::manifest::LocalAgentRegistry::new(self.inner.agent_registry_root.clone());
+        let registry = self.inner.agent_registry();
         let (record, alias) = registry.load_ref_with_alias_receipt(agent_ref)?;
         if &record.manifest_hash != expected_hash {
             return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
@@ -526,8 +525,7 @@ impl crate::adapters::app_server::VerletAppServer {
     ) -> crate::kernel::runtime_host::VerletResult<
         crate::agent::manifest_bind::AgentManifestBoundThread,
     > {
-        let registry =
-            crate::agent::manifest::LocalAgentRegistry::new(self.inner.agent_registry_root.clone());
+        let registry = self.inner.agent_registry();
         let (record, alias) = registry.load_ref_with_alias_receipt(agent_ref)?;
         let provider_surface = self.agent_manifest_provider_surface().await?;
         let mcp_server_refs = self.configured_mcp_server_refs().await?;
@@ -2101,6 +2099,7 @@ pub(super) struct CapsuleBindingRuntimeFactory {
     pub(super) blob_registry_root: Option<std::path::PathBuf>,
     pub(super) skill_registry_root: Option<std::path::PathBuf>,
     pub(super) cwd: Option<std::path::PathBuf>,
+    pub(super) hook_shell: Option<String>,
     pub(super) default_placement: crate::agent::manifest_bind::AgentManifestPlacementBinding,
     pub(super) default_workspace:
         Option<crate::agent::manifest_bind::AgentManifestWorkspaceBinding>,
@@ -2131,7 +2130,9 @@ impl crate::kernel::runtime_host::runtime_api::AgentRuntimeFactory
         let mut factory = crate::adapters::agent_loop::AgentLoopFactory::new(
             config,
             std::sync::Arc::clone(&self.client),
-        );
+        )
+        .with_hook_shell(self.hook_shell.clone())
+        .with_process_dispatcher_cwd(self.cwd.clone());
         if let Some(policy) = manifest_compaction_policy(context)? {
             factory = factory.with_compaction_policy(policy);
         }
@@ -2223,8 +2224,11 @@ impl crate::agent::agent_process::KernelThreadSpawnAgentResolver
     ) -> crate::kernel::runtime_host::VerletResult<
         crate::agent::agent_process::KernelThreadSpawnAgentBinding,
     > {
-        let registry =
+        let mut registry =
             crate::agent::manifest::LocalAgentRegistry::new(self.agent_registry_root.clone());
+        if let Some(blob_registry_root) = &self.blob_registry_root {
+            registry = registry.with_blob_registry_root(blob_registry_root.clone());
+        }
         let (record, alias) = registry.load_ref_with_alias_receipt(agent_ref)?;
         let mcp_server_refs = self.configured_mcp_server_refs().await?;
         let tool_universe_discoverer = self.tool_universe_discoverer().await?;

--- a/crates/verlet-kernel/src/agent/hooks.rs
+++ b/crates/verlet-kernel/src/agent/hooks.rs
@@ -239,12 +239,21 @@ pub trait HookHandler: Send + Sync + 'static {
         &self,
         request: HookRequest,
     ) -> crate::kernel::runtime_host::VerletResult<HookHandlerOutput>;
+
+    async fn run_with_shell(
+        &self,
+        request: HookRequest,
+        _shell: Option<&str>,
+    ) -> crate::kernel::runtime_host::VerletResult<HookHandlerOutput> {
+        self.run(request).await
+    }
 }
 
 #[derive(Clone, Default)]
 // lexicon-allow: hook - existing host debug hook pipeline API name retained for compatibility.
 pub struct HookPipeline {
     handlers: Vec<std::sync::Arc<dyn HookHandler>>,
+    shell: Option<String>,
 }
 
 impl HookPipeline {
@@ -257,9 +266,13 @@ impl HookPipeline {
         self
     }
 
-    pub fn with_command_handler(mut self, handler: CommandHookHandler) -> Self {
-        self.handlers.push(std::sync::Arc::new(handler));
+    pub(crate) fn with_shell(mut self, shell: Option<String>) -> Self {
+        self.shell = shell;
         self
+    }
+
+    pub fn with_command_handler(self, handler: CommandHookHandler) -> Self {
+        self.with_handler(std::sync::Arc::new(handler))
     }
 
     pub async fn run_session_start(
@@ -469,7 +482,10 @@ impl HookPipeline {
             on_started(&spec);
             let started_at_ms = unix_timestamp_ms();
             let started = std::time::Instant::now();
-            match handler.run(request.clone()).await {
+            match handler
+                .run_with_shell(request.clone(), self.shell.as_deref())
+                .await
+            {
                 Ok(output) => {
                     let status = status_for_output(&output);
                     let message = message_for_output(&output);
@@ -565,26 +581,16 @@ impl CommandHookHandler {
             HookRequest::Stop(request) => request.turn_context.cwd.clone(),
         }
     }
-}
 
-#[async_trait::async_trait]
-impl HookHandler for CommandHookHandler {
-    fn spec(&self) -> HookHandlerSpec {
-        self.spec.clone()
-    }
-
-    fn command_sha256(&self) -> Option<String> {
-        Some(verlet_agent::contracts::sha256_hex(self.command.as_bytes()))
-    }
-
-    async fn run(
+    async fn run_with_shell_override(
         &self,
         request: HookRequest,
+        shell: Option<&str>,
     ) -> crate::kernel::runtime_host::VerletResult<HookHandlerOutput> {
         let input = serde_json::to_string(&request).map_err(|err| {
             crate::kernel::runtime_host::VerletError::RuntimeExecution(err.to_string())
         })?;
-        let mut command = default_shell_command();
+        let mut command = default_shell_command(shell);
         command.arg(&self.command);
         command
             .stdin(std::process::Stdio::piped())
@@ -640,6 +646,32 @@ impl HookHandler for CommandHookHandler {
                 "failed to parse hook stdout: {err}"
             ))
         })
+    }
+}
+
+#[async_trait::async_trait]
+impl HookHandler for CommandHookHandler {
+    fn spec(&self) -> HookHandlerSpec {
+        self.spec.clone()
+    }
+
+    fn command_sha256(&self) -> Option<String> {
+        Some(verlet_agent::contracts::sha256_hex(self.command.as_bytes()))
+    }
+
+    async fn run(
+        &self,
+        request: HookRequest,
+    ) -> crate::kernel::runtime_host::VerletResult<HookHandlerOutput> {
+        self.run_with_shell_override(request, None).await
+    }
+
+    async fn run_with_shell(
+        &self,
+        request: HookRequest,
+        shell: Option<&str>,
+    ) -> crate::kernel::runtime_host::VerletResult<HookHandlerOutput> {
+        self.run_with_shell_override(request, shell).await
     }
 }
 
@@ -810,11 +842,13 @@ fn unix_timestamp_ms() -> u64 {
         .unwrap_or(u64::MAX)
 }
 
-fn default_shell_command() -> tokio::process::Command {
+fn default_shell_command(shell: Option<&str>) -> tokio::process::Command {
     #[cfg(windows)]
     {
-        let comspec = verlet_runtime_contracts::env_compat::var("COMSPEC")
-            .unwrap_or_else(|_| "cmd.exe".to_string());
+        let comspec = shell.map(str::to_string).unwrap_or_else(|| {
+            verlet_runtime_contracts::env_compat::var("COMSPEC")
+                .unwrap_or_else(|_| "cmd.exe".to_string())
+        });
         let mut command = tokio::process::Command::new(comspec);
         command.arg("/C");
         command
@@ -822,8 +856,10 @@ fn default_shell_command() -> tokio::process::Command {
 
     #[cfg(not(windows))]
     {
-        let shell = verlet_runtime_contracts::env_compat::var("SHELL")
-            .unwrap_or_else(|_| "/bin/sh".to_string());
+        let shell = shell.map(str::to_string).unwrap_or_else(|| {
+            verlet_runtime_contracts::env_compat::var("SHELL")
+                .unwrap_or_else(|_| "/bin/sh".to_string())
+        });
         let mut command = tokio::process::Command::new(shell);
         command.arg("-lc");
         command

--- a/crates/verlet-kernel/src/agent/hooks/tests.rs
+++ b/crates/verlet-kernel/src/agent/hooks/tests.rs
@@ -37,6 +37,49 @@ async fn command_hook_handler_reads_json_stdin_and_returns_pre_tool_output() {
     assert_eq!(outcome.additional_contexts, vec!["ctx"]);
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn command_hook_handler_prefers_injected_shell() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let root = std::env::temp_dir().join(format!(
+        "verlet-injected-hook-shell-{}",
+        uuid::Uuid::now_v7()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    let shell = root.join("injected-shell");
+    std::fs::write(
+        &shell,
+        "#!/bin/sh\nprintf '%s' '{\"additional_context\":\"injected shell\"}'\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&shell, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+    let hook = crate::agent::hooks::CommandHookHandler::new(
+        "injected-shell",
+        crate::agent::hooks::HookEventName::SessionStart,
+        "exit 99",
+    );
+    let request = crate::agent::hooks::SessionStartHookRequest {
+        coordinates: verlet_runtime_contracts::ThreadCoordinates::new("tenant", "user", "session"),
+        parent_thread_id: None,
+        source: "test".to_string(),
+        cwd: None,
+        provider: "test".to_string(),
+        model: "test".to_string(),
+        permission_profile: None,
+    };
+
+    let outcome = crate::agent::hooks::HookPipeline::new()
+        .with_shell(Some(shell.to_string_lossy().into_owned()))
+        .with_handler(std::sync::Arc::new(hook))
+        .run_session_start(request, |_| {})
+        .await;
+
+    assert_eq!(outcome.additional_contexts, ["injected shell"]);
+    let _ = std::fs::remove_dir_all(root);
+}
+
 #[test]
 fn hook_request_serializes_stable_shape() {
     let coordinates =

--- a/crates/verlet-process/src/live.rs
+++ b/crates/verlet-process/src/live.rs
@@ -36,6 +36,7 @@ pub struct AsyncExecutionManager {
 
 struct AsyncExecutionManagerInner {
     config: AsyncExecutionManagerConfig,
+    process_ids: std::sync::Arc<dyn crate::process::ProcessIdSource>,
     entries: tokio::sync::Mutex<
         std::collections::HashMap<crate::process::VerletProcessId, ProcessEntry>,
     >,
@@ -262,9 +263,20 @@ pub enum ProcessSnapshotStatus {
 
 impl AsyncExecutionManager {
     pub fn new(config: AsyncExecutionManagerConfig) -> Self {
+        Self::new_with_process_id_source(
+            config,
+            std::sync::Arc::new(crate::process::RandomProcessIds),
+        )
+    }
+
+    pub fn new_with_process_id_source(
+        config: AsyncExecutionManagerConfig,
+        process_ids: std::sync::Arc<dyn crate::process::ProcessIdSource>,
+    ) -> Self {
         Self {
             inner: std::sync::Arc::new(AsyncExecutionManagerInner {
                 config,
+                process_ids,
                 entries: tokio::sync::Mutex::new(std::collections::HashMap::new()),
             }),
         }
@@ -286,8 +298,11 @@ impl AsyncExecutionManager {
         cancellation: tokio_util::sync::CancellationToken,
     ) -> crate::VerletProcessResult<AsyncProcessOutcome> {
         self.cleanup_expired().await;
+        let process_id = request
+            .process_id
+            .unwrap_or_else(|| self.inner.process_ids.next_process_id());
         let process = crate::process::VerletProcessHandle::with_process_id(
-            request.process_id.unwrap_or_default(),
+            process_id,
             backend.backend_kind(),
             request.invocation.label(),
         );

--- a/crates/verlet-process/src/process.rs
+++ b/crates/verlet-process/src/process.rs
@@ -3,26 +3,49 @@ use futures_util::StreamExt as _;
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct VerletProcessId(uuid::Uuid);
 
-static FORCE_DETERMINISTIC_PROCESS_IDS: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-static NEXT_DETERMINISTIC_PROCESS_ID: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(1);
+/// Source of process ids for one process manager (EMO-552). Replaces the
+/// former process-global deterministic-ids switch so co-resident kernel
+/// instances can each carry their own source (random in production, a
+/// per-instance deterministic counter under simulation).
+pub trait ProcessIdSource: Send + Sync {
+    fn next_process_id(&self) -> VerletProcessId;
+}
 
-pub fn set_deterministic_process_ids_for_tests(enabled: bool) {
-    FORCE_DETERMINISTIC_PROCESS_IDS.store(enabled, std::sync::atomic::Ordering::SeqCst);
-    if enabled {
-        NEXT_DETERMINISTIC_PROCESS_ID.store(1, std::sync::atomic::Ordering::SeqCst);
+/// Production source: time-ordered random ids.
+pub struct RandomProcessIds;
+
+impl ProcessIdSource for RandomProcessIds {
+    fn next_process_id(&self) -> VerletProcessId {
+        VerletProcessId(uuid::Uuid::now_v7())
+    }
+}
+
+/// Deterministic per-source counter (1, 2, 3, ...). One instance of this
+/// type per simulated harness; two harnesses with separate sources produce
+/// identical id sequences independently.
+#[derive(Default)]
+pub struct DeterministicProcessIds {
+    next: std::sync::atomic::AtomicU64,
+}
+
+impl DeterministicProcessIds {
+    pub fn new() -> Self {
+        Self {
+            next: std::sync::atomic::AtomicU64::new(1),
+        }
+    }
+}
+
+impl ProcessIdSource for DeterministicProcessIds {
+    fn next_process_id(&self) -> VerletProcessId {
+        let next = self.next.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        VerletProcessId(uuid::Uuid::from_u128(u128::from(next)))
     }
 }
 
 impl VerletProcessId {
     pub fn new() -> Self {
-        if FORCE_DETERMINISTIC_PROCESS_IDS.load(std::sync::atomic::Ordering::SeqCst) {
-            let next =
-                NEXT_DETERMINISTIC_PROCESS_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            return Self(uuid::Uuid::from_u128(u128::from(next)));
-        }
-        Self(uuid::Uuid::now_v7())
+        RandomProcessIds.next_process_id()
     }
 }
 

--- a/crates/verlet-process/src/process/tests.rs
+++ b/crates/verlet-process/src/process/tests.rs
@@ -23,6 +23,31 @@ fn virtual_process_retains_output_and_exit_status() {
 }
 
 #[test]
+fn deterministic_process_id_sources_produce_independent_identical_sequences() {
+    use crate::process::ProcessIdSource as _;
+
+    let first = crate::process::DeterministicProcessIds::new();
+    let second = crate::process::DeterministicProcessIds::new();
+
+    let first_ids = (0..3)
+        .map(|_| first.next_process_id().to_string())
+        .collect::<Vec<_>>();
+    let second_ids = (0..3)
+        .map(|_| second.next_process_id().to_string())
+        .collect::<Vec<_>>();
+
+    assert_eq!(first_ids, second_ids);
+    assert_eq!(
+        first_ids,
+        [
+            "00000000-0000-0000-0000-000000000001",
+            "00000000-0000-0000-0000-000000000002",
+            "00000000-0000-0000-0000-000000000003",
+        ]
+    );
+}
+
+#[test]
 fn external_timeout_maps_to_terminal_process_state() {
     let request = crate::execution::ExternalCommandRequest {
         invocation: crate::execution::ExternalCommandInvocation::Script("sleep 10".to_string()),


### PR DESCRIPTION
Host v0 stage C (EMO-549 stage 2). Hosted kernel instances get exclusive filesystem roots and a fully injected environment.

- Six exclusive roots per instance: construction canonicalizes them (directories created first so symlink aliases resolve) and claims them in a process-wide reservation table; equality/nesting overlap among the set or against any live instance fails loudly before any SQLite open. The claim releases when its final owner drops; failure paths, panic unwind, and concurrent-reservation races are all pinned by tests.
- `VerletAppServerConfig::hosted(roots, environment, cwd, identity)`: requires injected provider auth, an absolute hook shell, and an absolute cwd; rejects ambient-environment settings outright and revalidates at every constructor so field mutation cannot escape the reservation. Operation bindings pinned under the runtime root. Config is no longer Clone so one reservation has exactly one owner.
- Deep process-state reads retired on hosted paths: provider auth env snapshots, COMSPEC/SHELL hook shell, process cwd fallbacks, and the process-global deterministic-ID switch (replaced by an injectable per-instance ProcessIdSource; DeterministicProcessIds gives the EMO-553 two-instance DST a per-harness source).
- Per-instance mutable naming: default-manifest alias isolation proven by a two-instance test.
- Standalone daemon defaults unchanged.

Verification: full scripts/verify.sh green on macOS (1092 passed / 0 failed; pre-push hook re-ran green), Linux lane rerunning serially after an OOM kill caused by running it concurrently with the pre-push verify (host resource contention, not a code failure) — merge gated on it. Review-and-fix pass applied 6 findings (3 High) before commit; receipts on the Linear issue.

Linear: https://linear.app/emotionscientific/issue/EMO-552/kernel-instance-config-hygiene-explicit-roots-overlap-rejection-per