### PR TITLE
EMO-562: store-backed model/select endpoints for anthropic, openai-responses, and openai-codex

### DIFF
--- a/crates/verlet-kernel/src/adapters/app_server.rs
+++ b/crates/verlet-kernel/src/adapters/app_server.rs
@@ -2164,24 +2164,15 @@ async fn retire_console_credential(
     Ok(())
 }
 
-struct ResolvedCatalogOpenAIChatCompletionsProvider {
-    runtime_config: crate::adapters::agent_loop::AgentLoopConfig,
-    endpoint: verlet_provider::ProviderEndpoint,
-}
-
-async fn resolve_catalog_openai_chat_completions_provider<C, A>(
-    provider_store: &C,
-    auth_store: &A,
+async fn resolve_catalog_provider(
+    provider_store: &verlet_metadata::provider_store::SqliteMetadataStore,
+    auth_store: &verlet_metadata::provider_store::SqliteMetadataStore,
     auth_context: &verlet_metadata::provider_store::LlmProviderAuthContext,
     provider_id: &str,
     model: Option<&str>,
     max_tokens: u32,
     stream: bool,
-) -> crate::kernel::runtime_host::VerletResult<ResolvedCatalogOpenAIChatCompletionsProvider>
-where
-    C: verlet_metadata::provider_store::LlmProviderCatalogStore,
-    A: verlet_metadata::provider_store::LlmProviderAuthStore,
-{
+) -> crate::kernel::runtime_host::VerletResult<crate::adapters::agent_loop::ResolvedTurnEndpoint> {
     let provider = provider_store
         .get_provider(provider_id)
         .await
@@ -2199,16 +2190,56 @@ where
     let api = model_record
         .and_then(|model| model.api.clone())
         .unwrap_or_else(|| provider.api.clone());
-    if api != verlet_history::ProviderApi::OpenAIChatCompletions {
-        return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
-            format!(
-                "catalog provider {provider_id:?} uses api {api:?}; only OpenAI Chat Completions catalog providers are supported here"
-            ),
-        ));
-    }
     let base_url = model_record
         .and_then(|model| model.base_url.clone())
         .unwrap_or_else(|| provider.base_url.clone());
+
+    let mut runtime_config = crate::adapters::agent_loop::AgentLoopConfig::new(
+        if provider_id == verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID {
+            verlet_history::ProviderApi::OpenAIResponses
+        } else {
+            api.clone()
+        },
+        provider.provider_id.clone(),
+        model_id,
+    );
+    runtime_config.max_tokens = max_tokens;
+    runtime_config.stream = stream;
+
+    if provider_id == verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID {
+        let credential = verlet_metadata::provider_store::LlmProviderAuthStore::get_credential(
+            auth_store,
+            provider_id,
+        )
+        .await
+        .map_err(provider_store_error)?;
+        if !matches!(
+            credential,
+            Some(verlet_metadata::provider_store::LlmProviderCredential::OAuth { .. })
+        ) {
+            return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                format!(
+                    "catalog provider {provider_id:?} requires a stored OAuth login; run `verlet auth login openai-codex`"
+                ),
+            ));
+        }
+        let client = std::sync::Arc::new(
+            crate::openai_codex::OpenAICodexProviderClient::with_responses_url(
+                auth_store.clone(),
+                base_url,
+            )
+            .map_err(|err| {
+                crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
+                    "failed to build catalog OpenAI Codex provider client: {err}"
+                ))
+            })?,
+        );
+        return Ok(crate::adapters::agent_loop::ResolvedTurnEndpoint {
+            config: runtime_config,
+            client,
+        });
+    }
+
     let resolved_auth = verlet_metadata::provider_store::resolve_llm_provider_auth(
         auth_store,
         &provider,
@@ -2221,13 +2252,37 @@ where
             format!("catalog provider {provider_id:?} requires an API key but none was configured"),
         ));
     }
-    let mut endpoint = verlet_provider::ProviderEndpoint::openai_chat_completions(
-        &base_url,
-        resolved_auth
-            .as_ref()
-            .map(|auth| auth.api_key.clone())
-            .unwrap_or_default(),
-    );
+    let api_key = resolved_auth
+        .as_ref()
+        .map(|auth| auth.api_key.clone())
+        .unwrap_or_default();
+    let (mut endpoint, adapter): (
+        verlet_provider::ProviderEndpoint,
+        std::sync::Arc<dyn verlet_provider::ProviderWireAdapter>,
+    ) = match api {
+        verlet_history::ProviderApi::OpenAIChatCompletions => (
+            verlet_provider::ProviderEndpoint::openai_chat_completions(&base_url, api_key),
+            std::sync::Arc::new(verlet_provider::OpenAIChatCompletionsAdapter),
+        ),
+        verlet_history::ProviderApi::OpenAIResponses => (
+            verlet_provider::ProviderEndpoint::openai_responses(&base_url, api_key),
+            std::sync::Arc::new(verlet_provider::OpenAIResponsesAdapter {
+                include_encrypted_reasoning: false,
+                reasoning_summary: verlet_provider::OpenAIReasoningSummary::Auto,
+            }),
+        ),
+        verlet_history::ProviderApi::AnthropicMessages => (
+            verlet_provider::ProviderEndpoint::anthropic_messages(&base_url, api_key),
+            std::sync::Arc::new(verlet_provider::AnthropicMessagesAdapter),
+        ),
+        verlet_history::ProviderApi::Other(_) => {
+            return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                format!(
+                    "catalog provider {provider_id:?} uses unsupported api {api:?}; supported store-backed provider APIs are OpenAI Chat Completions, OpenAI Responses, and Anthropic Messages"
+                ),
+            ));
+        }
+    };
     if !provider.auth_header {
         endpoint.auth = verlet_provider::ProviderAuth::None;
     }
@@ -2236,18 +2291,20 @@ where
     if let Some(model_record) = model_record {
         headers.extend(model_record.headers.clone());
     }
-    endpoint.headers = resolve_catalog_headers(&headers, auth_context)?;
+    endpoint
+        .headers
+        .extend(resolve_catalog_headers(&headers, auth_context)?);
 
-    let mut runtime_config = crate::adapters::agent_loop::AgentLoopConfig::new(
-        api,
-        provider.provider_id.clone(),
-        model_id,
+    let client = std::sync::Arc::new(
+        verlet_provider::ProviderHttpClient::new(endpoint, adapter).map_err(|err| {
+            crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
+                "failed to build catalog {api:?} provider client: {err}"
+            ))
+        })?,
     );
-    runtime_config.max_tokens = max_tokens;
-    runtime_config.stream = stream;
-    Ok(ResolvedCatalogOpenAIChatCompletionsProvider {
-        runtime_config,
-        endpoint,
+    Ok(crate::adapters::agent_loop::ResolvedTurnEndpoint {
+        config: runtime_config,
+        client,
     })
 }
 
@@ -2685,7 +2742,7 @@ pub(crate) async fn resolved_turn_endpoint_from_provider_config(
             stream,
             ..
         } => {
-            let resolved = resolve_catalog_openai_chat_completions_provider(
+            return resolve_catalog_provider(
                 provider_store,
                 auth_store,
                 auth_context,
@@ -2694,19 +2751,7 @@ pub(crate) async fn resolved_turn_endpoint_from_provider_config(
                 *max_tokens,
                 *stream,
             )
-            .await?;
-            let adapter: std::sync::Arc<dyn verlet_provider::ProviderWireAdapter> =
-                std::sync::Arc::new(verlet_provider::OpenAIChatCompletionsAdapter);
-            let client = std::sync::Arc::new(
-                verlet_provider::ProviderHttpClient::new(resolved.endpoint, adapter).map_err(
-                    |err| {
-                        crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
-                            "failed to build catalog OpenAI Chat Completions provider client: {err}"
-                        ))
-                    },
-                )?,
-            );
-            (resolved.runtime_config, client)
+            .await;
         }
     };
     Ok(crate::adapters::agent_loop::ResolvedTurnEndpoint {

--- a/crates/verlet-kernel/src/adapters/app_server.rs
+++ b/crates/verlet-kernel/src/adapters/app_server.rs
@@ -687,6 +687,17 @@ impl AppServerTurnEndpointRouter {
         self.write_state().cache.remove(provider_id);
     }
 
+    async fn invalidate_model(&self, provider_id: &str, model: &str) {
+        let mut state = self.write_state();
+        let remove_provider = state.cache.get_mut(provider_id).is_some_and(|models| {
+            models.remove(model);
+            models.is_empty()
+        });
+        if remove_provider {
+            state.cache.remove(provider_id);
+        }
+    }
+
     fn activate(&self, endpoint: crate::adapters::agent_loop::ResolvedTurnEndpoint) {
         let mut state = self.write_state();
         state
@@ -2179,7 +2190,7 @@ async fn resolve_catalog_provider(
         .map_err(provider_store_error)?
         .ok_or_else(|| {
             crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
-                "catalog provider {provider_id:?} is not in the provider metadata store"
+                "catalog provider {provider_id:?} is not in the provider metadata store; add it with modelProvider/upsert"
             ))
         })?;
     let model_id = selected_catalog_model_id(&provider, model)?;
@@ -2223,6 +2234,7 @@ async fn resolve_catalog_provider(
                 ),
             ));
         }
