### PR TITLE
EMO-571: provider setup wizard in verlet chat

### DIFF
--- a/crates/verlet-chat/src/app.rs
+++ b/crates/verlet-chat/src/app.rs
@@ -12,8 +12,11 @@ use ratatui::style::{Modifier, Style};
 use tuika::components::MarkdownState;
 use tuika::prelude::*;
 
+pub(crate) mod setup;
+
 use crate::cells::{Cell, ExecStatus, Tone, short_id};
 use crate::{Action, ChatEvent, ModelRow, SessionMeta};
+use setup::SetupStep;
 
 /// Whether the event loop should keep running.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -35,6 +38,7 @@ pub const COMMANDS: &[(&str, &str, bool)] = &[
     ("/rename", "name the current thread", true),
     ("/compact", "compact the current thread's context", false),
     ("/models", "pick the model for new turns", false),
+    ("/setup", "connect a provider and pick a model", false),
     ("/interrupt", "interrupt the active turn", false),
     ("/clear", "clear the transcript", false),
     ("/quit", "exit verlet chat", false),
@@ -56,6 +60,7 @@ pub enum SlashCommand {
     Fork,
     Compact,
     Models,
+    Setup,
 }
 
 /// Parse `input` as a slash command. `Ok(None)` means ordinary prompt text.
@@ -84,6 +89,7 @@ pub fn parse_slash_command(input: &str) -> Result<Option<SlashCommand>, String> 
         "fork" => Ok(Some(SlashCommand::Fork)),
         "compact" => Ok(Some(SlashCommand::Compact)),
         "models" => Ok(Some(SlashCommand::Models)),
+        "setup" => Ok(Some(SlashCommand::Setup)),
         "" => Err("slash command is empty; type /help".to_string()),
         other => Err(format!("unknown slash command /{other}; type /help")),
     }
