### PR TITLE
Re-home WASM secret and private-network enforcement to attachment config

### DIFF
--- a/crates/verlet-kernel/src/adapters/agent_loop/tests.rs
+++ b/crates/verlet-kernel/src/adapters/agent_loop/tests.rs
@@ -223,6 +223,7 @@ fn recovery_bind_receipt(
             artifact_hash: "test".to_string(),
             effect_class,
             grants: Vec::new(),
+            attachment_config: verlet_wasm::WasmAttachmentConfig::default(),
             grant_expiries: Vec::new(),
             operations: vec!["recovery_tool".to_string()],
             direct_tools: vec![

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -10580,6 +10580,7 @@ fn thread_manifest_operation_bindings_accept_legacy_metadata_without_operations(
                 .to_string(),
             effect_class: verlet_agent::manifest_schema::EffectClass::AtMostOnce,
             grants: vec!["net:https://example.com".to_string()],
+            attachment_config: verlet_wasm::WasmAttachmentConfig::default(),
             grant_expiries: Vec::new(),
             operations: Vec::new(),
             direct_tools: Vec::new(),

--- a/crates/verlet-kernel/src/adapters/app_server/threads.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/threads.rs
@@ -2459,6 +2459,7 @@ impl CapsuleBindingRuntimeFactory {
                 artifact_hash,
                 effect_class: _,
                 grants,
+                attachment_config,
                 grant_expiries,
                 operations,
                 direct_tools,
@@ -2487,7 +2488,8 @@ impl CapsuleBindingRuntimeFactory {
                 crate::operations::plugins::LocalPluginCatalogRecord::selected_operations(
                     record, operations,
                 )
-            };
+            }
+            .with_attachment_config(attachment_config);
             records.push(record);
         }
         let mounts = workspace

--- a/crates/verlet-kernel/src/agent/manifest_bind.rs
+++ b/crates/verlet-kernel/src/agent/manifest_bind.rs
@@ -2538,11 +2538,16 @@ fn operation_bindings_from_map(
         .into_iter()
         .map(|((name, artifact_hash), binding)| {
             let operations = binding.operation_names();
+            let attachment_config =
+                crate::capabilities::wasm_runner::attachment_config_from_legacy_grants(
+                    &binding.grants,
+                );
             AgentManifestOperationBinding {
                 name,
                 artifact_hash,
                 effect_class: binding.effect_class.unwrap_or_default(),
                 grants: binding.grants.into_iter().collect(),
+                attachment_config,
                 grant_expiries: binding.grant_expiries.into_iter().collect(),
                 operations,
                 direct_tools: binding.direct_tools.into_iter().collect(),
@@ -3442,6 +3447,11 @@ pub struct AgentManifestOperationBinding {
     pub effect_class: verlet_agent::manifest_schema::EffectClass,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub grants: Vec<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "verlet_wasm::WasmAttachmentConfig::is_empty"
+    )]
+    pub attachment_config: verlet_wasm::WasmAttachmentConfig,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub grant_expiries: Vec<verlet_agent::manifest_schema::AgentManifestGrantExpiry>,
     /// Empty means the binding exposes the whole record.

--- a/crates/verlet-kernel/src/agent/manifest_bind.rs
+++ b/crates/verlet-kernel/src/agent/manifest_bind.rs
@@ -3435,8 +3435,7 @@ impl AgentManifestCouplingBinding {
     }
 }
 
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
 pub struct AgentManifestOperationBinding {
     pub name: String,
     pub artifact_hash: String,
@@ -3460,6 +3459,62 @@ pub struct AgentManifestOperationBinding {
     /// Direct model/tool-router aliases declared by manifest `direct_tool` rows.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub direct_tools: Vec<AgentManifestDirectToolBinding>,
+}
+
+#[derive(Default)]
+struct OptionalWasmAttachmentConfig(Option<verlet_wasm::WasmAttachmentConfig>);
+
+impl<'de> serde::Deserialize<'de> for OptionalWasmAttachmentConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        <verlet_wasm::WasmAttachmentConfig as serde::Deserialize>::deserialize(deserializer)
+            .map(|config| Self(Some(config)))
+    }
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AgentManifestOperationBindingWire {
+    name: String,
+    artifact_hash: String,
+    #[serde(default)]
+    effect_class: verlet_agent::manifest_schema::EffectClass,
+    #[serde(default)]
+    grants: Vec<String>,
+    #[serde(default)]
+    attachment_config: OptionalWasmAttachmentConfig,
+    #[serde(default)]
+    grant_expiries: Vec<verlet_agent::manifest_schema::AgentManifestGrantExpiry>,
+    #[serde(default)]
+    operations: Vec<String>,
+    #[serde(default)]
+    direct_tools: Vec<AgentManifestDirectToolBinding>,
+}
+
+impl<'de> serde::Deserialize<'de> for AgentManifestOperationBinding {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let binding = AgentManifestOperationBindingWire::deserialize(deserializer)?;
+        let attachment_config = binding.attachment_config.0.unwrap_or_else(|| {
+            crate::capabilities::wasm_runner::attachment_config_from_legacy_grants(
+                &binding.grants.iter().cloned().collect(),
+            )
+        });
+        Ok(Self {
+            name: binding.name,
+            artifact_hash: binding.artifact_hash,
+            effect_class: binding.effect_class,
+            grants: binding.grants,
+            attachment_config,
+            grant_expiries: binding.grant_expiries,
+            operations: binding.operations,
+            direct_tools: binding.direct_tools,
+        })
+    }
 }
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]

--- a/crates/verlet-kernel/src/agent/manifest_bind/tests.rs
+++ b/crates/verlet-kernel/src/agent/manifest_bind/tests.rs
@@ -3278,6 +3278,130 @@ fn legacy_attachment_config_derivation_extracts_only_live_enforcement_grants() {
     );
 }
 
+#[test]
+fn legacy_private_http_derivation_preserves_matcher_semantics() {
+    fn legacy_matches(grant: &str, method: &str, origin: &str) -> bool {
+        let Some(rest) = grant.strip_prefix("net.http.private:") else {
+            return false;
+        };
+        if rest == "*" {
+            return true;
+        }
+        if let Some(origin_pattern) = rest.strip_prefix("*:") {
+            return wildcard_match(origin_pattern, origin);
+        }
+        if let Some(origin_pattern) = rest
+            .strip_prefix(method)
+            .and_then(|tail| tail.strip_prefix(':'))
+        {
+            return wildcard_match(origin_pattern, origin);
+        }
+        wildcard_match(rest, origin)
+    }
+
+    fn wildcard_match(pattern: &str, value: &str) -> bool {
+        let pattern = pattern.as_bytes();
+        let value = value.as_bytes();
+        let (mut pattern_index, mut value_index) = (0, 0);
+        let mut star_index = None;
+        let mut star_value_index = 0;
+
+        while value_index < value.len() {
+            if pattern_index < pattern.len() && pattern[pattern_index] == value[value_index] {
+                pattern_index += 1;
+                value_index += 1;
+            } else if pattern_index < pattern.len() && pattern[pattern_index] == b'*' {
+                star_index = Some(pattern_index);
+                star_value_index = value_index;
+                pattern_index += 1;
+            } else if let Some(index) = star_index {
+                pattern_index = index + 1;
+                star_value_index += 1;
+                value_index = star_value_index;
+            } else {
+                return false;
+            }
+        }
+
+        while pattern_index < pattern.len() && pattern[pattern_index] == b'*' {
+            pattern_index += 1;
+        }
+        pattern_index == pattern.len()
+    }
+
+    let cases = [
+        ("net.http.private:*", "GET", "http://127.0.0.1:9000"),
+        (
+            "net.http.private:*:http://127.0.0.1:9000",
+            "POST",
+            "http://127.0.0.1:9000",
+        ),
+        (
+            "net.http.private:*:http://127.0.0.1:9000",
+            "POST",
+            "http://127.0.0.1:9001",
+        ),
+        (
+            "net.http.private:GET:http://127.0.0.1:*",
+            "GET",
+            "http://127.0.0.1:9000",
+        ),
+        (
+            "net.http.private:GET:http://127.0.0.1:*",
+            "POST",
+            "http://127.0.0.1:9000",
+        ),
+        (
+            "net.http.private:http://127.0.0.1:9000",
+            "PATCH",
+            "http://127.0.0.1:9000",
+        ),
+        ("net.http.private:http:*", "GET", "http://127.0.0.1:9000"),
+        ("net.http.private:http*:*", "GET", "https://127.0.0.1:9000"),
+        (
+            "net.http.private:*127.0.0.1:*",
+            "GET",
+            "http://127.0.0.1:9000",
+        ),
+        (
+            "net.http.private:post:http://127.0.0.1:9000",
+            "POST",
+            "http://127.0.0.1:9000",
+        ),
+        (
+            "net.http.private:post:http://127.0.0.1:9000",
+            "post",
+            "http://127.0.0.1:9000",
+        ),
+        ("net.http.private:", "GET", "http://127.0.0.1:9000"),
+        ("net.http.private:*:", "GET", "http://127.0.0.1:9000"),
+        ("net.http.private::", "GET", "http://127.0.0.1:9000"),
+        ("net.http.private:GET:", "GET", "http://127.0.0.1:9000"),
+    ];
+
+    for (grant, method, origin) in cases {
+        let config = crate::capabilities::wasm_runner::attachment_config_from_legacy_grants(
+            &std::collections::BTreeSet::from([grant.to_string()]),
+        );
+        let method = reqwest::Method::from_bytes(method.as_bytes()).unwrap();
+        let actual = verlet_wasm::runner::ensure_http_capability(
+            &std::collections::BTreeSet::new(),
+            &config,
+            &method,
+            origin,
+            true,
+        )
+        .is_ok();
+
+        assert_eq!(
+            actual,
+            legacy_matches(grant, method.as_str(), origin),
+            "grant={grant:?} method={} origin={origin:?}",
+            method.as_str()
+        );
+    }
+}
+
 #[tokio::test]
 async fn operation_binding_merge_whole_record_absorbs_operation_subset() {
     let root = temp_dir("manifest-bind-merge-whole-record");
@@ -3396,11 +3520,12 @@ fn operation_binding_accumulator_merges_whole_record_order_independently() {
 }
 
 #[test]
-fn operation_binding_accepts_legacy_metadata_without_grants_or_operations() {
-    let bindings = serde_json::from_str::<Vec<crate::agent::manifest_bind::AgentManifestOperationBinding>>(
-            r#"[{"name":"search","artifact_hash":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}]"#,
-        )
-        .unwrap();
+fn operation_binding_round_trips_legacy_metadata_without_attachment_config() {
+    let raw = r#"[{"name":"search","artifact_hash":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","grants":["net.http:GET:https://example.com"]}]"#;
+    let bindings = serde_json::from_str::<
+        Vec<crate::agent::manifest_bind::AgentManifestOperationBinding>,
+    >(raw)
+    .unwrap();
 
     assert_eq!(
         bindings,
@@ -3409,13 +3534,67 @@ fn operation_binding_accepts_legacy_metadata_without_grants_or_operations() {
             artifact_hash: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
                 .to_string(),
             effect_class: verlet_agent::manifest_schema::EffectClass::AtMostOnce,
-            grants: Vec::new(),
+            grants: vec!["net.http:GET:https://example.com".to_string()],
             attachment_config: verlet_wasm::WasmAttachmentConfig::default(),
             grant_expiries: Vec::new(),
             operations: Vec::new(),
             direct_tools: Vec::new(),
         }]
     );
+    assert_eq!(serde_json::to_string(&bindings).unwrap(), raw);
+}
+
+#[test]
+fn operation_binding_derives_attachment_config_from_legacy_metadata() {
+    let binding = serde_json::from_str::<crate::agent::manifest_bind::AgentManifestOperationBinding>(
+        r#"{"name":"search","artifact_hash":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","grants":["net.http.private:POST:http://127.0.0.1:9000","secret:API_TOKEN"]}"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        binding.attachment_config,
+        verlet_wasm::WasmAttachmentConfig {
+            allowed_secrets: std::collections::BTreeSet::from(["API_TOKEN".to_string()]),
+            allowed_private_network: std::collections::BTreeMap::from([(
+                "http://127.0.0.1:9000".to_string(),
+                std::collections::BTreeSet::from(["POST".to_string()]),
+            )]),
+        }
+    );
+}
+
+#[test]
+fn operation_binding_preserves_explicit_empty_attachment_config() {
+    let binding = serde_json::from_str::<crate::agent::manifest_bind::AgentManifestOperationBinding>(
+        r#"{"name":"search","artifact_hash":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","grants":["net.http.private:POST:http://127.0.0.1:9000","secret:API_TOKEN"],"attachment_config":{}}"#,
+    )
+    .unwrap();
+
+    assert!(binding.attachment_config.is_empty());
+}
+
+#[test]
+fn operation_binding_rejects_null_attachment_config() {
+    let err = serde_json::from_str::<crate::agent::manifest_bind::AgentManifestOperationBinding>(
+        r#"{"name":"search","artifact_hash":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","attachment_config":null}"#,
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("invalid type"), "{err}");
+}
+
+#[test]
+fn operation_binding_rejects_unknown_fields() {
+    for raw in [
+        r#"{"name":"search","artifact_hash":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","unknown":[]}"#,
+        r#"{"name":"search","artifact_hash":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","attachment_config":{"unknown":[]}}"#,
+    ] {
+        let err =
+            serde_json::from_str::<crate::agent::manifest_bind::AgentManifestOperationBinding>(raw)
+                .unwrap_err();
+
+        assert!(err.to_string().contains("unknown field"), "{err}");
+    }
 }
 
 #[tokio::test]

--- a/crates/verlet-kernel/src/agent/manifest_bind/tests.rs
+++ b/crates/verlet-kernel/src/agent/manifest_bind/tests.rs
@@ -2935,6 +2935,7 @@ async fn operation_bind_requires_declared_grants() {
             artifact_hash: record.active_artifact_hash,
             effect_class: verlet_agent::manifest_schema::EffectClass::AtMostOnce,
             grants: vec!["net:https://example.com".to_string()],
+            attachment_config: verlet_wasm::WasmAttachmentConfig::default(),
             grant_expiries: Vec::new(),
             operations: Vec::new(),
             direct_tools: Vec::new(),
@@ -3097,6 +3098,7 @@ async fn two_segment_operation_ref_validates_only_named_operation() {
             artifact_hash: record.active_artifact_hash,
             effect_class: verlet_agent::manifest_schema::EffectClass::AtMostOnce,
             grants: vec!["net:https://profile.example".to_string()],
+            attachment_config: verlet_wasm::WasmAttachmentConfig::default(),
             grant_expiries: Vec::new(),
             operations: vec!["profile".to_string()],
             direct_tools: Vec::new(),
@@ -3236,12 +3238,44 @@ async fn operation_bindings_merge_grants_for_shared_artifact() {
                 "fs.read:/workspace".to_string(),
                 "net:https://example.com".to_string(),
             ],
+            attachment_config: verlet_wasm::WasmAttachmentConfig::default(),
             grant_expiries: Vec::new(),
             operations: Vec::new(),
             direct_tools: Vec::new(),
         }]
     );
     let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn legacy_attachment_config_derivation_extracts_only_live_enforcement_grants() {
+    let config = crate::capabilities::wasm_runner::attachment_config_from_legacy_grants(
+        &std::collections::BTreeSet::from([
+            "fs.read:/workspace".to_string(),
+            "net.http:GET:https://example.com".to_string(),
+            "net.http.private:GET:https://internal.example".to_string(),
+            "net.http.private:*:http://127.0.0.1:*".to_string(),
+            "secret:API_TOKEN".to_string(),
+        ]),
+    );
+
+    assert_eq!(
+        config.allowed_secrets,
+        std::collections::BTreeSet::from(["API_TOKEN".to_string()])
+    );
+    assert_eq!(
+        config.allowed_private_network,
+        std::collections::BTreeMap::from([
+            (
+                "http://127.0.0.1:*".to_string(),
+                std::collections::BTreeSet::from(["*".to_string()]),
+            ),
+            (
+                "https://internal.example".to_string(),
+                std::collections::BTreeSet::from(["GET".to_string()]),
+            ),
+        ])
+    );
 }
 
 #[tokio::test]
@@ -3298,6 +3332,7 @@ async fn operation_binding_merge_whole_record_absorbs_operation_subset() {
                 "net:https://profile.example".to_string(),
                 "net:https://summary.example".to_string(),
             ],
+            attachment_config: verlet_wasm::WasmAttachmentConfig::default(),
             grant_expiries: Vec::new(),
             operations: Vec::new(),
             direct_tools: Vec::new(),
@@ -3375,6 +3410,7 @@ fn operation_binding_accepts_legacy_metadata_without_grants_or_operations() {
                 .to_string(),
             effect_class: verlet_agent::manifest_schema::EffectClass::AtMostOnce,
             grants: Vec::new(),
+            attachment_config: verlet_wasm::WasmAttachmentConfig::default(),
             grant_expiries: Vec::new(),
             operations: Vec::new(),
             direct_tools: Vec::new(),

--- a/crates/verlet-kernel/src/capabilities/wasm_runner.rs
+++ b/crates/verlet-kernel/src/capabilities/wasm_runner.rs
@@ -2,6 +2,40 @@ pub struct WasmRuntimeFactory {
     core: std::sync::Arc<verlet_wasm::runner::WasmRuntimeFactory>,
 }
 
+pub(crate) fn attachment_config_from_legacy_grants(
+    grants: &std::collections::BTreeSet<String>,
+) -> verlet_wasm::WasmAttachmentConfig {
+    let mut config = verlet_wasm::WasmAttachmentConfig::default();
+    for grant in grants {
+        if let Some(secret_name) = grant.strip_prefix("secret:") {
+            config.allowed_secrets.insert(secret_name.to_string());
+            continue;
+        }
+        let Some(rule) = grant.strip_prefix("net.http.private:") else {
+            continue;
+        };
+        let (method, origin) = if rule == "*" {
+            ("*", "*")
+        } else if let Some(origin) = rule.strip_prefix("*:") {
+            ("*", origin)
+        } else if let Some((method, origin)) = rule.split_once(':') {
+            if origin.starts_with("//") {
+                ("*", rule)
+            } else {
+                (method, origin)
+            }
+        } else {
+            ("*", rule)
+        };
+        config
+            .allowed_private_network
+            .entry(origin.to_string())
+            .or_default()
+            .insert(method.to_string());
+    }
+    config
+}
+
 impl WasmRuntimeFactory {
     pub fn new(
         config: verlet_wasm::WasmRuntimeConfig,

--- a/crates/verlet-kernel/src/capabilities/wasm_runner.rs
+++ b/crates/verlet-kernel/src/capabilities/wasm_runner.rs
@@ -19,7 +19,10 @@ pub(crate) fn attachment_config_from_legacy_grants(
         } else if let Some(origin) = rule.strip_prefix("*:") {
             ("*", origin)
         } else if let Some((method, origin)) = rule.split_once(':') {
-            if origin.starts_with("//") {
+            if origin.starts_with("//")
+                || matches!(method, "http" | "https")
+                || method.contains('*')
+            {
                 ("*", rule)
             } else {
                 (method, origin)

--- a/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
+++ b/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
@@ -578,6 +578,20 @@ fn http_request_bytes(
     .unwrap()
 }
 
+fn http_attachment_config(
+    origin: &str,
+    method: &str,
+    allowed_secrets: impl IntoIterator<Item = &'static str>,
+) -> verlet_wasm::WasmAttachmentConfig {
+    verlet_wasm::WasmAttachmentConfig {
+        allowed_secrets: allowed_secrets.into_iter().map(String::from).collect(),
+        allowed_private_network: std::collections::BTreeMap::from([(
+            origin.to_string(),
+            std::collections::BTreeSet::from([method.to_string()]),
+        )]),
+    }
+}
+
 async fn next_output(
     events: &mut tokio::sync::broadcast::Receiver<
         crate::kernel::runtime_host::runtime_api::ThreadEvent,
@@ -1094,6 +1108,7 @@ async fn wasm_http_operation_can_call_mock_exa_api() {
         )))
         .with_capability_grant(http_grant)
         .with_capability_grant("secret:EXAMPLE_API_KEY")
+        .with_attachment_config(http_attachment_config(&origin, "POST", ["EXAMPLE_API_KEY"]))
         .with_secret("EXAMPLE_API_KEY", "test-secret"),
     )
     .unwrap();
@@ -1141,6 +1156,7 @@ async fn wasm_http_import_uses_invocation_context_grants_for_privileged_work() {
             &guest,
         )))
         .with_invocation_context(context)
+        .with_attachment_config(http_attachment_config(&origin, "POST", ["EXAMPLE_API_KEY"]))
         .with_secret("EXAMPLE_API_KEY", "delegated-secret"),
     )
     .unwrap();
@@ -1183,6 +1199,7 @@ async fn wasm_http_operation_treats_http_error_status_as_response() {
         )))
         .with_capability_grant(http_grant)
         .with_capability_grant("secret:EXAMPLE_API_KEY")