+        validate_catalog_codex_responses_url(provider_id, &base_url)?;
         let client = std::sync::Arc::new(
             crate::openai_codex::OpenAICodexProviderClient::with_responses_url(
                 auth_store.clone(),
@@ -2230,7 +2242,7 @@ async fn resolve_catalog_provider(
             )
             .map_err(|err| {
                 crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
-                    "failed to build catalog OpenAI Codex provider client: {err}"
+                    "failed to build catalog provider {provider_id:?} OpenAI Codex client: {err}; update its endpoint with modelProvider/upsert"
                 ))
             })?,
         );
@@ -2249,7 +2261,9 @@ async fn resolve_catalog_provider(
     .map_err(provider_store_error)?;
     if provider.auth_header && resolved_auth.is_none() {
         return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
-            format!("catalog provider {provider_id:?} requires an API key but none was configured"),
+            format!(
+                "catalog provider {provider_id:?} requires an API key but none was configured; set its environment credential or run `verlet auth set {provider_id} --api-key-stdin`"
+            ),
         ));
     }
     let api_key = resolved_auth
@@ -2278,7 +2292,7 @@ async fn resolve_catalog_provider(
         verlet_history::ProviderApi::Other(_) => {
             return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
                 format!(
-                    "catalog provider {provider_id:?} uses unsupported api {api:?}; supported store-backed provider APIs are OpenAI Chat Completions, OpenAI Responses, and Anthropic Messages"
+                    "catalog provider {provider_id:?} uses unsupported api {api:?}; update it with modelProvider/upsert to use OpenAI Chat Completions, OpenAI Responses, or Anthropic Messages"
                 ),
             ));
         }
@@ -2287,18 +2301,15 @@ async fn resolve_catalog_provider(
         endpoint.auth = verlet_provider::ProviderAuth::None;
     }
 
-    let mut headers = provider.headers.clone();
-    if let Some(model_record) = model_record {
-        headers.extend(model_record.headers.clone());
+    let headers = merged_catalog_headers(&provider, model_record);
+    for (name, value) in resolve_catalog_headers(provider_id, &headers, auth_context)? {
+        set_endpoint_header(&mut endpoint.headers, name, value);
     }
-    endpoint
-        .headers
-        .extend(resolve_catalog_headers(&headers, auth_context)?);
 
     let client = std::sync::Arc::new(
         verlet_provider::ProviderHttpClient::new(endpoint, adapter).map_err(|err| {
             crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
-                "failed to build catalog {api:?} provider client: {err}"
+                "failed to build catalog provider {provider_id:?} {api:?} client: {err}; update its endpoint with modelProvider/upsert"
             ))
         })?,
     );
@@ -2328,13 +2339,91 @@ fn selected_catalog_model_id(
         .map(|model| model.model_id.clone())
         .ok_or_else(|| {
             crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
-                "catalog provider {:?} has no models",
+                "catalog provider {:?} has no models; add one with modelProvider/upsert",
                 provider.provider_id
             ))
         })
 }
 
+fn validate_catalog_codex_responses_url(
+    provider_id: &str,
+    base_url: &str,
+) -> crate::kernel::runtime_host::VerletResult<()> {
+    const CODEX_RESPONSES_PATH: &str = "/backend-api/codex/responses";
+    let parsed = reqwest::Url::parse(base_url).ok();
+    let valid = parsed.as_ref().is_some_and(|url| {
+        let host = url.host_str().unwrap_or_default();
+        let is_chatgpt = url.scheme() == "https"
+            && host.eq_ignore_ascii_case("chatgpt.com")
+            && url.port().is_none();
+        let is_loopback = host.eq_ignore_ascii_case("localhost")
+            || host
+                .parse::<std::net::IpAddr>()
+                .is_ok_and(|address| address.is_loopback());
+        (is_chatgpt || (matches!(url.scheme(), "http" | "https") && is_loopback))
+            && url.username().is_empty()
+            && url.password().is_none()
+            && url.path() == CODEX_RESPONSES_PATH
+            && url.query().is_none()
+            && url.fragment().is_none()
+    });
+    if valid {
+        return Ok(());
+    }
+    Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+        format!(
+            "catalog provider {provider_id:?} has an invalid Codex base URL {base_url:?}; set provider or model baseUrl to https://chatgpt.com{CODEX_RESPONSES_PATH} (or a loopback test endpoint) with modelProvider/upsert"
+        ),
+    ))
+}
+
+pub(super) fn merged_catalog_headers(
+    provider: &verlet_metadata::provider_store::LlmProviderRecord,
+    model_record: Option<&verlet_metadata::provider_store::LlmProviderModelRecord>,
+) -> std::collections::BTreeMap<String, verlet_metadata::provider_store::LlmProviderConfigValue> {
+    let mut headers = std::collections::BTreeMap::new();
+    for (name, value) in &provider.headers {
+        insert_catalog_header(&mut headers, name.clone(), value.clone());
+    }
+    if let Some(model_record) = model_record {
+        for (name, value) in &model_record.headers {
+            insert_catalog_header(&mut headers, name.clone(), value.clone());
+        }
+    }
+    headers
+}
+
+fn insert_catalog_header(
+    headers: &mut std::collections::BTreeMap<
+        String,
+        verlet_metadata::provider_store::LlmProviderConfigValue,
+    >,
+    name: String,
+    value: verlet_metadata::provider_store::LlmProviderConfigValue,
+) {
+    if let Some(existing) = headers
+        .keys()
+        .find(|existing| existing.eq_ignore_ascii_case(&name))
+        .cloned()
+    {
+        headers.remove(&existing);
+    }
+    headers.insert(name, value);
+}
+
+fn set_endpoint_header(headers: &mut Vec<(String, String)>, name: String, value: String) {
+    if let Some(existing) = headers
+        .iter_mut()
+        .find(|(existing, _)| existing.eq_ignore_ascii_case(&name))
+    {
+        *existing = (name, value);
+    } else {
+        headers.push((name, value));
+    }
+}
+
 fn resolve_catalog_headers(
+    provider_id: &str,
     headers: &std::collections::BTreeMap<
         String,
         verlet_metadata::provider_store::LlmProviderConfigValue,
@@ -2346,13 +2435,15 @@ fn resolve_catalog_headers(
         .map(|(name, value)| {
             Ok((
                 name.clone(),
-                resolve_catalog_config_value(value, auth_context)?,
+                resolve_catalog_config_value(provider_id, name, value, auth_context)?,
             ))
         })
         .collect()
 }
 
 fn resolve_catalog_config_value(
+    provider_id: &str,
+    header_name: &str,
     value: &verlet_metadata::provider_store::LlmProviderConfigValue,
     auth_context: &verlet_metadata::provider_store::LlmProviderAuthContext,
 ) -> crate::kernel::runtime_host::VerletResult<String> {
@@ -2367,13 +2458,13 @@ fn resolve_catalog_config_value(
             .cloned()
             .ok_or_else(|| {
                 crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
-                    "catalog provider header env var {name} is not configured"
+                    "catalog provider {provider_id:?} header {header_name:?} requires environment variable {name}; set {name} or update/remove the header with modelProvider/upsert"
                 ))
             }),
         verlet_metadata::provider_store::LlmProviderConfigValue::Command { .. } => {
-            Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
-                "catalog provider command-backed header resolution is not enabled".to_string(),
-            ))
+            Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
+                "catalog provider {provider_id:?} header {header_name:?} uses unsupported command-backed resolution; update or remove the header with modelProvider/upsert"
+            )))
         }
     }
 }