@@ -119,6 +125,10 @@ pub struct App {
     pub scroll: ScrollState,
     pub(crate) popup: Option<Popup>,
     pub(crate) picker: Option<ModelPicker>,
+    pub(crate) setup: Option<SetupStep>,
+    /// A model choice waiting on credentials: re-issued as
+    /// [`Action::SelectModel`] once the provider's credential lands.
+    pub(crate) pending_selection: Option<(String, String)>,
     pub meta: SessionMeta,
     /// Turn state label for the footer: "idle", "running", "steered", ...
     pub turn_state: String,
@@ -153,6 +163,8 @@ impl App {
             scroll: ScrollState::new(),
             popup: None,
             picker: None,
+            setup: None,
+            pending_selection: None,
             meta,
             turn_state: "idle".to_string(),
             turn_active: false,
@@ -223,9 +235,14 @@ impl App {
     }
 
     fn route(&mut self, event: &Event) -> Flow {
-        // The model picker owns the whole input surface while open. Keep this
-        // ahead of transcript scrolling, paste handling, global controls, and
-        // slash completion so none of them can leak through the modal.
+        // The setup wizard and the model picker own the whole input surface
+        // while open. Keep them ahead of transcript scrolling, paste
+        // handling, global controls, and slash completion so none of those
+        // can leak through the modal.
+        if self.setup_visible() {
+            self.handle_setup(event);
+            return Flow::Continue;
+        }
         if self.picker.is_some() {
             self.handle_picker(event);
             return Flow::Continue;
@@ -367,6 +384,13 @@ impl App {
                         format!("{}/{} is already active", row.provider_id, row.model),
                         Vec::new(),
                     );
+                    return;
+                }
+                if row.auth_status == "missing" {
+                    // Selecting the row would only earn a server rejection;
+                    // route through the wizard's credential step instead and
+                    // re-issue this choice once a credential lands.
+                    self.setup_for_model(row.provider_id, row.model);
                     return;
                 }
                 self.actions.push(Action::SelectModel {
@@ -517,6 +541,7 @@ impl App {
                 }
             }
             SlashCommand::Models => self.actions.push(Action::ListModels),
+            SlashCommand::Setup => self.actions.push(Action::ListProviders),
         }
     }
 
@@ -672,6 +697,29 @@ impl App {
                 // selectable rows behind.
                 self.popup = None;
                 self.picker = None;
+                // The wizard's model step: the same picker, scoped to the
+                // provider that was just connected or chosen.
+                let rows = match self.setup.take() {
+                    Some(SetupStep::AwaitModels { provider_id }) => {
+                        let scoped: Vec<ModelRow> = rows
+                            .into_iter()
+                            .filter(|row| row.provider_id == provider_id)
+                            .collect();
+                        if scoped.is_empty() {
+                            self.notice(
+                                Tone::Error,
+                                format!("no models available for {provider_id}"),
+                                Vec::new(),
+                            );
+                            return;
+                        }
+                        scoped
+                    }
+                    step => {
+                        self.setup = step;
+                        rows
+                    }
+                };
                 if rows.is_empty() {
                     self.notice(Tone::Error, "no models available".to_string(), Vec::new());
                     return;
@@ -681,6 +729,7 @@ impl App {
                 self.picker = Some(ModelPicker { rows, state });
             }
             ChatEvent::ModelSelected { provider_id, model } => {
+                self.pending_selection = None;
                 self.meta.model_label = format!("{provider_id}/{model}");
                 let body = if self.turn_active {
                     vec!["applies to turns after the current one".to_string()]
@@ -692,6 +741,17 @@ impl App {
                     format!("model set to {provider_id}/{model}"),
                     body,
                 );
+            }
+            ChatEvent::Providers(rows) => self.open_setup(rows),
+            ChatEvent::LoginDeviceCode {
+                verification_uri,
+                user_code,
+            } => self.apply_device_code(verification_uri, user_code),
+            ChatEvent::CredentialResult { provider_id, error } => {
+                self.apply_credential_result(provider_id, error);
+            }
+            ChatEvent::CredentialCleared { provider_id } => {
+                self.apply_credential_cleared(provider_id);
             }
             ChatEvent::ThreadStatus(status) => {
                 if !self.turn_active {

--- a/crates/verlet-chat/src/app.rs
+++ b/crates/verlet-chat/src/app.rs
@@ -129,6 +129,9 @@ pub struct App {
     /// A model choice waiting on credentials: re-issued as
     /// [`Action::SelectModel`] once the provider's credential lands.
     pub(crate) pending_selection: Option<(String, String)>,
+    /// Submitted keys retained until one host reply so late generic errors
+    /// can be redacted after the user leaves the input step.
+    pub(crate) pending_key_redactions: Vec<(String, String)>,
     pub meta: SessionMeta,
     /// Turn state label for the footer: "idle", "running", "steered", ...
     pub turn_state: String,
@@ -165,6 +168,7 @@ impl App {
             picker: None,
             setup: None,
             pending_selection: None,
+            pending_key_redactions: Vec::new(),
             meta,
             turn_state: "idle".to_string(),
             turn_active: false,
@@ -540,8 +544,21 @@ impl App {
                     self.actions.push(Action::Compact);
                 }
             }
-            SlashCommand::Models => self.actions.push(Action::ListModels),
-            SlashCommand::Setup => self.actions.push(Action::ListProviders),
+            SlashCommand::Models => {
+                if matches!(
+                    self.setup,
+                    Some(SetupStep::AwaitModels { .. } | SetupStep::AwaitProviders { .. })
+                ) {
+                    self.setup = None;
+                    self.pending_selection = None;
+                }
+                self.actions.push(Action::ListModels);
+            }
+            SlashCommand::Setup => {
+                self.setup = None;
+                self.pending_selection = None;
+                self.actions.push(Action::ListProviders);
+            }
         }
     }
 
@@ -692,13 +709,6 @@ impl App {
                 self.follow();
             }
             ChatEvent::Models(rows) => {
-                // A model result supersedes completion and any older model
-                // result. Clear first so an empty refresh cannot leave stale
-                // selectable rows behind.
-                self.popup = None;
-                self.picker = None;
-                // The wizard's model step: the same picker, scoped to the
-                // provider that was just connected or chosen.
                 let rows = match self.setup.take() {
                     Some(SetupStep::AwaitModels { provider_id }) => {
                         let scoped: Vec<ModelRow> = rows
@@ -715,11 +725,17 @@ impl App {
                         }
                         scoped
                     }
+                    None => rows,
                     step => {
                         self.setup = step;
-                        rows
+                        return;
                     }
                 };
+                // A model result supersedes completion and any older model
+                // result. Clear first so an empty refresh cannot leave stale
+                // selectable rows behind.
+                self.popup = None;
+                self.picker = None;
                 if rows.is_empty() {
                     self.notice(Tone::Error, "no models available".to_string(), Vec::new());
                     return;
@@ -759,9 +775,7 @@ impl App {
                 }
             }
             ChatEvent::Info { title, body } => self.notice(Tone::Info, title, body),
-            ChatEvent::Error { title, body } => {
-                self.notice(Tone::Error, title, body);
-            }
+            ChatEvent::Error { title, body } => self.apply_error(title, body),
             ChatEvent::ResyncStarted => {
                 self.notice(
                     Tone::Warn,

--- a/crates/verlet-chat/src/app/setup.rs
+++ b/crates/verlet-chat/src/app/setup.rs
@@ -1,0 +1,604 @@
+//! Setup wizard state machine.
+//!
+//! Ported from yolop's `/setup` overlay (`yolop/src/app/setup.rs`, MIT) and
+//! rewired for the presentation-only discipline: the `SetupStep` enum is the
+//! wizard's state, these `impl App` methods are its transitions, and every
+//! side effect is an [`Action`] for the host to execute. The wizard owns the
+//! whole input surface while open — provider rows, credential options, key
+//! entry, and login-wait screens never echo through the composer. Rendering
+//! lives in `ui.rs`; this module is state and transitions only.
+
+use tuika::prelude::*;
+
+use super::App;
+use crate::cells::Tone;
+use crate::{Action, LoginMethod, ProviderRow};
+
+/// Where the wizard is. Steps carry everything they need to render and to
+/// return to the previous step, so transitions never re-fetch.
+pub(crate) enum SetupStep {
+    /// Pick a provider. Connected rows go straight to models; the rest go
+    /// through credentials.
+    Provider {
+        rows: Vec<ProviderRow>,
+        state: SelectState,
+    },
+    /// Pick how to authenticate the provider.
+    Credential {
+        rows: Vec<ProviderRow>,
+        provider: ProviderRow,
+        state: SelectState,
+        error: Option<String>,
+    },
+    /// Masked API-key entry. `busy` is set between submitting the key and
+    /// the host's [`crate::ChatEvent::CredentialResult`].
+    KeyInput {
+        rows: Vec<ProviderRow>,
+        provider: ProviderRow,
+        value: String,
+        busy: bool,
+        error: Option<String>,
+    },
+    /// An OAuth login is running in the host. Device logins fill
+    /// `device_code` with `(verification_uri, user_code)` when it arrives.
+    LoginWait {
+        rows: Vec<ProviderRow>,
+        provider: ProviderRow,
+        method: LoginMethod,
+        device_code: Option<(String, String)>,
+    },
+    /// A model list was requested for the chosen provider; the wizard closes
+    /// into the model picker when [`crate::ChatEvent::Models`] arrives.
+    AwaitModels { provider_id: String },
+    /// The provider catalog was requested to route a "needs login" model row
+    /// into its credential step.
+    AwaitProviders { provider_id: String },
+}
+
+/// One selectable row of the credential step.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CredentialOption {
+    pub action: CredentialAction,
+    pub label: &'static str,
+    pub hint: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CredentialAction {
+    BrowserLogin,
+    DeviceLogin,
+    PasteKey,
+    ClearSaved,
+    Skip,
+}
+
+/// The credential choices for a provider: sign-in flows for OAuth-shaped
+/// providers, key entry for the rest.
+pub(crate) fn credential_options(provider: &ProviderRow) -> Vec<CredentialOption> {
+    if provider.oauth {
+        vec![
+            CredentialOption {
+                action: CredentialAction::BrowserLogin,
+                label: "Sign in with browser",
+                hint: "opens on this machine",
+            },
+            CredentialOption {
+                action: CredentialAction::DeviceLogin,
+                label: "Sign in with device code",
+                hint: "works on headless terminals",
+            },
+            CredentialOption {
+                action: CredentialAction::ClearSaved,
+                label: "Clear saved login",
+                hint: "remove the stored tokens",
+            },
+            CredentialOption {
+                action: CredentialAction::Skip,
+                label: "Skip for now",
+                hint: "leave setup unchanged",
+            },
+        ]
+    } else {
+        vec![
+            CredentialOption {
+                action: CredentialAction::PasteKey,
+                label: "Paste API key",
+                hint: "stored by the server, never shown",
+            },
+            CredentialOption {
+                action: CredentialAction::ClearSaved,
+                label: "Clear saved key",
+                hint: "remove this provider's key",
+            },
+            CredentialOption {
+                action: CredentialAction::Skip,
+                label: "Skip for now",
+                hint: "leave setup unchanged",
+            },
+        ]
+    }
+}
+
+/// The status suffix for a provider row, yolop-style.
+pub(crate) fn provider_status(row: &ProviderRow) -> String {
+    match row.auth_status.as_str() {
+        "configured" | "env" => format!("✓ {}", row.label),
+        _ if row.oauth => "needs sign-in".to_string(),
+        _ => "needs API key".to_string(),
+    }
+}
+
+pub(crate) fn provider_connected(row: &ProviderRow) -> bool {
+    matches!(row.auth_status.as_str(), "configured" | "env")
+}
+
+impl App {
+    /// Open the wizard's provider step over a fresh catalog. If the wizard
+    /// was waiting to route a "needs login" model row, jump straight to that
+    /// provider's credential step.
+    pub(crate) fn open_setup(&mut self, rows: Vec<ProviderRow>) {
+        self.popup = None;
+        self.picker = None;
+        if rows.is_empty() {
+            self.setup = None;
+            self.pending_selection = None;
+            self.notice(
+                Tone::Error,
+                "no providers available".to_string(),
+                Vec::new(),
+            );
+            return;
+        }
+        if let Some(SetupStep::AwaitProviders { provider_id }) = self.setup.as_ref()
+            && let Some(provider) = rows.iter().find(|row| row.provider_id == *provider_id)
+        {
+            let provider = provider.clone();
+            self.setup = Some(SetupStep::Credential {
+                rows,
+                provider,
+                state: SelectState::new(),
+                error: None,
+            });
+            return;
+        }
+        let mut state = SelectState::new();
+        state.select(rows.iter().position(|row| row.active).or(Some(0)));
+        self.setup = Some(SetupStep::Provider { rows, state });
+    }
+
+    /// Route a chosen "needs login" model row into the wizard: remember the
+    /// selection, fetch the catalog, and land on the provider's credential
+    /// step when it arrives.
+    pub(crate) fn setup_for_model(&mut self, provider_id: String, model: String) {
+        self.pending_selection = Some((provider_id.clone(), model));
+        self.setup = Some(SetupStep::AwaitProviders { provider_id });
+        self.actions.push(Action::ListProviders);
+    }
+
+    /// The wizard is modal while it has a visible step; every event lands
+    /// here. Await states are invisible (a fetch is in flight) and do not
+    /// capture input.
+    pub(crate) fn setup_visible(&self) -> bool {
+        !matches!(
+            self.setup,
+            None | Some(SetupStep::AwaitModels { .. }) | Some(SetupStep::AwaitProviders { .. })
+        )
+    }
+
+    pub(crate) fn handle_setup(&mut self, event: &Event) {
+        let Some(step) = self.setup.take() else {
+            return;
+        };
+        match step {
+            SetupStep::Provider { rows, state } => self.handle_provider_step(event, rows, state),
+            SetupStep::Credential {
+                rows,
+                provider,
+                state,
+                error,
+            } => self.handle_credential_step(event, rows, provider, state, error),
+            SetupStep::KeyInput {
+                rows,
+                provider,
+                value,
+                busy,
+                error,
+            } => self.handle_key_input(event, rows, provider, value, busy, error),
+            SetupStep::LoginWait {
+                rows,
+                provider,
+                method,
+                device_code,
+            } => self.handle_login_wait(event, rows, provider, method, device_code),
+            step @ (SetupStep::AwaitModels { .. } | SetupStep::AwaitProviders { .. }) => {
+                self.setup = Some(step);
+            }
+        }
+    }
+
+    fn handle_provider_step(
+        &mut self,
+        event: &Event,
+        rows: Vec<ProviderRow>,
+        mut state: SelectState,
+    ) {
+        // `c` forces the credential step even when connected (rotate or
+        // clear a key), mirroring yolop.
+        if let Event::Key(key) = event
+            && key.plain()
+            && key.code == KeyCode::Char('c')
+        {
+            if let Some(provider) = state.selected().and_then(|index| rows.get(index)).cloned() {
+                self.setup = Some(SetupStep::Credential {
+                    rows,
+                    provider,
+                    state: SelectState::new(),
+                    error: None,
+                });
+            } else {
+                self.setup = Some(SetupStep::Provider { rows, state });
+            }
+            return;
+        }
+        match state.handle(event, rows.len()) {
+            InputOutcome::Submitted => {
+                let Some(provider) = state.selected().and_then(|index| rows.get(index)).cloned()
+                else {
+                    self.setup = Some(SetupStep::Provider { rows, state });
+                    return;
+                };
+                if provider_connected(&provider) {
+                    self.setup = Some(SetupStep::AwaitModels {
+                        provider_id: provider.provider_id,
+                    });
+                    self.actions.push(Action::ListModels);
+                } else {
+                    self.setup = Some(SetupStep::Credential {
+                        rows,
+                        provider,
+                        state: SelectState::new(),
+                        error: None,
+                    });
+                }
+            }
+            InputOutcome::Cancelled => {
+                self.setup = None;
+                self.pending_selection = None;
+            }
+            _ => self.setup = Some(SetupStep::Provider { rows, state }),
+        }
+    }
+
+    fn handle_credential_step(
+        &mut self,
+        event: &Event,
+        rows: Vec<ProviderRow>,
+        provider: ProviderRow,
+        mut state: SelectState,
+        error: Option<String>,
+    ) {
+        let options = credential_options(&provider);
+        match state.handle(event, options.len()) {
+            InputOutcome::Submitted => {
+                let action = state
+                    .selected()
+                    .and_then(|index| options.get(index))
+                    .map(|option| option.action)
+                    .unwrap_or(CredentialAction::Skip);
+                match action {
+                    CredentialAction::BrowserLogin => {
+                        self.actions.push(Action::StartLogin {
+                            provider_id: provider.provider_id.clone(),
+                            method: LoginMethod::Browser,
+                        });
+                        self.setup = Some(SetupStep::LoginWait {
+                            rows,
+                            provider,
+                            method: LoginMethod::Browser,
+                            device_code: None,
+                        });
+                    }
+                    CredentialAction::DeviceLogin => {
+                        self.actions.push(Action::StartLogin {
+                            provider_id: provider.provider_id.clone(),
+                            method: LoginMethod::Device,
+                        });
+                        self.setup = Some(SetupStep::LoginWait {
+                            rows,
+                            provider,
+                            method: LoginMethod::Device,
+                            device_code: None,
+                        });
+                    }
+                    CredentialAction::PasteKey => {
+                        self.setup = Some(SetupStep::KeyInput {
+                            rows,
+                            provider,
+                            value: String::new(),
+                            busy: false,
+                            error: None,
+                        });
+                    }
+                    CredentialAction::ClearSaved => {
+                        self.actions.push(Action::ClearCredential {
+                            provider_id: provider.provider_id.clone(),
+                        });
+                        self.setup = Some(SetupStep::Credential {
+                            rows,
+                            provider,
+                            state,
+                            error,
+                        });
+                    }
+                    CredentialAction::Skip => {
+                        self.setup = None;
+                        self.pending_selection = None;
+                        self.notice(Tone::Info, "setup skipped".to_string(), Vec::new());
+                    }
+                }
+            }
+            InputOutcome::Cancelled => {
+                let mut provider_state = SelectState::new();
+                provider_state.select(
+                    rows.iter()
+                        .position(|row| row.provider_id == provider.provider_id)
+                        .or(Some(0)),
+                );
+                self.setup = Some(SetupStep::Provider {
+                    rows,
+                    state: provider_state,
+                });
+            }
+            _ => {
+                self.setup = Some(SetupStep::Credential {
+                    rows,
+                    provider,
+                    state,
+                    error,
+                });
+            }
+        }
+    }
+
+    fn handle_key_input(
+        &mut self,
+        event: &Event,
+        rows: Vec<ProviderRow>,
+        provider: ProviderRow,
+        mut value: String,
+        busy: bool,
+        error: Option<String>,
+    ) {
+        // While the key is being saved only Esc (back to credentials) works;
+        // typing into a submitted form would race the host's answer.
+        if busy {
+            if matches!(event, Event::Key(key) if key.plain() && key.code == KeyCode::Esc) {
+                self.setup = Some(SetupStep::Credential {
+                    rows,
+                    provider,
+                    state: SelectState::new(),
+                    error: None,
+                });
+            } else {
+                self.setup = Some(SetupStep::KeyInput {
+                    rows,
+                    provider,
+                    value,
+                    busy,
+                    error,
+                });
+            }
+            return;
+        }
+        if let Event::Paste(pasted) = event {
+            value.push_str(pasted.trim());
+            self.setup = Some(SetupStep::KeyInput {
+                rows,
+                provider,
+                value,
+                busy: false,
+                error: None,
+            });
+            return;
+        }
+        let Event::Key(key) = event else {
+            self.setup = Some(SetupStep::KeyInput {
+                rows,
+                provider,
+                value,
+                busy,
+                error,
+            });
+            return;
+        };
+        match key.code {
+            KeyCode::Esc => {
+                self.setup = Some(SetupStep::Credential {
+                    rows,
+                    provider,
+                    state: SelectState::new(),
+                    error: None,
+                });
+            }
+            KeyCode::Enter => {
+                let trimmed = value.trim().to_string();
+                if trimmed.is_empty() {
+                    self.setup = Some(SetupStep::KeyInput {
+                        rows,
+                        provider,
+                        value,
+                        busy: false,
+                        error: Some("API key is empty — paste a key, or press Esc".to_string()),
+                    });
+                    return;
+                }
+                self.actions.push(Action::SetProviderKey {
+                    provider_id: provider.provider_id.clone(),
+                    api_key: trimmed,
+                });
+                self.setup = Some(SetupStep::KeyInput {
+                    rows,
+                    provider,
+                    value,
+                    busy: true,
+                    error: None,
+                });
+            }
+            KeyCode::Backspace => {
+                value.pop();
+                self.setup = Some(SetupStep::KeyInput {
+                    rows,
+                    provider,
+                    value,
+                    busy: false,
+                    error: None,
+                });
+            }
+            KeyCode::Char(ch) if !key.ctrl => {
+                value.push(ch);
+                self.setup = Some(SetupStep::KeyInput {
+                    rows,
+                    provider,
+                    value,
+                    busy: false,
+                    error: None,
+                });
+            }
+            _ => {
+                self.setup = Some(SetupStep::KeyInput {
+                    rows,
+                    provider,
+                    value,
+                    busy,
+                    error,
+                });
+            }
+        }
+    }
+
+    fn handle_login_wait(
+        &mut self,
+        event: &Event,
+        rows: Vec<ProviderRow>,
+        provider: ProviderRow,
+        method: LoginMethod,
+        device_code: Option<(String, String)>,
+    ) {
+        if matches!(event, Event::Key(key) if key.plain() && key.code == KeyCode::Esc) {
+            self.actions.push(Action::CancelLogin);
+            self.setup = Some(SetupStep::Credential {
+                rows,
+                provider,
+                state: SelectState::new(),
+                error: Some("sign-in canceled".to_string()),
+            });
+        } else {
+            self.setup = Some(SetupStep::LoginWait {
+                rows,
+                provider,
+                method,
+                device_code,
+            });
+        }
+    }
+
+    /// Fold a host credential answer into the wizard.
+    pub(crate) fn apply_credential_result(&mut self, provider_id: String, error: Option<String>) {
+        match self.setup.take() {
+            Some(SetupStep::KeyInput { rows, provider, .. })
+                if provider.provider_id == provider_id =>
+            {
+                if let Some(message) = error {
+                    self.setup = Some(SetupStep::KeyInput {
+                        rows,
+                        provider,
+                        value: String::new(),
+                        busy: false,
+                        error: Some(message),
+                    });
+                } else {
+                    self.finish_credential(provider_id);
+                }
+            }
+            Some(SetupStep::LoginWait { rows, provider, .. })
+                if provider.provider_id == provider_id =>
+            {
+                if let Some(message) = error {
+                    self.setup = Some(SetupStep::Credential {
+                        rows,
+                        provider,
+                        state: SelectState::new(),
+                        error: Some(message),
+                    });
+                } else {
+                    self.finish_credential(provider_id);
+                }
+            }
+            step => {
+                // The wizard moved on (or was dismissed): report out of band.
+                self.setup = step;
+                match error {
+                    Some(message) => self.notice(
+                        Tone::Error,
+                        format!("{provider_id}: credential failed"),
+                        vec![message],
+                    ),
+                    None => {
+                        self.notice(
+                            Tone::Info,
+                            format!("{provider_id}: credential saved"),
+                            Vec::new(),
+                        );
+                        // A wizard still showing pre-save rows is stale now.
+                        // (Await states are mid-fetch already; refreshing
+                        // them would clobber the answer they wait on.)
+                        if self.setup_visible() {
+                            self.actions.push(Action::ListProviders);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// A credential landed: re-issue the selection that routed us here, or
+    /// continue into the provider's model list.
+    fn finish_credential(&mut self, provider_id: String) {
+        self.notice(
+            Tone::Info,
+            format!("{provider_id}: credential saved"),
+            Vec::new(),
+        );
+        if let Some((pending_provider, model)) = self.pending_selection.take() {
+            if pending_provider == provider_id {
+                self.setup = None;
+                self.actions.push(Action::SelectModel {
+                    provider_id: pending_provider,
+                    model,
+                });
+                return;
+            }
+            self.pending_selection = Some((pending_provider, model));
+        }
+        self.setup = Some(SetupStep::AwaitModels { provider_id });
+        self.actions.push(Action::ListModels);
+    }
+
+    pub(crate) fn apply_device_code(&mut self, verification_uri: String, user_code: String) {
+        if let Some(SetupStep::LoginWait { device_code, .. }) = self.setup.as_mut() {
+            *device_code = Some((verification_uri, user_code));
+        }
+    }
+
+    pub(crate) fn apply_credential_cleared(&mut self, provider_id: String) {
+        self.notice(
+            Tone::Info,
+            format!("{provider_id}: credential cleared"),
+            Vec::new(),
+        );
+        // The provider rows held by the wizard are stale now; refresh them.
+        if self.setup_visible() {
+            self.actions.push(Action::ListProviders);
+        }
+    }
+}

--- a/crates/verlet-chat/src/app/setup.rs
+++ b/crates/verlet-chat/src/app/setup.rs
@@ -137,6 +137,44 @@ impl App {
     /// was waiting to route a "needs login" model row, jump straight to that
     /// provider's credential step.
     pub(crate) fn open_setup(&mut self, rows: Vec<ProviderRow>) {
+        let previous = self.setup.take();
+        match previous {
+            step @ Some(
+                SetupStep::Credential { .. }
+                | SetupStep::KeyInput { .. }
+                | SetupStep::LoginWait { .. }
+                | SetupStep::AwaitModels { .. },
+            ) => {
+                self.setup = step;
+                return;
+            }
+            Some(SetupStep::AwaitProviders { provider_id }) => {
+                if let Some(provider) = rows
+                    .iter()
+                    .find(|row| row.provider_id == provider_id)
+                    .cloned()
+                {
+                    self.popup = None;
+                    self.picker = None;
+                    self.setup = Some(SetupStep::Credential {
+                        rows,
+                        provider,
+                        state: SelectState::new(),
+                        error: None,
+                    });
+                    return;
+                }
+                self.pending_selection = None;
+                self.notice(
+                    Tone::Error,
+                    format!("provider {provider_id} is no longer available"),
+                    Vec::new(),
+                );
+            }
+            None | Some(SetupStep::Provider { .. }) => {
+                self.pending_selection = None;
+            }
+        }
         self.popup = None;
         self.picker = None;
         if rows.is_empty() {
@@ -147,18 +185,6 @@ impl App {
                 "no providers available".to_string(),
                 Vec::new(),
             );
-            return;
-        }
-        if let Some(SetupStep::AwaitProviders { provider_id }) = self.setup.as_ref()
-            && let Some(provider) = rows.iter().find(|row| row.provider_id == *provider_id)
-        {
-            let provider = provider.clone();
-            self.setup = Some(SetupStep::Credential {
-                rows,
-                provider,
-                state: SelectState::new(),
-                error: None,
-            });
             return;
         }
         let mut state = SelectState::new();
@@ -373,6 +399,7 @@ impl App {
         // typing into a submitted form would race the host's answer.
         if busy {
             if matches!(event, Event::Key(key) if key.plain() && key.code == KeyCode::Esc) {
+                self.pending_selection = None;
                 self.setup = Some(SetupStep::Credential {
                     rows,
                     provider,
@@ -434,8 +461,14 @@ impl App {
                 }
                 self.actions.push(Action::SetProviderKey {
                     provider_id: provider.provider_id.clone(),
-                    api_key: trimmed,
+                    api_key: trimmed.clone(),
                 });
+                self.pending_key_redactions
+                    .push((provider.provider_id.clone(), trimmed));
+                // Bound the belt-and-braces list if answers never arrive.
+                if self.pending_key_redactions.len() > 8 {
+                    self.pending_key_redactions.remove(0);
+                }
                 self.setup = Some(SetupStep::KeyInput {
                     rows,
                     provider,
@@ -486,6 +519,7 @@ impl App {
     ) {
         if matches!(event, Event::Key(key) if key.plain() && key.code == KeyCode::Esc) {
             self.actions.push(Action::CancelLogin);
+            self.pending_selection = None;
             self.setup = Some(SetupStep::Credential {
                 rows,
                 provider,
@@ -504,11 +538,16 @@ impl App {
 
     /// Fold a host credential answer into the wizard.
     pub(crate) fn apply_credential_result(&mut self, provider_id: String, error: Option<String>) {
+        let answered_provider = provider_id.clone();
         match self.setup.take() {
-            Some(SetupStep::KeyInput { rows, provider, .. })
-                if provider.provider_id == provider_id =>
-            {
+            Some(SetupStep::KeyInput {
+                rows,
+                provider,
+                busy: true,
+                ..
+            }) if provider.provider_id == provider_id => {
                 if let Some(message) = error {
+                    let message = self.redact_secrets(&message);
                     self.setup = Some(SetupStep::KeyInput {
                         rows,
                         provider,
@@ -524,6 +563,7 @@ impl App {
                 if provider.provider_id == provider_id =>
             {
                 if let Some(message) = error {
+                    let message = self.redact_secrets(&message);
                     self.setup = Some(SetupStep::Credential {
                         rows,
                         provider,
@@ -537,28 +577,30 @@ impl App {
             step => {
                 // The wizard moved on (or was dismissed): report out of band.
                 self.setup = step;
+                if self
+                    .pending_selection
+                    .as_ref()
+                    .is_some_and(|(pending_provider, _)| pending_provider == &provider_id)
+                {
+                    self.pending_selection = None;
+                }
                 match error {
-                    Some(message) => self.notice(
+                    Some(_) => self.notice(
                         Tone::Error,
                         format!("{provider_id}: credential failed"),
-                        vec![message],
+                        Vec::new(),
                     ),
-                    None => {
-                        self.notice(
-                            Tone::Info,
-                            format!("{provider_id}: credential saved"),
-                            Vec::new(),
-                        );
-                        // A wizard still showing pre-save rows is stale now.
-                        // (Await states are mid-fetch already; refreshing
-                        // them would clobber the answer they wait on.)
-                        if self.setup_visible() {
-                            self.actions.push(Action::ListProviders);
-                        }
-                    }
+                    None => self.notice(
+                        Tone::Info,
+                        format!("{provider_id}: credential saved"),
+                        Vec::new(),
+                    ),
                 }
             }
         }
+        // The submission is answered; its redaction entry has done its job.
+        self.pending_key_redactions
+            .retain(|(pending_provider, _)| pending_provider != &answered_provider);
     }
 
     /// A credential landed: re-issue the selection that routed us here, or
@@ -585,7 +627,12 @@ impl App {
     }
 
     pub(crate) fn apply_device_code(&mut self, verification_uri: String, user_code: String) {
-        if let Some(SetupStep::LoginWait { device_code, .. }) = self.setup.as_mut() {
+        if let Some(SetupStep::LoginWait {
+            method: LoginMethod::Device,
+            device_code,
+            ..
+        }) = self.setup.as_mut()
+        {
             *device_code = Some((verification_uri, user_code));
         }
     }
@@ -596,9 +643,92 @@ impl App {
             format!("{provider_id}: credential cleared"),
             Vec::new(),
         );
-        // The provider rows held by the wizard are stale now; refresh them.
-        if self.setup_visible() {
-            self.actions.push(Action::ListProviders);
+        match self.setup.as_ref() {
+            Some(SetupStep::Credential { provider, .. }) if provider.provider_id == provider_id => {
+                self.setup = Some(SetupStep::AwaitProviders {
+                    provider_id: provider_id.clone(),
+                });
+                self.actions.push(Action::ListProviders);
+            }
+            Some(SetupStep::Provider { rows, .. })
+                if rows.iter().any(|row| row.provider_id == provider_id) =>
+            {
+                self.actions.push(Action::ListProviders);
+            }
+            _ => {}
         }
     }
+
+    /// Replace any submitted key material occurring in `text`. Entries are
+    /// dropped on their matching [`crate::ChatEvent::CredentialResult`] and
+    /// capped at push time, so unmatched submissions keep redacting for the
+    /// rest of the session rather than expiring on unrelated errors.
+    pub(crate) fn redact_secrets(&self, text: &str) -> String {
+        let mut text = text.to_string();
+        for (_, secret) in &self.pending_key_redactions {
+            text = text.replace(secret, "[redacted]");
+        }
+        text
+    }
+
+    pub(crate) fn apply_error(&mut self, mut title: String, mut body: Vec<String>) {
+        title = self.redact_secrets(&title);
+        for line in &mut body {
+            *line = self.redact_secrets(line);
+        }
+        match self.setup.take() {
+            Some(SetupStep::KeyInput {
+                rows,
+                provider,
+                value,
+                busy,
+                error,
+            }) => {
+                let secret = value.trim();
+                if !secret.is_empty() {
+                    title = title.replace(secret, "[redacted]");
+                    for line in &mut body {
+                        *line = line.replace(secret, "[redacted]");
+                    }
+                }
+                if busy {
+                    self.setup = Some(SetupStep::KeyInput {
+                        rows,
+                        provider,
+                        value: String::new(),
+                        busy: false,
+                        error: Some(error_summary(&title, &body)),
+                    });
+                } else {
+                    self.setup = Some(SetupStep::KeyInput {
+                        rows,
+                        provider,
+                        value,
+                        busy,
+                        error,
+                    });
+                }
+            }
+            Some(SetupStep::LoginWait { rows, provider, .. }) => {
+                self.setup = Some(SetupStep::Credential {
+                    rows,
+                    provider,
+                    state: SelectState::new(),
+                    error: Some(error_summary(&title, &body)),
+                });
+            }
+            Some(SetupStep::AwaitModels { .. } | SetupStep::AwaitProviders { .. }) => {
+                self.setup = None;
+                self.pending_selection = None;
+            }
+            step => self.setup = step,
+        }
+        self.notice(Tone::Error, title, body);
+    }
+}
+
+fn error_summary(title: &str, body: &[String]) -> String {
+    body.first()
+        .map(|line| format!("{title}: {line}"))
+        .unwrap_or_else(|| title.to_string())
 }

--- a/crates/verlet-chat/src/lib.rs
+++ b/crates/verlet-chat/src/lib.rs
@@ -53,6 +53,54 @@ pub enum Action {
     ListModels,
     /// A picker row was chosen: switch the app-server's active model.
     SelectModel { provider_id: String, model: String },
+    /// `/setup` — fetch the provider auth catalog; the host answers with
+    /// [`ChatEvent::Providers`], which opens the setup wizard.
+    ListProviders,
+    /// A pasted API key to store for the provider; the host answers with
+    /// [`ChatEvent::CredentialResult`].
+    SetProviderKey {
+        provider_id: String,
+        api_key: String,
+    },
+    /// Start an OAuth login for the provider. The host runs the flow in the
+    /// background and reports [`ChatEvent::LoginDeviceCode`] (device method)
+    /// and [`ChatEvent::CredentialResult`].
+    StartLogin {
+        provider_id: String,
+        method: LoginMethod,
+    },
+    /// Abort the in-flight OAuth login, if any.
+    CancelLogin,
+    /// Delete the provider's stored credential; the host answers with
+    /// [`ChatEvent::CredentialCleared`] (or an error notice).
+    ClearCredential { provider_id: String },
+}
+
+/// How an OAuth-capable provider signs in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LoginMethod {
+    /// PKCE flow through the local browser.
+    Browser,
+    /// Device-code flow: the UI shows a URL and code to enter elsewhere.
+    Device,
+}
+
+/// One row of the setup wizard's provider step.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProviderRow {
+    pub provider_id: String,
+    pub display_name: String,
+    /// `configured` | `env` | `missing`, as reported by
+    /// `modelProvider/auth/status`.
+    pub auth_status: String,
+    /// The server's human status label ("stored credential",
+    /// "OPENAI_API_KEY detected", ...). Shown as the row hint.
+    pub label: String,
+    /// OAuth-shaped provider (openai-codex): sign-in options instead of a
+    /// pasted API key.
+    pub oauth: bool,
+    /// Whether this provider owns the active model selection.
+    pub active: bool,
 }
 
 /// One row of the `/models` picker.
@@ -120,6 +168,21 @@ pub enum ChatEvent {
     Models(Vec<ModelRow>),
     /// `model/select` succeeded; the active model changed for later turns.
     ModelSelected { provider_id: String, model: String },
+    /// Provider auth catalog: opens (or refreshes) the setup wizard. Sent
+    /// unsolicited at bootstrap when the active model has no credentials.
+    Providers(Vec<ProviderRow>),
+    /// A device-code login started: show the URL and code to the user.
+    LoginDeviceCode {
+        verification_uri: String,
+        user_code: String,
+    },
+    /// A credential attempt (pasted key or OAuth login) finished.
+    CredentialResult {
+        provider_id: String,
+        error: Option<String>,
+    },
+    /// The provider's stored credential was deleted.
+    CredentialCleared { provider_id: String },
     /// The thread's runtime status changed ("idle", "running", ...).
     ThreadStatus(String),
     /// An informational notice for the transcript.

--- a/crates/verlet-chat/src/tests.rs
+++ b/crates/verlet-chat/src/tests.rs
@@ -717,10 +717,18 @@ fn models_event_opens_the_picker_preselecting_the_active_row() {
     assert!(!grid.contains("Select a model"), "picker closed:\n{grid}");
 }
 
+/// `model_rows()` with the second row authenticated, for pinning the plain
+/// selection path (a `missing` row routes into the setup wizard instead).
+fn configured_model_rows() -> Vec<crate::ModelRow> {
+    let mut rows = model_rows();
+    rows[1].auth_status = "configured".to_string();
+    rows
+}
+
 #[test]
 fn picker_selection_emits_select_model_and_esc_dismisses() {
     let mut app = app();
-    app.apply(ChatEvent::Models(model_rows()));
+    app.apply(ChatEvent::Models(configured_model_rows()));
     let _ = app.handle(&key(tuika::KeyCode::Down));
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     assert_eq!(
@@ -834,12 +842,26 @@ fn models_event_replaces_popup_and_picker_and_empty_result_closes_stale_picker()
 }
 
 #[test]
-fn rejected_missing_auth_selection_keeps_model_and_active_turn_consistent() {
+fn missing_auth_selection_routes_into_the_setup_wizard() {
+    let mut app = app();
+    app.apply(ChatEvent::Models(model_rows()));
+    let _ = app.handle(&key(tuika::KeyCode::Down));
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    // No doomed SelectModel: the UI fetches the provider catalog to open the
+    // credential step for `provider` instead.
+    assert_eq!(app.drain_actions(), vec![Action::ListProviders]);
+    assert!(app.picker.is_none());
+}
+
+#[test]
+fn rejected_selection_keeps_model_and_active_turn_consistent() {
     let mut app = app();
     app.apply(ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
-    app.apply(ChatEvent::Models(model_rows()));
+    // Authenticated on the client's view, but the server still rejects the
+    // switch (stale key, unreachable endpoint).
+    app.apply(ChatEvent::Models(configured_model_rows()));
     let _ = app.handle(&key(tuika::KeyCode::Down));
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     assert!(matches!(
@@ -1087,4 +1109,353 @@ fn renders_a_turn_in_flight_snapshot() {
     assert!(grid.contains("Working ("), "working row:\n{grid}");
     assert!(grid.contains("Esc to interrupt"), "interrupt hint:\n{grid}");
     assert!(grid.contains("Looking at the snapshot…"), "answer:\n{grid}");
+}
+
+// --- setup wizard ---
+
+fn provider_rows() -> Vec<crate::ProviderRow> {
+    vec![
+        crate::ProviderRow {
+            provider_id: "anthropic".to_string(),
+            display_name: "Anthropic".to_string(),
+            auth_status: "configured".to_string(),
+            label: "stored credential".to_string(),
+            oauth: false,
+            active: true,
+        },
+        crate::ProviderRow {
+            provider_id: "openai".to_string(),
+            display_name: "OpenAI".to_string(),
+            auth_status: "missing".to_string(),
+            label: "no credential".to_string(),
+            oauth: false,
+            active: false,
+        },
+        crate::ProviderRow {
+            provider_id: "openai-codex".to_string(),
+            display_name: "OpenAI Codex".to_string(),
+            auth_status: "missing".to_string(),
+            label: "no credential".to_string(),
+            oauth: true,
+            active: false,
+        },
+    ]
+}
+
+fn open_wizard(app: &mut App) {
+    app.submit("/setup");
+    assert_eq!(app.drain_actions(), vec![Action::ListProviders]);
+    app.apply(ChatEvent::Providers(provider_rows()));
+}
+
+#[test]
+fn setup_command_opens_the_provider_step_preselecting_the_active_row() {
+    let mut app = app();
+    open_wizard(&mut app);
+    let grid = render(&mut app, true);
+    assert!(grid.contains("Set up a provider"), "title:\n{grid}");
+    assert!(grid.contains("Anthropic"), "provider name:\n{grid}");
+    assert!(
+        grid.contains("✓ stored credential"),
+        "connected status:\n{grid}"
+    );
+    assert!(grid.contains("needs API key"), "key status:\n{grid}");
+    assert!(grid.contains("needs sign-in"), "oauth status:\n{grid}");
+    assert!(grid.contains("active"), "active marker:\n{grid}");
+    assert!(grid.contains("c configure"), "footer hints:\n{grid}");
+
+    // Enter on the preselected (connected) row heads to the model step.
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    assert_eq!(app.drain_actions(), vec![Action::ListModels]);
+    let grid = render(&mut app, true);
+    assert!(
+        !grid.contains("Set up a provider"),
+        "wizard hidden:\n{grid}"
+    );
+}
+
+#[test]
+fn wizard_model_step_scopes_the_picker_to_the_chosen_provider() {
+    let mut app = app();
+    open_wizard(&mut app);
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    let _ = app.drain_actions();
+    app.apply(ChatEvent::Models(vec![
+        crate::ModelRow {
+            provider_id: "anthropic".to_string(),
+            model: "model-a".to_string(),
+            display_name: "Model A".to_string(),
+            auth_status: "configured".to_string(),
+            active: true,
+        },
+        crate::ModelRow {
+            provider_id: "openai".to_string(),
+            model: "model-b".to_string(),
+            display_name: "Model B".to_string(),
+            auth_status: "missing".to_string(),
+            active: false,
+        },
+    ]));
+    let grid = render(&mut app, true);
+    assert!(grid.contains("Select a model"), "picker title:\n{grid}");
+    assert!(grid.contains("Model A"), "scoped row:\n{grid}");
+    assert!(!grid.contains("Model B"), "other provider leaked:\n{grid}");
+}
+
+#[test]
+fn unconnected_provider_routes_through_the_credential_step_to_key_entry() {
+    let mut app = app();
+    open_wizard(&mut app);
+    let _ = app.handle(&key(tuika::KeyCode::Down));
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    let grid = render(&mut app, true);
+    assert!(grid.contains("Connect OpenAI"), "credential title:\n{grid}");
+    assert!(grid.contains("Paste API key"), "key option:\n{grid}");
+    assert!(grid.contains("Clear saved key"), "clear option:\n{grid}");
+    assert!(
+        !grid.contains("Sign in with browser"),
+        "oauth leaked:\n{grid}"
+    );
+
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    let grid = render(&mut app, true);
+    assert!(
+        grid.contains("Paste the OpenAI API key"),
+        "input title:\n{grid}"
+    );
+
+    type_text(&mut app, "sk-secret-123");
+    let grid = render(&mut app, true);
+    assert!(!grid.contains("sk-secret-123"), "key echoed:\n{grid}");
+    assert!(grid.contains("•••"), "mask missing:\n{grid}");
+
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    assert_eq!(
+        app.drain_actions(),
+        vec![Action::SetProviderKey {
+            provider_id: "openai".to_string(),
+            api_key: "sk-secret-123".to_string(),
+        }]
+    );
+    let grid = render(&mut app, true);
+    assert!(grid.contains("saving…"), "busy hint:\n{grid}");
+
+    // Success continues into the provider's model list.
+    app.apply(ChatEvent::CredentialResult {
+        provider_id: "openai".to_string(),
+        error: None,
+    });
+    assert_eq!(app.drain_actions(), vec![Action::ListModels]);
+    assert!(app.cells.iter().any(|cell| matches!(
+        cell,
+        crate::Cell::Notice { title, .. } if title == "openai: credential saved"
+    )));
+}
+
+#[test]
+fn empty_and_failed_key_submissions_surface_errors_in_place() {
+    let mut app = app();
+    open_wizard(&mut app);
+    let _ = app.handle(&key(tuika::KeyCode::Down));
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    assert_eq!(app.drain_actions(), Vec::new());
+    let grid = render(&mut app, true);
+    assert!(grid.contains("API key is empty"), "empty error:\n{grid}");
+
+    type_text(&mut app, "sk-bad");
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    let _ = app.drain_actions();
+    app.apply(ChatEvent::CredentialResult {
+        provider_id: "openai".to_string(),
+        error: Some("provider rejected the key".to_string()),
+    });
+    assert_eq!(app.drain_actions(), Vec::new());
+    let grid = render(&mut app, true);
+    assert!(
+        grid.contains("provider rejected the key"),
+        "failure shown in place:\n{grid}"
+    );
+}
+
+#[test]
+fn oauth_provider_offers_sign_in_and_shows_the_device_code() {
+    let mut app = app();
+    open_wizard(&mut app);
+    let _ = app.handle(&key(tuika::KeyCode::Down));
+    let _ = app.handle(&key(tuika::KeyCode::Down));
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    let grid = render(&mut app, true);
+    assert!(grid.contains("Connect OpenAI Codex"), "title:\n{grid}");
+    assert!(
+        grid.contains("Sign in with browser"),
+        "browser option:\n{grid}"
+    );
+
+    // Pick the device flow (second option).
+    let _ = app.handle(&key(tuika::KeyCode::Down));
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    assert_eq!(
+        app.drain_actions(),
+        vec![Action::StartLogin {
+            provider_id: "openai-codex".to_string(),
+            method: crate::LoginMethod::Device,
+        }]
+    );
+    let grid = render(&mut app, true);
+    assert!(
+        grid.contains("Sign in to OpenAI Codex"),
+        "wait title:\n{grid}"
+    );
+    assert!(
+        grid.contains("requesting a device code"),
+        "wait body:\n{grid}"
+    );
+
+    app.apply(ChatEvent::LoginDeviceCode {
+        verification_uri: "https://auth.example/device".to_string(),
+        user_code: "ABCD-1234".to_string(),
+    });
+    let grid = render(&mut app, true);
+    assert!(
+        grid.contains("https://auth.example/device"),
+        "verification uri:\n{grid}"
+    );
+    assert!(grid.contains("ABCD-1234"), "user code:\n{grid}");
+
+    // Esc cancels the login and lands back on credentials with a notice.
+    let _ = app.handle(&key(tuika::KeyCode::Esc));
+    assert_eq!(app.drain_actions(), vec![Action::CancelLogin]);
+    let grid = render(&mut app, true);
+    assert!(
+        grid.contains("Connect OpenAI Codex"),
+        "back on credentials:\n{grid}"
+    );
+    assert!(grid.contains("sign-in canceled"), "cancel notice:\n{grid}");
+}
+
+#[test]
+fn login_success_reissues_the_selection_that_started_the_wizard() {
+    let mut app = app();
+    // Enter on a "needs login" model row routes into the wizard.
+    app.apply(ChatEvent::Models(vec![crate::ModelRow {
+        provider_id: "openai-codex".to_string(),
+        model: "gpt-5.6-sol".to_string(),
+        display_name: "GPT 5.6 sol".to_string(),
+        auth_status: "missing".to_string(),
+        active: false,
+    }]));
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    assert_eq!(app.drain_actions(), vec![Action::ListProviders]);
+
+    // The catalog answer lands directly on the provider's credential step.
+    app.apply(ChatEvent::Providers(provider_rows()));
+    let grid = render(&mut app, true);
+    assert!(
+        grid.contains("Connect OpenAI Codex"),
+        "credential step:\n{grid}"
+    );
+
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    assert_eq!(
+        app.drain_actions(),
+        vec![Action::StartLogin {
+            provider_id: "openai-codex".to_string(),
+            method: crate::LoginMethod::Browser,
+        }]
+    );
+    app.apply(ChatEvent::CredentialResult {
+        provider_id: "openai-codex".to_string(),
+        error: None,
+    });
+    assert_eq!(
+        app.drain_actions(),
+        vec![Action::SelectModel {
+            provider_id: "openai-codex".to_string(),
+            model: "gpt-5.6-sol".to_string(),
+        }]
+    );
+    let grid = render(&mut app, true);
+    assert!(!grid.contains("Sign in to"), "wizard closed:\n{grid}");
+}
+
+#[test]
+fn wizard_swallows_composer_input_and_esc_dismisses_from_the_provider_step() {
+    let mut app = app();
+    open_wizard(&mut app);
+    type_text(&mut app, "hello");
+    assert!(app.composer.is_empty(), "composer must stay untouched");
+    assert_eq!(app.drain_actions(), Vec::new());
+
+    let _ = app.handle(&key(tuika::KeyCode::Esc));
+    let grid = render(&mut app, true);
+    assert!(
+        !grid.contains("Set up a provider"),
+        "wizard closed:\n{grid}"
+    );
+    type_text(&mut app, "hi");
+    assert!(!app.composer.is_empty(), "composer usable again");
+}
+
+#[test]
+fn stale_credential_results_report_out_of_band_without_reopening_the_wizard() {
+    let mut app = app();
+    app.apply(ChatEvent::CredentialResult {
+        provider_id: "openai".to_string(),
+        error: Some("boom".to_string()),
+    });
+    let grid = render(&mut app, true);
+    assert!(
+        !grid.contains("Set up a provider"),
+        "wizard stayed shut:\n{grid}"
+    );
+    assert!(app.cells.iter().any(|cell| matches!(
+        cell,
+        crate::Cell::Notice { tone: crate::Tone::Error, title, .. }
+            if title == "openai: credential failed"
+    )));
+}
+
+#[test]
+fn clearing_a_credential_refreshes_the_open_wizard() {
+    let mut app = app();
+    open_wizard(&mut app);
+    // `c` opens the credential step even on a connected provider.
+    let _ = app.handle(&key(tuika::KeyCode::Char('c')));
+    let grid = render(&mut app, true);
+    assert!(grid.contains("Connect Anthropic"), "config step:\n{grid}");
+
+    // Pick "Clear saved key" (second option for a key provider).
+    let _ = app.handle(&key(tuika::KeyCode::Down));
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    assert_eq!(
+        app.drain_actions(),
+        vec![Action::ClearCredential {
+            provider_id: "anthropic".to_string(),
+        }]
+    );
+    app.apply(ChatEvent::CredentialCleared {
+        provider_id: "anthropic".to_string(),
+    });
+    assert_eq!(app.drain_actions(), vec![Action::ListProviders]);
+    assert!(app.cells.iter().any(|cell| matches!(
+        cell,
+        crate::Cell::Notice { title, .. } if title == "anthropic: credential cleared"
+    )));
+}
+
+#[test]
+fn setup_wizard_build_is_safe_at_zero_and_tiny_terminal_sizes() {
+    for (width, height) in [(0u16, 0u16), (1, 1), (20, 4)] {
+        let mut app = app();
+        open_wizard(&mut app);
+        let _ = render_at(&mut app, true, width, height);
+        let _ = app.handle(&key(tuika::KeyCode::Down));
+        let _ = app.handle(&key(tuika::KeyCode::Enter));
+        let _ = render_at(&mut app, true, width, height);
+        let _ = app.handle(&key(tuika::KeyCode::Enter));
+        let _ = render_at(&mut app, true, width, height);
+    }
 }

--- a/crates/verlet-chat/src/tests.rs
+++ b/crates/verlet-chat/src/tests.rs
@@ -1366,6 +1366,18 @@ fn login_success_reissues_the_selection_that_started_the_wizard() {
             method: crate::LoginMethod::Browser,
         }]
     );
+    app.apply(ChatEvent::LoginDeviceCode {
+        verification_uri: "https://stale.example/device".to_string(),
+        user_code: "STALE".to_string(),
+    });
+    assert!(matches!(
+        app.setup.as_ref(),
+        Some(crate::app::setup::SetupStep::LoginWait {
+            method: crate::LoginMethod::Browser,
+            device_code: None,
+            ..
+        })
+    ));
     app.apply(ChatEvent::CredentialResult {
         provider_id: "openai-codex".to_string(),
         error: None,
@@ -1385,11 +1397,22 @@ fn login_success_reissues_the_selection_that_started_the_wizard() {
 fn wizard_swallows_composer_input_and_esc_dismisses_from_the_provider_step() {
     let mut app = app();
     open_wizard(&mut app);
+    app.apply(ChatEvent::TurnStarted {
+        turn_id: "turn-1".to_string(),
+    });
     type_text(&mut app, "hello");
+    let _ = app.handle(&tuika::Event::Paste("pasted".to_string()));
+    let _ = app.handle(&tuika::Event::Key(tuika::Key {
+        code: tuika::KeyCode::Char('c'),
+        ctrl: true,
+        alt: false,
+        shift: false,
+    }));
     assert!(app.composer.is_empty(), "composer must stay untouched");
     assert_eq!(app.drain_actions(), Vec::new());
 
     let _ = app.handle(&key(tuika::KeyCode::Esc));
+    assert_eq!(app.drain_actions(), Vec::new());
     let grid = render(&mut app, true);
     assert!(
         !grid.contains("Set up a provider"),
@@ -1416,6 +1439,293 @@ fn stale_credential_results_report_out_of_band_without_reopening_the_wizard() {
         crate::Cell::Notice { tone: crate::Tone::Error, title, .. }
             if title == "openai: credential failed"
     )));
+}
+
+#[test]
+fn setup_request_errors_release_invisible_wait_states() {
+    let mut app = app();
+    app.apply(ChatEvent::Models(vec![crate::ModelRow {
+        provider_id: "missing-provider".to_string(),
+        model: "model-a".to_string(),
+        display_name: "Model A".to_string(),
+        auth_status: "missing".to_string(),
+        active: false,
+    }]));
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    let _ = app.drain_actions();
+    app.apply(ChatEvent::Error {
+        title: "provider catalog failed".to_string(),
+        body: Vec::new(),
+    });
+    assert!(app.setup.is_none());
+    assert!(app.pending_selection.is_none());
+
+    open_wizard(&mut app);
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    let _ = app.drain_actions();
+    app.apply(ChatEvent::Error {
+        title: "model catalog failed".to_string(),
+        body: Vec::new(),
+    });
+    assert!(app.setup.is_none());
+    app.apply(ChatEvent::Models(vec![
+        crate::ModelRow {
+            provider_id: "anthropic".to_string(),
+            model: "model-a".to_string(),
+            display_name: "Model A".to_string(),
+            auth_status: "configured".to_string(),
+            active: true,
+        },
+        crate::ModelRow {
+            provider_id: "openai".to_string(),
+            model: "model-b".to_string(),
+            display_name: "Model B".to_string(),
+            auth_status: "missing".to_string(),
+            active: false,
+        },
+    ]));
+    let grid = render(&mut app, true);
+    assert!(grid.contains("Model A"), "first model missing:\n{grid}");
+    assert!(grid.contains("Model B"), "result stayed scoped:\n{grid}");
+}
+
+#[test]
+fn setup_action_errors_return_busy_steps_to_interactive_state() {
+    let mut app = app();
+    open_wizard(&mut app);
+    let _ = app.handle(&key(tuika::KeyCode::Down));
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    type_text(&mut app, "sk-secret");
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    let _ = app.drain_actions();
+    app.apply(ChatEvent::Error {
+        title: "saving sk-secret failed".to_string(),
+        body: vec!["sk-secret was rejected".to_string()],
+    });
+    let grid = render(&mut app, true);
+    assert!(!grid.contains("sk-secret"), "secret leaked:\n{grid}");
+    assert!(!grid.contains("saving…"), "key input stayed busy:\n{grid}");
+    type_text(&mut app, "sk-retry");
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    assert_eq!(
+        app.drain_actions(),
+        vec![Action::SetProviderKey {
+            provider_id: "openai".to_string(),
+            api_key: "sk-retry".to_string(),
+        }]
+    );
+
+    let mut oauth_app = App::new(meta());
+    open_wizard(&mut oauth_app);
+    let _ = oauth_app.handle(&key(tuika::KeyCode::Down));
+    let _ = oauth_app.handle(&key(tuika::KeyCode::Down));
+    let _ = oauth_app.handle(&key(tuika::KeyCode::Enter));
+    let _ = oauth_app.handle(&key(tuika::KeyCode::Enter));
+    let _ = oauth_app.drain_actions();
+    oauth_app.apply(ChatEvent::Error {
+        title: "login failed".to_string(),
+        body: Vec::new(),
+    });
+    let grid = render(&mut oauth_app, true);
+    assert!(
+        grid.contains("Connect OpenAI Codex"),
+        "login stayed busy:\n{grid}"
+    );
+    assert!(
+        !grid.contains("Sign in to OpenAI Codex"),
+        "login wait stayed open:\n{grid}"
+    );
+}
+
+#[test]
+fn credential_failure_never_renders_the_submitted_secret() {
+    let mut app = app();
+    open_wizard(&mut app);
+    let _ = app.handle(&key(tuika::KeyCode::Down));
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    type_text(&mut app, "sk-do-not-render");
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    let _ = app.drain_actions();
+    app.apply(ChatEvent::CredentialResult {
+        provider_id: "openai".to_string(),
+        error: Some("provider echoed sk-do-not-render".to_string()),
+    });
+    let grid = render(&mut app, true);
+    assert!(!grid.contains("sk-do-not-render"), "secret leaked:\n{grid}");
+    assert!(
+        grid.contains("provider echoed [redacted]"),
+        "redacted error missing:\n{grid}"
+    );
+
+    let mut late_app = App::new(meta());
+    open_wizard(&mut late_app);
+    let _ = late_app.handle(&key(tuika::KeyCode::Down));
+    let _ = late_app.handle(&key(tuika::KeyCode::Enter));
+    let _ = late_app.handle(&key(tuika::KeyCode::Enter));
+    type_text(&mut late_app, "sk-late-error");
+    let _ = late_app.handle(&key(tuika::KeyCode::Enter));
+    let _ = late_app.drain_actions();
+    let _ = late_app.handle(&key(tuika::KeyCode::Esc));
+    late_app.apply(ChatEvent::Error {
+        title: "saving sk-late-error failed".to_string(),
+        body: vec!["rejected sk-late-error".to_string()],
+    });
+    let grid = render(&mut late_app, true);
+    assert!(
+        !grid.contains("sk-late-error"),
+        "late error leaked:\n{grid}"
+    );
+}
+
+#[test]
+fn catalog_events_do_not_clobber_open_credential_input() {
+    let mut app = app();
+    open_wizard(&mut app);
+    let _ = app.handle(&key(tuika::KeyCode::Down));
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    type_text(&mut app, "sk-kept");
+
+    app.apply(ChatEvent::Providers(provider_rows()));
+    app.apply(ChatEvent::Models(vec![crate::ModelRow {
+        provider_id: "anthropic".to_string(),
+        model: "model-a".to_string(),
+        display_name: "Must Not Open".to_string(),
+        auth_status: "configured".to_string(),
+        active: true,
+    }]));
+    app.apply(ChatEvent::CredentialCleared {
+        provider_id: "anthropic".to_string(),
+    });
+    app.apply(ChatEvent::CredentialResult {
+        provider_id: "anthropic".to_string(),
+        error: None,
+    });
+
+    assert_eq!(app.drain_actions(), Vec::new());
+    let grid = render(&mut app, true);
+    assert!(
+        grid.contains("Paste the OpenAI API key"),
+        "input was replaced:\n{grid}"
+    );
+    assert!(
+        !grid.contains("Must Not Open"),
+        "picker opened behind setup:\n{grid}"
+    );
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    assert_eq!(
+        app.drain_actions(),
+        vec![Action::SetProviderKey {
+            provider_id: "openai".to_string(),
+            api_key: "sk-kept".to_string(),
+        }]
+    );
+}
+
+#[test]
+fn manual_models_command_supersedes_the_wizard_model_scope() {
+    let mut app = app();
+    open_wizard(&mut app);
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    let _ = app.drain_actions();
+
+    app.submit("/models");
+    assert_eq!(app.drain_actions(), vec![Action::ListModels]);
+    app.apply(ChatEvent::Models(vec![
+        crate::ModelRow {
+            provider_id: "anthropic".to_string(),
+            model: "model-a".to_string(),
+            display_name: "Model A".to_string(),
+            auth_status: "configured".to_string(),
+            active: true,
+        },
+        crate::ModelRow {
+            provider_id: "openai".to_string(),
+            model: "model-b".to_string(),
+            display_name: "Model B".to_string(),
+            auth_status: "missing".to_string(),
+            active: false,
+        },
+    ]));
+    let grid = render(&mut app, true);
+    assert!(grid.contains("Model A"), "first model missing:\n{grid}");
+    assert!(
+        grid.contains("Model B"),
+        "manual result was scoped:\n{grid}"
+    );
+}
+
+#[test]
+fn missing_awaited_provider_and_canceled_login_clear_pending_selection() {
+    let mut app = app();
+    app.apply(ChatEvent::Models(vec![crate::ModelRow {
+        provider_id: "gone".to_string(),
+        model: "model-a".to_string(),
+        display_name: "Model A".to_string(),
+        auth_status: "missing".to_string(),
+        active: false,
+    }]));
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    let _ = app.drain_actions();
+    app.apply(ChatEvent::Providers(provider_rows()));
+    assert!(app.pending_selection.is_none());
+
+    let mut cancel_app = App::new(meta());
+    cancel_app.apply(ChatEvent::Models(vec![crate::ModelRow {
+        provider_id: "openai-codex".to_string(),
+        model: "gpt-5.6-sol".to_string(),
+        display_name: "GPT 5.6 sol".to_string(),
+        auth_status: "missing".to_string(),
+        active: false,
+    }]));
+    let _ = cancel_app.handle(&key(tuika::KeyCode::Enter));
+    let _ = cancel_app.drain_actions();
+    cancel_app.apply(ChatEvent::Providers(provider_rows()));
+    let _ = cancel_app.handle(&key(tuika::KeyCode::Enter));
+    let _ = cancel_app.drain_actions();
+    let _ = cancel_app.handle(&key(tuika::KeyCode::Esc));
+    let _ = cancel_app.drain_actions();
+    assert!(cancel_app.pending_selection.is_none());
+    cancel_app.apply(ChatEvent::CredentialResult {
+        provider_id: "openai-codex".to_string(),
+        error: None,
+    });
+    assert_eq!(cancel_app.drain_actions(), Vec::new());
+
+    let mut key_app = App::new(meta());
+    key_app.apply(ChatEvent::Models(vec![crate::ModelRow {
+        provider_id: "openai".to_string(),
+        model: "gpt-key".to_string(),
+        display_name: "GPT key".to_string(),
+        auth_status: "missing".to_string(),
+        active: false,
+    }]));
+    let _ = key_app.handle(&key(tuika::KeyCode::Enter));
+    let _ = key_app.drain_actions();
+    key_app.apply(ChatEvent::Providers(provider_rows()));
+    let _ = key_app.handle(&key(tuika::KeyCode::Enter));
+    type_text(&mut key_app, "sk-key");
+    let _ = key_app.handle(&key(tuika::KeyCode::Enter));
+    let _ = key_app.drain_actions();
+    let _ = key_app.handle(&key(tuika::KeyCode::Esc));
+    assert!(key_app.pending_selection.is_none());
+}
+
+#[test]
+fn long_and_wide_provider_rows_preserve_the_active_marker() {
+    let mut app = app();
+    app.apply(ChatEvent::Providers(vec![crate::ProviderRow {
+        provider_id: "provider".to_string(),
+        display_name: "模型🙂 provider with a very long display name".repeat(2),
+        auth_status: "configured".to_string(),
+        label: "a very long stored credential status".repeat(2),
+        oauth: false,
+        active: true,
+    }]));
+    let grid = render_at(&mut app, true, 40, 12);
+    assert!(grid.contains("active"), "active marker clipped:\n{grid}");
 }
 
 #[test]

--- a/crates/verlet-chat/src/ui.rs
+++ b/crates/verlet-chat/src/ui.rs
@@ -289,21 +289,27 @@ fn setup_providers(
     theme: &Theme,
     width: u16,
 ) -> Element {
-    let content_w = width.saturating_sub(2);
+    let scrollbar_w = u16::from(rows.len() > MAX_PICKER_ROWS);
+    let content_w = width.saturating_sub(2).saturating_sub(scrollbar_w);
+    let max_suffix_w = u16::from(rows.iter().any(|row| row.active)) * 8;
     let max_name_w = rows
         .iter()
         .map(|row| tuika::width::str_cols(&row.display_name))
         .max()
         .unwrap_or(0);
-    let name_w = max_name_w.min(content_w / 2);
+    let name_w = max_name_w.min(content_w.saturating_sub(max_suffix_w.saturating_add(2)) / 2);
     let lines: Vec<Line<'static>> = rows
         .iter()
         .map(|row| {
+            let suffix_w = if row.active { 8 } else { 0 };
             let name = fit_columns(&row.display_name, name_w);
             let name_pad = name_w.saturating_sub(tuika::width::str_cols(&name));
             let status = fit_columns(
                 &provider_status(row),
-                content_w.saturating_sub(name_w).saturating_sub(2),
+                content_w
+                    .saturating_sub(name_w)
+                    .saturating_sub(2)
+                    .saturating_sub(suffix_w),
             );
             let connected = provider_connected(row);
             let mut spans = vec![

--- a/crates/verlet-chat/src/ui.rs
+++ b/crates/verlet-chat/src/ui.rs
@@ -13,7 +13,9 @@ use tuika::prelude::*;
 use tuika::probe::RectProbe;
 
 use crate::app::App;
+use crate::app::setup::{SetupStep, credential_options, provider_connected, provider_status};
 use crate::cells::short_id;
+use crate::{LoginMethod, ProviderRow};
 
 /// Columns of blank kept down each side of the UI.
 pub const GUTTER: u16 = 1;
@@ -50,13 +52,14 @@ pub fn build(
         .as_ref()
         .map(|picker| picker.rows.len().min(MAX_PICKER_ROWS) as u16 + 2)
         .unwrap_or(0);
+    let setup_h = setup_height(app);
     let working_h = if app.turn_active() { 2 } else { 0 };
     let composer_rows = app
         .composer
         .visual_height(width.saturating_sub(4))
         .clamp(1, MAX_COMPOSER_ROWS);
     let body_h = composer_rows + 2;
-    let bottom_h = working_h + popup_h + picker_h + body_h + 1;
+    let bottom_h = working_h + popup_h + picker_h + setup_h + body_h + 1;
     let transcript_h = area.height.saturating_sub(bottom_h).max(1);
 
     // Reconcile the scroll offset with this frame's dimensions, then stash
@@ -86,6 +89,9 @@ pub fn build(
     if picker_h > 0 {
         root = root.fixed(picker_h, picker(app, theme, width));
     }
+    if setup_h > 0 {
+        root = root.fixed(setup_h, setup(app, theme, width));
+    }
     root = root.fixed(body_h, composer(app, theme, probe));
     root = root.fixed(1, footer(app, theme));
     element(root)
@@ -100,9 +106,9 @@ fn working(app: &App, theme: &Theme) -> Element {
             Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
         ),
         Span::styled(
-            // While the picker is open it owns Esc (dismiss, not interrupt),
-            // so the interrupt hint would lie.
-            if app.picker.is_some() {
+            // While the picker or the setup wizard is open it owns Esc
+            // (dismiss, not interrupt), so the interrupt hint would lie.
+            if app.picker.is_some() || app.setup_visible() {
                 format!(" ({}s)", app.elapsed_secs())
             } else {
                 format!(" ({}s • Esc to interrupt)", app.elapsed_secs())
@@ -225,6 +231,262 @@ fn picker(app: &App, theme: &Theme, width: u16) -> Element {
     )
 }
 
+/// Rows the setup wizard needs this frame, measured like the picker: list
+/// rows capped at [`MAX_PICKER_ROWS`], plus spacer, title, and (when
+/// present) a trailing error/hint line.
+fn setup_height(app: &App) -> u16 {
+    match app.setup.as_ref() {
+        None | Some(SetupStep::AwaitModels { .. }) | Some(SetupStep::AwaitProviders { .. }) => 0,
+        Some(SetupStep::Provider { rows, .. }) => rows.len().min(MAX_PICKER_ROWS) as u16 + 2,
+        Some(SetupStep::Credential {
+            provider, error, ..
+        }) => credential_options(provider).len() as u16 + 2 + u16::from(error.is_some()),
+        // Spacer, title, input row, hint/error row.
+        Some(SetupStep::KeyInput { .. }) => 4,
+        // Spacer, title, one or two content rows, hint row.
+        Some(SetupStep::LoginWait { device_code, .. }) => 4 + u16::from(device_code.is_some()),
+    }
+}
+
+/// The setup wizard panel. Same visual language as the model picker: a bold
+/// title, a selectable list (or input/wait body), muted annotations.
+fn setup(app: &App, theme: &Theme, width: u16) -> Element {
+    match app.setup.as_ref() {
+        Some(SetupStep::Provider { rows, state }) => setup_providers(rows, state, theme, width),
+        Some(SetupStep::Credential {
+            provider,
+            state,
+            error,
+            ..
+        }) => setup_credentials(provider, state, error.as_deref(), theme),
+        Some(SetupStep::KeyInput {
+            provider,
+            value,
+            busy,
+            error,
+            ..
+        }) => setup_key_input(provider, value, *busy, error.as_deref(), theme, width),
+        Some(SetupStep::LoginWait {
+            provider,
+            method,
+            device_code,
+            ..
+        }) => setup_login_wait(provider, *method, device_code.as_ref(), app, theme),
+        _ => element(Spacer),
+    }
+}
+
+fn setup_title(text: String, theme: &Theme) -> Element {
+    element(Text::new(vec![Line::from(Span::styled(
+        text,
+        Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+    ))]))
+}
+
+fn setup_providers(
+    rows: &[ProviderRow],
+    state: &SelectState,
+    theme: &Theme,
+    width: u16,
+) -> Element {
+    let content_w = width.saturating_sub(2);
+    let max_name_w = rows
+        .iter()
+        .map(|row| tuika::width::str_cols(&row.display_name))
+        .max()
+        .unwrap_or(0);
+    let name_w = max_name_w.min(content_w / 2);
+    let lines: Vec<Line<'static>> = rows
+        .iter()
+        .map(|row| {
+            let name = fit_columns(&row.display_name, name_w);
+            let name_pad = name_w.saturating_sub(tuika::width::str_cols(&name));
+            let status = fit_columns(
+                &provider_status(row),
+                content_w.saturating_sub(name_w).saturating_sub(2),
+            );
+            let connected = provider_connected(row);
+            let mut spans = vec![
+                Span::styled(
+                    format!("{name}{:width$}  ", "", width = usize::from(name_pad)),
+                    Style::default().fg(theme.text),
+                ),
+                Span::styled(
+                    status,
+                    if connected {
+                        Style::default().fg(theme.accent)
+                    } else {
+                        theme.muted_style()
+                    },
+                ),
+            ];
+            if row.active {
+                spans.push(Span::styled(
+                    "  active",
+                    Style::default()
+                        .fg(theme.accent)
+                        .add_modifier(Modifier::BOLD),
+                ));
+            }
+            Line::from(spans)
+        })
+        .collect();
+    let list = SelectList::new(lines, state).viewport(MAX_PICKER_ROWS as u16);
+    element(
+        Flex::column()
+            .fixed(1, element(Spacer))
+            .fixed(1, setup_title("Set up a provider".to_string(), theme))
+            .grow(1, element(list)),
+    )
+}
+
+fn setup_credentials(
+    provider: &ProviderRow,
+    state: &SelectState,
+    error: Option<&str>,
+    theme: &Theme,
+) -> Element {
+    let lines: Vec<Line<'static>> = credential_options(provider)
+        .iter()
+        .map(|option| {
+            Line::from(vec![
+                Span::styled(
+                    format!("{}  ", option.label),
+                    Style::default().fg(theme.text),
+                ),
+                Span::styled(option.hint.to_string(), theme.muted_style()),
+            ])
+        })
+        .collect();
+    let list = SelectList::new(lines, state).viewport(MAX_PICKER_ROWS as u16);
+    let mut column = Flex::column()
+        .fixed(1, element(Spacer))
+        .fixed(
+            1,
+            setup_title(format!("Connect {}", provider.display_name), theme),
+        )
+        .grow(1, element(list));
+    if let Some(message) = error {
+        column = column.fixed(1, setup_error(message, theme));
+    }
+    element(column)
+}
+
+fn setup_error(message: &str, theme: &Theme) -> Element {
+    // Matches the notice-cell error glyph and color in `cells.rs`.
+    element(Text::new(vec![Line::from(vec![
+        Span::styled("✗ ", Style::default().fg(theme.accent)),
+        Span::styled(message.to_string(), Style::default().fg(theme.text)),
+    ])]))
+}
+
+fn setup_key_input(
+    provider: &ProviderRow,
+    value: &str,
+    busy: bool,
+    error: Option<&str>,
+    theme: &Theme,
+    width: u16,
+) -> Element {
+    // The key never renders: a masked run of bullets stands in for it, and
+    // overlong keys clip from the left so the caret edge stays visible.
+    let masked = "•".repeat(
+        value
+            .chars()
+            .count()
+            .min(usize::from(width.saturating_sub(6))),
+    );
+    let body = Line::from(vec![
+        Span::styled("› ", Style::default().fg(theme.accent_alt)),
+        Span::styled(masked, Style::default().fg(theme.text)),
+    ]);
+    let hint: Element = if let Some(message) = error {
+        setup_error(message, theme)
+    } else if busy {
+        element(Text::new(vec![Line::from(Span::styled(
+            "saving…",
+            theme.muted_style(),
+        ))]))
+    } else {
+        element(Text::new(vec![Line::from(Span::styled(
+            "⏎ save   esc back",
+            theme.muted_style(),
+        ))]))
+    };
+    element(
+        Flex::column()
+            .fixed(1, element(Spacer))
+            .fixed(
+                1,
+                setup_title(
+                    format!("Paste the {} API key", provider.display_name),
+                    theme,
+                ),
+            )
+            .fixed(1, element(Text::new(vec![body])))
+            .fixed(1, hint),
+    )
+}
+
+fn setup_login_wait(
+    provider: &ProviderRow,
+    method: LoginMethod,
+    device_code: Option<&(String, String)>,
+    app: &App,
+    theme: &Theme,
+) -> Element {
+    let title = setup_title(format!("Sign in to {}", provider.display_name), theme);
+    let mut column = Flex::column().fixed(1, element(Spacer)).fixed(1, title);
+    match (method, device_code) {
+        (LoginMethod::Device, Some((uri, code))) => {
+            column = column
+                .fixed(
+                    1,
+                    element(Text::new(vec![Line::from(vec![
+                        Span::styled("Open ".to_string(), theme.muted_style()),
+                        Span::styled(uri.clone(), Style::default().fg(theme.text)),
+                    ])])),
+                )
+                .fixed(
+                    1,
+                    element(Text::new(vec![Line::from(vec![
+                        Span::styled("Enter code ".to_string(), theme.muted_style()),
+                        Span::styled(
+                            code.clone(),
+                            Style::default()
+                                .fg(theme.accent)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                    ])])),
+                );
+        }
+        _ => {
+            let waiting = match method {
+                LoginMethod::Browser => "waiting for the browser sign-in to finish",
+                LoginMethod::Device => "requesting a device code",
+            };
+            let row = view! {
+                row(gap = 1) {
+                    fixed(1) { node(Spinner::new(app.frame).color(theme.accent)) }
+                    grow(1) { node(Text::new(vec![Line::from(Span::styled(
+                        waiting.to_string(),
+                        theme.muted_style(),
+                    ))])) }
+                }
+            };
+            column = column.fixed(1, row);
+        }
+    }
+    column = column.fixed(
+        1,
+        element(Text::new(vec![Line::from(Span::styled(
+            "esc cancel",
+            theme.muted_style(),
+        ))])),
+    );
+    element(column)
+}
+
 fn model_row_suffix(row: &crate::ModelRow) -> String {
     let mut suffix = String::new();
     if row.active {
@@ -287,7 +549,14 @@ fn composer(app: &App, theme: &Theme, probe: &RectProbe) -> Element {
 
 /// Key hints on the left; connection, thread, and turn state on the right.
 fn footer(app: &App, theme: &Theme) -> Element {
-    let hints = if app.picker.is_some() {
+    let hints = if matches!(
+        app.setup.as_ref(),
+        Some(SetupStep::KeyInput { .. } | SetupStep::LoginWait { .. })
+    ) {
+        "  ⏎ confirm   esc back"
+    } else if matches!(app.setup.as_ref(), Some(SetupStep::Provider { .. })) {
+        "  ↑↓ move   ⏎ select   c configure   esc dismiss"
+    } else if app.setup_visible() || app.picker.is_some() {
         "  ↑↓ move   ⏎ select   esc dismiss"
     } else if app.popup.is_some() {
         "  ↑↓ move   ⇥ complete   ⏎ run   esc dismiss"

--- a/crates/verlet-kernel/src/cli/chat.rs
+++ b/crates/verlet-kernel/src/cli/chat.rs
@@ -365,6 +365,18 @@ impl ChatDriver {
                     model: selected.active.model,
                 });
             }
+            // Setup-wizard wiring lands with EMO-572; until then the wizard
+            // actions answer with an honest notice instead of dead air.
+            verlet_chat::Action::ListProviders
+            | verlet_chat::Action::SetProviderKey { .. }
+            | verlet_chat::Action::StartLogin { .. }
+            | verlet_chat::Action::CancelLogin
+            | verlet_chat::Action::ClearCredential { .. } => {
+                let _ = events.send(verlet_chat::ChatEvent::Error {
+                    title: "provider setup is not wired to this server yet".to_string(),
+                    body: vec!["use `verlet auth` from a shell for now".to_string()],
+                });
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
## Maintainer Summary

EMO-571 (EMO-557 track). `/setup` in `verlet chat` opens a provider setup wizard, ported from yolop's `/setup` overlay (MIT, friendly collaborator): provider rows with live auth status, a credential step per provider (masked API-key entry, or browser / device-code sign-in options for OAuth providers), a device-code display screen, and a provider-scoped model step reusing the EMO-559 picker. Enter on a "needs login" model row now routes into the wizard's credential step and re-issues the selection once a credential lands, instead of firing a `model/select` the server rejects.

`verlet-chat` stays presentation-only: new `Action`s (ListProviders, SetProviderKey, StartLogin, CancelLogin, ClearCredential) and `ChatEvent`s (Providers, LoginDeviceCode, CredentialResult, CredentialCleared) carry everything. The chat driver answers the new actions with an honest not-wired-yet notice until EMO-572 lands the RPC + client-side OAuth wiring, so the wizard is inert but recoverable on today's servers.

A review pass hardened the state machine: submitted API keys cannot surface in any error path (late errors are redacted against submitted keys), host error events release the await/busy states they answer, unsolicited catalog events cannot clobber an open credential step, every wizard exit clears the pending selection, device codes only land on device-method waits, and the provider list reserves scrollbar/active-marker columns.

Before: Enter on a `needs login` row fires a doomed select; credentials require dropping to `verlet auth` in a shell.
After: the same Enter opens "Connect <provider>" with paste-key / sign-in options; `/setup` offers the full provider → credential → model flow.

## Verification

- 69 hermetic tuika render tests in `verlet-chat` (17 new): every wizard step, masked entry (secret never rendered), device-code display, cancel paths, stale-event handling, redaction, tiny-terminal safety.
- Existing picker tests updated for the new missing-auth contract; plain selection path re-pinned on an authenticated row.
- `scripts/verify.sh` and `scripts/verify-linux.sh` green; full pre-push suite green.

## Risk

UI-only plus one interim driver match arm; no RPC or persistence changes. The known protocol gap (events carry no request id, so overlapping same-provider credential attempts cannot be causally distinguished) is documented and deferred to the EMO-572 wiring, which owns the request lifecycle.

## Checklist

- [x] I understand the change and can explain it.
- [x] This is a maintainer-owned pull request.
- [x] I kept the pull request scoped and reviewable.
- [x] I did not include secrets, private credentials, local machine paths, or scratch artifacts.
- [x] I updated docs or tests where the behavior changed.
