### PR TITLE
release: bump kernel version to 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5827,7 +5827,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "verlet"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-trait",
  "base64",

--- a/crates/verlet-kernel/Cargo.toml
+++ b/crates/verlet-kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verlet"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 publish = false
 autobins = false


### PR DESCRIPTION
Version bump for the v0.3.4 release: first release carrying verlet host run (EMO-564, cedfdc3), needed by the verlet-cloud host service image (EMO-566).