+        .with_attachment_config(http_attachment_config(&origin, "POST", ["EXAMPLE_API_KEY"]))
         .with_secret("EXAMPLE_API_KEY", "test-secret"),
     )
     .unwrap();
@@ -1229,6 +1246,7 @@ async fn wasm_http_request_truncates_response_to_requested_cap() {
         http_request_bytes(&url, Some(4), Vec::new()),
         br#"{"query":"verlet"}"#.to_vec(),
         grants,
+        http_attachment_config(&origin, "POST", []),
         std::collections::BTreeMap::new(),
     )
     .await
@@ -1262,6 +1280,7 @@ async fn wasm_http_response_envelope_stays_valid_and_within_the_requested_cap() 
         serde_json::to_vec(&request).unwrap(),
         Vec::new(),
         grants,
+        http_attachment_config(&origin, "POST", []),
         std::collections::BTreeMap::new(),
     )
     .await
@@ -1304,6 +1323,7 @@ async fn wasm_http_input_mapping_enforces_pinned_parameter_schemas() {
         serde_json::to_vec(&request).unwrap(),
         br#"{"id":"not-an-integer"}"#.to_vec(),
         grants,
+        http_attachment_config(&origin, "GET", []),
         std::collections::BTreeMap::new(),
     )
     .await
