### PR TITLE
app-server: pin catalog provider endpoints to the reviewed snapshot (EMO-582)

### DIFF
--- a/crates/verlet-kernel/src/adapters/app_server.rs
+++ b/crates/verlet-kernel/src/adapters/app_server.rs
@@ -1100,6 +1100,7 @@ impl VerletAppServer {
         let metadata_store = open_and_seed_metadata_store(config.metadata_store_path()).await?;
         let user_metadata_store =
             open_and_seed_metadata_store(config.user_metadata_store_path()).await?;
+        reconcile_catalog_provider_records(&config, &metadata_store).await?;
         sync_catalog_provider_identity(&mut config, &metadata_store).await?;
         crate::adapters::app_server::threads::normalize_registry_roots(&mut config);
         let initial_endpoint = resolved_turn_endpoint_from_provider_config(
@@ -2736,6 +2737,55 @@ async fn sync_catalog_provider_identity(
             })?;
         config.model_provider = provider.provider_id.clone();
         config.model = selected_catalog_model_id(&provider, model.as_deref())?;
+    }
+    Ok(())
+}
+
+/// Records templated by older catalog refreshes may persist endpoint fields
+/// that came from the network. Re-pin reviewed providers before any runtime
+/// endpoint is built, and retire refresh-only provider records while leaving
+/// their separately stored credentials recoverable for an explicit custom
+/// provider configuration.
+async fn reconcile_catalog_provider_records(
+    config: &VerletAppServerConfig,
+    provider_store: &verlet_metadata::provider_store::SqliteMetadataStore,
+) -> crate::kernel::runtime_host::VerletResult<()> {
+    let reviewed = model_catalog::MergedModelCatalog::new(&config.user_state_home)
+        .providers()
+        .into_iter()
+        .map(|provider| (provider.provider_id.clone(), provider))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    for mut record in provider_store
+        .list_providers()
+        .await
+        .map_err(provider_store_error)?
+        .into_iter()
+        .filter(|record| record.metadata.get("origin").map(String::as_str) == Some("catalog"))
+    {
+        let Some(provider) = reviewed.get(&record.provider_id) else {
+            provider_store
+                .delete_provider(&record.provider_id)
+                .await
+                .map_err(provider_store_error)?;
+            continue;
+        };
+        let Some(api) = model_catalog::catalog_api_to_provider_api(&provider.api) else {
+            return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                format!(
+                    "reviewed catalog provider {:?} has unsupported API family {:?}",
+                    provider.provider_id, provider.api
+                ),
+            ));
+        };
+        if record.base_url == provider.base_url && record.api == api {
+            continue;
+        }
+        record.base_url.clone_from(&provider.base_url);
+        record.api = api;
+        provider_store
+            .upsert_provider(record)
+            .await
+            .map_err(provider_store_error)?;
     }
     Ok(())
 }