--- a/crates/verlet-kernel/src/adapters/app_server/connection.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/connection.rs
@@ -6539,6 +6539,11 @@ fn missing_model_provider_auth_message(
     provider_id: &str,
     provider: Option<&verlet_metadata::provider_store::LlmProviderRecord>,
 ) -> String {
+    if provider_id == verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID {
+        return format!(
+            "model provider {provider_id:?} is missing authentication; run `verlet auth login openai-codex`"
+        );
+    }
     let env_name = provider.and_then(|provider| {
         if let verlet_metadata::provider_store::LlmProviderAuthConfig::Env { name } = &provider.auth
         {

--- a/crates/verlet-kernel/src/adapters/app_server/connection.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/connection.rs
@@ -5281,30 +5281,35 @@ impl crate::adapters::app_server::VerletAppServer {
             .ok_or_else(|| {
                 jsonrpc_error(
                     -32602,
-                    format!("model {provider_id}/{model} was not found in model/list"),
+                    format!(
+                        "model {provider_id}/{model} was not found in model/list; choose a provider/model pair returned by model/list"
+                    ),
                 )
             })?;
+        let auth_context = self.inner.instance_environment.provider_auth.resolve();
+        let provider = self
+            .inner
+            .metadata_store
+            .get_provider(&provider_id)
+            .await
+            .map_err(|err| {
+                internal_error(crate::adapters::app_server::provider_store_error(err))
+            })?;
         if entry.get("authStatus").and_then(serde_json::Value::as_str) == Some("missing") {
-            let provider = self
-                .inner
-                .metadata_store
-                .get_provider(&provider_id)
-                .await
-                .map_err(|err| {
-                    internal_error(crate::adapters::app_server::provider_store_error(err))
-                })?;
             return Err(jsonrpc_error(
                 -32602,
-                missing_model_provider_auth_message(&provider_id, provider.as_ref()),
+                missing_model_provider_auth_message(
+                    &provider_id,
+                    &model,
+                    provider.as_ref(),
+                    &auth_context,
+                ),
             ));
         }
 
         let launch_selection =
             provider_id == self.inner.model_provider && model == self.inner.model;
-        let provider_config = if launch_selection {
-            self.inner.provider.clone()
-        } else {
-            let provider = self.model_provider_record(&provider_id).await?;
+        let provider_config = if let Some(provider) = provider.as_ref() {
             let max_tokens = provider
                 .models
                 .iter()
@@ -5317,30 +5322,53 @@ impl crate::adapters::app_server::VerletAppServer {
                 max_tokens,
                 stream: true,
             }
+        } else if launch_selection {
+            self.inner.provider.clone()
+        } else {
+            return Err(jsonrpc_error(
+                -32602,
+                format!(
+                    "model provider {provider_id:?} is not configured; add it with modelProvider/upsert"
+                ),
+            ));
         };
-        let endpoint = match self
-            .inner
-            .turn_endpoint_router
-            .cached(&provider_id, &model)
-            .await
-        {
+        let discard_launch_endpoint = {
+            let active = self.inner.active_model.read().await;
+            active.model_provider == self.inner.model_provider
+                && active.model == self.inner.model
+                && !matches!(
+                    &active.provider,
+                    crate::adapters::app_server::AppServerProviderConfig::CatalogOpenAIChatCompletions { .. }
+                )
+                && (!launch_selection || provider.is_some())
+        };
+        let cached = if discard_launch_endpoint && launch_selection {
+            None
+        } else {
+            self.inner
+                .turn_endpoint_router
+                .cached(&provider_id, &model)
+                .await
+        };
+        let endpoint = match cached {
             Some(endpoint) => endpoint,
-            None => {
-                let auth_context = self.inner.instance_environment.provider_auth.resolve();
-                let endpoint =
-                    crate::adapters::app_server::resolved_turn_endpoint_from_provider_config(
-                        &provider_config,
-                        &provider_id,
-                        &model,
-                        &self.inner.metadata_store,
-                        &self.inner.user_metadata_store,
-                        &auth_context,
-                    )
-                    .await
-                    .map_err(|err| jsonrpc_error(-32602, err.to_string()))?;
-                endpoint
-            }
+            None => crate::adapters::app_server::resolved_turn_endpoint_from_provider_config(
+                &provider_config,
+                &provider_id,
+                &model,
+                &self.inner.metadata_store,
+                &self.inner.user_metadata_store,
+                &auth_context,
+            )
+            .await
+            .map_err(|err| jsonrpc_error(-32602, err.to_string()))?,
         };
+        if discard_launch_endpoint {
+            self.inner
+                .turn_endpoint_router
+                .invalidate_model(&self.inner.model_provider, &self.inner.model)
+                .await;
+        }
 
         let mut active_model = self.inner.active_model.write().await;
         self.inner.turn_endpoint_router.activate(endpoint);
@@ -6506,15 +6534,12 @@ fn model_header_auth_status(
     auth_context: &verlet_metadata::provider_store::LlmProviderAuthContext,
 ) -> &'static str {
     let mut saw_environment = false;
-    let values = provider.headers.values().chain(
-        provider
-            .models
-            .iter()
-            .find(|model| model.model_id == model_id)
-            .into_iter()
-            .flat_map(|model| model.headers.values()),
-    );
-    for value in values {
+    let model = provider
+        .models
+        .iter()
+        .find(|model| model.model_id == model_id);
+    let headers = crate::adapters::app_server::merged_catalog_headers(provider, model);
+    for value in headers.values() {
         match value {
             verlet_metadata::provider_store::LlmProviderConfigValue::Literal { .. } => {}
             verlet_metadata::provider_store::LlmProviderConfigValue::Env { name } => {
@@ -6537,12 +6562,42 @@ fn model_header_auth_status(
 
 fn missing_model_provider_auth_message(
     provider_id: &str,
+    model_id: &str,
     provider: Option<&verlet_metadata::provider_store::LlmProviderRecord>,
+    auth_context: &verlet_metadata::provider_store::LlmProviderAuthContext,
 ) -> String {
     if provider_id == verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID {
         return format!(
             "model provider {provider_id:?} is missing authentication; run `verlet auth login openai-codex`"
         );
+    }
+    if let Some(provider) = provider {
+        let model = provider
+            .models
+            .iter()
+            .find(|model| model.model_id == model_id);
+        let headers = crate::adapters::app_server::merged_catalog_headers(provider, model);
+        for (header_name, value) in headers {
+            match value {
+                verlet_metadata::provider_store::LlmProviderConfigValue::Env { name }
+                    if !auth_context
+                        .environment
+                        .get(&name)
+                        .is_some_and(|value| !value.is_empty()) =>
+                {
+                    return format!(
+                        "model provider {provider_id:?} header {header_name:?} requires environment variable {name}; set {name} or update/remove the header with modelProvider/upsert"
+                    );
+                }
+                verlet_metadata::provider_store::LlmProviderConfigValue::Command { .. } => {
+                    return format!(
+                        "model provider {provider_id:?} header {header_name:?} uses unsupported command-backed resolution; update or remove the header with modelProvider/upsert"
+                    );
+                }
+                verlet_metadata::provider_store::LlmProviderConfigValue::Literal { .. }
+                | verlet_metadata::provider_store::LlmProviderConfigValue::Env { .. } => {}
+            }
+        }
     }
     let env_name = provider.and_then(|provider| {
         if let verlet_metadata::provider_store::LlmProviderAuthConfig::Env { name } = &provider.auth

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -3080,15 +3080,27 @@ async fn model_select_routes_anthropic_store_provider_with_stored_key() {
             .with_auth_header(true)
             .with_header(
                 "x-store-header",
-                verlet_metadata::provider_store::LlmProviderConfigValue::literal(
-                    "anthropic-header",
-                ),
+                verlet_metadata::provider_store::LlmProviderConfigValue::Env {
+                    name: "ANTHROPIC_HEADER_OVERRIDDEN_BY_MODEL".to_string(),
+                },
             )
-            .with_model(
-                verlet_metadata::provider_store::LlmProviderModelRecord::new(
+            .with_model({
+                let mut model = verlet_metadata::provider_store::LlmProviderModelRecord::new(
                     "claude-store-fixture",
-                ),
-            ),
+                )
+                .with_max_output_tokens(321);
+                model.headers.insert(
+                    "x-store-header".to_string(),
+                    verlet_metadata::provider_store::LlmProviderConfigValue::literal(
+                        "anthropic-model-header",
+                    ),
+                );
+                model.headers.insert(
+                    "anthropic-version".to_string(),
+                    verlet_metadata::provider_store::LlmProviderConfigValue::literal("2024-01-01"),
+                );
+                model
+            }),
         )
         .await
         .unwrap();
@@ -3125,6 +3137,12 @@ async fn model_select_routes_anthropic_store_provider_with_stored_key() {
     )
     .await
     .unwrap();
+    let endpoint = crate::adapters::agent_loop::TurnEndpointRouter::resolve(
+        app.inner.turn_endpoint_router.as_ref(),
+    )
+    .unwrap();
+    assert_eq!(endpoint.config.max_tokens, 321);
+    assert!(endpoint.config.stream);
     let completed = start_and_wait_for_model_select_turn(
         &app,
         &connection,
@@ -3139,10 +3157,53 @@ async fn model_select_routes_anthropic_store_provider_with_stored_key() {
     );
     let request = server.request.await.unwrap();
     assert!(request.starts_with("POST /v1/messages HTTP/1.1"));
-    let request = request.to_ascii_lowercase();
-    assert!(request.contains("x-api-key: anthropic-store-secret"));
-    assert!(request.contains("anthropic-version: 2023-06-01"));
-    assert!(request.contains("x-store-header: anthropic-header"));
+    let request_lower = request.to_ascii_lowercase();
+    assert!(request_lower.contains("x-api-key: anthropic-store-secret"));
+    assert!(request_lower.contains("anthropic-version: 2024-01-01"));
+    assert_eq!(request_lower.matches("anthropic-version:").count(), 1);
+    assert!(request_lower.contains("x-store-header: anthropic-model-header"));
+    let body = provider_request_body(&request);
+    assert_eq!(body["model"], "claude-store-fixture");
+    assert_eq!(body["max_tokens"], 321);
+    assert_eq!(body["stream"], true);
+    assert_latest_assistant_coordinates(
+        &app,
+        &thread_id,
+        "anthropic-store-fixture",
+        "claude-store-fixture",
+    )
+    .await;
+    app.dispatch_request(
+        &connection,
+        "modelProvider/auth/set",
+        Some(serde_json::json!({
+            "providerId": "anthropic-store-fixture",
+            "apiKey": "rotated-anthropic-secret",
+        })),
+    )
+    .await
+    .unwrap();
+    let rotated_endpoint = crate::adapters::agent_loop::TurnEndpointRouter::resolve(
+        app.inner.turn_endpoint_router.as_ref(),
+    )
+    .unwrap();
+    assert!(
+        !std::sync::Arc::ptr_eq(&endpoint.client, &rotated_endpoint.client),
+        "rotating Anthropic auth must rebuild the cached endpoint"
+    );
+    let mutation_error = app
+        .dispatch_request(
+            &connection,
+            "modelProvider/delete",
+            Some(serde_json::json!({ "providerId": "anthropic-store-fixture" })),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        mutation_error
+            .message
+            .contains("select a different provider")
+    );
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -3178,7 +3239,8 @@ async fn model_select_routes_generic_openai_responses_store_provider() {
             .with_model(
                 verlet_metadata::provider_store::LlmProviderModelRecord::new(
                     "responses-store-model",
-                ),
+                )
+                .with_max_output_tokens(654),
             ),
         )
         .await
@@ -3216,6 +3278,12 @@ async fn model_select_routes_generic_openai_responses_store_provider() {
     )
     .await
     .unwrap();
+    let endpoint = crate::adapters::agent_loop::TurnEndpointRouter::resolve(
+        app.inner.turn_endpoint_router.as_ref(),
+    )
+    .unwrap();
+    assert_eq!(endpoint.config.max_tokens, 654);
+    assert!(endpoint.config.stream);
     let completed = start_and_wait_for_model_select_turn(
         &app,
         &connection,
@@ -3236,6 +3304,83 @@ async fn model_select_routes_generic_openai_responses_store_provider() {
             .contains("authorization: bearer responses-store-secret")
     );
     assert!(request.contains("x-store-header: responses-header"));
+    let body = provider_request_body(&request);
+    assert_eq!(body["model"], "responses-store-model");
+    assert_eq!(body["max_output_tokens"], 654);
+    assert_eq!(body["stream"], true);
+    assert_latest_assistant_coordinates(
+        &app,
+        &thread_id,
+        "responses-store-fixture",
+        "responses-store-model",
+    )
+    .await;
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn model_select_routes_auth_free_responses_without_authorization() {
+    let server = spawn_provider_sse_fixture(concat!(
+        "event: response.output_text.delta\n",
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"AUTH_FREE_OK\"}\n\n",
+        "event: response.completed\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":2}}}\n\n",
+    ))
+    .await;
+    let root = unique_test_root("app-server-model-select-responses-auth-free");
+    let config = local_model_select_test_config(&root, "responses-auth-free");
+    let project_store =
+        verlet_metadata::provider_store::SqliteMetadataStore::open(config.metadata_store_path())
+            .await
+            .unwrap();
+    project_store
+        .upsert_provider(
+            verlet_metadata::provider_store::LlmProviderRecord::new(
+                "responses-auth-free-fixture",
+                verlet_history::ProviderApi::OpenAIResponses,
+                format!("{}/v1", server.base_url),
+            )
+            .with_auth_header(false)
+            .with_model(
+                verlet_metadata::provider_store::LlmProviderModelRecord::new(
+                    "responses-auth-free-model",
+                ),
+            ),
+        )
+        .await
+        .unwrap();
+    drop(project_store);
+
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    let thread_id = start_model_select_test_thread(&app, &connection).await;
+    app.dispatch_request(
+        &connection,
+        "model/select",
+        Some(serde_json::json!({
+            "providerId": "responses-auth-free-fixture",
+            "model": "responses-auth-free-model",
+        })),
+    )
+    .await
+    .unwrap();
+    let completed = start_and_wait_for_model_select_turn(
+        &app,
+        &connection,
+        &mut outbound_rx,
+        &thread_id,
+        "route without authorization",
+    )
+    .await;
+    assert_eq!(
+        completed_turn_agent_text(&completed).as_deref(),
+        Some("AUTH_FREE_OK")
+    );
+    let request = server.request.await.unwrap();
+    assert!(!request.to_ascii_lowercase().contains("authorization:"));
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -3316,6 +3461,62 @@ async fn model_select_rejects_missing_auth_without_changing_active_model() {
 }
 
 #[tokio::test]
+async fn model_select_names_missing_header_environment_and_remediation() {
+    let root = unique_test_root("app-server-model-select-missing-header-env");
+    let config = local_model_select_test_config(&root, "missing-header-env");
+    let project_store =
+        verlet_metadata::provider_store::SqliteMetadataStore::open(config.metadata_store_path())
+            .await
+            .unwrap();
+    project_store
+        .upsert_provider(
+            verlet_metadata::provider_store::LlmProviderRecord::new(
+                "missing-header-fixture",
+                verlet_history::ProviderApi::OpenAIResponses,
+                "https://missing-header.example.invalid/v1",
+            )
+            .with_auth_header(false)
+            .with_header(
+                "x-required-header",
+                verlet_metadata::provider_store::LlmProviderConfigValue::Env {
+                    name: "MISSING_SELECT_HEADER_VALUE".to_string(),
+                },
+            )
+            .with_model(
+                verlet_metadata::provider_store::LlmProviderModelRecord::new(
+                    "missing-header-model",
+                ),
+            ),
+        )
+        .await
+        .unwrap();
+    drop(project_store);
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+
+    let error = app
+        .dispatch_request(
+            &connection,
+            "model/select",
+            Some(serde_json::json!({
+                "providerId": "missing-header-fixture",
+                "model": "missing-header-model",
+            })),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, -32602);
+    assert!(error.message.contains("missing-header-fixture"));
+    assert!(error.message.contains("x-required-header"));
+    assert!(error.message.contains("MISSING_SELECT_HEADER_VALUE"));
+    assert!(error.message.contains("modelProvider/upsert"));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
 async fn model_select_rejects_unsupported_store_api_without_changing_active_model() {
     let root = unique_test_root("app-server-model-select-unsupported-api");
     let config = local_model_select_test_config(&root, "unsupported-api");
@@ -3360,6 +3561,7 @@ async fn model_select_rejects_unsupported_store_api_without_changing_active_mode
     assert!(error.message.contains("unsupported api"));
     assert!(error.message.contains("OpenAI Responses"));
     assert!(error.message.contains("Anthropic Messages"));
+    assert!(error.message.contains("modelProvider/upsert"));
     let active = crate::adapters::agent_loop::TurnEndpointRouter::resolve(
         app.inner.turn_endpoint_router.as_ref(),
     )
@@ -3411,7 +3613,14 @@ async fn model_select_routes_store_backed_codex_through_oauth_client() {
         .unwrap();
     let mut provider = verlet_metadata::provider_store::default_openai_codex_llm_provider_record();
     provider.api = verlet_history::ProviderApi::Other("ignored-for-codex".to_string());
-    provider.base_url = format!("{}/backend-api/codex/responses", server.base_url);
+    provider.base_url = "https://api.openai.com/v1/responses".to_string();
+    let selected_model = provider
+        .models
+        .iter_mut()
+        .find(|model| model.model_id == verlet_metadata::provider_store::OPENAI_CODEX_DEFAULT_MODEL)
+        .unwrap();
+    selected_model.base_url = Some(format!("{}/backend-api/codex/responses", server.base_url));
+    selected_model.max_output_tokens = Some(733);
     app.inner
         .metadata_store
         .upsert_provider(provider)
@@ -3430,6 +3639,12 @@ async fn model_select_routes_store_backed_codex_through_oauth_client() {
     )
     .await
     .unwrap();
+    let endpoint = crate::adapters::agent_loop::TurnEndpointRouter::resolve(
+        app.inner.turn_endpoint_router.as_ref(),
+    )
+    .unwrap();
+    assert_eq!(endpoint.config.max_tokens, 733);
+    assert!(endpoint.config.stream);
     let completed = start_and_wait_for_model_select_turn(
         &app,
         &connection,
@@ -3449,6 +3664,20 @@ async fn model_select_routes_store_backed_codex_through_oauth_client() {
     assert!(request.contains("chatgpt-account-id: select-account"));
     assert!(request.contains("openai-beta: responses=experimental"));
     assert!(request.contains("originator: verlet"));
+    let body = provider_request_body(&request);
+    assert_eq!(
+        body["model"],
+        verlet_metadata::provider_store::OPENAI_CODEX_DEFAULT_MODEL
+    );
+    assert_eq!(body["max_output_tokens"], 733);
+    assert_eq!(body["stream"], true);
+    assert_latest_assistant_coordinates(
+        &app,
+        &thread_id,
+        verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID,
+        verlet_metadata::provider_store::OPENAI_CODEX_DEFAULT_MODEL,
+    )
+    .await;
     let auth_delete_error = app
         .dispatch_request(
             &connection,
@@ -3502,6 +3731,179 @@ async fn model_select_rejects_missing_codex_oauth_with_login_command() {
     assert!(error.message.contains("verlet auth login openai-codex"));
     assert!(!error.message.contains("--api-key-stdin"));
     let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn model_select_accepts_expired_codex_oauth_for_request_time_refresh() {
+    let root = unique_test_root("app-server-model-select-codex-expired-auth");
+    let config = local_model_select_test_config(&root, "codex-expired-auth");
+    let user_store = verlet_metadata::provider_store::SqliteMetadataStore::open(
+        config.user_metadata_store_path(),
+    )
+    .await
+    .unwrap();
+    user_store
+        .set_credential(
+            verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID,
+            verlet_metadata::provider_store::LlmProviderCredential::OAuth {
+                access: "expired-access".to_string(),
+                refresh: "expired-refresh".to_string(),
+                expires_at_ms: verlet_history::now_ms() - 1,
+                account_id: Some("expired-account".to_string()),
+                email: None,
+            },
+        )
+        .await
+        .unwrap();
+    drop(user_store);
+
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    let selected = app
+        .dispatch_request(
+            &connection,
+            "model/select",
+            Some(serde_json::json!({
+                "providerId": verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID,
+                "model": verlet_metadata::provider_store::OPENAI_CODEX_DEFAULT_MODEL,
+            })),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        selected["active"]["providerId"],
+        verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn model_select_rejects_api_key_for_codex_with_login_command() {
+    let root = unique_test_root("app-server-model-select-codex-api-key");
+    let config = local_model_select_test_config(&root, "codex-api-key")
+        .with_openai_codex(verlet_metadata::provider_store::OPENAI_CODEX_DEFAULT_MODEL);
+    let user_store = verlet_metadata::provider_store::SqliteMetadataStore::open(
+        config.user_metadata_store_path(),
+    )
+    .await
+    .unwrap();
+    user_store
+        .set_credential(
+            verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID,
+            verlet_metadata::provider_store::LlmProviderCredential::ApiKey {
+                key: "wrong-credential-kind".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    drop(user_store);
+
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    let error = app
+        .dispatch_request(
+            &connection,
+            "model/select",
+            Some(serde_json::json!({
+                "providerId": verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID,
+                "model": verlet_metadata::provider_store::OPENAI_CODEX_DEFAULT_MODEL,
+            })),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, -32602);
+    assert!(error.message.contains("openai-codex"));
+    assert!(error.message.contains("verlet auth login openai-codex"));
+    assert!(!error.message.contains("--api-key-stdin"));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn model_select_rejects_invalid_codex_response_urls_eagerly() {
+    for (case, base_url) in [
+        ("empty", ""),
+        ("malformed", "not-a-url"),
+        ("wrong-endpoint", "https://api.openai.com/v1/responses"),
+        (
+            "wrong-host",
+            "https://example.com/backend-api/codex/responses",
+        ),
+    ] {
+        let root = unique_test_root(&format!("app-server-model-select-codex-url-{case}"));
+        let config = local_model_select_test_config(&root, &format!("codex-url-{case}"))
+            .with_openai_codex(verlet_metadata::provider_store::OPENAI_CODEX_DEFAULT_MODEL);
+        let user_store = verlet_metadata::provider_store::SqliteMetadataStore::open(
+            config.user_metadata_store_path(),
+        )
+        .await
+        .unwrap();
+        user_store
+            .set_credential(
+                verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID,
+                verlet_metadata::provider_store::LlmProviderCredential::OAuth {
+                    access: "url-access".to_string(),
+                    refresh: "url-refresh".to_string(),
+                    expires_at_ms: verlet_history::now_ms() + 3_600_000,
+                    account_id: Some("url-account".to_string()),
+                    email: None,
+                },
+            )
+            .await
+            .unwrap();
+        drop(user_store);
+        let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+            .await
+            .unwrap();
+        let mut provider =
+            verlet_metadata::provider_store::default_openai_codex_llm_provider_record();
+        provider.base_url = base_url.to_string();
+        app.inner
+            .metadata_store
+            .upsert_provider(provider)
+            .await
+            .unwrap();
+        let (connection, _outbound_rx) = test_connection(app.clone()).await;
+        initialize_for_test(&connection).await;
+        let active_before = crate::adapters::agent_loop::TurnEndpointRouter::resolve(
+            app.inner.turn_endpoint_router.as_ref(),
+        )
+        .unwrap();
+
+        let error = app
+            .dispatch_request(
+                &connection,
+                "model/select",
+                Some(serde_json::json!({
+                    "providerId": verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID,
+                    "model": verlet_metadata::provider_store::OPENAI_CODEX_DEFAULT_MODEL,
+                })),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.code, -32602, "case {case}");
+        assert!(error.message.contains("openai-codex"), "case {case}");
+        assert!(error.message.contains("base URL"), "case {case}");
+        assert!(
+            error.message.contains("modelProvider/upsert"),
+            "case {case}"
+        );
+        let active_after = crate::adapters::agent_loop::TurnEndpointRouter::resolve(
+            app.inner.turn_endpoint_router.as_ref(),
+        )
+        .unwrap();
+        assert_eq!(active_after.config, active_before.config, "case {case}");
+        assert!(
+            std::sync::Arc::ptr_eq(&active_after.client, &active_before.client),
+            "case {case} must leave the active endpoint unchanged"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
 }
 
 #[tokio::test]
@@ -16440,6 +16842,41 @@ async fn start_model_select_test_thread(
         .await
         .unwrap();
     thread["thread"]["id"].as_str().unwrap().to_string()
+}
+
+fn provider_request_body(request: &str) -> serde_json::Value {
+    let (_, body) = request
+        .split_once("\r\n\r\n")
+        .expect("provider request must have an HTTP body");
+    serde_json::from_str(body).expect("provider request body must be JSON")
+}
+
+async fn assert_latest_assistant_coordinates(
+    app: &crate::adapters::app_server::VerletAppServer,
+    thread_id: &str,
+    expected_provider: &str,
+    expected_model: &str,
+) {
+    let session = app
+        .handle_for_thread(thread_id)
+        .await
+        .unwrap()
+        .session_context()
+        .await
+        .unwrap();
+    let (provider, model) = session
+        .messages
+        .iter()
+        .rev()
+        .find_map(|message| match message {
+            verlet_history::CanonicalMessage::Assistant {
+                provider, model, ..
+            } => Some((provider, model)),
+            _ => None,
+        })
+        .expect("completed routed turn must persist an assistant message");
+    assert_eq!(provider, expected_provider);
+    assert_eq!(model, expected_model);
 }
 
 struct ProviderSseFixture {

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -3052,6 +3052,194 @@ async fn model_select_switches_active_model_and_restart_restores_launch_default(
 }
 
 #[tokio::test]
+async fn model_select_routes_anthropic_store_provider_with_stored_key() {
+    let server = spawn_provider_sse_fixture(concat!(
+        "event: message_start\n",
+        "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":3}}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ANTHROPIC_STORE_OK\"}}\n\n",
+        "event: message_delta\n",
+        "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":4}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+    ))
+    .await;
+    let root = unique_test_root("app-server-model-select-anthropic");
+    let config = local_model_select_test_config(&root, "anthropic");
+    let project_store =
+        verlet_metadata::provider_store::SqliteMetadataStore::open(config.metadata_store_path())
+            .await
+            .unwrap();
+    project_store
+        .upsert_provider(
+            verlet_metadata::provider_store::LlmProviderRecord::new(
+                "anthropic-store-fixture",
+                verlet_history::ProviderApi::AnthropicMessages,
+                &server.base_url,
+            )
+            .with_auth_header(true)
+            .with_header(
+                "x-store-header",
+                verlet_metadata::provider_store::LlmProviderConfigValue::literal(
+                    "anthropic-header",
+                ),
+            )
+            .with_model(
+                verlet_metadata::provider_store::LlmProviderModelRecord::new(
+                    "claude-store-fixture",
+                ),
+            ),
+        )
+        .await
+        .unwrap();
+    let user_store = verlet_metadata::provider_store::SqliteMetadataStore::open(
+        config.user_metadata_store_path(),
+    )
+    .await
+    .unwrap();
+    user_store
+        .set_credential(
+            "anthropic-store-fixture",
+            verlet_metadata::provider_store::LlmProviderCredential::ApiKey {
+                key: "anthropic-store-secret".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    drop(project_store);
+    drop(user_store);
+
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    let thread_id = start_model_select_test_thread(&app, &connection).await;
+    app.dispatch_request(
+        &connection,
+        "model/select",
+        Some(serde_json::json!({
+            "providerId": "anthropic-store-fixture",
+            "model": "claude-store-fixture",
+        })),
+    )
+    .await
+    .unwrap();
+    let completed = start_and_wait_for_model_select_turn(
+        &app,
+        &connection,
+        &mut outbound_rx,
+        &thread_id,
+        "route to stored Anthropic",
+    )
+    .await;
+    assert_eq!(
+        completed_turn_agent_text(&completed).as_deref(),
+        Some("ANTHROPIC_STORE_OK")
+    );
+    let request = server.request.await.unwrap();
+    assert!(request.starts_with("POST /v1/messages HTTP/1.1"));
+    let request = request.to_ascii_lowercase();
+    assert!(request.contains("x-api-key: anthropic-store-secret"));
+    assert!(request.contains("anthropic-version: 2023-06-01"));
+    assert!(request.contains("x-store-header: anthropic-header"));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn model_select_routes_generic_openai_responses_store_provider() {
+    let server = spawn_provider_sse_fixture(concat!(
+        "event: response.output_text.delta\n",
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"RESPONSES_STORE_OK\"}\n\n",
+        "event: response.completed\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":2}}}\n\n",
+    ))
+    .await;
+    let root = unique_test_root("app-server-model-select-responses");
+    let config = local_model_select_test_config(&root, "responses");
+    let project_store =
+        verlet_metadata::provider_store::SqliteMetadataStore::open(config.metadata_store_path())
+            .await
+            .unwrap();
+    project_store
+        .upsert_provider(
+            verlet_metadata::provider_store::LlmProviderRecord::new(
+                "responses-store-fixture",
+                verlet_history::ProviderApi::OpenAIResponses,
+                format!("{}/v1", server.base_url),
+            )
+            .with_auth_header(true)
+            .with_header(
+                "x-store-header",
+                verlet_metadata::provider_store::LlmProviderConfigValue::literal(
+                    "responses-header",
+                ),
+            )
+            .with_model(
+                verlet_metadata::provider_store::LlmProviderModelRecord::new(
+                    "responses-store-model",
+                ),
+            ),
+        )
+        .await
+        .unwrap();
+    let user_store = verlet_metadata::provider_store::SqliteMetadataStore::open(
+        config.user_metadata_store_path(),
+    )
+    .await
+    .unwrap();
+    user_store
+        .set_credential(
+            "responses-store-fixture",
+            verlet_metadata::provider_store::LlmProviderCredential::ApiKey {
+                key: "responses-store-secret".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    drop(project_store);
+    drop(user_store);
+
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    let thread_id = start_model_select_test_thread(&app, &connection).await;
+    app.dispatch_request(
+        &connection,
+        "model/select",
+        Some(serde_json::json!({
+            "providerId": "responses-store-fixture",
+            "model": "responses-store-model",
+        })),
+    )
+    .await
+    .unwrap();
+    let completed = start_and_wait_for_model_select_turn(
+        &app,
+        &connection,
+        &mut outbound_rx,
+        &thread_id,
+        "route to stored Responses",
+    )
+    .await;
+    assert_eq!(
+        completed_turn_agent_text(&completed).as_deref(),
+        Some("RESPONSES_STORE_OK")
+    );
+    let request = server.request.await.unwrap();
+    assert!(request.starts_with("POST /v1/responses HTTP/1.1"));
+    assert!(
+        request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer responses-store-secret")
+    );
+    assert!(request.contains("x-store-header: responses-header"));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
 async fn model_select_rejects_missing_auth_without_changing_active_model() {
     let root = unique_test_root("app-server-model-select-missing-auth");
     let listen = crate::adapters::app_server::AppServerListenAddr::Unix(
@@ -3128,19 +3316,76 @@ async fn model_select_rejects_missing_auth_without_changing_active_model() {
 }
 
 #[tokio::test]
-async fn model_select_rejects_store_backed_codex_without_changing_active_model() {
+async fn model_select_rejects_unsupported_store_api_without_changing_active_model() {
+    let root = unique_test_root("app-server-model-select-unsupported-api");
+    let config = local_model_select_test_config(&root, "unsupported-api");
+    let project_store =
+        verlet_metadata::provider_store::SqliteMetadataStore::open(config.metadata_store_path())
+            .await
+            .unwrap();
+    project_store
+        .upsert_provider(
+            verlet_metadata::provider_store::LlmProviderRecord::new(
+                "unsupported-api-fixture",
+                verlet_history::ProviderApi::Other("fixture_api".to_string()),
+                "https://unsupported.example.invalid",
+            )
+            .with_auth_header(false)
+            .with_model(
+                verlet_metadata::provider_store::LlmProviderModelRecord::new("unsupported-model"),
+            ),
+        )
+        .await
+        .unwrap();
+    drop(project_store);
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+
+    let error = app
+        .dispatch_request(
+            &connection,
+            "model/select",
+            Some(serde_json::json!({
+                "providerId": "unsupported-api-fixture",
+                "model": "unsupported-model",
+            })),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, -32602);
+    assert!(error.message.contains("unsupported-api-fixture"));
+    assert!(error.message.contains("unsupported api"));
+    assert!(error.message.contains("OpenAI Responses"));
+    assert!(error.message.contains("Anthropic Messages"));
+    let active = crate::adapters::agent_loop::TurnEndpointRouter::resolve(
+        app.inner.turn_endpoint_router.as_ref(),
+    )
+    .unwrap();
+    assert_eq!(
+        active.config.provider,
+        crate::adapters::app_server::APP_SERVER_LOCAL_PROVIDER
+    );
+    assert_eq!(
+        active.config.model,
+        crate::adapters::app_server::APP_SERVER_LOCAL_MODEL
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn model_select_routes_store_backed_codex_through_oauth_client() {
+    let server = spawn_provider_sse_fixture(concat!(
+        "event: response.output_text.delta\n",
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"CODEX_STORE_OK\"}\n\n",
+        "event: response.completed\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":2}}}\n\n",
+    ))
+    .await;
     let root = unique_test_root("app-server-model-select-codex");
-    let listen = crate::adapters::app_server::AppServerListenAddr::Unix(
-        root.join("model-select-codex.sock"),
-    );
-    let mut config = crate::adapters::app_server::VerletAppServerConfig::local(
-        listen,
-        std::env::current_dir().unwrap(),
-    );
-    config.runtime_home = root.join("runtime");
-    config.state_home = root.join("state");
-    config.user_state_home = root.join("user-state");
-    config.agent_registry_root = root.join("agents");
+    let config = local_model_select_test_config(&root, "codex");
     let user_store = verlet_metadata::provider_store::SqliteMetadataStore::open(
         config.user_metadata_store_path(),
     )
@@ -3164,12 +3409,84 @@ async fn model_select_rejects_store_backed_codex_without_changing_active_model()
     let app = crate::adapters::app_server::VerletAppServer::new_local(config)
         .await
         .unwrap();
+    let mut provider = verlet_metadata::provider_store::default_openai_codex_llm_provider_record();
+    provider.api = verlet_history::ProviderApi::Other("ignored-for-codex".to_string());
+    provider.base_url = format!("{}/backend-api/codex/responses", server.base_url);
+    app.inner
+        .metadata_store
+        .upsert_provider(provider)
+        .await
+        .unwrap();
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    let thread_id = start_model_select_test_thread(&app, &connection).await;
+    app.dispatch_request(
+        &connection,
+        "model/select",
+        Some(serde_json::json!({
+            "providerId": verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID,
+            "model": verlet_metadata::provider_store::OPENAI_CODEX_DEFAULT_MODEL,
+        })),
+    )
+    .await
+    .unwrap();
+    let completed = start_and_wait_for_model_select_turn(
+        &app,
+        &connection,
+        &mut outbound_rx,
+        &thread_id,
+        "route through Codex OAuth",
+    )
+    .await;
+    assert_eq!(
+        completed_turn_agent_text(&completed).as_deref(),
+        Some("CODEX_STORE_OK")
+    );
+    let request = server.request.await.unwrap();
+    assert!(request.starts_with("POST /backend-api/codex/responses HTTP/1.1"));
+    let request = request.to_ascii_lowercase();
+    assert!(request.contains("authorization: bearer select-access"));
+    assert!(request.contains("chatgpt-account-id: select-account"));
+    assert!(request.contains("openai-beta: responses=experimental"));
+    assert!(request.contains("originator: verlet"));
+    let auth_delete_error = app
+        .dispatch_request(
+            &connection,
+            "modelProvider/auth/delete",
+            Some(serde_json::json!({
+                "providerId": verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID,
+            })),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(auth_delete_error.code, -32602);
+    assert!(
+        auth_delete_error
+            .message
+            .contains("verlet auth login openai-codex")
+    );
+    assert!(
+        app.inner
+            .user_metadata_store
+            .get_credential(verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID)
+            .await
+            .unwrap()
+            .is_some(),
+        "failed active Codex auth deletion must restore the OAuth credential"
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn model_select_rejects_missing_codex_oauth_with_login_command() {
+    let root = unique_test_root("app-server-model-select-codex-missing-auth");
+    let config = local_model_select_test_config(&root, "codex-missing-auth");
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
     let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
-    let before = crate::adapters::agent_loop::TurnEndpointRouter::resolve(
-        app.inner.turn_endpoint_router.as_ref(),
-    )
-    .unwrap();
+
     let error = app
         .dispatch_request(
             &connection,
@@ -3182,29 +3499,8 @@ async fn model_select_rejects_store_backed_codex_without_changing_active_model()
         .await
         .unwrap_err();
     assert_eq!(error.code, -32602);
-    assert!(error.message.contains("only OpenAI Chat Completions"));
-
-    let after = crate::adapters::agent_loop::TurnEndpointRouter::resolve(
-        app.inner.turn_endpoint_router.as_ref(),
-    )
-    .unwrap();
-    assert!(std::sync::Arc::ptr_eq(&before.client, &after.client));
-    assert_eq!(before.config.provider, after.config.provider);
-    assert_eq!(before.config.model, after.config.model);
-    let models = app
-        .dispatch_request(&connection, "model/list", None)
-        .await
-        .unwrap();
-    let active = models["data"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .find(|entry| entry["active"] == true)
-        .unwrap();
-    assert_eq!(
-        active["providerId"],
-        crate::adapters::app_server::APP_SERVER_LOCAL_PROVIDER
-    );
+    assert!(error.message.contains("verlet auth login openai-codex"));
+    assert!(!error.message.contains("--api-key-stdin"));
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -9671,7 +9967,7 @@ async fn catalog_provider_resolution_uses_seeded_openai_compatible_store_and_sto
         .await
         .unwrap();
 
-    let resolved = crate::adapters::app_server::resolve_catalog_openai_chat_completions_provider(
+    let resolved = crate::adapters::app_server::resolve_catalog_provider(
         &store,
         &store,
         &verlet_metadata::provider_store::LlmProviderAuthContext::new(),
@@ -9684,29 +9980,15 @@ async fn catalog_provider_resolution_uses_seeded_openai_compatible_store_and_sto
     .unwrap();
 
     assert_eq!(
-        resolved.runtime_config.provider,
+        resolved.config.provider,
         verlet_metadata::provider_store::OPENAI_COMPATIBLE_PROVIDER_ID
     );
     assert_eq!(
-        resolved.runtime_config.model,
+        resolved.config.model,
         verlet_metadata::provider_store::OPENAI_COMPATIBLE_DEFAULT_MODEL
     );
-    assert_eq!(resolved.runtime_config.max_tokens, 777);
-    assert!(!resolved.runtime_config.stream);
-    assert_eq!(
-        resolved.endpoint.url,
-        "https://api.example.invalid/v1/chat/completions"
-    );
-    assert_eq!(
-        resolved.endpoint.auth,
-        verlet_provider::ProviderAuth::Bearer {
-            token: "stored-openai_compatible-key".to_string()
-        }
-    );
-    assert_eq!(
-        resolved.endpoint.headers,
-        vec![("X-Example-Provider".to_string(), "required".to_string())]
-    );
+    assert_eq!(resolved.config.max_tokens, 777);
+    assert!(!resolved.config.stream);
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -16116,6 +16398,99 @@ async fn start_text_turn(
         .await
         .unwrap();
     turn["turn"]["id"].as_str().unwrap().to_string()
+}
+
+fn local_model_select_test_config(
+    root: &std::path::Path,
+    name: &str,
+) -> crate::adapters::app_server::VerletAppServerConfig {
+    let listen = crate::adapters::app_server::AppServerListenAddr::Unix(
+        root.join(format!("model-select-{name}.sock")),
+    );
+    let mut config = crate::adapters::app_server::VerletAppServerConfig::local(
+        listen,
+        std::env::current_dir().unwrap(),
+    );
+    config.runtime_home = root.join("runtime");
+    config.state_home = root.join("state");
+    config.user_state_home = root.join("user-state");
+    config.agent_registry_root = root.join("agents");
+    config
+}
+
+async fn start_and_wait_for_model_select_turn(
+    app: &crate::adapters::app_server::VerletAppServer,
+    connection: &crate::adapters::app_server::connection::ConnectionState,
+    outbound_rx: &mut tokio::sync::mpsc::UnboundedReceiver<
+        crate::adapters::app_server::connection::JsonRpcMessage,
+    >,
+    thread_id: &str,
+    input: &str,
+) -> serde_json::Value {
+    let turn_id = start_text_turn(app, connection, thread_id, input).await;
+    wait_for_turn_completed_notification(outbound_rx, thread_id, &turn_id).await
+}
+
+async fn start_model_select_test_thread(
+    app: &crate::adapters::app_server::VerletAppServer,
+    connection: &crate::adapters::app_server::connection::ConnectionState,
+) -> String {
+    let thread = app
+        .dispatch_request(connection, "thread/start", Some(serde_json::json!({})))
+        .await
+        .unwrap();
+    thread["thread"]["id"].as_str().unwrap().to_string()
+}
+
+struct ProviderSseFixture {
+    base_url: String,
+    request: tokio::task::JoinHandle<String>,
+}
+
+async fn spawn_provider_sse_fixture(body: impl Into<String>) -> ProviderSseFixture {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let body = body.into();
+    let request = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut buffer = Vec::new();
+        let header_end = loop {
+            let mut chunk = [0_u8; 1024];
+            let read = stream.read(&mut chunk).await.unwrap();
+            assert!(read > 0, "provider request ended before its headers");
+            buffer.extend_from_slice(&chunk[..read]);
+            if let Some(index) = find_http_header_end(&buffer) {
+                break index;
+            }
+        };
+        let content_length = String::from_utf8_lossy(&buffer[..header_end])
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().unwrap())
+            })
+            .unwrap_or(0);
+        let request_end = header_end + 4 + content_length;
+        while buffer.len() < request_end {
+            let mut chunk = [0_u8; 1024];
+            let read = stream.read(&mut chunk).await.unwrap();
+            assert!(read > 0, "provider request ended before its body");
+            buffer.extend_from_slice(&chunk[..read]);
+        }
+        let request = String::from_utf8(buffer[..request_end].to_vec()).unwrap();
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body,
+        );
+        stream.write_all(response.as_bytes()).await.unwrap();
+        request
+    });
+    ProviderSseFixture {
+        base_url: format!("http://{address}"),
+        request,
+    }
 }
 
 fn unique_test_root(name: &str) -> std::path::PathBuf {

--- a/crates/verlet-kernel/src/openai_codex.rs
+++ b/crates/verlet-kernel/src/openai_codex.rs
@@ -514,6 +514,13 @@ impl OpenAICodexProviderClient {
         )
     }
 
+    pub(crate) fn with_responses_url(
+        store: verlet_metadata::provider_store::SqliteMetadataStore,
+        responses_url: impl Into<String>,
+    ) -> Result<Self> {
+        Self::with_urls(store, TOKEN_URL, responses_url)
+    }
+
     fn with_urls(
         store: verlet_metadata::provider_store::SqliteMetadataStore,
         token_url: impl Into<String>,

--- a/docs/app-server.md
+++ b/docs/app-server.md
@@ -682,6 +682,9 @@ nothing and returns JSON-RPC `-32602` with the provider or credential problem.
 Store-backed selection supports OpenAI Chat Completions, OpenAI Responses, and
 Anthropic Messages provider APIs. The `openai-codex` provider id always uses
 the dedicated ChatGPT-plan OAuth client regardless of its stored API value.
+Its resolved `baseUrl` must be the canonical
+`https://chatgpt.com/backend-api/codex/responses` endpoint; loopback URLs with
+the same path are accepted for local endpoint tests.
 
 Selection applies to turns started after the call. A turn already running keeps
 the endpoint it resolved at its own start, including subsequent tool rounds.

--- a/docs/app-server.md
+++ b/docs/app-server.md
@@ -679,6 +679,9 @@ The pair must exist in `model/list`, and its provider must have a stored
 credential or satisfied environment credential. Validation and provider-client
 construction complete before the selection changes, so a failed call changes
 nothing and returns JSON-RPC `-32602` with the provider or credential problem.
+Store-backed selection supports OpenAI Chat Completions, OpenAI Responses, and
+Anthropic Messages provider APIs. The `openai-codex` provider id always uses
+the dedicated ChatGPT-plan OAuth client regardless of its stored API value.
 
 Selection applies to turns started after the call. A turn already running keeps
 the endpoint it resolved at its own start, including subsequent tool rounds.


### PR DESCRIPTION
model/select now builds endpoints for store providers with API AnthropicMessages and OpenAIResponses (record base URL + headers + stored/env key, policy-parity with the launch arms), and routes the openai-codex provider id through the ChatGPT-plan OAuth client (refresh discipline included) before generic API dispatch. Unsupported APIs keep the eager, clearly worded error naming a corrective action.

Includes the pre-push review-and-fix pass (6d369ac): case-insensitive header merge with model-row precedence, codex URL provenance validation, credential edge coverage (expired OAuth selects and refreshes at request time; ApiKey-on-codex rejected with relogin action), and a deliberate behavior revision accepted by the architect: explicit selections matching the launch pair route through the store record that was validated, not the launch client.

Verification: workspace tests 1154 passed / 0 failed, clippy, fmt, scripts/verify.sh and scripts/verify-linux.sh green at 6d369ac.

Linear: EMO-562.