### PR TITLE
EMO-570: modelProvider/auth/setOAuth RPC for client-run OAuth logins

### DIFF
--- a/crates/verlet-kernel/src/adapters/app_server/connection.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/connection.rs
@@ -329,6 +329,19 @@ pub(super) struct ModelProviderAuthSetParams {
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub(super) struct ModelProviderAuthSetOAuthParams {
+    pub(super) provider_id: String,
+    pub(super) access: String,
+    pub(super) refresh: String,
+    pub(super) expires_at_ms: i64,
+    #[serde(default)]
+    pub(super) account_id: Option<String>,
+    #[serde(default)]
+    pub(super) email: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub(super) struct ModelProviderAuthDeleteParams {
     pub(super) provider_id: String,
 }
@@ -871,6 +884,10 @@ pub(super) const DISPATCH_METHOD_AUTHORITY_CLASSES: &[(
         crate::daemon::identity::AuthorityClass::Host,
     ),
     (
+        "modelProvider/auth/setOAuth",
+        crate::daemon::identity::AuthorityClass::Host,
+    ),
+    (
         "modelProvider/auth/delete",
         crate::daemon::identity::AuthorityClass::Host,
     ),
@@ -1109,6 +1126,7 @@ pub(super) const HOST_EFFECT_METHODS: &[&str] = &[
     "modelProvider/delete",
     "modelProvider/auth/status",
     "modelProvider/auth/set",
+    "modelProvider/auth/setOAuth",
     "modelProvider/auth/delete",
     // Runtime construction, reconstruction, and standing-grant changes.
     "thread/start",
@@ -1575,6 +1593,10 @@ impl crate::adapters::app_server::VerletAppServer {
             "modelProvider/auth/set" => {
                 let params: ModelProviderAuthSetParams = parse_params(params)?;
                 self.model_provider_auth_set(params).await
+            }
+            "modelProvider/auth/setOAuth" => {
+                let params: ModelProviderAuthSetOAuthParams = parse_params(params)?;
+                self.model_provider_auth_set_oauth(params).await
             }
             "modelProvider/auth/delete" => {
                 let params: ModelProviderAuthDeleteParams = parse_params(params)?;
@@ -2399,6 +2421,79 @@ impl crate::adapters::app_server::VerletAppServer {
                 &provider.provider_id,
                 verlet_metadata::provider_store::LlmProviderCredential::ApiKey {
                     key: api_key.to_string(),
+                },
+            )
+            .await
+            .map_err(|err| {
+                internal_error(crate::adapters::app_server::provider_store_error(err))
+            })?;
+        match self
+            .rebuild_active_catalog_provider_endpoint(&provider.provider_id)
+            .await
+        {
+            Ok(Some(endpoint)) => self.inner.turn_endpoint_router.activate(endpoint),
+            Ok(None) => {
+                self.inner
+                    .turn_endpoint_router
+                    .invalidate(&provider.provider_id)
+                    .await;
+            }
+            Err(error) => {
+                self.restore_model_provider_credential(&provider.provider_id, previous)
+                    .await?;
+                return Err(error);
+            }
+        }
+        Ok(serde_json::json!({ "auth": self.model_provider_auth_json(&provider).await? }))
+    }
+
+    pub(super) async fn model_provider_auth_set_oauth(
+        &self,
+        params: ModelProviderAuthSetOAuthParams,
+    ) -> Result<serde_json::Value, JsonRpcErrorError> {
+        let access = params.access.trim().to_string();
+        if access.is_empty() {
+            return Err(jsonrpc_error(
+                -32602,
+                "modelProvider/auth/setOAuth requires a non-empty access token",
+            ));
+        }
+        let refresh = params.refresh.trim().to_string();
+        if refresh.is_empty() {
+            return Err(jsonrpc_error(
+                -32602,
+                "modelProvider/auth/setOAuth requires a non-empty refresh token",
+            ));
+        }
+        let _mutation = self.inner.model_mutation.lock().await;
+        let provider = self.model_provider_record(&params.provider_id).await?;
+        if provider.provider_id != verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID {
+            return Err(jsonrpc_error(
+                -32602,
+                format!(
+                    "model provider {:?} does not use OAuth; use modelProvider/auth/set",
+                    provider.provider_id
+                ),
+            ));
+        }
+        let previous = self
+            .inner
+            .user_metadata_store
+            .get_credential(&provider.provider_id)
+            .await
+            .map_err(|err| {
+                internal_error(crate::adapters::app_server::provider_store_error(err))
+            })?;
+        self.inner
+            .user_metadata_store
+            .set_credential(
+                &provider.provider_id,
+                verlet_metadata::provider_store::LlmProviderCredential::OAuth {
+                    access,
+                    refresh,
+                    expires_at_ms: params.expires_at_ms,
+                    account_id: params.account_id,
+                    email: params.email,
                 },
             )
             .await

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -142,6 +142,10 @@ fn dispatcher_method_authority_classes_are_exhaustive_and_explicit() {
             crate::daemon::identity::AuthorityClass::Host,
         ),
         (
+            "modelProvider/auth/setOAuth",
+            crate::daemon::identity::AuthorityClass::Host,
+        ),
+        (
             "modelProvider/auth/delete",
             crate::daemon::identity::AuthorityClass::Host,
         ),
@@ -1260,6 +1264,339 @@ async fn openai_codex_oauth_status_is_redacted_and_api_key_set_cannot_replace_it
         .await
         .unwrap();
     assert_eq!(deleted["auth"]["configured"], false);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn model_provider_auth_set_oauth_rotates_active_codex_endpoint_and_selects() {
+    let server = spawn_provider_sse_fixture(concat!(
+        "event: response.output_text.delta\n",
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"SET_OAUTH_OK\"}\n\n",
+        "event: response.completed\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":2}}}\n\n",
+    ))
+    .await;
+    let root = unique_test_root("app-server-set-oauth-active-codex");
+    let config = local_model_select_test_config(&root, "set-oauth-active-codex");
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let provider_id = verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID;
+    let mut provider = verlet_metadata::provider_store::default_openai_codex_llm_provider_record();
+    provider.base_url = format!("{}/backend-api/codex/responses", server.base_url);
+    app.inner
+        .metadata_store
+        .upsert_provider(provider)
+        .await
+        .unwrap();
+    app.inner
+        .user_metadata_store
+        .set_credential(
+            provider_id,
+            verlet_metadata::provider_store::LlmProviderCredential::OAuth {
+                access: "old-access".to_string(),
+                refresh: "old-refresh".to_string(),
+                expires_at_ms: verlet_history::now_ms() + 3_600_000,
+                account_id: Some("old-account".to_string()),
+                email: None,
+            },
+        )
+        .await
+        .unwrap();
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    let thread_id = start_model_select_test_thread(&app, &connection).await;
+    app.dispatch_request(
+        &connection,
+        "model/select",
+        Some(serde_json::json!({
+            "providerId": provider_id,
+            "model": verlet_metadata::provider_store::OPENAI_CODEX_DEFAULT_MODEL,
+        })),
+    )
+    .await
+    .unwrap();
+    let endpoint_before = crate::adapters::agent_loop::TurnEndpointRouter::resolve(
+        app.inner.turn_endpoint_router.as_ref(),
+    )
+    .unwrap();
+
+    let set = app
+        .dispatch_request(
+            &connection,
+            "modelProvider/auth/setOAuth",
+            Some(serde_json::json!({
+                "providerId": provider_id,
+                "access": "new-access",
+                "refresh": "new-refresh",
+                "expiresAtMs": verlet_history::now_ms() + 7_200_000,
+                "accountId": "new-account",
+                "email": "new@example.com",
+            })),
+        )
+        .await
+        .unwrap();
+    assert_eq!(set["auth"]["configured"], true);
+    assert_eq!(set["auth"]["source"], "stored");
+    let encoded = serde_json::to_string(&set).unwrap();
+    for secret in [
+        "new-access",
+        "new-refresh",
+        "new-account",
+        "new@example.com",
+    ] {
+        assert!(!encoded.contains(secret));
+    }
+    assert!(matches!(
+        app.inner
+            .user_metadata_store
+            .get_credential(provider_id)
+            .await
+            .unwrap(),
+        Some(verlet_metadata::provider_store::LlmProviderCredential::OAuth {
+            access,
+            refresh,
+            account_id: Some(account_id),
+            email: Some(email),
+            ..
+        }) if access == "new-access"
+            && refresh == "new-refresh"
+            && account_id == "new-account"
+            && email == "new@example.com"
+    ));
+    let endpoint_after = crate::adapters::agent_loop::TurnEndpointRouter::resolve(
+        app.inner.turn_endpoint_router.as_ref(),
+    )
+    .unwrap();
+    assert!(
+        !std::sync::Arc::ptr_eq(&endpoint_before.client, &endpoint_after.client),
+        "rotating active OAuth must replace the future-turn endpoint snapshot"
+    );
+
+    app.dispatch_request(
+        &connection,
+        "model/select",
+        Some(serde_json::json!({
+            "providerId": provider_id,
+            "model": verlet_metadata::provider_store::OPENAI_CODEX_DEFAULT_MODEL,
+        })),
+    )
+    .await
+    .unwrap();
+    let completed = start_and_wait_for_model_select_turn(
+        &app,
+        &connection,
+        &mut outbound_rx,
+        &thread_id,
+        "use the newly stored OAuth credential",
+    )
+    .await;
+    assert_eq!(
+        completed_turn_agent_text(&completed).as_deref(),
+        Some("SET_OAUTH_OK")
+    );
+    let request = server.request.await.unwrap().to_ascii_lowercase();
+    assert!(request.contains("authorization: bearer new-access"));
+    assert!(request.contains("chatgpt-account-id: new-account"));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn model_provider_auth_set_oauth_rejects_api_key_provider_without_storing() {
+    let root = unique_test_root("app-server-set-oauth-api-key-provider");
+    let config = local_model_select_test_config(&root, "set-oauth-api-key-provider");
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    let provider_id = verlet_metadata::provider_store::OPENAI_COMPATIBLE_PROVIDER_ID;
+
+    let error = app
+        .dispatch_request(
+            &connection,
+            "modelProvider/auth/setOAuth",
+            Some(serde_json::json!({
+                "providerId": provider_id,
+                "access": "must-not-store-access",
+                "refresh": "must-not-store-refresh",
+                "expiresAtMs": verlet_history::now_ms() + 3_600_000,
+            })),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, -32602);
+    assert!(error.message.contains("modelProvider/auth/set"));
+    assert!(!error.message.contains("must-not-store-access"));
+    assert!(!error.message.contains("must-not-store-refresh"));
+    assert_eq!(
+        app.inner
+            .user_metadata_store
+            .get_credential(provider_id)
+            .await
+            .unwrap(),
+        None
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn model_provider_auth_set_oauth_restores_previous_credential_on_rebuild_failure() {
+    let root = unique_test_root("app-server-set-oauth-rollback");
+    let config = local_model_select_test_config(&root, "set-oauth-rollback");
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let provider_id = verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID;
+    let previous = verlet_metadata::provider_store::LlmProviderCredential::OAuth {
+        access: "previous-access".to_string(),
+        refresh: "previous-refresh".to_string(),
+        expires_at_ms: verlet_history::now_ms() + 3_600_000,
+        account_id: Some("previous-account".to_string()),
+        email: Some("previous@example.com".to_string()),
+    };
+    app.inner
+        .user_metadata_store
+        .set_credential(provider_id, previous.clone())
+        .await
+        .unwrap();
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    app.dispatch_request(
+        &connection,
+        "model/select",
+        Some(serde_json::json!({
+            "providerId": provider_id,
+            "model": verlet_metadata::provider_store::OPENAI_CODEX_DEFAULT_MODEL,
+        })),
+    )
+    .await
+    .unwrap();
+    let mut provider = app
+        .inner
+        .metadata_store
+        .get_provider(provider_id)
+        .await
+        .unwrap()
+        .unwrap();
+    provider.base_url = "https://api.openai.com/v1/responses".to_string();
+    app.inner
+        .metadata_store
+        .upsert_provider(provider)
+        .await
+        .unwrap();
+
+    let error = app
+        .dispatch_request(
+            &connection,
+            "modelProvider/auth/setOAuth",
+            Some(serde_json::json!({
+                "providerId": provider_id,
+                "access": "replacement-access",
+                "refresh": "replacement-refresh",
+                "expiresAtMs": verlet_history::now_ms() + 7_200_000,
+            })),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, -32602);
+    assert!(!error.message.contains("replacement-access"));
+    assert!(!error.message.contains("replacement-refresh"));
+    assert_eq!(
+        app.inner
+            .user_metadata_store
+            .get_credential(provider_id)
+            .await
+            .unwrap(),
+        Some(previous)
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn model_provider_auth_set_oauth_flips_model_list_auth_status() {
+    let root = unique_test_root("app-server-set-oauth-model-list");
+    let config = local_model_select_test_config(&root, "set-oauth-model-list");
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    let provider_id = verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID;
+    let codex_auth_statuses = |models: &serde_json::Value| {
+        models["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|entry| entry["providerId"] == provider_id)
+            .map(|entry| entry["authStatus"].as_str().unwrap().to_string())
+            .collect::<Vec<_>>()
+    };
+
+    let missing = app
+        .dispatch_request(&connection, "model/list", None)
+        .await
+        .unwrap();
+    assert!(
+        codex_auth_statuses(&missing)
+            .iter()
+            .all(|status| status == "missing")
+    );
+    app.dispatch_request(
+        &connection,
+        "modelProvider/auth/setOAuth",
+        Some(serde_json::json!({
+            "providerId": provider_id,
+            "access": "list-access",
+            "refresh": "list-refresh",
+            "expiresAtMs": verlet_history::now_ms() + 3_600_000,
+        })),
+    )
+    .await
+    .unwrap();
+    let configured = app
+        .dispatch_request(&connection, "model/list", None)
+        .await
+        .unwrap();
+    assert!(
+        codex_auth_statuses(&configured)
+            .iter()
+            .all(|status| status == "configured")
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn model_provider_auth_set_oauth_rejects_empty_tokens_before_mutation_lock() {
+    let root = unique_test_root("app-server-set-oauth-empty");
+    let config = local_model_select_test_config(&root, "set-oauth-empty");
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    let _mutation = app.inner.model_mutation.lock().await;
+
+    for (access, refresh) in [("   ", "refresh"), ("access", "\n\t")] {
+        // tight-timeout: rejection must return without waiting on the held mutation lock
+        let error = tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            app.dispatch_request(
+                &connection,
+                "modelProvider/auth/setOAuth",
+                Some(serde_json::json!({
+                    "providerId": verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID,
+                    "access": access,
+                    "refresh": refresh,
+                    "expiresAtMs": verlet_history::now_ms() + 3_600_000,
+                })),
+            ),
+        )
+        .await
+        .expect("empty OAuth tokens must be rejected before waiting on the mutation lock")
+        .unwrap_err();
+        assert_eq!(error.code, -32602);
+    }
     let _ = std::fs::remove_dir_all(root);
 }
 

--- a/crates/verlet-kernel/src/adapters/operator_client.rs
+++ b/crates/verlet-kernel/src/adapters/operator_client.rs
@@ -104,6 +104,31 @@ pub struct OperatorModelSelectResult {
     pub active: OperatorActiveModel,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperatorModelProviderAuth {
+    pub provider_id: String,
+    pub configured: bool,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperatorModelProviderAuthList {
+    #[serde(default)]
+    pub auth: Option<OperatorModelProviderAuth>,
+    pub data: Vec<OperatorModelProviderAuth>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct OperatorModelProviderAuthResult {
+    auth: OperatorModelProviderAuth,
+}
+
 #[derive(Clone, Debug)]
 pub struct OperatorCompletedTurn {
     pub thread_id: String,
@@ -281,6 +306,98 @@ where
         let value = self.model_select(provider_id, model).await?;
         serde_json::from_value(value)
             .map_err(|err| tui_error(format!("invalid model/select response: {err}")))
+    }
+
+    pub async fn model_provider_auth_status(
+        &mut self,
+    ) -> crate::kernel::runtime_host::VerletResult<serde_json::Value> {
+        self.request("modelProvider/auth/status", serde_json::json!({}))
+            .await
+    }
+
+    pub async fn model_provider_auth_status_typed(
+        &mut self,
+    ) -> crate::kernel::runtime_host::VerletResult<OperatorModelProviderAuthList> {
+        let value = self.model_provider_auth_status().await?;
+        serde_json::from_value(value)
+            .map_err(|err| tui_error(format!("invalid modelProvider/auth/status response: {err}")))
+    }
+
+    pub async fn model_provider_auth_set(
+        &mut self,
+        provider_id: &str,
+        api_key: &str,
+    ) -> crate::kernel::runtime_host::VerletResult<serde_json::Value> {
+        self.request(
+            "modelProvider/auth/set",
+            serde_json::json!({
+                "providerId": provider_id,
+                "apiKey": api_key,
+            }),
+        )
+        .await
+    }
+
+    pub async fn model_provider_auth_set_typed(
+        &mut self,
+        provider_id: &str,
+        api_key: &str,
+    ) -> crate::kernel::runtime_host::VerletResult<OperatorModelProviderAuth> {
+        let value = self.model_provider_auth_set(provider_id, api_key).await?;
+        serde_json::from_value::<OperatorModelProviderAuthResult>(value)
+            .map(|result| result.auth)
+            .map_err(|err| tui_error(format!("invalid modelProvider/auth/set response: {err}")))
+    }
+
+    pub async fn model_provider_auth_set_oauth(
+        &mut self,
+        provider_id: &str,
+        access: &str,
+        refresh: &str,
+        expires_at_ms: i64,
+        account_id: Option<&str>,
+        email: Option<&str>,
+    ) -> crate::kernel::runtime_host::VerletResult<serde_json::Value> {
+        self.request(
+            "modelProvider/auth/setOAuth",
+            serde_json::json!({
+                "providerId": provider_id,
+                "access": access,
+                "refresh": refresh,
+                "expiresAtMs": expires_at_ms,
+                "accountId": account_id,
+                "email": email,
+            }),
+        )
+        .await
+    }
+
+    pub async fn model_provider_auth_set_oauth_typed(
+        &mut self,
+        provider_id: &str,
+        access: &str,
+        refresh: &str,
+        expires_at_ms: i64,
+        account_id: Option<&str>,
+        email: Option<&str>,
+    ) -> crate::kernel::runtime_host::VerletResult<OperatorModelProviderAuth> {
+        let value = self
+            .model_provider_auth_set_oauth(
+                provider_id,
+                access,
+                refresh,
+                expires_at_ms,
+                account_id,
+                email,
+            )
+            .await?;
+        serde_json::from_value::<OperatorModelProviderAuthResult>(value)
+            .map(|result| result.auth)
+            .map_err(|err| {
+                tui_error(format!(
+                    "invalid modelProvider/auth/setOAuth response: {err}"
+                ))
+            })
     }
 
     pub async fn config_read(

--- a/crates/verlet-kernel/src/adapters/operator_client/tests.rs
+++ b/crates/verlet-kernel/src/adapters/operator_client/tests.rs
@@ -111,6 +111,37 @@ async fn operator_client_driver_runs_prompt_against_app_server() {
             .unwrap()
             .is_empty()
     );
+    let initial_auth = client.model_provider_auth_status_typed().await.unwrap();
+    assert!(initial_auth.auth.is_none());
+    assert!(
+        initial_auth
+            .data
+            .iter()
+            .any(|auth| auth.provider_id
+                == verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID)
+    );
+    let api_key_auth = client
+        .model_provider_auth_set_typed(
+            verlet_metadata::provider_store::OPENAI_COMPATIBLE_PROVIDER_ID,
+            "operator-api-key",
+        )
+        .await
+        .unwrap();
+    assert!(api_key_auth.configured);
+    assert_eq!(api_key_auth.source.as_deref(), Some("stored"));
+    let oauth_auth = client
+        .model_provider_auth_set_oauth_typed(
+            verlet_metadata::provider_store::OPENAI_CODEX_PROVIDER_ID,
+            "operator-access",
+            "operator-refresh",
+            verlet_history::now_ms() + 3_600_000,
+            Some("operator-account"),
+            Some("operator@example.com"),
+        )
+        .await
+        .unwrap();
+    assert!(oauth_auth.configured);
+    assert_eq!(oauth_auth.label.as_deref(), Some("stored credential"));
 
     let completed = client
         .run_prompt("hello from copied tui", std::time::Duration::from_secs(5))

--- a/crates/verlet-metadata/src/provider_store.rs
+++ b/crates/verlet-metadata/src/provider_store.rs
@@ -333,9 +333,21 @@ impl LlmProviderAuthContext {
     }
 
     pub fn from_process_env() -> Self {
+        Self::from_env_vars(std::env::vars_os())
+    }
+
+    /// `std::env::vars()` panics on non-unicode values, and a foreign
+    /// non-UTF8 variable anywhere in the environment must not take down auth
+    /// resolution; such entries can never match a provider variable, so they
+    /// are skipped.
+    fn from_env_vars(vars: impl Iterator<Item = (std::ffi::OsString, std::ffi::OsString)>) -> Self {
         Self {
             runtime_api_keys: std::collections::BTreeMap::new(),
-            environment: std::env::vars().collect(),
+            environment: vars
+                .filter_map(|(name, value)| {
+                    Some((name.into_string().ok()?, value.into_string().ok()?))
+                })
+                .collect(),
         }
     }
 

--- a/crates/verlet-metadata/src/provider_store/tests.rs
+++ b/crates/verlet-metadata/src/provider_store/tests.rs
@@ -859,6 +859,32 @@ async fn command_auth_is_visible_but_not_executed_by_default() {
     ));
 }
 
+#[test]
+fn auth_context_skips_non_unicode_environment_entries_instead_of_panicking() {
+    use std::os::unix::ffi::OsStringExt as _;
+
+    let non_unicode = std::ffi::OsString::from_vec(vec![b's', b'e', b'c', 0xff]);
+    let context = crate::provider_store::LlmProviderAuthContext::from_env_vars(
+        [
+            (
+                std::ffi::OsString::from("PLAIN_KEY"),
+                std::ffi::OsString::from("plain-value"),
+            ),
+            (
+                std::ffi::OsString::from("BROKEN_VALUE"),
+                non_unicode.clone(),
+            ),
+            (non_unicode, std::ffi::OsString::from("broken-name")),
+        ]
+        .into_iter(),
+    );
+    assert_eq!(
+        context.environment.get("PLAIN_KEY").map(String::as_str),
+        Some("plain-value")
+    );
+    assert_eq!(context.environment.len(), 1);
+}
+
 fn temp_db_path(prefix: &str) -> std::path::PathBuf {
     std::env::temp_dir().join(format!(
         "{prefix}-{}.sqlite3",

--- a/docs/app-server.md
+++ b/docs/app-server.md
@@ -824,11 +824,21 @@ Entries report `providerId`, optional `displayName`, whether a credential is
 configured, its non-secret source/label, and whether the provider uses an auth
 header. Credential values are never returned.
 
-`modelProvider/auth/set` and `modelProvider/auth/delete` serialize with
-`model/select`. When they target the active catalog provider, the app-server
-eagerly rebuilds and atomically replaces the future-turn endpoint. If deleting
-the credential would leave that provider unauthenticated, deletion fails and
-the credential is restored; an in-flight turn keeps its existing snapshot.
+### `modelProvider/auth/setOAuth`
+
+Params: `{ "providerId": "openai-codex", "access": "...", "refresh": "...", "expiresAtMs": 1720000000000, "accountId": "...", "email": "..." }`.
+`accountId` and `email` are optional. Access and refresh tokens must be
+non-empty. The method accepts only OAuth-backed providers; use
+`modelProvider/auth/set` for API-key providers.
+
+Result: `{ "auth": { ... } }` with the same redacted auth status returned by
+`modelProvider/auth/status`. Token and account values are never returned.
+
+`modelProvider/auth/set`, `modelProvider/auth/setOAuth`, and
+`modelProvider/auth/delete` serialize with `model/select`. When they target the
+active catalog provider, the app-server eagerly rebuilds and atomically replaces
+the future-turn endpoint. If rebuilding fails, the previous credential is
+restored; an in-flight turn keeps its existing snapshot.
 
 ### `mcpSource/list`
 


### PR DESCRIPTION
## Maintainer Summary

EMO-570. The chat TUI is gaining in-TUI provider sign-in (EMO-557 track); the OAuth dance runs in the chat client, so the app-server needs a host-authority method that accepts the finished credential. `modelProvider/auth/setOAuth` stores an OAuth credential for OAuth-shaped providers (openai-codex today), mirroring `auth/set` exactly: same mutation lock, eager endpoint rebuild, previous-credential rollback on rebuild failure, redacted auth-status response. API-key providers are rejected with a pointer at `auth/set`, the mirror image of `auth/set`'s existing openai-codex rejection. Typed operator-client methods (auth-status catalog, auth set, setOAuth) land alongside for the chat driver (EMO-572).

Also fixes a latent panic this work exposed: `LlmProviderAuthContext::from_process_env` collected `std::env::vars()`, which panics when any environment variable in the process is non-unicode. A stray non-UTF8 variable would take down every auth-status resolution; in the test suite the host CLI's non-unicode-secret test made concurrently running auth-status tests panic. Now collects `vars_os()` and skips non-UTF8 entries.

Before: `modelProvider/auth/set` rejects openai-codex with "run `verlet auth login`"; no RPC path exists for OAuth credentials.
After: setOAuth on openai-codex stores tokens, rebuilds the endpoint, and a following `model/select` to openai-codex succeeds on stored credentials alone; `model/list` authStatus flips missing→configured.

## Verification

- New app-server tests: endpoint rotation + select on stored OAuth, API-key-provider rejection (nothing stored), rollback on rebuild failure, authStatus flip, empty-token rejection before the mutation lock, and token non-disclosure assertions on every error path.
- New operator-client typed-method tests over a real RPC connection; new provider-store test for the non-unicode environment fix.
- `scripts/verify.sh` and `scripts/verify-linux.sh` green; full pre-push suite green.

## Risk

Host-authority surface only; method registered in the same authority/mutation tables as its `modelProvider/auth/*` siblings. Token values are pinned out of error strings by test. The env fix strictly widens tolerated environments (skips entries that could never match a provider variable). No persistence-format changes.

## Checklist

- [x] I understand the change and can explain it.
- [x] This is a maintainer-owned pull request.
- [x] I kept the pull request scoped and reviewable.
- [x] I did not include secrets, private credentials, local machine paths, or scratch artifacts.
- [x] I updated docs or tests where the behavior changed.