@@ -1342,6 +1362,7 @@ async fn wasm_http_input_mapping_allows_an_omitted_optional_body() {
         serde_json::to_vec(&request).unwrap(),
         br#"{}"#.to_vec(),
         grants,
+        http_attachment_config(&origin, "POST", []),
         std::collections::BTreeMap::new(),
     )
     .await
@@ -1376,6 +1397,7 @@ async fn wasm_http_rejects_protected_secret_header_injection() {
         serde_json::to_vec(&request).unwrap(),
         Vec::new(),
         grants,
+        http_attachment_config(&origin, "POST", ["HOST_OVERRIDE"]),
         std::collections::BTreeMap::from([(
             "HOST_OVERRIDE".to_string(),
             "other.example".to_string(),
@@ -1404,6 +1426,7 @@ async fn wasm_http_request_does_not_follow_redirects() {
         http_request_bytes(&url, None, Vec::new()),
         Vec::new(),
         grants,
+        http_attachment_config(&origin, "POST", []),
         std::collections::BTreeMap::new(),
     )
     .await
@@ -1424,6 +1447,7 @@ async fn wasm_http_request_requires_private_grant_for_loopback() {
         http_request_bytes(url, None, Vec::new()),
         Vec::new(),
         grants,
+        verlet_wasm::WasmAttachmentConfig::default(),
         std::collections::BTreeMap::new(),
     )
     .await
@@ -1431,6 +1455,147 @@ async fn wasm_http_request_requires_private_grant_for_loopback() {
 
     assert_eq!(err.status, verlet_wasm::runner::STATUS_CAPABILITY_DENIED);
     assert!(err.message.contains("net.http.private:POST"));
+}
+
+#[test]
+fn wasm_private_http_attachment_config_allows_only_listed_origin_and_method() {
+    let origin = "http://127.0.0.1:9000";
+    let attachment_config = verlet_wasm::WasmAttachmentConfig {
+        allowed_secrets: std::collections::BTreeSet::new(),
+        allowed_private_network: std::collections::BTreeMap::from([(
+            origin.to_string(),
+            std::collections::BTreeSet::from(["POST".to_string()]),
+        )]),
+    };
+
+    verlet_wasm::runner::ensure_http_capability(
+        &std::collections::BTreeSet::new(),
+        &attachment_config,
+        &reqwest::Method::POST,
+        origin,
+        true,
+    )
+    .unwrap();
+
+    for (method, denied_origin) in [
+        (reqwest::Method::GET, origin),
+        (reqwest::Method::POST, "http://127.0.0.1:9001"),
+    ] {
+        let err = verlet_wasm::runner::ensure_http_capability(
+            &std::collections::BTreeSet::new(),
+            &attachment_config,
+            &method,
+            denied_origin,
+            true,
+        )
+        .unwrap_err();
+        assert_eq!(err.status, verlet_wasm::runner::STATUS_CAPABILITY_DENIED);
+    }
+}
+
+#[tokio::test]
+async fn wasm_http_attachment_config_injects_only_listed_secret() {
+    let (base_url, server) =
+        spawn_http_server(200, r#"{"ok":true}"#, vec!["x-api-key: test-secret"]).await;
+    let url = format!("{base_url}/search");
+    let origin = verlet_wasm::runner::http_origin(&reqwest::Url::parse(&url).unwrap()).unwrap();
+    let grants = std::collections::BTreeSet::from([
+        format!("net.http.private:POST:{origin}"),
+        "secret:EXAMPLE_API_KEY".to_string(),
+    ]);
+    let secrets = std::collections::BTreeMap::from([(
+        "EXAMPLE_API_KEY".to_string(),
+        "test-secret".to_string(),
+    )]);
+    let private_network = std::collections::BTreeMap::from([(
+        origin,
+        std::collections::BTreeSet::from(["POST".to_string()]),
+    )]);
+
+    let denied = verlet_wasm::runner::execute_http_request(
+        http_request_bytes(
+            &url,
+            None,
+            vec![("x-api-key".to_string(), "EXAMPLE_API_KEY".to_string())],
+        ),
+        Vec::new(),
+        grants,
+        verlet_wasm::WasmAttachmentConfig {
+            allowed_secrets: std::collections::BTreeSet::new(),
+            allowed_private_network: private_network.clone(),
+        },
+        secrets.clone(),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(denied.status, verlet_wasm::runner::STATUS_CAPABILITY_DENIED);
+    assert_eq!(denied.message, "missing required secret capability");
+
+    let exchange = verlet_wasm::runner::execute_http_request(
+        http_request_bytes(
+            &url,
+            None,
+            vec![("x-api-key".to_string(), "EXAMPLE_API_KEY".to_string())],
+        ),
+        Vec::new(),
+        std::collections::BTreeSet::new(),
+        verlet_wasm::WasmAttachmentConfig {
+            allowed_secrets: std::collections::BTreeSet::from(["EXAMPLE_API_KEY".to_string()]),
+            allowed_private_network: private_network,
+        },
+        secrets,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(exchange.response.status, 200);
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn wasm_http_attachment_without_config_denies_private_network_and_secret_injection() {
+    let url = "http://127.0.0.1:9/search";
+    let origin = verlet_wasm::runner::http_origin(&reqwest::Url::parse(url).unwrap()).unwrap();
+    let grants = std::collections::BTreeSet::from([format!("net.http.private:POST:{origin}")]);
+
+    let err = verlet_wasm::runner::execute_http_request(
+        http_request_bytes(url, None, Vec::new()),
+        Vec::new(),
+        grants,
+        verlet_wasm::WasmAttachmentConfig::default(),
+        std::collections::BTreeMap::new(),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(err.status, verlet_wasm::runner::STATUS_CAPABILITY_DENIED);
+    assert!(err.message.contains("net.http.private:POST"));
+
+    let public_url = "https://example.com/search";
+    let public_origin =
+        verlet_wasm::runner::http_origin(&reqwest::Url::parse(public_url).unwrap()).unwrap();
+    let err = verlet_wasm::runner::execute_http_request(
+        http_request_bytes(
+            public_url,
+            None,
+            vec![("x-api-key".to_string(), "EXAMPLE_API_KEY".to_string())],
+        ),
+        Vec::new(),
+        std::collections::BTreeSet::from([
+            format!("net.http:POST:{public_origin}"),
+            "secret:EXAMPLE_API_KEY".to_string(),
+        ]),
+        verlet_wasm::WasmAttachmentConfig::default(),
+        std::collections::BTreeMap::from([(
+            "EXAMPLE_API_KEY".to_string(),
+            "test-secret".to_string(),
+        )]),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(err.status, verlet_wasm::runner::STATUS_CAPABILITY_DENIED);
+    assert_eq!(err.message, "missing required secret capability");
 }
 
 #[test]
@@ -1442,6 +1607,7 @@ fn wasm_http_capability_allows_public_origin_wildcards() {
 
     verlet_wasm::runner::ensure_http_capability(
         &grants,
+        &verlet_wasm::WasmAttachmentConfig::default(),
         &reqwest::Method::GET,
         "https://example.com",
         false,
@@ -1449,6 +1615,7 @@ fn wasm_http_capability_allows_public_origin_wildcards() {
     .unwrap();
     verlet_wasm::runner::ensure_http_capability(
         &grants,
+        &verlet_wasm::WasmAttachmentConfig::default(),
         &reqwest::Method::GET,
         "http://news.example:8080",
         false,
@@ -1456,6 +1623,7 @@ fn wasm_http_capability_allows_public_origin_wildcards() {
     .unwrap();
     let err = verlet_wasm::runner::ensure_http_capability(
         &grants,
+        &verlet_wasm::WasmAttachmentConfig::default(),
         &reqwest::Method::POST,
         "https://example.com",
         false,
@@ -1470,6 +1638,7 @@ fn wasm_http_capability_wildcards_do_not_cross_private_namespace() {
 
     let err = verlet_wasm::runner::ensure_http_capability(
         &grants,
+        &verlet_wasm::WasmAttachmentConfig::default(),
         &reqwest::Method::GET,
         "http://127.0.0.1:9",
         true,
@@ -1487,6 +1656,7 @@ fn wasm_http_capability_allows_method_wildcards() {
 
     verlet_wasm::runner::ensure_http_capability(
         &grants,
+        &verlet_wasm::WasmAttachmentConfig::default(),
         &reqwest::Method::GET,
         "https://api.example.com",
         false,
@@ -1494,6 +1664,7 @@ fn wasm_http_capability_allows_method_wildcards() {
     .unwrap();
     verlet_wasm::runner::ensure_http_capability(
         &grants,
+        &verlet_wasm::WasmAttachmentConfig::default(),
         &reqwest::Method::POST,
         "https://api.example.com",
         false,
@@ -1512,6 +1683,7 @@ async fn wasm_http_secret_diagnostics_redact_secret_names() {
         http_request_bytes(url, None, secret_headers.clone()),
         Vec::new(),
         grants.clone(),
+        http_attachment_config(&origin, "POST", []),
         std::collections::BTreeMap::new(),
     )
     .await
@@ -1530,6 +1702,7 @@ async fn wasm_http_secret_diagnostics_redact_secret_names() {
             .into_iter()
             .chain(["secret:EXAMPLE_API_KEY".to_string()])
             .collect(),
+        http_attachment_config(&origin, "POST", ["EXAMPLE_API_KEY"]),
         std::collections::BTreeMap::new(),
     )
     .await

--- a/crates/verlet-kernel/src/cli/tool.rs
+++ b/crates/verlet-kernel/src/cli/tool.rs
@@ -491,10 +491,16 @@ pub(super) async fn run_tool_package_fixtures(
     interface: &verlet_operations::tool_package::ToolInterfaceContract,
 ) -> crate::kernel::runtime_host::VerletResult<Vec<verlet_operations::tool_package::ToolFixtureRun>>
 {
+    let capability_requests = interface.capability_requests();
     let mut config = verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::path(
         artifact_path.to_path_buf(),
     ))
-    .with_capability_grants(interface.capability_requests());
+    .with_capability_grants(capability_requests.clone())
+    .with_attachment_config(
+        crate::capabilities::wasm_runner::attachment_config_from_legacy_grants(
+            &capability_requests,
+        ),
+    );
     config = config.with_vfs(package_fixture_vfs(package)?);
     if let Some(max_input_bytes) = package.manifest.runtime.max_input_bytes {
         config = config.with_max_input_bytes(size_limit("max_input_bytes", max_input_bytes)?);
@@ -744,6 +750,11 @@ pub(super) async fn tool_run(
                 std::collections::BTreeMap::new()
             };
             let mut config = registry.load_runtime_config_for_record(&record).await?;
+            config = config.with_attachment_config(
+                crate::capabilities::wasm_runner::attachment_config_from_legacy_grants(
+                    &record.capability_grants,
+                ),
+            );
             if !resolved_secrets.is_empty() {
                 config = config.with_secrets(resolved_secrets);
             }

--- a/crates/verlet-kernel/src/operations/plugins.rs
+++ b/crates/verlet-kernel/src/operations/plugins.rs
@@ -96,10 +96,14 @@ impl LocalPluginCatalogRecord {
     pub fn whole_record(
         record: verlet_operations::operation_store::PublishedOperationRecord,
     ) -> Self {
+        let attachment_config =
+            crate::capabilities::wasm_runner::attachment_config_from_legacy_grants(
+                &record.capability_grants,
+            );
         Self {
             record,
             operation_names: std::collections::BTreeSet::new(),
-            attachment_config: verlet_wasm::WasmAttachmentConfig::default(),
+            attachment_config,
         }
     }
 
@@ -111,10 +115,14 @@ impl LocalPluginCatalogRecord {
         I: IntoIterator<Item = S>,
         S: Into<String>,
     {
+        let attachment_config =
+            crate::capabilities::wasm_runner::attachment_config_from_legacy_grants(
+                &record.capability_grants,
+            );
         Self {
             record,
             operation_names: operation_names.into_iter().map(Into::into).collect(),
-            attachment_config: verlet_wasm::WasmAttachmentConfig::default(),
+            attachment_config,
         }
     }
 

--- a/crates/verlet-kernel/src/operations/plugins.rs
+++ b/crates/verlet-kernel/src/operations/plugins.rs
@@ -89,6 +89,7 @@ impl LocalPluginCatalogConfig {
 pub struct LocalPluginCatalogRecord {
     pub record: verlet_operations::operation_store::PublishedOperationRecord,
     pub operation_names: std::collections::BTreeSet<String>,
+    pub attachment_config: verlet_wasm::WasmAttachmentConfig,
 }
 
 impl LocalPluginCatalogRecord {
@@ -98,6 +99,7 @@ impl LocalPluginCatalogRecord {
         Self {
             record,
             operation_names: std::collections::BTreeSet::new(),
+            attachment_config: verlet_wasm::WasmAttachmentConfig::default(),
         }
     }
 
@@ -112,7 +114,16 @@ impl LocalPluginCatalogRecord {
         Self {
             record,
             operation_names: operation_names.into_iter().map(Into::into).collect(),
+            attachment_config: verlet_wasm::WasmAttachmentConfig::default(),
         }
+    }
+
+    pub fn with_attachment_config(
+        mut self,
+        attachment_config: verlet_wasm::WasmAttachmentConfig,
+    ) -> Self {
+        self.attachment_config = attachment_config;
+        self
     }
 }
 
@@ -221,6 +232,7 @@ impl LocalPluginCatalog {
             let LocalPluginCatalogRecord {
                 record,
                 operation_names,
+                attachment_config,
             } = selected_record;
             if matches!(
                 &record.source,
@@ -274,7 +286,9 @@ impl LocalPluginCatalog {
                 }
                 runtime_config = runtime_config.with_secrets(resolution.values);
             };
-            runtime_config = runtime_config.with_vfs(std::sync::Arc::clone(&vfs));
+            runtime_config = runtime_config
+                .with_attachment_config(attachment_config)
+                .with_vfs(std::sync::Arc::clone(&vfs));
             let mut registration =
                 verlet_operations::operation_registry::OperationRegistration::from_config(
                     record.name.clone(),

--- a/crates/verlet-kernel/tests/abi_search_fixture.rs
+++ b/crates/verlet-kernel/tests/abi_search_fixture.rs
@@ -162,12 +162,9 @@ async fn published_search_operation_resolves_secret_store_and_invokes_through_ag
         .unwrap();
 
     let catalog =
-        verlet::operations::plugins::LocalPluginCatalog::load_selected_records_with_secret_resolver(
+        verlet::operations::plugins::LocalPluginCatalog::load_records_with_secret_resolver(
             &registry_root,
-            vec![
-                verlet::operations::plugins::LocalPluginCatalogRecord::whole_record(record)
-                    .with_attachment_config(search_attachment_config(&base_url)),
-            ],
+            vec![record],
             Vec::new(),
             std::sync::Arc::new(secret_store),
         )

--- a/crates/verlet-kernel/tests/abi_search_fixture.rs
+++ b/crates/verlet-kernel/tests/abi_search_fixture.rs
@@ -24,13 +24,14 @@ async fn search_style_http_operation_registers_and_invokes_through_registry() {
 
     registry
         .register(
-            verlet_operations::operation_registry::OperationRegistration::new(
+            verlet_operations::operation_registry::OperationRegistration::from_config(
                 "search",
-                verlet_wasm::WasmRuntimeArtifact::bytes(wasm),
+                verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(wasm))
+                    .with_capability_grant(http_grant)
+                    .with_capability_grant("secret:EXAMPLE_API_KEY")
+                    .with_attachment_config(search_attachment_config(&base_url))
+                    .with_secret("EXAMPLE_API_KEY", "fixture-secret"),
             )
-            .with_capability_grant(http_grant)
-            .with_capability_grant("secret:EXAMPLE_API_KEY")
-            .with_secret("EXAMPLE_API_KEY", "fixture-secret")
             .with_metadata("provider", "search")
             .with_metadata("shape", "http-api-wrapper"),
         )
@@ -73,13 +74,14 @@ async fn search_style_http_operation_runs_through_shell_command() {
 
     registry
         .register(
-            verlet_operations::operation_registry::OperationRegistration::new(
+            verlet_operations::operation_registry::OperationRegistration::from_config(
                 "search",
-                verlet_wasm::WasmRuntimeArtifact::bytes(wasm),
+                verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(wasm))
+                    .with_capability_grant(http_grant.clone())
+                    .with_capability_grant("secret:EXAMPLE_API_KEY")
+                    .with_attachment_config(search_attachment_config(&base_url))
+                    .with_secret("EXAMPLE_API_KEY", "fixture-secret"),
             )
-            .with_capability_grant(http_grant.clone())
-            .with_capability_grant("secret:EXAMPLE_API_KEY")
-            .with_secret("EXAMPLE_API_KEY", "fixture-secret")
             .with_metadata("provider", "search")
             .with_metadata("shape", "http-api-wrapper"),
         )
@@ -160,9 +162,12 @@ async fn published_search_operation_resolves_secret_store_and_invokes_through_ag
         .unwrap();
 
     let catalog =
-        verlet::operations::plugins::LocalPluginCatalog::load_records_with_secret_resolver(
+        verlet::operations::plugins::LocalPluginCatalog::load_selected_records_with_secret_resolver(
             &registry_root,
-            vec![record],
+            vec![
+                verlet::operations::plugins::LocalPluginCatalogRecord::whole_record(record)
+                    .with_attachment_config(search_attachment_config(&base_url)),
+            ],
             Vec::new(),
             std::sync::Arc::new(secret_store),
         )
@@ -197,6 +202,16 @@ async fn published_search_operation_resolves_secret_store_and_invokes_through_ag
     ));
     server.await.unwrap();
     let _ = std::fs::remove_dir_all(root);
+}
+
+fn search_attachment_config(origin: &str) -> verlet_wasm::WasmAttachmentConfig {
+    verlet_wasm::WasmAttachmentConfig {
+        allowed_secrets: std::collections::BTreeSet::from(["EXAMPLE_API_KEY".to_string()]),
+        allowed_private_network: std::collections::BTreeMap::from([(
+            origin.to_string(),
+            std::collections::BTreeSet::from(["POST".to_string()]),
+        )]),
+    }
 }
 
 fn render_search_fixture(url: &str, http_grant: &str) -> String {

--- a/crates/verlet-kernel/tests/standard_operations.rs
+++ b/crates/verlet-kernel/tests/standard_operations.rs
@@ -165,7 +165,8 @@ async fn http_fetch_reads_from_local_server() {
         verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(
             http_fetch_wasm(),
         ))
-        .with_capability_grant(grant),
+        .with_capability_grant(grant)
+        .with_attachment_config(private_get_attachment_config(&base_url)),
     )
     .unwrap();
 
@@ -199,7 +200,8 @@ async fn http_fetch_reports_cap_edge_truncation() {
         verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(
             http_fetch_wasm(),
         ))
-        .with_capability_grant(zero_grant),
+        .with_capability_grant(zero_grant)
+        .with_attachment_config(private_get_attachment_config(&zero_base_url)),
     )
     .unwrap();
     let zero = zero_factory
@@ -223,7 +225,8 @@ async fn http_fetch_reports_cap_edge_truncation() {
         verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(
             http_fetch_wasm(),
         ))
-        .with_capability_grant(exact_grant),
+        .with_capability_grant(exact_grant)
+        .with_attachment_config(private_get_attachment_config(&exact_base_url)),
     )
     .unwrap();
     let exact = exact_factory
@@ -265,6 +268,16 @@ fn standard_operation_factory(
         verlet_wasm::WasmRuntimeArtifact::bytes(wasm),
     ))
     .unwrap()
+}
+
+fn private_get_attachment_config(origin: &str) -> verlet_wasm::WasmAttachmentConfig {
+    verlet_wasm::WasmAttachmentConfig {
+        allowed_secrets: std::collections::BTreeSet::new(),
+        allowed_private_network: std::collections::BTreeMap::from([(
+            origin.to_string(),
+            std::collections::BTreeSet::from(["GET".to_string()]),
+        )]),
+    }
 }
 
 fn http_fetch_wasm() -> Vec<u8> {

--- a/crates/verlet-wasm/src/lib.rs
+++ b/crates/verlet-wasm/src/lib.rs
@@ -52,6 +52,24 @@ pub enum WasmHostImportPolicy {
     PureCompute,
 }
 
+#[derive(
+    Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, serde::Deserialize, serde::Serialize,
+)]
+#[serde(deny_unknown_fields)]
+pub struct WasmAttachmentConfig {
+    #[serde(default, skip_serializing_if = "std::collections::BTreeSet::is_empty")]
+    pub allowed_secrets: std::collections::BTreeSet<String>,
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub allowed_private_network:
+        std::collections::BTreeMap<String, std::collections::BTreeSet<String>>,
+}
+
+impl WasmAttachmentConfig {
+    pub fn is_empty(&self) -> bool {
+        self.allowed_secrets.is_empty() && self.allowed_private_network.is_empty()
+    }
+}
+
 #[derive(Clone)]
 pub struct WasmRuntimeConfig {
     pub artifact: WasmRuntimeArtifact,
@@ -63,6 +81,7 @@ pub struct WasmRuntimeConfig {
     pub fuel: Option<u64>,
     pub fuel_yield_interval: Option<u64>,
     pub capability_grants: std::collections::BTreeSet<String>,
+    pub attachment_config: WasmAttachmentConfig,
     pub invocation_context: verlet_abi::InvocationContext,
     pub secrets: std::collections::BTreeMap<String, String>,
     pub vfs: Option<std::sync::Arc<verlet_vfs::VerletVfs>>,
@@ -81,6 +100,7 @@ impl WasmRuntimeConfig {
             fuel: Some(DEFAULT_FUEL),
             fuel_yield_interval: Some(DEFAULT_FUEL_YIELD_INTERVAL),
             capability_grants: std::collections::BTreeSet::new(),
+            attachment_config: WasmAttachmentConfig::default(),
             invocation_context: verlet_abi::InvocationContext::anonymous(),
             secrets: std::collections::BTreeMap::new(),
             vfs: None,
@@ -133,6 +153,11 @@ impl WasmRuntimeConfig {
         self
     }
 
+    pub fn with_attachment_config(mut self, attachment_config: WasmAttachmentConfig) -> Self {
+        self.attachment_config = attachment_config;
+        self
+    }
+
     pub fn with_invocation_context(mut self, context: verlet_abi::InvocationContext) -> Self {
         self.invocation_context = context;
         self
@@ -179,6 +204,7 @@ impl std::fmt::Debug for WasmRuntimeConfig {
             .field("fuel", &self.fuel)
             .field("fuel_yield_interval", &self.fuel_yield_interval)
             .field("capability_grants", &self.capability_grants)
+            .field("attachment_config", &self.attachment_config)
             .field("invocation_context", &self.invocation_context)
             .field("secrets", &"<redacted>")
             .field("vfs", &self.vfs.as_ref().map(|_| "<VerletVfs>"))

--- a/crates/verlet-wasm/src/runner.rs
+++ b/crates/verlet-wasm/src/runner.rs
@@ -553,6 +553,7 @@ struct WasmTurnState {
     output_truncated: bool,
     max_output_bytes: usize,
     capability_grants: std::collections::BTreeSet<String>,
+    attachment_config: crate::WasmAttachmentConfig,
     invocation_context: verlet_abi::InvocationContext,
     secrets: std::collections::BTreeMap<String, String>,
     vfs: Option<std::sync::Arc<verlet_vfs::VerletVfs>>,
@@ -586,6 +587,7 @@ impl WasmTurnState {
             output_truncated: false,
             max_output_bytes: config.max_output_bytes,
             capability_grants: config.effective_capability_grants(),
+            attachment_config: config.attachment_config.clone(),
             invocation_context: config.invocation_context.clone(),
             secrets: config.secrets.clone(),
             vfs: config.vfs.clone(),
@@ -853,9 +855,18 @@ fn add_verlet_imports(linker: &mut wasmtime::Linker<WasmTurnState>) -> wasmtime:
                     return STATUS_NOT_FOUND;
                 }
                 let grants = caller.data().capability_grants.clone();
+                let attachment_config = caller.data().attachment_config.clone();
                 let secrets = caller.data().secrets.clone();
 
-                match execute_http_request(request_bytes, body_bytes, grants, secrets).await {
+                match execute_http_request(
+                    request_bytes,
+                    body_bytes,
+                    grants,
+                    attachment_config,
+                    secrets,
+                )
+                .await
+                {
                     Ok(exchange) => {
                         let Some(body_source_ptr) = out_ptr.checked_add(4) else {
                             return STATUS_INVALID_ARGUMENT;
@@ -1114,6 +1125,7 @@ pub async fn execute_http_request(
     request_bytes: Vec<u8>,
     body: Vec<u8>,
     grants: std::collections::BTreeSet<String>,
+    attachment_config: crate::WasmAttachmentConfig,
     secrets: std::collections::BTreeMap<String, String>,
 ) -> Result<WasmHttpExchange, WasmHttpError> {
     let mut request: crate::WasmHttpRequest = serde_json::from_slice(&request_bytes)
@@ -1137,7 +1149,13 @@ pub async fn execute_http_request(
     }
     let url = reqwest::Url::parse(&target.url)
         .map_err(|_| WasmHttpError::invalid_argument("invalid canonical HTTP URL"))?;
-    ensure_http_capability(&grants, &method, &target.origin, target.private_destination)?;
+    ensure_http_capability(
+        &grants,
+        &attachment_config,
+        &method,
+        &target.origin,
+        target.private_destination,
+    )?;
 
     let mut builder = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -1160,8 +1178,7 @@ pub async fn execute_http_request(
     }
     for (name, secret_name) in request.secret_headers {
         let name = outbound_header_name(&name, "invalid HTTP secret header name")?;
-        let capability = format!("secret:{secret_name}");
-        if !grants.contains(&capability) {
+        if !attachment_config.allowed_secrets.contains(&secret_name) {
             return Err(WasmHttpError::capability_denied(
                 "missing required secret capability",
             ));
@@ -1178,8 +1195,7 @@ pub async fn execute_http_request(
     }
     for (name, secret_name, prefix) in request.secret_header_prefixes {
         let name = outbound_header_name(&name, "invalid HTTP prefixed secret header name")?;
-        let capability = format!("secret:{secret_name}");
-        if !grants.contains(&capability) {
+        if !attachment_config.allowed_secrets.contains(&secret_name) {
             return Err(WasmHttpError::capability_denied(
                 "missing required secret capability",
             ));
@@ -1529,15 +1545,30 @@ fn percent_encode_path_segment(value: &str) -> String {
 #[doc(hidden)]
 pub fn ensure_http_capability(
     grants: &std::collections::BTreeSet<String>,
+    attachment_config: &crate::WasmAttachmentConfig,
     method: &reqwest::Method,
     origin: &str,
     private_destination: bool,
 ) -> Result<(), WasmHttpError> {
-    let namespace = if private_destination {
-        "net.http.private"
-    } else {
-        "net.http"
-    };
+    if private_destination {
+        let allowed =
+            attachment_config
+                .allowed_private_network
+                .iter()
+                .any(|(origin_pattern, methods)| {
+                    (methods.contains("*") || methods.contains(method.as_str()))
+                        && wildcard_match(origin_pattern, origin)
+                });
+        if allowed {
+            return Ok(());
+        }
+        return Err(WasmHttpError::capability_denied(format!(
+            "missing required capability net.http.private:{}:{origin}",
+            method.as_str()
+        )));
+    }
+
+    let namespace = "net.http";
     let method_grant = format!("{namespace}:{}:{origin}", method.as_str());
     if grants
         .iter()

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -5,6 +5,13 @@ set -euo pipefail
 # need more test-thread stack headroom than libtest's default.
 export RUST_MIN_STACK=16777216
 
+# The parallel daemon IO tests exhaust macOS's default 256-descriptor soft
+# limit (EMFILE flakes in daemon_io tests); raise it before running anything.
+soft_fd_limit="$(ulimit -n)"
+if [[ "$soft_fd_limit" != "unlimited" && "$soft_fd_limit" -lt 8192 ]]; then
+  ulimit -n 8192 || true
+fi
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 . "$ROOT/scripts/env-compat.sh"
 for env_name in \


### PR DESCRIPTION
## Summary
- Adds WasmAttachmentConfig (allowed secrets; allowed private-network origins and methods) and moves the two live enforcement points in the WASM runner off capability strings (EMO-580, parent EMO-579).
- Legacy grants derive into the config through one quarantined function at the binding and catalog boundary; the runner no longer parses capability strings. Public net.http grant behavior is unchanged.
- Review pass fixed two High regressions (plugin-catalog constructors built an empty config; persisted bindings without the new field lost authorization on resume) and one Medium parse bug (origin wildcards misread as method rules).
- Rider: verify.sh raises its fd soft limit to stop EMFILE flakes in the daemon IO tests.

#### Test plan
- [x] cargo test --workspace green after implementation and again after review fixes
- [x] Parity table test drives the derived config against the legacy matcher (wildcards, :// origins, ports, method case, degenerate grants)
- [x] Serialization tests: legacy metadata round-trips byte-identical; absent field derives from grants; explicit {} stays default-deny; unknown fields rejected
- [x] Default-deny regression: no config means no secret injection and no private network
- [x] Local gate green: scripts/verify.sh (macOS) and scripts/verify-linux.sh; pre-push hook re-ran verify green with the fd fix active
