### PR TITLE
release: bump kernel version to 0.3.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5827,7 +5827,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "verlet"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "async-trait",
  "base64",

--- a/crates/verlet-kernel/Cargo.toml
+++ b/crates/verlet-kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verlet"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 publish = false
 autobins = false


### PR DESCRIPTION
## Summary
- Bump kernel version 0.3.6 -> 0.3.7 ahead of tagging v0.3.7.
- First release carrying the in-TUI provider setup flow: `modelProvider/auth/setOAuth` (#102), the `/setup` wizard (#103), and the chat-driver credential/OAuth wiring (#104).

## Test plan
- [x] Pre-push verify suite (fmt, clippy, full workspace tests, smokes, lints) passed locally
- [ ] CI green