### PR TITLE
Fix OpenAI Codex requests and release 0.3.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5827,7 +5827,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "verlet"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "base64",

--- a/crates/verlet-kernel/Cargo.toml
+++ b/crates/verlet-kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verlet"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 publish = false
 autobins = false

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -3669,7 +3669,7 @@ async fn model_select_routes_store_backed_codex_through_oauth_client() {
         body["model"],
         verlet_metadata::provider_store::OPENAI_CODEX_DEFAULT_MODEL
     );
-    assert_eq!(body["max_output_tokens"], 733);
+    assert!(body.get("max_output_tokens").is_none());
     assert_eq!(body["stream"], true);
     assert_latest_assistant_coordinates(
         &app,

--- a/crates/verlet-kernel/src/openai_codex.rs
+++ b/crates/verlet-kernel/src/openai_codex.rs
@@ -496,13 +496,60 @@ fn credential_needs_refresh(expires_at_ms: i64, now_ms: i64) -> bool {
     expires_at_ms <= now_ms.saturating_add(60_000)
 }
 
+/// Provider-specific wire adapter for the ChatGPT-plan Codex endpoint.
+///
+/// The endpoint speaks the Responses protocol but does not accept every field
+/// supported by the public Responses API. Keep those differences here so the
+/// generic Responses adapter remains faithful to its own contract.
+#[derive(Clone)]
+struct OpenAICodexResponsesAdapter {
+    inner: verlet_provider::OpenAIResponsesAdapter,
+}
+
+impl OpenAICodexResponsesAdapter {
+    fn omit_unsupported_max_output_tokens(mut body: serde_json::Value) -> serde_json::Value {
+        if let Some(body) = body.as_object_mut() {
+            body.remove("max_output_tokens");
+        }
+        body
+    }
+}
+
+impl verlet_provider::ProviderWireAdapter for OpenAICodexResponsesAdapter {
+    fn api(&self) -> verlet_history::ProviderApi {
+        verlet_provider::ProviderWireAdapter::api(&self.inner)
+    }
+
+    fn build_request_body(
+        &self,
+        request: &verlet_provider::ProviderRequest,
+    ) -> verlet_provider::ProviderResult<serde_json::Value> {
+        verlet_provider::ProviderWireAdapter::build_request_body(&self.inner, request)
+            .map(Self::omit_unsupported_max_output_tokens)
+    }
+
+    fn decode_response_body(
+        &self,
+        body: &serde_json::Value,
+    ) -> verlet_provider::ProviderResult<verlet_provider::ProviderResponse> {
+        verlet_provider::ProviderWireAdapter::decode_response_body(&self.inner, body)
+    }
+
+    fn decode_stream_events(
+        &self,
+        sse: &str,
+    ) -> verlet_provider::ProviderResult<Vec<verlet_provider::ProviderStreamEvent>> {
+        verlet_provider::ProviderWireAdapter::decode_stream_events(&self.inner, sse)
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct OpenAICodexProviderClient {
     store: verlet_metadata::provider_store::SqliteMetadataStore,
     http: reqwest::Client,
     token_url: String,
     responses_url: String,
-    adapter: std::sync::Arc<verlet_provider::OpenAIResponsesAdapter>,
+    adapter: std::sync::Arc<OpenAICodexResponsesAdapter>,
 }
 
 impl OpenAICodexProviderClient {
@@ -535,9 +582,11 @@ impl OpenAICodexProviderClient {
             http,
             token_url: token_url.into(),
             responses_url: responses_url.into(),
-            adapter: std::sync::Arc::new(verlet_provider::OpenAIResponsesAdapter {
-                include_encrypted_reasoning: false,
-                reasoning_summary: verlet_provider::OpenAIReasoningSummary::Auto,
+            adapter: std::sync::Arc::new(OpenAICodexResponsesAdapter {
+                inner: verlet_provider::OpenAIResponsesAdapter {
+                    include_encrypted_reasoning: false,
+                    reasoning_summary: verlet_provider::OpenAIReasoningSummary::Auto,
+                },
             }),
         })
     }
@@ -760,7 +809,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
     use verlet_metadata::provider_store::LlmProviderAuthStore as _;
-    use verlet_provider::ProviderClient as _;
+    use verlet_provider::{ProviderClient as _, ProviderWireAdapter as _};
 
     static CALLBACK_TEST_GATE: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
@@ -1351,6 +1400,43 @@ mod tests {
         );
     }
 
+    #[test]
+    fn codex_adapter_removes_only_max_output_tokens_from_complete_and_stream_requests() {
+        let inner = verlet_provider::OpenAIResponsesAdapter {
+            include_encrypted_reasoning: false,
+            reasoning_summary: verlet_provider::OpenAIReasoningSummary::Auto,
+        };
+        let adapter = OpenAICodexResponsesAdapter {
+            inner: inner.clone(),
+        };
+        let request = verlet_provider::ProviderRequest::new(
+            verlet_history::ProviderApi::OpenAIResponses,
+            verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID,
+            "gpt-5.6-sol",
+        );
+
+        let bodies = [
+            (
+                adapter.build_request_body(&request).unwrap(),
+                inner.build_request_body(&request).unwrap(),
+            ),
+            (
+                adapter.build_stream_request_body(&request).unwrap(),
+                inner.build_stream_request_body(&request).unwrap(),
+            ),
+        ];
+        for (codex_body, mut generic_body) in bodies {
+            assert_eq!(
+                generic_body
+                    .as_object_mut()
+                    .unwrap()
+                    .remove("max_output_tokens"),
+                Some(serde_json::json!(request.max_tokens))
+            );
+            assert_eq!(codex_body, generic_body);
+        }
+    }
+
     #[tokio::test]
     async fn provider_reuses_responses_plumbing_with_codex_url_and_headers() {
         let server = fake_http_server(vec![(
@@ -1400,5 +1486,6 @@ mod tests {
         assert!(request.contains("openai-beta: responses=experimental"));
         assert!(request.contains("\"model\":\"gpt-5.6-sol\""));
         assert!(request.contains("\"store\":false"));
+        assert!(!request.contains("\"max_output_tokens\""));
     }
 }


### PR DESCRIPTION
## What changed

- Route ChatGPT-plan Codex requests through a provider-specific Responses wrapper that omits the unsupported `max_output_tokens` field.
- Preserve generic OpenAI Responses behavior.
- Update the app-server routing regression and bump Verlet to 0.3.6.

## Root cause

OAuth login succeeded, but the ChatGPT-plan endpoint rejected the public Responses API's `max_output_tokens` field with HTTP 400.

## Verification

- Live authenticated TUI request on `gpt-5.6-sol` returned successfully.
- `scripts/verify.sh`
- `scripts/verify-linux.sh`
- Independent pre-commit review and follow-up review found no unresolved issues.