--- a/crates/verlet-kernel/src/adapters/app_server/connection.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/connection.rs
@@ -2919,7 +2919,8 @@ impl crate::adapters::app_server::VerletAppServer {
         provider_id: &str,
     ) -> Option<verlet_metadata::provider_store::LlmProviderRecord> {
         let provider = self.catalog_provider(provider_id)?;
-        let api = catalog_api_to_provider_api(&provider.api)?;
+        let api =
+            crate::adapters::app_server::model_catalog::catalog_api_to_provider_api(&provider.api)?;
         let mut record = verlet_metadata::provider_store::LlmProviderRecord::new(
             provider.provider_id.clone(),
             api,
@@ -7271,21 +7272,6 @@ fn model_provider_not_found(provider_id: &str) -> JsonRpcErrorError {
         -32602,
         format!("model provider {provider_id:?} was not found"),
     )
-}
-
-fn catalog_api_to_provider_api(api: &str) -> Option<verlet_history::ProviderApi> {
-    match api {
-        crate::adapters::app_server::model_catalog::CATALOG_API_OPENAI_CHAT_COMPLETIONS => {
-            Some(verlet_history::ProviderApi::OpenAIChatCompletions)
-        }
-        crate::adapters::app_server::model_catalog::CATALOG_API_ANTHROPIC_MESSAGES => {
-            Some(verlet_history::ProviderApi::AnthropicMessages)
-        }
-        crate::adapters::app_server::model_catalog::CATALOG_API_OPENAI_RESPONSES => {
-            Some(verlet_history::ProviderApi::OpenAIResponses)
-        }
-        _ => None,
-    }
 }
 
 /// A record still equals its catalog template when every field except the

--- a/crates/verlet-kernel/src/adapters/app_server/model_catalog.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/model_catalog.rs
@@ -19,6 +19,17 @@ pub(crate) const CATALOG_API_OPENAI_RESPONSES: &str = "openai_responses";
 pub(crate) const CATALOG_AUTH_KIND_API_KEY: &str = "api_key";
 pub(crate) const CATALOG_AUTH_KIND_OAUTH: &str = "oauth";
 
+pub(crate) fn catalog_api_to_provider_api(api: &str) -> Option<verlet_history::ProviderApi> {
+    match api {
+        CATALOG_API_OPENAI_CHAT_COMPLETIONS => {
+            Some(verlet_history::ProviderApi::OpenAIChatCompletions)
+        }
+        CATALOG_API_ANTHROPIC_MESSAGES => Some(verlet_history::ProviderApi::AnthropicMessages),
+        CATALOG_API_OPENAI_RESPONSES => Some(verlet_history::ProviderApi::OpenAIResponses),
+        _ => None,
+    }
+}
+
 /// Trust-bearing base-URL/family pins for majors whose models.dev entry has no
 /// `api` URL (or a non-derivable SDK); each URL is verified against the
 /// provider's public API docs. Overrides win over derivation.
@@ -1226,6 +1237,22 @@ mod tests {
         assert!(!super::valid_catalog_base_url("ftp://example.com"));
         assert!(!super::valid_catalog_base_url("https://"));
         assert!(!super::valid_catalog_base_url("api.example.com/v1"));
+    }
+
+    #[test]
+    fn built_in_snapshot_keeps_every_provider_override_pinned() {
+        let providers = super::built_in_snapshot()
+            .providers
+            .iter()
+            .map(|provider| (provider.provider_id.as_str(), provider))
+            .collect::<std::collections::BTreeMap<_, _>>();
+        for (provider_id, base_url, api) in super::PROVIDER_OVERRIDES {
+            let provider = providers
+                .get(provider_id)
+                .unwrap_or_else(|| panic!("built-in snapshot omitted override {provider_id}"));
+            assert_eq!(provider.base_url, *base_url, "base URL for {provider_id}");
+            assert_eq!(provider.api, *api, "API family for {provider_id}");
+        }
     }
 
     #[test]

--- a/crates/verlet-kernel/src/adapters/app_server/model_catalog.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/model_catalog.rs
@@ -613,7 +613,15 @@ impl MergedModelCatalog {
             // provider metadata; the built-in provider set stays authoritative.
             Ok(Some(cached)) => {
                 for provider in cached.providers {
-                    merged.insert(provider.provider_id.clone(), provider);
+                    let Some(reviewed) = merged.get_mut(&provider.provider_id) else {
+                        continue;
+                    };
+                    // Endpoint and auth semantics are trust-bearing and ship
+                    // only in the reviewed snapshot. The refresh may update
+                    // non-endpoint provider display metadata.
+                    reviewed.display_name = provider.display_name;
+                    reviewed.env_vars = provider.env_vars;
+                    reviewed.doc_url = provider.doc_url;
                 }
             }
             Ok(None) => {}
@@ -1318,6 +1326,11 @@ mod tests {
     fn cached_remote_overlays_builtin_by_provider_and_model() {
         let state_home = test_state_home("overlay");
         let built_in = super::built_in_snapshot();
+        let built_in_provider = built_in
+            .providers
+            .iter()
+            .find(|provider| provider.provider_id == "anthropic")
+            .unwrap();
         let target = built_in
             .models
             .iter()
@@ -1325,7 +1338,32 @@ mod tests {
             .unwrap();
         let cached = super::ModelCatalogSnapshot {
             comment: None,
-            providers: Vec::new(),
+            providers: vec![
+                super::ModelCatalogProvider {
+                    provider_id: "anthropic".to_string(),
+                    display_name: "Remote Anthropic".to_string(),
+                    base_url: "https://credential-redirect.example.invalid".to_string(),
+                    api: super::CATALOG_API_OPENAI_RESPONSES.to_string(),
+                    auth_kind: super::CATALOG_AUTH_KIND_OAUTH.to_string(),
+                    env_vars: vec!["REMOTE_ANTHROPIC_API_KEY".to_string()],
+                    doc_url: Some("https://remote-docs.example.invalid".to_string()),
+                },
+                super::ModelCatalogProvider {
+                    provider_id: "remote-only-provider".to_string(),
+                    display_name: "Remote Only Provider".to_string(),
+                    base_url: "https://remote-only.example.invalid/v1".to_string(),
+                    api: super::CATALOG_API_OPENAI_CHAT_COMPLETIONS.to_string(),
+                    auth_kind: super::CATALOG_AUTH_KIND_API_KEY.to_string(),
+                    env_vars: vec!["REMOTE_ONLY_API_KEY".to_string()],
+                    doc_url: None,
+                },
+                built_in
+                    .providers
+                    .iter()
+                    .find(|provider| provider.provider_id == "openai")
+                    .unwrap()
+                    .clone(),
+            ],
             models: vec![
                 super::ModelCatalogModel {
                     provider_id: target.provider_id.clone(),
@@ -1354,6 +1392,26 @@ mod tests {
         super::write_catalog_cache(&state_home, &cached).unwrap();
 
         let catalog = super::MergedModelCatalog::new(&state_home);
+        let providers = catalog.providers();
+        let provider = providers
+            .iter()
+            .find(|provider| provider.provider_id == "anthropic")
+            .unwrap();
+        assert_eq!(provider.display_name, "Remote Anthropic");
+        assert_eq!(provider.base_url, built_in_provider.base_url);
+        assert_eq!(provider.api, built_in_provider.api);
+        assert_eq!(provider.auth_kind, built_in_provider.auth_kind);
+        assert_eq!(provider.env_vars, vec!["REMOTE_ANTHROPIC_API_KEY"]);
+        assert_eq!(
+            provider.doc_url.as_deref(),
+            Some("https://remote-docs.example.invalid")
+        );
+        assert!(
+            providers
+                .iter()
+                .all(|provider| provider.provider_id != "remote-only-provider"),
+            "providers absent from the reviewed snapshot must not enter the merged view"
+        );
         let full = catalog.full_entries();
         let replaced = full
             .iter()

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -1282,6 +1282,139 @@ async fn model_provider_auth_set_templates_a_catalog_provider_record_on_demand()
 }
 
 #[tokio::test]
+async fn app_start_repins_legacy_catalog_records_and_drops_remote_only_origins() {
+    let root = unique_test_root("app-server-repin-legacy-catalog-records");
+    let config = local_model_select_test_config(&root, "repin-legacy-catalog-records");
+    let cache_dir = config.user_state_home.join("model-catalog");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    std::fs::write(
+        cache_dir.join("models.json"),
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "providers": [
+                {
+                    "provider_id": "anthropic",
+                    "display_name": "Remote Anthropic",
+                    "base_url": "https://credential-redirect.example.invalid",
+                    "api": "openai_responses",
+                    "auth_kind": "oauth"
+                },
+                {
+                    "provider_id": "remote-only-provider",
+                    "display_name": "Remote Only Provider",
+                    "base_url": "https://remote-only.example.invalid/v1",
+                    "api": "openai_chat_completions",
+                    "auth_kind": "api_key"
+                }
+            ],
+            "models": [{
+                "provider_id": "remote-only-provider",
+                "model_id": "remote-only-model",
+                "display_name": "Remote Only Model"
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let metadata_store =
+        verlet_metadata::provider_store::SqliteMetadataStore::open(config.metadata_store_path())
+            .await
+            .unwrap();
+    for provider_id in ["anthropic", "remote-only-provider"] {
+        metadata_store
+            .upsert_provider(
+                verlet_metadata::provider_store::LlmProviderRecord::new(
+                    provider_id,
+                    verlet_history::ProviderApi::OpenAIResponses,
+                    if provider_id == "anthropic" {
+                        "https://credential-redirect.example.invalid"
+                    } else {
+                        "https://remote-only.example.invalid/v1"
+                    },
+                )
+                .with_auth_header(true)
+                .with_metadata("origin", "catalog"),
+            )
+            .await
+            .unwrap();
+    }
+    metadata_store
+        .upsert_provider(verlet_metadata::provider_store::LlmProviderRecord::new(
+            "custom-provider",
+            verlet_history::ProviderApi::OpenAIResponses,
+            "https://custom.example.invalid/v1",
+        ))
+        .await
+        .unwrap();
+    drop(metadata_store);
+    let user_metadata_store = verlet_metadata::provider_store::SqliteMetadataStore::open(
+        config.user_metadata_store_path(),
+    )
+    .await
+    .unwrap();
+    user_metadata_store
+        .set_credential(
+            "remote-only-provider",
+            verlet_metadata::provider_store::LlmProviderCredential::ApiKey {
+                key: "recoverable-remote-only-key".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    drop(user_metadata_store);
+
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let anthropic = app
+        .inner
+        .metadata_store
+        .get_provider("anthropic")
+        .await
+        .unwrap()
+        .expect("the reviewed provider must remain configured");
+    assert_eq!(anthropic.base_url, "https://api.anthropic.com");
+    assert_eq!(
+        anthropic.api,
+        verlet_history::ProviderApi::AnthropicMessages
+    );
+    assert!(
+        app.inner
+            .metadata_store
+            .get_provider("remote-only-provider")
+            .await
+            .unwrap()
+            .is_none(),
+        "a provider materialized only from the remote catalog must be retired"
+    );
+    assert_eq!(
+        app.inner
+            .user_metadata_store
+            .get_credential("remote-only-provider")
+            .await
+            .unwrap(),
+        Some(
+            verlet_metadata::provider_store::LlmProviderCredential::ApiKey {
+                key: "recoverable-remote-only-key".to_string(),
+            }
+        ),
+        "retiring an unreviewed provider record must preserve its credential"
+    );
+    assert_eq!(
+        app.inner
+            .metadata_store
+            .get_provider("custom-provider")
+            .await
+            .unwrap()
+            .expect("explicit custom providers must not be repinned")
+            .base_url,
+        "https://custom.example.invalid/v1"
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
 async fn model_provider_auth_set_keeps_not_found_for_remote_only_provider() {
     let root = unique_test_root("app-server-auth-set-remote-only");
     let config = local_model_select_test_config(&root, "auth-set-remote-only");
@@ -1336,6 +1469,16 @@ async fn model_provider_auth_set_keeps_not_found_for_remote_only_provider() {
             .await
             .unwrap()
             .is_none()
+    );
+    let models = app
+        .dispatch_request(&connection, "model/list", None)
+        .await
+        .unwrap();
+    assert!(
+        models["data"].as_array().unwrap().iter().all(|model| {
+            model["providerId"] != "remote-only-provider" && model["id"] != "remote-only-model"
+        }),
+        "orphaned remote-only models must remain outside model/list"
     );
     assert_eq!(
         app.inner

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -1282,9 +1282,31 @@ async fn model_provider_auth_set_templates_a_catalog_provider_record_on_demand()
 }
 
 #[tokio::test]
-async fn model_provider_auth_set_keeps_not_found_for_unknown_provider() {
-    let root = unique_test_root("app-server-auth-set-unknown");
-    let config = local_model_select_test_config(&root, "auth-set-unknown");
+async fn model_provider_auth_set_keeps_not_found_for_remote_only_provider() {
+    let root = unique_test_root("app-server-auth-set-remote-only");
+    let config = local_model_select_test_config(&root, "auth-set-remote-only");
+    let cache_dir = config.user_state_home.join("model-catalog");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    std::fs::write(
+        cache_dir.join("models.json"),
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "providers": [{
+                "provider_id": "remote-only-provider",
+                "display_name": "Remote Only Provider",
+                "base_url": "https://remote-only.example.invalid/v1",
+                "api": "openai_chat_completions",
+                "auth_kind": "api_key",
+                "env_vars": ["REMOTE_ONLY_API_KEY"]
+            }],
+            "models": [{
+                "provider_id": "remote-only-provider",
+                "model_id": "remote-only-model",
+                "display_name": "Remote Only Model"
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
     let app = crate::adapters::app_server::VerletAppServer::new_local(config)
         .await
         .unwrap();
@@ -1296,7 +1318,7 @@ async fn model_provider_auth_set_keeps_not_found_for_unknown_provider() {
             &connection,
             "modelProvider/auth/set",
             Some(serde_json::json!({
-                "providerId": "unknown-everywhere",
+                "providerId": "remote-only-provider",
                 "apiKey": "must-not-store",
             })),
         )
@@ -1305,12 +1327,12 @@ async fn model_provider_auth_set_keeps_not_found_for_unknown_provider() {
     assert_eq!(error.code, -32602);
     assert_eq!(
         error.message,
-        "model provider \"unknown-everywhere\" was not found"
+        "model provider \"remote-only-provider\" was not found"
     );
     assert!(
         app.inner
             .metadata_store
-            .get_provider("unknown-everywhere")
+            .get_provider("remote-only-provider")
             .await
             .unwrap()
             .is_none()
@@ -1318,7 +1340,7 @@ async fn model_provider_auth_set_keeps_not_found_for_unknown_provider() {
     assert_eq!(
         app.inner
             .user_metadata_store
-            .get_credential("unknown-everywhere")
+            .get_credential("remote-only-provider")
             .await
             .unwrap(),
         None

--- a/docs/app-server.md
+++ b/docs/app-server.md
@@ -889,6 +889,11 @@ without a catalog entry), and `active` (the provider of the runtime-active
 model). Configured providers sort first, then the active provider, then
 alphabetical display names. Credential values are never returned.
 
+Provider base URLs, API families, and auth kinds ship only in the reviewed
+checked-in snapshot. The background refresh updates model metadata and
+non-endpoint provider display metadata for providers already in that snapshot.
+Providers found only by the refresh do not enter the catalog provider view.
+
 ### `mcpSource/list`
 
 Params: none.

--- a/docs/app-server.md
+++ b/docs/app-server.md
@@ -893,6 +893,11 @@ Provider base URLs, API families, and auth kinds ship only in the reviewed
 checked-in snapshot. The background refresh updates model metadata and
 non-endpoint provider display metadata for providers already in that snapshot.
 Providers found only by the refresh do not enter the catalog provider view.
+At startup, records materialized by older catalog versions are reconciled
+before endpoint construction: reviewed provider endpoints are re-pinned, and
+refresh-only provider records are retired. Their separately stored credentials
+are preserved so an operator can recover them through an explicit custom
+provider configuration.
 
 ### `mcpSource/list`
 


### PR DESCRIPTION
## Summary

The models.dev runtime refresh could overwrite provider base URLs, API families, and auth kinds in the merged catalog view, and records materialized by an earlier refresh kept network-supplied endpoints in the provider store. Base URLs decide where API keys are sent, so both paths bypassed the release-time snapshot review that exists to vet them.

- `MergedModelCatalog::providers()` now pins `base_url`, `api`, and `auth_kind` to the built-in reviewed snapshot; the refresh may only update display name, env var hints, and doc URL. Providers found only by the refresh are dropped from the merged view and cannot be materialized through `modelProvider/auth/set`.
- Startup reconciliation re-pins endpoints on previously materialized `origin=catalog` records and retires refresh-only ones, preserving their stored credentials for recovery through an explicit custom provider. Custom providers are untouched.
- `docs/app-server.md` documents the trust rule.

Closes EMO-582.

## Verification

- `scripts/verify.sh` green locally (macOS)
- `scripts/verify-linux.sh` green (Linux lane)
- New tests: pinning under a poisoned cache, remote-only provider exclusion from `providers()` / `auth/set` / `model/list`, startup reconciliation lifecycle with credential preservation