### PR TITLE
Journaled binding.attached/binding.detached events + thread bindings fold (EMO-584)

### DIFF
--- a/crates/verlet-history/src/lib.rs
+++ b/crates/verlet-history/src/lib.rs
@@ -19,7 +19,7 @@ pub const STREAM_APPEND_ACK_SCHEMA_V1: &str = "cooldis.stream.append_ack/1";
 pub const STREAM_ROUTING_DECISION_SCHEMA_V1: &str = "cooldis.stream.routing_decision/1";
 pub const CONTEXT_READ_PLAN_SCHEMA_V1: &str = "cooldis.context.read_plan/1";
 pub const DEBUG_THREAD_EXPORT_SCHEMA_V1: &str = "cooldis.debug.thread_export/1";
-pub const EVENT_KIND_SCHEMA_VERSION: &str = "cooldis.events/0.3";
+pub const EVENT_KIND_SCHEMA_VERSION: &str = "cooldis.events/0.4";
 
 pub const COMPACTION_SUMMARY_PREFIX: &str = "Compacted conversation summary:";
 
@@ -198,7 +198,7 @@ impl std::fmt::Display for EventRecordId {
     }
 }
 
-/// Frozen event-kind vocabulary, version `cooldis.events/0.3`.
+/// Frozen event-kind vocabulary, version `cooldis.events/0.4`.
 ///
 /// Laws:
 /// - The vocabulary is append-only: kinds may be added in later versions,
@@ -244,6 +244,13 @@ pub enum EventKind {
     /// the payload is the bind receipt. Emitted at publish and at run time.
     #[strum(serialize = "manifest.bind.completed")]
     ManifestBindCompleted,
+    /// An operation package binding became active. Its event id is the
+    /// binding identity referenced by a later detach.
+    #[strum(serialize = "binding.attached")]
+    BindingAttached,
+    /// An active operation package binding ended.
+    #[strum(serialize = "binding.detached")]
+    BindingDetached,
     /// A tool universe's contracts were witnessed (at bind or on demand);
     /// the payload is `ToolUniverseDiscoveryReceipt` — server ref, discovery
     /// hash, and per-tool schema hashes. Witnessed origin: the contracts

--- a/crates/verlet-history/src/lib.rs
+++ b/crates/verlet-history/src/lib.rs
@@ -454,6 +454,88 @@ pub enum AdmissionDecision {
     Coalesce,
 }
 
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum BindingEffectClass {
+    Pure,
+    Idempotent,
+    #[default]
+    AtMostOnce,
+}
+
+impl BindingEffectClass {
+    fn is_at_most_once(&self) -> bool {
+        *self == Self::AtMostOnce
+    }
+}
+
+#[derive(
+    Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize,
+)]
+#[serde(deny_unknown_fields)]
+pub struct BindingAttachmentConfig {
+    #[serde(default, skip_serializing_if = "std::collections::BTreeSet::is_empty")]
+    pub allowed_secrets: std::collections::BTreeSet<String>,
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub allowed_private_network:
+        std::collections::BTreeMap<String, std::collections::BTreeSet<String>>,
+}
+
+impl BindingAttachmentConfig {
+    fn is_empty(&self) -> bool {
+        self.allowed_secrets.is_empty() && self.allowed_private_network.is_empty()
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BindingAttachedDirectToolBinding {
+    pub tool_name: String,
+    pub operation: String,
+    #[serde(default, skip_serializing_if = "BindingEffectClass::is_at_most_once")]
+    pub effect_class: BindingEffectClass,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BindingAttachedPayload {
+    pub name: String,
+    pub artifact_hash: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub operations: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub direct_tools: Vec<BindingAttachedDirectToolBinding>,
+    #[serde(default, skip_serializing_if = "BindingAttachmentConfig::is_empty")]
+    pub attachment_config: BindingAttachmentConfig,
+    #[serde(default, skip_serializing_if = "BindingEffectClass::is_at_most_once")]
+    pub effect_class: BindingEffectClass,
+    pub requested_by: String,
+    pub decided_by: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decision_event_id: Option<EventRecordId>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BindingDetachedPayload {
+    pub attach_event_id: EventRecordId,
+    pub requested_by: String,
+    pub decided_by: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decision_event_id: Option<EventRecordId>,
+}
+
 /// Payload of `thread.spawn.requested`: a coupling's proposal to spawn
 /// supervised child work. The projector that consumes it performs the spawn
 /// under the parent's attached supervisor coupling and `allow_child_agents`
@@ -1228,6 +1310,14 @@ pub fn stream_schema_registry_v1() -> &'static verlet_runtime_contracts::schema:
                 context_read_plan_set_payload_schema_v1(),
             )?;
             registry.register(
+                EventKind::BindingAttached.payload_schema_id(),
+                binding_attached_payload_schema_v1(),
+            )?;
+            registry.register(
+                EventKind::BindingDetached.payload_schema_id(),
+                binding_detached_payload_schema_v1(),
+            )?;
+            registry.register(
                 EventKind::ThreadSpawnRequested.payload_schema_id(),
                 thread_spawn_requested_payload_schema_v1(),
             )?;
@@ -1686,6 +1776,69 @@ fn context_read_plan_set_payload_schema_v1() -> serde_json::Value {
             "read_plan": context_read_plan_schema_v1()
         }
     })
+}
+
+pub fn binding_attached_payload_schema_v1() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "required": ["name", "artifact_hash", "requested_by", "decided_by"],
+        "additionalProperties": false,
+        "properties": {
+            "name": {"type": "string"},
+            "artifact_hash": {"type": "string"},
+            "operations": string_array_schema_v1(),
+            "direct_tools": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["tool_name", "operation"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "tool_name": {"type": "string"},
+                        "operation": {"type": "string"},
+                        "effect_class": binding_effect_class_schema_v1()
+                    }
+                }
+            },
+            "attachment_config": binding_attachment_config_schema_v1(),
+            "effect_class": binding_effect_class_schema_v1(),
+            "requested_by": {"type": "string"},
+            "decided_by": {"type": "string"},
+            "decision_event_id": {"type": "string"}
+        }
+    })
+}
+
+pub fn binding_detached_payload_schema_v1() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "required": ["attach_event_id", "requested_by", "decided_by"],
+        "additionalProperties": false,
+        "properties": {
+            "attach_event_id": {"type": "string"},
+            "requested_by": {"type": "string"},
+            "decided_by": {"type": "string"},
+            "decision_event_id": {"type": "string"}
+        }
+    })
+}
+
+fn binding_attachment_config_schema_v1() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "allowed_secrets": string_array_schema_v1(),
+            "allowed_private_network": {
+                "type": "object",
+                "additionalProperties": string_array_schema_v1()
+            }
+        }
+    })
+}
+
+fn binding_effect_class_schema_v1() -> serde_json::Value {
+    serde_json::json!({"enum": ["pure", "idempotent", "at-most-once"]})
 }
 
 fn thread_spawned_payload_schema_v1() -> serde_json::Value {

--- a/crates/verlet-history/src/tests.rs
+++ b/crates/verlet-history/src/tests.rs
@@ -677,6 +677,115 @@ fn event_kind_payload_schema_ids_are_frozen_for_stream_schema_v1() {
 }
 
 #[test]
+fn binding_attached_payload_wire_shape_is_frozen() {
+    let payload = crate::BindingAttachedPayload {
+        name: "search-tools".to_string(),
+        artifact_hash: "sha256:search-tools".to_string(),
+        operations: vec!["search".to_string(), "answer".to_string()],
+        direct_tools: vec![crate::BindingAttachedDirectToolBinding {
+            tool_name: "search_web".to_string(),
+            operation: "search".to_string(),
+            effect_class: crate::BindingEffectClass::Pure,
+        }],
+        attachment_config: crate::BindingAttachmentConfig {
+            allowed_secrets: std::collections::BTreeSet::from(["SEARCH_TOKEN".to_string()]),
+            allowed_private_network: std::collections::BTreeMap::from([(
+                "http://127.0.0.1:*".to_string(),
+                std::collections::BTreeSet::from(["GET".to_string(), "POST".to_string()]),
+            )]),
+        },
+        effect_class: crate::BindingEffectClass::Idempotent,
+        requested_by: "principal:operator".to_string(),
+        decided_by: "principal:operator".to_string(),
+        decision_event_id: None,
+    };
+
+    let expected = serde_json::json!({
+        "name": "search-tools",
+        "artifact_hash": "sha256:search-tools",
+        "operations": ["search", "answer"],
+        "direct_tools": [{
+            "tool_name": "search_web",
+            "operation": "search",
+            "effect_class": "pure"
+        }],
+        "attachment_config": {
+            "allowed_secrets": ["SEARCH_TOKEN"],
+            "allowed_private_network": {
+                "http://127.0.0.1:*": ["GET", "POST"]
+            }
+        },
+        "effect_class": "idempotent",
+        "requested_by": "principal:operator",
+        "decided_by": "principal:operator"
+    });
+    let actual = serde_json::to_value(&payload).unwrap();
+
+    assert_eq!(actual, expected);
+    assert_eq!(
+        serde_json::from_value::<crate::BindingAttachedPayload>(actual).unwrap(),
+        payload
+    );
+    crate::stream_schema_registry_v1()
+        .validate(
+            &crate::EventKind::BindingAttached.payload_schema_id(),
+            &expected,
+        )
+        .unwrap();
+}
+
+#[test]
+fn binding_detached_payload_wire_shape_is_frozen() {
+    let attach_event_id = crate::EventRecordId::from_uuid(
+        uuid::Uuid::parse_str("018f0000-0000-7000-8000-000000000041").unwrap(),
+    );
+    let payload = crate::BindingDetachedPayload {
+        attach_event_id,
+        requested_by: "principal:operator".to_string(),
+        decided_by: "principal:operator".to_string(),
+        decision_event_id: None,
+    };
+    let expected = serde_json::json!({
+        "attach_event_id": "018f0000-0000-7000-8000-000000000041",
+        "requested_by": "principal:operator",
+        "decided_by": "principal:operator"
+    });
+    let actual = serde_json::to_value(&payload).unwrap();
+
+    assert_eq!(actual, expected);
+    assert_eq!(
+        serde_json::from_value::<crate::BindingDetachedPayload>(actual).unwrap(),
+        payload
+    );
+    crate::stream_schema_registry_v1()
+        .validate(
+            &crate::EventKind::BindingDetached.payload_schema_id(),
+            &expected,
+        )
+        .unwrap();
+}
+
+#[test]
+fn binding_payloads_reject_unknown_fields() {
+    let attached = serde_json::json!({
+        "name": "search-tools",
+        "artifact_hash": "sha256:search-tools",
+        "requested_by": "principal:operator",
+        "decided_by": "principal:operator",
+        "scheduled_detach": true
+    });
+    assert!(serde_json::from_value::<crate::BindingAttachedPayload>(attached).is_err());
+
+    let detached = serde_json::json!({
+        "attach_event_id": "018f0000-0000-7000-8000-000000000041",
+        "requested_by": "principal:operator",
+        "decided_by": "principal:operator",
+        "scheduled_detach": true
+    });
+    assert!(serde_json::from_value::<crate::BindingDetachedPayload>(detached).is_err());
+}
+
+#[test]
 fn client_record_carrier_payload_schema_is_registered_and_strict() {
     let registry = crate::stream_schema_registry_v1();
     let schema = crate::EventKind::ClientRecordAppended.payload_schema_id();

--- a/crates/verlet-history/src/tests.rs
+++ b/crates/verlet-history/src/tests.rs
@@ -523,6 +523,8 @@ fn event_kind_parse_round_trips_and_fails_closed() {
         "context.read_plan.set",
         "manifest.compile.completed",
         "manifest.bind.completed",
+        "binding.attached",
+        "binding.detached",
         "tool.universe.discovery.completed",
         "tool.universe.call.completed",
         "tool.call.requested",
@@ -564,7 +566,7 @@ fn event_kind_parse_round_trips_and_fails_closed() {
         "io.egress.failed",
         "admission.decided",
     ];
-    assert_eq!(crate::EVENT_KIND_SCHEMA_VERSION, "cooldis.events/0.3");
+    assert_eq!(crate::EVENT_KIND_SCHEMA_VERSION, "cooldis.events/0.4");
     let kinds = <crate::EventKind as strum::VariantArray>::VARIANTS;
     let actual: Vec<&str> = kinds.iter().map(|kind| kind.as_ref()).collect();
     assert_eq!(actual, expected);
@@ -588,6 +590,14 @@ fn event_kind_parse_round_trips_and_fails_closed() {
 
 #[test]
 fn event_kind_payload_schema_ids_are_frozen_for_stream_schema_v1() {
+    assert_eq!(
+        crate::EventKind::BindingAttached.payload_schema_id(),
+        "cooldis.event.binding.attached/1"
+    );
+    assert_eq!(
+        crate::EventKind::BindingDetached.payload_schema_id(),
+        "cooldis.event.binding.detached/1"
+    );
     assert_eq!(
         crate::EventKind::ContextCompileCompleted.payload_schema_id(),
         "cooldis.event.context.compile.completed/1"

--- a/crates/verlet-history/src/tests.rs
+++ b/crates/verlet-history/src/tests.rs
@@ -589,6 +589,81 @@ fn event_kind_parse_round_trips_and_fails_closed() {
 }
 
 #[test]
+fn v03_journal_event_kinds_remain_decodable_after_v04_bump() {
+    let v03_kinds = [
+        "session.entry.appended",
+        "context.compile.completed",
+        "context.summary.completed",
+        "context.read_plan.set",
+        "manifest.compile.completed",
+        "manifest.bind.completed",
+        "tool.universe.discovery.completed",
+        "tool.universe.call.completed",
+        "tool.call.requested",
+        "tool.call.suspended",
+        "tool.call.decision",
+        "tool.call.completed",
+        "turn.submitted",
+        "turn.waiting",
+        "turn.resumed",
+        "turn.completed",
+        "approval.requested",
+        "approval.resolved",
+        "mandate.started",
+        "mandate.revoked",
+        "turn.continue.requested",
+        "turn.continuation.accepted",
+        "turn.continuation.rejected",
+        "loop.completed",
+        "loop.blocked",
+        "loop.budget_exhausted",
+        "loop.denied",
+        "coupling.run.completed",
+        "coupling.run.failed",
+        "placement.decision",
+        "thread.spawn.requested",
+        "thread.spawned",
+        "thread.joined",
+        "thread.branch.selected",
+        "thread.reload.degraded",
+        "policy.bound",
+        "grant.petitioned",
+        "timer.fired",
+        "client.record.appended",
+        "io.ingress.received",
+        "io.ingress.claimed",
+        "io.ingress.settled",
+        "io.egress.requested",
+        "io.egress.delivered",
+        "io.egress.failed",
+        "admission.decided",
+    ];
+    let coordinates = coords("tenant_a", "user_1", "v03-journal");
+    let stream_id = crate::EventStreamId::for_thread(&coordinates);
+
+    for (index, encoded_kind) in v03_kinds.into_iter().enumerate() {
+        let kind = encoded_kind.parse::<crate::EventKind>().unwrap();
+        let record = crate::EventRecord::from_new(
+            stream_id.clone(),
+            crate::EventSequence::new(index as i64 + 1),
+            crate::NewEventRecord::witnessed(
+                coordinates.clone(),
+                kind,
+                serde_json::json!({"legacy": true}),
+            ),
+        );
+        let decoded =
+            serde_json::from_value::<crate::EventRecord>(serde_json::to_value(&record).unwrap())
+                .unwrap();
+
+        assert_eq!(
+            decoded.kind, kind,
+            "failed to decode v0.3 kind {encoded_kind}"
+        );
+    }
+}
+
+#[test]
 fn event_kind_payload_schema_ids_are_frozen_for_stream_schema_v1() {
     assert_eq!(
         crate::EventKind::BindingAttached.payload_schema_id(),

--- a/crates/verlet-kernel/src/adapters/agent_loop/tests.rs
+++ b/crates/verlet-kernel/src/adapters/agent_loop/tests.rs
@@ -1300,7 +1300,7 @@ impl crate::agent::agent_process::KernelThreadSpawnAgentResolver
 
     async fn resolve_agent_ref(
         &self,
-        _caller: &verlet_runtime_contracts::ThreadContext,
+        caller: &verlet_runtime_contracts::ThreadContext,
         agent_ref: &str,
     ) -> crate::kernel::runtime_host::VerletResult<
         crate::agent::agent_process::KernelThreadSpawnAgentBinding,
@@ -1341,6 +1341,7 @@ impl crate::agent::agent_process::KernelThreadSpawnAgentResolver
                 },
             )
             .unwrap(),
+            principal_id: caller.coordinates.user_id.clone(),
         })
     }
 }

--- a/crates/verlet-kernel/src/adapters/app_server/connection.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/connection.rs
@@ -4076,15 +4076,11 @@ impl crate::adapters::app_server::VerletAppServer {
                 })
             })
             .transpose()?;
-        let workspace_metadata = workspace
-            .as_ref()
-            .map(serde_json::to_string)
-            .transpose()
-            .map_err(|err| {
-                internal_error(crate::kernel::runtime_host::VerletError::RuntimeFactory(
-                    format!("source thread workspace binding could not be encoded: {err}"),
-                ))
-            })?;
+        let operation_bindings =
+            crate::adapters::app_server::threads::thread_manifest_operation_bindings(
+                source_handle.context(),
+            )
+            .map_err(internal_error)?;
         let skill_packages = crate::adapters::app_server::threads::thread_manifest_skill_packages(
             source_handle.context(),
         )
@@ -4099,28 +4095,34 @@ impl crate::adapters::app_server::VerletAppServer {
                 source_handle.context(),
             )
             .map_err(internal_error)?;
-        let skill_packages_metadata = source_handle
-            .context()
-            .metadata
-            .get(crate::agent::manifest_bind::THREAD_AGENT_SKILL_PACKAGES_METADATA)
-            .cloned();
-        let skill_discovery_metadata = source_handle
-            .context()
-            .metadata
-            .get(crate::agent::manifest_bind::THREAD_AGENT_SKILL_DISCOVERY_METADATA)
-            .cloned();
-        let skill_context_metadata = source_handle
-            .context()
-            .metadata
-            .get(crate::agent::manifest_bind::THREAD_AGENT_SKILL_CONTEXT_SEGMENTS_METADATA)
-            .cloned();
+        let inherited_binding_metadata = [
+            crate::adapters::app_server::THREAD_AGENT_OPERATION_BINDINGS_METADATA,
+            crate::kernel::runtime_host::THREAD_OPERATION_REGISTRY_ROOT_METADATA,
+            crate::adapters::app_server::THREAD_AGENT_WORKSPACE_METADATA,
+            crate::agent::manifest_bind::THREAD_AGENT_SKILL_PACKAGES_METADATA,
+            crate::agent::manifest_bind::THREAD_AGENT_SKILL_DISCOVERY_METADATA,
+            crate::agent::manifest_bind::THREAD_AGENT_SKILL_CONTEXT_SEGMENTS_METADATA,
+        ]
+        .into_iter()
+        .filter_map(|key| {
+            source_handle
+                .context()
+                .metadata
+                .get(key)
+                .cloned()
+                .map(|value| (key.to_string(), value))
+        })
+        .collect::<std::collections::BTreeMap<_, _>>();
         let inherited_manifest_receipts = if workspace.is_some()
+            || !operation_bindings.is_empty()
             || !skill_packages.is_empty()
             || skill_discovery.is_some()
             || !skill_context_segments.is_empty()
         {
             let missing_witness = if workspace.is_some() {
                 "source thread workspace binding has no durable manifest bind witness"
+            } else if !operation_bindings.is_empty() {
+                "source thread operation binding has no durable manifest bind witness"
             } else {
                 "source thread skill package binding has no durable manifest bind witness"
             };
@@ -4152,6 +4154,27 @@ impl crate::adapters::app_server::VerletAppServer {
             if witnessed_workspace.as_ref() != workspace.as_ref() {
                 return Err(internal_error(crate::kernel::runtime_host::VerletError::RuntimeFactory(
                     "source thread workspace metadata disagrees with its durable manifest bind witness"
+                        .to_string(),
+                )));
+            }
+            let witnessed_operation_bindings = bind_payload
+                .get("operation_bindings")
+                .cloned()
+                .map(
+                    serde_json::from_value::<
+                        Vec<crate::agent::manifest_bind::AgentManifestOperationBinding>,
+                    >,
+                )
+                .transpose()
+                .map_err(|err| {
+                    internal_error(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                        format!("source thread manifest operation witness is invalid: {err}"),
+                    ))
+                })?
+                .unwrap_or_default();
+            if witnessed_operation_bindings != operation_bindings {
+                return Err(internal_error(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                    "source thread operation metadata disagrees with its durable manifest bind witness"
                         .to_string(),
                 )));
             }
@@ -4271,31 +4294,7 @@ impl crate::adapters::app_server::VerletAppServer {
         } else {
             None
         };
-        if let Some(raw) = &workspace_metadata {
-            checkpoint_metadata.insert(
-                crate::adapters::app_server::THREAD_AGENT_WORKSPACE_METADATA.to_string(),
-                raw.clone(),
-            );
-        }
-        if let Some(raw) = &skill_packages_metadata {
-            checkpoint_metadata.insert(
-                crate::agent::manifest_bind::THREAD_AGENT_SKILL_PACKAGES_METADATA.to_string(),
-                raw.clone(),
-            );
-        }
-        if let Some(raw) = &skill_discovery_metadata {
-            checkpoint_metadata.insert(
-                crate::agent::manifest_bind::THREAD_AGENT_SKILL_DISCOVERY_METADATA.to_string(),
-                raw.clone(),
-            );
-        }
-        if let Some(raw) = &skill_context_metadata {
-            checkpoint_metadata.insert(
-                crate::agent::manifest_bind::THREAD_AGENT_SKILL_CONTEXT_SEGMENTS_METADATA
-                    .to_string(),
-                raw.clone(),
-            );
-        }
+        checkpoint_metadata.extend(inherited_binding_metadata.clone());
         let mut checkpoint = match params.checkpoint_id.as_deref() {
             Some(checkpoint_id) => {
                 let checkpoint_id =
@@ -4329,31 +4328,7 @@ impl crate::adapters::app_server::VerletAppServer {
                 .await
                 .map_err(internal_error)?,
         };
-        if let Some(raw) = workspace_metadata {
-            checkpoint.metadata.insert(
-                crate::adapters::app_server::THREAD_AGENT_WORKSPACE_METADATA.to_string(),
-                raw,
-            );
-        }
-        if let Some(raw) = skill_packages_metadata {
-            checkpoint.metadata.insert(
-                crate::agent::manifest_bind::THREAD_AGENT_SKILL_PACKAGES_METADATA.to_string(),
-                raw,
-            );
-        }
-        if let Some(raw) = skill_discovery_metadata {
-            checkpoint.metadata.insert(
-                crate::agent::manifest_bind::THREAD_AGENT_SKILL_DISCOVERY_METADATA.to_string(),
-                raw,
-            );
-        }
-        if let Some(raw) = skill_context_metadata {
-            checkpoint.metadata.insert(
-                crate::agent::manifest_bind::THREAD_AGENT_SKILL_CONTEXT_SEGMENTS_METADATA
-                    .to_string(),
-                raw,
-            );
-        }
+        checkpoint.metadata.extend(inherited_binding_metadata);
         let source_cut = thread_source_cut_json(&coordinates, &checkpoint, None);
         let handle = self
             .inner
@@ -4839,6 +4814,7 @@ impl crate::adapters::app_server::VerletAppServer {
                 self.app_server_thread_spawn_agent_resolver(
                     params.placement.clone(),
                     params.workspace.clone(),
+                    connection.resolved_principal.principal_id.to_string(),
                 )
                 .await
                 .map_err(internal_error)?,

--- a/crates/verlet-kernel/src/adapters/app_server/connection.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/connection.rs
@@ -3843,8 +3843,12 @@ impl crate::adapters::app_server::VerletAppServer {
             })
             .await
             .map_err(internal_error)?;
-        self.witness_bound_agent_and_persist_lifecycle(handle.clone(), bound_agent)
-            .await?;
+        self.witness_bound_agent_and_persist_lifecycle(
+            handle.clone(),
+            bound_agent,
+            connection.resolved_principal.principal_id.to_string(),
+        )
+        .await?;
         crate::adapters::app_server::subscriptions::wait_for_initial_thread_status(&handle).await;
         let context = handle.context();
         let coordinates = context.coordinates.clone();
@@ -4362,6 +4366,7 @@ impl crate::adapters::app_server::VerletAppServer {
                 handle.clone(),
                 compile_payload,
                 bind_payload,
+                connection.resolved_principal.principal_id.to_string(),
             )
             .await?;
         } else {
@@ -4547,8 +4552,12 @@ impl crate::adapters::app_server::VerletAppServer {
             })
             .await
             .map_err(internal_error)?;
-        self.witness_bound_agent_and_persist_lifecycle(handle.clone(), bound_agent.clone())
-            .await?;
+        self.witness_bound_agent_and_persist_lifecycle(
+            handle.clone(),
+            bound_agent.clone(),
+            connection.resolved_principal.principal_id.to_string(),
+        )
+        .await?;
         crate::adapters::app_server::subscriptions::wait_for_initial_thread_status(&handle).await;
 
         let child_coordinates = handle.context().coordinates.clone();

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -483,6 +483,47 @@ fn event_by_kind(
         .unwrap_or_else(|| panic!("expected {kind} event"))
 }
 
+fn assert_binding_fold_matches_latest_bind(
+    events: &[verlet_history::EventRecord],
+    expected_principal: &str,
+) {
+    let bind = events
+        .iter()
+        .filter(|event| event.kind == verlet_history::EventKind::ManifestBindCompleted)
+        .max_by_key(|event| event.sequence.get())
+        .expect("expected a manifest bind receipt");
+    let receipt = serde_json::from_value::<crate::agent::manifest_bind::AgentManifestBindReceipt>(
+        bind.payload.clone(),
+    )
+    .unwrap();
+    let folded = crate::kernel::binding_projector::fold_thread_bindings(events);
+
+    assert!(folded.anomalies.is_empty());
+    assert_eq!(
+        folded
+            .active
+            .iter()
+            .map(|binding| binding.payload.clone())
+            .collect::<Vec<_>>(),
+        receipt
+            .operation_bindings
+            .iter()
+            .map(|binding| {
+                crate::agent::manifest_bind::binding_attached_payload(binding, expected_principal)
+            })
+            .collect::<Vec<_>>()
+    );
+    for binding in folded.active {
+        let event = events
+            .iter()
+            .find(|event| event.id == binding.attach_event_id)
+            .expect("active binding must retain its attach event");
+        assert_eq!(event.provenance.source_event_ids, vec![bind.id]);
+        assert_eq!(binding.payload.requested_by, expected_principal);
+        assert_eq!(binding.payload.decided_by, expected_principal);
+    }
+}
+
 #[test]
 fn thinking_params_parse_supported_shapes() {
     let effort: crate::adapters::app_server::connection::ThreadStartParams =
@@ -13073,7 +13114,7 @@ async fn model_provider_capabilities_read_reports_bedrock_streaming() {
 }
 
 #[tokio::test]
-async fn app_server_capsule_bindings_expose_published_operation_to_tools_and_bash() {
+async fn app_server_manifest_bindings_expose_tools_and_replay_across_lifecycle() {
     let registry_root = unique_test_root("capsule-global-registry");
     let record = publish_echo_operation(&registry_root, "search", "search", "search").await;
     let client = std::sync::Arc::new(BashCallingCapsuleClient::new(
@@ -13090,7 +13131,9 @@ async fn app_server_capsule_bindings_expose_published_operation_to_tools_and_bas
             .with_global_operation_name("search"),
     )
     .await;
-    let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    let mut principal = operator_principal(&app);
+    principal.principal_id = crate::daemon::identity::PrincipalId::new("principal:binding-review");
+    let (connection, _outbound_rx) = test_connection_for_principal(app.clone(), principal).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -13119,6 +13162,93 @@ async fn app_server_capsule_bindings_expose_published_operation_to_tools_and_bas
         Some(record.active_artifact_hash.as_str())
     );
     assert_eq!(exa_binding["operations"], serde_json::json!(["search"]));
+    assert_binding_fold_matches_latest_bind(
+        &events,
+        connection.resolved_principal.principal_id.as_str(),
+    );
+
+    app.inner
+        .supervisor
+        .shutdown_thread_at(&lifecycle.coordinates)
+        .await
+        .unwrap();
+    app.inner.state.write().await.threads.remove(&thread_id);
+    app.dispatch_request(
+        &connection,
+        "thread/resume",
+        Some(serde_json::json!({
+            "threadId": thread_id,
+            "excludeTurns": true,
+        })),
+    )
+    .await
+    .unwrap();
+    let resumed_events = session_store.read_events(&stream_id, None).await.unwrap();
+    assert_eq!(
+        resumed_events
+            .iter()
+            .filter(|event| event.kind == verlet_history::EventKind::ManifestBindCompleted)
+            .count(),
+        2
+    );
+    assert_binding_fold_matches_latest_bind(&resumed_events, &lifecycle.coordinates.user_id);
+    let expected_fork_bindings =
+        crate::adapters::app_server::threads::thread_manifest_operation_bindings(
+            app.handle_for_thread(&thread_id).await.unwrap().context(),
+        )
+        .unwrap();
+
+    let fork = app
+        .dispatch_request(
+            &connection,
+            "thread/fork",
+            Some(serde_json::json!({"threadId": thread_id})),
+        )
+        .await
+        .unwrap();
+    let fork_id =
+        verlet_runtime_contracts::ThreadId::parse_str(fork["thread"]["id"].as_str().unwrap())
+            .unwrap();
+    let fork_lifecycle = app
+        .inner
+        .metadata_store
+        .get_thread_lifecycle(fork_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let fork_events = session_store
+        .read_events(
+            &verlet_history::EventStreamId::for_thread(&fork_lifecycle.coordinates),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        fork_events
+            .iter()
+            .filter(|event| event.kind == verlet_history::EventKind::ManifestBindCompleted)
+            .count(),
+        1
+    );
+    assert_binding_fold_matches_latest_bind(
+        &fork_events,
+        connection.resolved_principal.principal_id.as_str(),
+    );
+    let fork_handle = app
+        .inner
+        .supervisor
+        .get_thread(&app.inner.tenant_id, fork_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        crate::adapters::app_server::threads::thread_manifest_operation_bindings(
+            fork_handle.context()
+        )
+        .unwrap()
+        .as_slice(),
+        expected_fork_bindings.as_slice()
+    );
+
     app.dispatch_request(
         &connection,
         "turn/start",
@@ -13134,6 +13264,55 @@ async fn app_server_capsule_bindings_expose_published_operation_to_tools_and_bas
     let requests = client.requests();
     assert!(tool_names(&requests[0]).contains(&"search".to_string()));
     assert_bash_tool_describes(&requests[0], "search");
+
+    let spawned = app
+        .dispatch_request(
+            &connection,
+            "thread/spawn",
+            Some(serde_json::json!({
+                "threadId": thread_id,
+                "taskName": "binding-review-child",
+                "message": "use search",
+                "agentRef": crate::adapters::app_server::default_manifest::DEFAULT_AGENT_REF,
+            })),
+        )
+        .await
+        .unwrap();
+    let spawned_id =
+        verlet_runtime_contracts::ThreadId::parse_str(spawned["thread"]["id"].as_str().unwrap())
+            .unwrap();
+    let spawned_lifecycle = app
+        .inner
+        .metadata_store
+        .get_thread_lifecycle(spawned_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let spawned_events = session_store
+        .read_events(
+            &verlet_history::EventStreamId::for_thread(&spawned_lifecycle.coordinates),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_binding_fold_matches_latest_bind(
+        &spawned_events,
+        connection.resolved_principal.principal_id.as_str(),
+    );
+    let spawned_handle = app
+        .inner
+        .supervisor
+        .get_thread(&app.inner.tenant_id, spawned_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        crate::adapters::app_server::threads::thread_manifest_operation_bindings(
+            spawned_handle.context()
+        )
+        .unwrap()
+        .as_slice(),
+        expected_fork_bindings.as_slice()
+    );
     let _ = std::fs::remove_dir_all(registry_root);
 }
 
@@ -18068,10 +18247,20 @@ async fn test_connection(
     crate::adapters::app_server::connection::ConnectionState,
     tokio::sync::mpsc::UnboundedReceiver<crate::adapters::app_server::connection::JsonRpcMessage>,
 ) {
+    let resolved_principal = operator_principal(&app);
+    test_connection_for_principal(app, resolved_principal).await
+}
+
+async fn test_connection_for_principal(
+    app: crate::adapters::app_server::VerletAppServer,
+    resolved_principal: crate::daemon::identity::ResolvedPrincipal,
+) -> (
+    crate::adapters::app_server::connection::ConnectionState,
+    tokio::sync::mpsc::UnboundedReceiver<crate::adapters::app_server::connection::JsonRpcMessage>,
+) {
     let (outbound, rx) = tokio::sync::mpsc::unbounded_channel::<
         crate::adapters::app_server::connection::JsonRpcMessage,
     >();
-    let resolved_principal = operator_principal(&app);
     let witnessed_session_id = format!("test-session-{}", uuid::Uuid::now_v7());
     app.inner
         .identity_authority

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -8428,11 +8428,15 @@ async fn thread_start_with_agent_ref_records_manifest_receipts_before_turns() {
     let root = unique_test_root("app-server-manifest-start");
     let workspace = root.join("workspace");
     std::fs::create_dir_all(&workspace).unwrap();
+    let operation_registry_root = root.join("operations");
+    let operation =
+        publish_echo_operation(&operation_registry_root, "search", "search", "search").await;
     let agent_registry_root = root.join("agents");
     let manifest_path = root.join("local.verlet.agent.toml");
     std::fs::write(
         &manifest_path,
-        r#"
+        format!(
+            r#"
 [agent]
 name = "local-runner"
 version = "0.1.0"
@@ -8444,6 +8448,19 @@ id = "default"
 provider_ref = "provider://local_offline"
 model_ref = "model://echo"
 
+[[tools]]
+type = "direct_tool"
+id = "search"
+tool_name = "search"
+operation_ref = "op://search@sha256:{}"
+effect_class = "idempotent"
+
+[tools.attachment]
+allowed_secrets = ["SEARCH_TOKEN"]
+
+[tools.attachment.allowed_private_network]
+"http://127.0.0.1:9000" = ["POST"]
+
 [runtime]
 default_cwd = "agent-workspace"
 streaming = true
@@ -8451,13 +8468,19 @@ streaming = true
 [runtime.overrides]
 allow = ["streaming"]
 "#,
+            operation.active_artifact_hash
+        ),
     )
     .unwrap();
     let record = crate::agent::manifest::LocalAgentRegistry::new(&agent_registry_root)
-        .publish_manifest_path(&manifest_path)
+        .publish_manifest_path_with_operation_registry(&manifest_path, &operation_registry_root)
         .unwrap();
 
-    let mut config = crate::adapters::app_server::VerletAppServerConfig::local(listen, &workspace);
+    let mut config = crate::adapters::app_server::VerletAppServerConfig::local(listen, &workspace)
+        .with_capsule_bindings(
+            crate::adapters::app_server::CapsuleBindingsConfig::default()
+                .with_registry_root(&operation_registry_root),
+        );
     config.runtime_home = root.join("runtime");
     config.state_home = root.join("state");
     config.agent_registry_root = agent_registry_root;
@@ -8467,6 +8490,7 @@ allow = ["streaming"]
         .await
         .unwrap();
     let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    let expected_principal = connection.resolved_principal.principal_id.to_string();
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -8524,9 +8548,70 @@ allow = ["streaming"]
         .unwrap();
     let stream_id = verlet_history::EventStreamId::for_thread(&lifecycle.coordinates);
     let events = session_store.read_events(&stream_id, None).await.unwrap();
-    assert_eq!(events.len(), 4);
     let compile = event_by_kind(&events, verlet_history::EventKind::ManifestCompileCompleted);
     let bind = event_by_kind(&events, verlet_history::EventKind::ManifestBindCompleted);
+    let bind_receipt = serde_json::from_value::<
+        crate::agent::manifest_bind::AgentManifestBindReceipt,
+    >(bind.payload.clone())
+    .unwrap();
+    let attached = events
+        .iter()
+        .filter(|event| event.kind == verlet_history::EventKind::BindingAttached)
+        .collect::<Vec<_>>();
+    assert_eq!(attached.len(), bind_receipt.operation_bindings.len());
+    for (index, (event, binding)) in attached
+        .iter()
+        .zip(&bind_receipt.operation_bindings)
+        .enumerate()
+    {
+        assert_eq!(event.sequence.get(), bind.sequence.get() + index as i64 + 1);
+        assert_eq!(event.origin, verlet_history::EventOrigin::Discharged);
+        assert_eq!(
+            event.provenance.source_event_ids,
+            vec![bind.id],
+            "attachment must cite its bind receipt"
+        );
+        assert_eq!(
+            event.provenance.discharged_by.as_deref(),
+            Some(crate::agent::manifest_bind::MANIFEST_BINDER_DISCHARGED_BY)
+        );
+        let payload =
+            serde_json::from_value::<verlet_history::BindingAttachedPayload>(event.payload.clone())
+                .unwrap();
+        assert_eq!(payload.name, binding.name);
+        assert_eq!(payload.artifact_hash, binding.artifact_hash);
+        assert_eq!(payload.operations, binding.operations);
+        assert_eq!(
+            serde_json::to_value(&payload.direct_tools).unwrap(),
+            serde_json::to_value(&binding.direct_tools).unwrap()
+        );
+        assert_eq!(
+            serde_json::to_value(&payload.attachment_config).unwrap(),
+            serde_json::to_value(&binding.attachment_config).unwrap()
+        );
+        assert_eq!(
+            serde_json::to_value(payload.effect_class).unwrap(),
+            serde_json::to_value(binding.effect_class).unwrap()
+        );
+        assert_eq!(payload.requested_by, expected_principal);
+        assert_eq!(payload.decided_by, expected_principal);
+        assert_eq!(payload.decision_event_id, None);
+    }
+    let folded = crate::kernel::binding_projector::fold_thread_bindings(&events);
+    assert!(folded.anomalies.is_empty());
+    assert_eq!(folded.active.len(), bind_receipt.operation_bindings.len());
+    assert_eq!(
+        folded
+            .active
+            .iter()
+            .map(|binding| binding.payload.name.as_str())
+            .collect::<Vec<_>>(),
+        bind_receipt
+            .operation_bindings
+            .iter()
+            .map(|binding| binding.name.as_str())
+            .collect::<Vec<_>>()
+    );
     assert_eq!(compile.origin, verlet_history::EventOrigin::Discharged);
     assert_eq!(bind.origin, verlet_history::EventOrigin::Discharged);
     assert_eq!(
@@ -8616,8 +8701,13 @@ async fn cancelled_manifest_lifecycle_caller_cannot_split_receipt_from_metadata(
             .witness_and_persist_lifecycle(handle, move |handle| async move {
                 operation_entered.notify_one();
                 operation_release.notified().await;
-                crate::adapters::app_server::threads::record_bound_agent_receipts(&handle, &bound)
-                    .await?;
+                let principal_id = handle.context().coordinates.user_id.clone();
+                crate::adapters::app_server::threads::record_bound_agent_receipts(
+                    &handle,
+                    &bound,
+                    &principal_id,
+                )
+                .await?;
                 operation_app
                     .persist_thread_lifecycle_record_with_metadata(
                         &handle,
@@ -14317,6 +14407,7 @@ async fn restored_thread_provider_requests_end_with_current_input() {
         &root,
         &workspace,
         provider_client,
+        // lexicon-allow: capsule - existing app-server test config type
         crate::adapters::app_server::CapsuleBindingsConfig::default(),
     )
     .await;
@@ -14376,6 +14467,7 @@ async fn restored_thread_notifications_use_current_completion_and_persist_once()
     let workspace = root.join("workspace");
     std::fs::create_dir_all(&workspace).unwrap();
     let thread_id = {
+        // lexicon-allow: capsule - existing app-server test client name
         let first_client = std::sync::Arc::new(SequencedStreamCapsuleClient::new([
             "before restart completion",
         ]));

--- a/crates/verlet-kernel/src/adapters/app_server/threads.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/threads.rs
@@ -469,7 +469,10 @@ impl crate::adapters::app_server::VerletAppServer {
                 ),
             ));
         }
-        record_bound_agent_receipts(handle, &bound).await.map(Some)
+        let principal_id = handle.context().coordinates.user_id.clone();
+        record_bound_agent_receipts(handle, &bound, &principal_id)
+            .await
+            .map(Some)
     }
 
     pub(crate) fn agent_registry_root(&self) -> &std::path::Path {
@@ -1702,6 +1705,7 @@ is present in the conversation.",
 pub(super) async fn record_bound_agent_receipts(
     handle: &crate::kernel::runtime_host::RuntimeThreadHandle,
     bound: &crate::agent::manifest_bind::AgentManifestBoundThread,
+    principal_id: &str,
 ) -> crate::kernel::runtime_host::VerletResult<(
     verlet_history::EventRecord,
     verlet_history::EventRecord,
@@ -1717,7 +1721,7 @@ pub(super) async fn record_bound_agent_receipts(
         ))
     })?;
     let manifest_events = handle
-        .record_manifest_receipts(compile_payload, bind_payload)
+        .record_manifest_receipts_for_principal(compile_payload, bind_payload, principal_id)
         .await?;
     let discovery_payloads = bound
         .tool_universes
@@ -1777,10 +1781,11 @@ impl crate::adapters::app_server::VerletAppServer {
         &self,
         handle: crate::kernel::runtime_host::RuntimeThreadHandle,
         bound: crate::agent::manifest_bind::AgentManifestBoundThread,
+        principal_id: String,
     ) -> Result<(), crate::adapters::app_server::connection::JsonRpcErrorError> {
         let app = self.clone();
         self.witness_and_persist_lifecycle(handle, move |handle| async move {
-            record_bound_agent_receipts(&handle, &bound).await?;
+            record_bound_agent_receipts(&handle, &bound, &principal_id).await?;
             app.persist_thread_lifecycle_record_with_metadata(
                 &handle,
                 std::collections::BTreeMap::new(),
@@ -1796,11 +1801,16 @@ impl crate::adapters::app_server::VerletAppServer {
         handle: crate::kernel::runtime_host::RuntimeThreadHandle,
         compile_payload: serde_json::Value,
         bind_payload: serde_json::Value,
+        principal_id: String,
     ) -> Result<(), crate::adapters::app_server::connection::JsonRpcErrorError> {
         let app = self.clone();
         self.witness_and_persist_lifecycle(handle, move |handle| async move {
             handle
-                .record_manifest_receipts(compile_payload, bind_payload)
+                .record_manifest_receipts_for_principal(
+                    compile_payload,
+                    bind_payload,
+                    &principal_id,
+                )
                 .await?;
             app.persist_thread_lifecycle_record_with_metadata(
                 &handle,

--- a/crates/verlet-kernel/src/adapters/app_server/threads.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/threads.rs
@@ -514,6 +514,7 @@ impl crate::adapters::app_server::VerletAppServer {
             &self.inner.cwd,
             self.inner.capsule_bindings.registry_root.as_deref(),
             None,
+            self.inner.user_id.clone(),
         )
     }
 
@@ -1867,6 +1868,7 @@ fn kernel_thread_spawn_agent_binding(
     cwd_root: &std::path::Path,
     operation_registry_root: Option<&std::path::Path>,
     overrides: Option<&crate::agent::manifest_bind::AgentManifestBindOverrides>,
+    principal_id: String,
 ) -> crate::kernel::runtime_host::VerletResult<
     crate::agent::agent_process::KernelThreadSpawnAgentBinding,
 > {
@@ -1891,6 +1893,7 @@ fn kernel_thread_spawn_agent_binding(
         metadata,
         compile_receipt,
         bind_receipt,
+        principal_id,
     })
 }
 
@@ -2213,6 +2216,7 @@ pub(super) struct AppServerThreadSpawnAgentResolver {
     remote_event_store_served: std::sync::Arc<std::sync::atomic::AtomicBool>,
     placement_override: Option<crate::agent::manifest_bind::AgentManifestPlacementBinding>,
     workspace_override: Option<crate::agent::manifest_bind::AgentManifestWorkspaceBinding>,
+    binding_principal_id: Option<String>,
 }
 
 #[async_trait::async_trait]
@@ -2228,7 +2232,7 @@ impl crate::agent::agent_process::KernelThreadSpawnAgentResolver
 
     async fn resolve_agent_ref(
         &self,
-        _caller: &verlet_runtime_contracts::ThreadContext,
+        caller: &verlet_runtime_contracts::ThreadContext,
         agent_ref: &str,
     ) -> crate::kernel::runtime_host::VerletResult<
         crate::agent::agent_process::KernelThreadSpawnAgentBinding,
@@ -2267,6 +2271,9 @@ impl crate::agent::agent_process::KernelThreadSpawnAgentResolver
             &self.cwd,
             self.operation_registry_root.as_deref(),
             None,
+            self.binding_principal_id
+                .clone()
+                .unwrap_or_else(|| caller.coordinates.user_id.clone()),
         )
     }
 }
@@ -2331,6 +2338,7 @@ impl crate::adapters::app_server::VerletAppServer {
         &self,
         placement_override: Option<crate::agent::manifest_bind::AgentManifestPlacementBinding>,
         workspace_override: Option<crate::agent::manifest_bind::AgentManifestWorkspaceBinding>,
+        binding_principal_id: String,
     ) -> crate::kernel::runtime_host::VerletResult<AppServerThreadSpawnAgentResolver> {
         Ok(AppServerThreadSpawnAgentResolver {
             agent_registry_root: self.inner.agent_registry_root.clone(),
@@ -2346,6 +2354,7 @@ impl crate::adapters::app_server::VerletAppServer {
             remote_event_store_served: std::sync::Arc::clone(&self.inner.remote_event_store_served),
             placement_override,
             workspace_override,
+            binding_principal_id: Some(binding_principal_id),
         })
     }
 }
@@ -2370,6 +2379,7 @@ impl CapsuleBindingRuntimeFactory {
             remote_event_store_served: std::sync::Arc::clone(&self.remote_event_store_served),
             placement_override: None,
             workspace_override: None,
+            binding_principal_id: None,
         })
     }
 

--- a/crates/verlet-kernel/src/agent/agent_process.rs
+++ b/crates/verlet-kernel/src/agent/agent_process.rs
@@ -651,6 +651,7 @@ pub struct KernelThreadSpawnAgentBinding {
     pub metadata: std::collections::BTreeMap<String, String>,
     pub compile_receipt: serde_json::Value,
     pub bind_receipt: serde_json::Value,
+    pub principal_id: String,
 }
 
 #[async_trait::async_trait]

--- a/crates/verlet-kernel/src/agent/manifest_bind.rs
+++ b/crates/verlet-kernel/src/agent/manifest_bind.rs
@@ -3286,6 +3286,51 @@ pub struct AgentManifestDirectToolBinding {
     pub effect_class: verlet_agent::manifest_schema::EffectClass,
 }
 
+pub(crate) fn binding_attached_payload(
+    binding: &AgentManifestOperationBinding,
+    principal_id: &str,
+) -> verlet_history::BindingAttachedPayload {
+    fn effect_class(
+        effect_class: verlet_agent::manifest_schema::EffectClass,
+    ) -> verlet_history::BindingEffectClass {
+        match effect_class {
+            verlet_agent::manifest_schema::EffectClass::Pure => {
+                verlet_history::BindingEffectClass::Pure
+            }
+            verlet_agent::manifest_schema::EffectClass::Idempotent => {
+                verlet_history::BindingEffectClass::Idempotent
+            }
+            verlet_agent::manifest_schema::EffectClass::AtMostOnce => {
+                verlet_history::BindingEffectClass::AtMostOnce
+            }
+        }
+    }
+    let direct_tools = binding
+        .direct_tools
+        .iter()
+        .map(|direct| verlet_history::BindingAttachedDirectToolBinding {
+            tool_name: direct.tool_name.clone(),
+            operation: direct.operation.clone(),
+            effect_class: effect_class(direct.effect_class),
+        })
+        .collect();
+
+    verlet_history::BindingAttachedPayload {
+        name: binding.name.clone(),
+        artifact_hash: binding.artifact_hash.clone(),
+        operations: binding.operations.clone(),
+        direct_tools,
+        attachment_config: verlet_history::BindingAttachmentConfig {
+            allowed_secrets: binding.attachment_config.allowed_secrets.clone(),
+            allowed_private_network: binding.attachment_config.allowed_private_network.clone(),
+        },
+        effect_class: effect_class(binding.effect_class),
+        requested_by: principal_id.to_string(),
+        decided_by: principal_id.to_string(),
+        decision_event_id: None,
+    }
+}
+
 /// Apply caller overrides onto the manifest's runtime defaults, enforcing
 /// the deny-by-default allowlist. Returns the effective defaults plus the
 /// list of keys actually overridden, for the bind receipt.

--- a/crates/verlet-kernel/src/agent/manifest_bind/tests.rs
+++ b/crates/verlet-kernel/src/agent/manifest_bind/tests.rs
@@ -707,6 +707,28 @@ async fn manifest_operation_attachments_land_in_operation_bindings_and_merge() {
     let _ = std::fs::remove_dir_all(root);
 }
 
+#[test]
+fn binding_attachment_config_matches_wasm_attachment_wire_shape() {
+    let allowed_secrets = std::collections::BTreeSet::from(["SEARCH_TOKEN".to_string()]);
+    let allowed_private_network = std::collections::BTreeMap::from([(
+        "http://127.0.0.1:*".to_string(),
+        std::collections::BTreeSet::from(["GET".to_string(), "POST".to_string()]),
+    )]);
+    let history = verlet_history::BindingAttachmentConfig {
+        allowed_secrets: allowed_secrets.clone(),
+        allowed_private_network: allowed_private_network.clone(),
+    };
+    let wasm = verlet_wasm::WasmAttachmentConfig {
+        allowed_secrets,
+        allowed_private_network,
+    };
+
+    assert_eq!(
+        serde_json::to_value(history).unwrap(),
+        serde_json::to_value(wasm).unwrap()
+    );
+}
+
 #[tokio::test]
 async fn protocol_tool_import_pin_drift_fails_bind_with_both_hashes() {
     let witnessed = witnessed_tool("verlet_mcp_echo", "string");

--- a/crates/verlet-kernel/src/agent/manifest_bind/tests.rs
+++ b/crates/verlet-kernel/src/agent/manifest_bind/tests.rs
@@ -729,6 +729,70 @@ fn binding_attachment_config_matches_wasm_attachment_wire_shape() {
     );
 }
 
+#[test]
+fn binding_direct_tool_matches_manifest_binding_wire_shape() {
+    let cases = [
+        (
+            verlet_agent::manifest_schema::EffectClass::Pure,
+            verlet_history::BindingEffectClass::Pure,
+        ),
+        (
+            verlet_agent::manifest_schema::EffectClass::Idempotent,
+            verlet_history::BindingEffectClass::Idempotent,
+        ),
+        (
+            verlet_agent::manifest_schema::EffectClass::AtMostOnce,
+            verlet_history::BindingEffectClass::AtMostOnce,
+        ),
+    ];
+
+    for (manifest_effect, history_effect) in cases {
+        let manifest = crate::agent::manifest_bind::AgentManifestDirectToolBinding {
+            tool_name: "search_web".to_string(),
+            operation: "search".to_string(),
+            effect_class: manifest_effect,
+        };
+        let history = verlet_history::BindingAttachedDirectToolBinding {
+            tool_name: "search_web".to_string(),
+            operation: "search".to_string(),
+            effect_class: history_effect,
+        };
+
+        assert_eq!(
+            serde_json::to_value(history).unwrap(),
+            serde_json::to_value(manifest).unwrap()
+        );
+    }
+}
+
+#[test]
+fn binding_effect_class_matches_manifest_wire_values() {
+    let cases = [
+        (
+            verlet_agent::manifest_schema::EffectClass::Pure,
+            verlet_history::BindingEffectClass::Pure,
+            "pure",
+        ),
+        (
+            verlet_agent::manifest_schema::EffectClass::Idempotent,
+            verlet_history::BindingEffectClass::Idempotent,
+            "idempotent",
+        ),
+        (
+            verlet_agent::manifest_schema::EffectClass::AtMostOnce,
+            verlet_history::BindingEffectClass::AtMostOnce,
+            "at-most-once",
+        ),
+    ];
+
+    for (manifest, history, expected) in cases {
+        let manifest = serde_json::to_value(manifest).unwrap();
+        let history = serde_json::to_value(history).unwrap();
+        assert_eq!(history, manifest);
+        assert_eq!(history, serde_json::json!(expected));
+    }
+}
+
 #[tokio::test]
 async fn protocol_tool_import_pin_drift_fails_bind_with_both_hashes() {
     let witnessed = witnessed_tool("verlet_mcp_echo", "string");

--- a/crates/verlet-kernel/src/daemon/daemon_io.rs
+++ b/crates/verlet-kernel/src/daemon/daemon_io.rs
@@ -3331,7 +3331,11 @@ impl VerletDaemonIoBridge {
             };
             if let Some(binding) = agent_binding
                 && let Err(err) = handle
-                    .record_manifest_receipts(binding.compile_receipt, binding.bind_receipt)
+                    .record_manifest_receipts_for_principal(
+                        binding.compile_receipt,
+                        binding.bind_receipt,
+                        &binding.principal_id,
+                    )
                     .await
             {
                 let _ = supervisor

--- a/crates/verlet-kernel/src/daemon/daemon_io/tests.rs
+++ b/crates/verlet-kernel/src/daemon/daemon_io/tests.rs
@@ -9195,6 +9195,7 @@ async fn cancelled_daemon_start_finishes_the_workspace_bind_witness() {
             "placement": {"target": "local"},
             "workspace": workspace
         }),
+        principal_id: coordinates.user_id.clone(),
     };
     let request = crate::kernel::supervisor::ThreadStartRequest {
         tenant_id: coordinates.tenant_id.clone(),

--- a/crates/verlet-kernel/src/daemon/remote_store/placement.rs
+++ b/crates/verlet-kernel/src/daemon/remote_store/placement.rs
@@ -16,6 +16,8 @@ pub struct RemoteThreadSpawnRequest {
     pub spawned_event_id: verlet_history::EventRecordId,
     pub compile_payload: Option<serde_json::Value>,
     pub bind_payload: Option<serde_json::Value>,
+    #[serde(default)]
+    pub binding_principal_id: Option<String>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]

--- a/crates/verlet-kernel/src/daemon/remote_store/process_executor.rs
+++ b/crates/verlet-kernel/src/daemon/remote_store/process_executor.rs
@@ -765,9 +765,15 @@ pub(crate) async fn run_remote_child(
         bootstrap.request.compile_payload.clone(),
         bootstrap.request.bind_payload.clone(),
     ) {
-        child_handle
-            .record_remote_manifest_receipts(compile, bind)
-            .await?;
+        if let Some(principal_id) = bootstrap.request.binding_principal_id.as_deref() {
+            child_handle
+                .record_remote_manifest_receipts_for_principal(compile, bind, principal_id)
+                .await?;
+        } else {
+            child_handle
+                .record_remote_manifest_receipts(compile, bind)
+                .await?;
+        }
     }
 
     let local_store = verlet_history_sqlite::SqliteSessionStore::open(app.session_store_path())
@@ -1142,6 +1148,7 @@ mod tests {
             spawned_event_id: verlet_history::EventRecordId::new(),
             compile_payload: None,
             bind_payload: None,
+            binding_principal_id: None,
         }
     }
 
@@ -1162,6 +1169,26 @@ mod tests {
         .unwrap_err();
 
         assert!(error.to_string().contains("cannot carry"));
+    }
+
+    #[test]
+    fn remote_spawn_request_round_trips_the_binding_principal() {
+        let mut request = request_fixture();
+        request.binding_principal_id = Some("principal:remote-operator".to_string());
+
+        let encoded = serde_json::to_value(&request).unwrap();
+        let decoded: crate::daemon::remote_store::placement::RemoteThreadSpawnRequest =
+            serde_json::from_value(encoded.clone()).unwrap();
+        assert_eq!(decoded.binding_principal_id, request.binding_principal_id);
+
+        let mut legacy = encoded;
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("binding_principal_id");
+        let decoded: crate::daemon::remote_store::placement::RemoteThreadSpawnRequest =
+            serde_json::from_value(legacy).unwrap();
+        assert_eq!(decoded.binding_principal_id, None);
     }
 
     fn child_record(

--- a/crates/verlet-kernel/src/kernel/binding_projector.rs
+++ b/crates/verlet-kernel/src/kernel/binding_projector.rs
@@ -1,0 +1,272 @@
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ThreadBinding {
+    pub attach_event_id: verlet_history::EventRecordId,
+    pub payload: verlet_history::BindingAttachedPayload,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ThreadBindingAnomaly {
+    UndecodableAttached {
+        event_id: verlet_history::EventRecordId,
+        message: String,
+    },
+    UndecodableDetached {
+        event_id: verlet_history::EventRecordId,
+        message: String,
+    },
+    UnknownDetach {
+        detach_event_id: verlet_history::EventRecordId,
+        attach_event_id: verlet_history::EventRecordId,
+    },
+    AlreadyDetached {
+        detach_event_id: verlet_history::EventRecordId,
+        attach_event_id: verlet_history::EventRecordId,
+    },
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ThreadBindingsFold {
+    pub active: Vec<ThreadBinding>,
+    pub anomalies: Vec<ThreadBindingAnomaly>,
+}
+
+pub fn fold_thread_bindings(events: &[verlet_history::EventRecord]) -> ThreadBindingsFold {
+    let mut folded = ThreadBindingsFold::default();
+    let mut detached = std::collections::HashSet::new();
+
+    for event in events {
+        match event.kind {
+            verlet_history::EventKind::BindingAttached => {
+                match serde_json::from_value::<verlet_history::BindingAttachedPayload>(
+                    event.payload.clone(),
+                ) {
+                    Ok(payload) => folded.active.push(ThreadBinding {
+                        attach_event_id: event.id,
+                        payload,
+                    }),
+                    Err(err) => folded
+                        .anomalies
+                        .push(ThreadBindingAnomaly::UndecodableAttached {
+                            event_id: event.id,
+                            message: err.to_string(),
+                        }),
+                }
+            }
+            verlet_history::EventKind::BindingDetached => {
+                let payload = match serde_json::from_value::<verlet_history::BindingDetachedPayload>(
+                    event.payload.clone(),
+                ) {
+                    Ok(payload) => payload,
+                    Err(err) => {
+                        folded
+                            .anomalies
+                            .push(ThreadBindingAnomaly::UndecodableDetached {
+                                event_id: event.id,
+                                message: err.to_string(),
+                            });
+                        continue;
+                    }
+                };
+                if let Some(index) = folded
+                    .active
+                    .iter()
+                    .position(|binding| binding.attach_event_id == payload.attach_event_id)
+                {
+                    folded.active.remove(index);
+                    detached.insert(payload.attach_event_id);
+                } else if detached.contains(&payload.attach_event_id) {
+                    folded
+                        .anomalies
+                        .push(ThreadBindingAnomaly::AlreadyDetached {
+                            detach_event_id: event.id,
+                            attach_event_id: payload.attach_event_id,
+                        });
+                } else {
+                    folded.anomalies.push(ThreadBindingAnomaly::UnknownDetach {
+                        detach_event_id: event.id,
+                        attach_event_id: payload.attach_event_id,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    folded
+}
+
+#[cfg(test)]
+mod tests {
+    fn event(
+        sequence: i64,
+        id: u128,
+        kind: verlet_history::EventKind,
+        payload: serde_json::Value,
+    ) -> verlet_history::EventRecord {
+        let coordinates =
+            verlet_runtime_contracts::ThreadCoordinates::new("tenant", "user", "session");
+        let mut event =
+            verlet_history::NewEventRecord::witnessed(coordinates.clone(), kind, payload);
+        event.id = verlet_history::EventRecordId::from_uuid(uuid::Uuid::from_u128(id));
+        verlet_history::EventRecord::from_new(
+            verlet_history::EventStreamId::for_thread(&coordinates),
+            verlet_history::EventSequence::new(sequence),
+            event,
+        )
+    }
+
+    fn attached(name: &str) -> verlet_history::BindingAttachedPayload {
+        verlet_history::BindingAttachedPayload {
+            name: name.to_string(),
+            artifact_hash: format!("sha256:{name}"),
+            operations: Vec::new(),
+            direct_tools: Vec::new(),
+            attachment_config: verlet_history::BindingAttachmentConfig::default(),
+            effect_class: verlet_history::BindingEffectClass::AtMostOnce,
+            requested_by: "principal:operator".to_string(),
+            decided_by: "principal:operator".to_string(),
+            decision_event_id: None,
+        }
+    }
+
+    fn attach_event(sequence: i64, id: u128, name: &str) -> verlet_history::EventRecord {
+        event(
+            sequence,
+            id,
+            verlet_history::EventKind::BindingAttached,
+            serde_json::to_value(attached(name)).unwrap(),
+        )
+    }
+
+    fn detach_event(
+        sequence: i64,
+        id: u128,
+        attach_event_id: verlet_history::EventRecordId,
+    ) -> verlet_history::EventRecord {
+        event(
+            sequence,
+            id,
+            verlet_history::EventKind::BindingDetached,
+            serde_json::to_value(verlet_history::BindingDetachedPayload {
+                attach_event_id,
+                requested_by: "principal:operator".to_string(),
+                decided_by: "principal:operator".to_string(),
+                decision_event_id: None,
+            })
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn empty_and_unrelated_streams_fold_to_empty() {
+        assert_eq!(
+            super::fold_thread_bindings(&[]),
+            super::ThreadBindingsFold::default()
+        );
+        let unrelated = event(
+            1,
+            1,
+            verlet_history::EventKind::TurnSubmitted,
+            serde_json::json!({"turn_id": "turn-1"}),
+        );
+
+        assert_eq!(
+            super::fold_thread_bindings(&[unrelated]),
+            super::ThreadBindingsFold::default()
+        );
+    }
+
+    #[test]
+    fn attach_detach_interleavings_and_reattach_are_deterministic() {
+        let first = attach_event(1, 1, "search-tools");
+        let second = attach_event(2, 2, "file-tools");
+        let unrelated = event(
+            3,
+            3,
+            verlet_history::EventKind::TurnCompleted,
+            serde_json::json!({"turn_id": "turn-1"}),
+        );
+        let detach_first = detach_event(4, 4, first.id);
+        let reattached = attach_event(5, 5, "search-tools");
+        let events = vec![
+            first,
+            second.clone(),
+            unrelated,
+            detach_first,
+            reattached.clone(),
+        ];
+
+        let folded = super::fold_thread_bindings(&events);
+
+        assert_eq!(folded, super::fold_thread_bindings(&events));
+        assert_eq!(folded.anomalies, Vec::new());
+        assert_eq!(
+            folded
+                .active
+                .iter()
+                .map(|binding| (binding.attach_event_id, binding.payload.name.as_str()))
+                .collect::<Vec<_>>(),
+            vec![(second.id, "file-tools"), (reattached.id, "search-tools")]
+        );
+    }
+
+    #[test]
+    fn unknown_and_already_detached_ids_are_typed_anomalies() {
+        let attached = attach_event(1, 1, "search-tools");
+        let detached = detach_event(2, 2, attached.id);
+        let repeated = detach_event(3, 3, attached.id);
+        let unknown_id = verlet_history::EventRecordId::from_uuid(uuid::Uuid::from_u128(99));
+        let unknown = detach_event(4, 4, unknown_id);
+
+        let folded =
+            super::fold_thread_bindings(&[attached, detached, repeated.clone(), unknown.clone()]);
+
+        assert!(folded.active.is_empty());
+        assert_eq!(
+            folded.anomalies,
+            vec![
+                super::ThreadBindingAnomaly::AlreadyDetached {
+                    detach_event_id: repeated.id,
+                    attach_event_id: verlet_history::EventRecordId::from_uuid(
+                        uuid::Uuid::from_u128(1)
+                    ),
+                },
+                super::ThreadBindingAnomaly::UnknownDetach {
+                    detach_event_id: unknown.id,
+                    attach_event_id: unknown_id,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn undecodable_binding_payloads_are_typed_anomalies() {
+        let bad_attach = event(
+            1,
+            1,
+            verlet_history::EventKind::BindingAttached,
+            serde_json::json!({"name": "missing-fields"}),
+        );
+        let bad_detach = event(
+            2,
+            2,
+            verlet_history::EventKind::BindingDetached,
+            serde_json::json!({"attach_event_id": 42}),
+        );
+
+        let folded = super::fold_thread_bindings(&[bad_attach.clone(), bad_detach.clone()]);
+
+        assert!(folded.active.is_empty());
+        assert_eq!(folded.anomalies.len(), 2);
+        assert!(matches!(
+            &folded.anomalies[0],
+            super::ThreadBindingAnomaly::UndecodableAttached { event_id, message }
+                if *event_id == bad_attach.id && !message.is_empty()
+        ));
+        assert!(matches!(
+            &folded.anomalies[1],
+            super::ThreadBindingAnomaly::UndecodableDetached { event_id, message }
+                if *event_id == bad_detach.id && !message.is_empty()
+        ));
+    }
+}

--- a/crates/verlet-kernel/src/kernel/binding_projector.rs
+++ b/crates/verlet-kernel/src/kernel/binding_projector.rs
@@ -32,18 +32,39 @@ pub struct ThreadBindingsFold {
 
 pub fn fold_thread_bindings(events: &[verlet_history::EventRecord]) -> ThreadBindingsFold {
     let mut folded = ThreadBindingsFold::default();
-    let mut detached = std::collections::HashSet::new();
+    let mut inactive = std::collections::HashSet::new();
+    let mut active_bind_batch_id = None;
 
     for event in events {
         match event.kind {
             verlet_history::EventKind::BindingAttached => {
+                if let Some(bind_batch_id) = event.provenance.source_event_ids.first().copied()
+                    && active_bind_batch_id != Some(bind_batch_id)
+                {
+                    inactive.extend(
+                        folded
+                            .active
+                            .drain(..)
+                            .map(|binding| binding.attach_event_id),
+                    );
+                    active_bind_batch_id = Some(bind_batch_id);
+                }
                 match serde_json::from_value::<verlet_history::BindingAttachedPayload>(
                     event.payload.clone(),
                 ) {
-                    Ok(payload) => folded.active.push(ThreadBinding {
-                        attach_event_id: event.id,
-                        payload,
-                    }),
+                    Ok(payload) => {
+                        if let Some(index) = folded.active.iter().position(|binding| {
+                            binding.payload.name == payload.name
+                                && binding.payload.artifact_hash == payload.artifact_hash
+                        }) {
+                            let superseded = folded.active.remove(index);
+                            inactive.insert(superseded.attach_event_id);
+                        }
+                        folded.active.push(ThreadBinding {
+                            attach_event_id: event.id,
+                            payload,
+                        });
+                    }
                     Err(err) => folded
                         .anomalies
                         .push(ThreadBindingAnomaly::UndecodableAttached {
@@ -73,8 +94,8 @@ pub fn fold_thread_bindings(events: &[verlet_history::EventRecord]) -> ThreadBin
                     .position(|binding| binding.attach_event_id == payload.attach_event_id)
                 {
                     folded.active.remove(index);
-                    detached.insert(payload.attach_event_id);
-                } else if detached.contains(&payload.attach_event_id) {
+                    inactive.insert(payload.attach_event_id);
+                } else if inactive.contains(&payload.attach_event_id) {
                     folded
                         .anomalies
                         .push(ThreadBindingAnomaly::AlreadyDetached {
@@ -136,6 +157,19 @@ mod tests {
             verlet_history::EventKind::BindingAttached,
             serde_json::to_value(attached(name)).unwrap(),
         )
+    }
+
+    fn attach_event_for_bind(
+        sequence: i64,
+        id: u128,
+        name: &str,
+        bind_id: u128,
+    ) -> verlet_history::EventRecord {
+        let mut event = attach_event(sequence, id, name);
+        event.provenance.source_event_ids = vec![verlet_history::EventRecordId::from_uuid(
+            uuid::Uuid::from_u128(bind_id),
+        )];
+        event
     }
 
     fn detach_event(
@@ -211,6 +245,61 @@ mod tests {
     }
 
     #[test]
+    fn repeated_bind_batches_replace_same_operation_artifacts_in_stream_order() {
+        let first_search = attach_event_for_bind(1, 400, "search-tools", 900);
+        let first_files = attach_event_for_bind(2, 300, "file-tools", 900);
+        let mut rebound_search = attach_event_for_bind(3, 200, "search-tools", 901);
+        rebound_search.payload["artifact_hash"] = serde_json::json!("sha256:search-tools-v2");
+        let rebound_files = attach_event_for_bind(4, 100, "file-tools", 901);
+
+        let folded = super::fold_thread_bindings(&[
+            first_search,
+            first_files,
+            rebound_search.clone(),
+            rebound_files.clone(),
+        ]);
+
+        assert!(folded.anomalies.is_empty());
+        assert_eq!(
+            folded
+                .active
+                .iter()
+                .map(|binding| (binding.attach_event_id, binding.payload.name.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                (rebound_search.id, "search-tools"),
+                (rebound_files.id, "file-tools"),
+            ]
+        );
+    }
+
+    #[test]
+    fn distinct_artifacts_with_the_same_operation_name_remain_active() {
+        let first = attach_event_for_bind(1, 1, "search-tools", 900);
+        let mut second_payload = attached("search-tools");
+        second_payload.artifact_hash = "sha256:search-tools-v2".to_string();
+        let mut second = event(
+            2,
+            2,
+            verlet_history::EventKind::BindingAttached,
+            serde_json::to_value(second_payload).unwrap(),
+        );
+        second.provenance.source_event_ids = first.provenance.source_event_ids.clone();
+
+        let folded = super::fold_thread_bindings(&[first.clone(), second.clone()]);
+
+        assert!(folded.anomalies.is_empty());
+        assert_eq!(
+            folded
+                .active
+                .iter()
+                .map(|binding| binding.attach_event_id)
+                .collect::<Vec<_>>(),
+            vec![first.id, second.id]
+        );
+    }
+
+    #[test]
     fn unknown_and_already_detached_ids_are_typed_anomalies() {
         let attached = attach_event(1, 1, "search-tools");
         let detached = detach_event(2, 2, attached.id);
@@ -268,5 +357,83 @@ mod tests {
             super::ThreadBindingAnomaly::UndecodableDetached { event_id, message }
                 if *event_id == bad_detach.id && !message.is_empty()
         ));
+    }
+
+    #[test]
+    fn undecodable_new_bind_batch_retires_the_previous_batch() {
+        let old = attach_event_for_bind(1, 1, "search-tools", 900);
+        let mut bad_attach = event(
+            2,
+            2,
+            verlet_history::EventKind::BindingAttached,
+            serde_json::json!({"name": "missing-fields"}),
+        );
+        bad_attach.provenance.source_event_ids = vec![verlet_history::EventRecordId::from_uuid(
+            uuid::Uuid::from_u128(901),
+        )];
+
+        let folded = super::fold_thread_bindings(&[old, bad_attach.clone()]);
+
+        assert!(folded.active.is_empty());
+        assert!(matches!(
+            folded.anomalies.as_slice(),
+            [super::ThreadBindingAnomaly::UndecodableAttached { event_id, .. }]
+                if *event_id == bad_attach.id
+        ));
+    }
+
+    #[test]
+    fn adversarial_binding_payloads_report_anomalies_without_panicking() {
+        let garbage = [
+            serde_json::Value::Null,
+            serde_json::json!(false),
+            serde_json::json!(17),
+            serde_json::json!("not-an-object"),
+            serde_json::json!(["not", "an", "object"]),
+            serde_json::json!({"unexpected": true}),
+        ];
+        let mut events = Vec::new();
+        for (index, payload) in garbage.into_iter().enumerate() {
+            let sequence = index as i64 * 2 + 1;
+            events.push(event(
+                sequence,
+                sequence as u128,
+                verlet_history::EventKind::BindingAttached,
+                payload.clone(),
+            ));
+            events.push(event(
+                sequence + 1,
+                sequence as u128 + 1,
+                verlet_history::EventKind::BindingDetached,
+                payload,
+            ));
+        }
+
+        let folded = super::fold_thread_bindings(&events);
+
+        assert!(folded.active.is_empty());
+        assert_eq!(folded.anomalies.len(), events.len());
+        assert_eq!(
+            folded
+                .anomalies
+                .iter()
+                .filter(|anomaly| matches!(
+                    anomaly,
+                    super::ThreadBindingAnomaly::UndecodableAttached { .. }
+                ))
+                .count(),
+            events.len() / 2
+        );
+        assert_eq!(
+            folded
+                .anomalies
+                .iter()
+                .filter(|anomaly| matches!(
+                    anomaly,
+                    super::ThreadBindingAnomaly::UndecodableDetached { .. }
+                ))
+                .count(),
+            events.len() / 2
+        );
     }
 }

--- a/crates/verlet-kernel/src/kernel/runtime_host/kernel_control.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/kernel_control.rs
@@ -381,6 +381,7 @@ impl RuntimeKernelControl {
         witness: ThreadSpawnWitness,
         compile_payload: serde_json::Value,
         bind_payload: serde_json::Value,
+        principal_id: String,
     ) -> crate::kernel::runtime_host::VerletResult<AgentProcessSpawnReceipt> {
         self.spawn_child_cancellation_safe(
             caller,
@@ -388,7 +389,7 @@ impl RuntimeKernelControl {
             input,
             metadata,
             witness,
-            Some((compile_payload, bind_payload)),
+            Some((compile_payload, bind_payload, principal_id)),
         )
         .await
     }
@@ -400,7 +401,7 @@ impl RuntimeKernelControl {
         input: crate::kernel::runtime_host::turn::TurnInput,
         metadata: std::collections::BTreeMap<String, String>,
         witness: ThreadSpawnWitness,
-        manifest_payloads: Option<(serde_json::Value, serde_json::Value)>,
+        manifest_payloads: Option<(serde_json::Value, serde_json::Value, String)>,
     ) -> crate::kernel::runtime_host::VerletResult<AgentProcessSpawnReceipt> {
         let control = self.clone();
         let caller = caller.clone();
@@ -431,7 +432,7 @@ impl RuntimeKernelControl {
         input: crate::kernel::runtime_host::turn::TurnInput,
         mut metadata: std::collections::BTreeMap<String, String>,
         witness: ThreadSpawnWitness,
-        manifest_payloads: Option<(serde_json::Value, serde_json::Value)>,
+        manifest_payloads: Option<(serde_json::Value, serde_json::Value, String)>,
     ) -> crate::kernel::runtime_host::VerletResult<AgentProcessSpawnReceipt> {
         let host = self.host()?;
         let coordinates = verlet_runtime_contracts::ThreadCoordinates::new(
@@ -484,9 +485,13 @@ impl RuntimeKernelControl {
             let _ = host.shutdown_thread(child_thread_id).await;
             return Err(err);
         }
-        if let Some((compile_payload, bind_payload)) = manifest_payloads
+        if let Some((compile_payload, bind_payload, principal_id)) = manifest_payloads
             && let Err(err) = child
-                .record_manifest_receipts(compile_payload, bind_payload)
+                .record_manifest_receipts_for_principal(
+                    compile_payload,
+                    bind_payload,
+                    &principal_id,
+                )
                 .await
         {
             let _ = host.shutdown_thread(child_thread_id).await;
@@ -523,6 +528,7 @@ impl RuntimeKernelControl {
         witness: ThreadSpawnWitness,
         compile_payload: Option<serde_json::Value>,
         bind_payload: Option<serde_json::Value>,
+        binding_principal_id: Option<String>,
     ) -> crate::kernel::runtime_host::VerletResult<AgentProcessSpawnReceipt> {
         let host = self.host()?;
         let executor = host.remote_thread_executor().await.ok_or_else(|| {
@@ -578,6 +584,7 @@ impl RuntimeKernelControl {
             spawned_event_id: spawned.id,
             compile_payload,
             bind_payload,
+            binding_principal_id,
         };
         if let Err(error) = executor.spawn(request).await {
             let _ = crate::kernel::runtime_host::runtime_services::append_thread_joined_first_wins(

--- a/crates/verlet-kernel/src/kernel/runtime_host/tests.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/tests.rs
@@ -687,6 +687,29 @@ impl verlet_history::EventStore for AdmissionTestStore {
         self.inner.append_events(stream_id, records).await
     }
 
+    async fn append_events_fenced(
+        &self,
+        stream_id: &verlet_history::EventStreamId,
+        expected_next_sequence: verlet_history::EventSequence,
+        records: Vec<verlet_history::NewEventRecord>,
+    ) -> verlet_history::HistoryResult<Vec<verlet_history::EventRecord>> {
+        let appends_admission = records
+            .iter()
+            .any(|record| record.kind == verlet_history::EventKind::AdmissionDecided);
+        if appends_admission && let Some(barrier) = &self.admission_barrier {
+            barrier.arrive_and_wait().await;
+        }
+        let appends_manifest_bind = records
+            .iter()
+            .any(|record| record.kind == verlet_history::EventKind::ManifestBindCompleted);
+        if appends_manifest_bind && let Some(barrier) = &self.manifest_barrier {
+            barrier.arrive_and_wait().await;
+        }
+        self.inner
+            .append_events_fenced(stream_id, expected_next_sequence, records)
+            .await
+    }
+
     async fn read_events(
         &self,
         stream_id: &verlet_history::EventStreamId,
@@ -5086,7 +5109,7 @@ async fn manifest_bind_receipt_and_placement_witness_share_one_atomic_append() {
             verlet_history::InMemorySessionStore::new(),
         ))
         .fail_nth(
-            "append_events",
+            "append_events_fenced",
             2,
             "a second manifest append must not occur",
         ),
@@ -5119,7 +5142,7 @@ async fn manifest_bind_receipt_and_placement_witness_share_one_atomic_append() {
         .await
         .unwrap();
 
-    assert_eq!(store.call_count("append_events"), 1);
+    assert_eq!(store.call_count("append_events_fenced"), 1);
     let events = store
         .read_events(
             &verlet_history::EventStreamId::for_thread(&thread.context().coordinates),
@@ -5281,7 +5304,7 @@ async fn failed_manifest_batch_leaves_no_bind_receipt_without_placement_witness(
         crate::support::fault::FaultingRuntimeStore::new(std::sync::Arc::new(
             verlet_history::InMemorySessionStore::new(),
         ))
-        .fail_nth("append_events", 1, "manifest batch failed"),
+        .fail_nth("append_events_fenced", 1, "manifest batch failed"),
     );
     let host = crate::kernel::runtime_host::RuntimeHost::with_session_store(
         std::sync::Arc::new(EchoRuntimeFactory),

--- a/crates/verlet-kernel/src/kernel/runtime_host/tests.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/tests.rs
@@ -5174,6 +5174,59 @@ async fn manifest_bind_receipt_and_placement_witness_share_one_atomic_append() {
 }
 
 #[tokio::test]
+async fn manifest_binding_rejects_an_empty_principal_before_append() {
+    let store = std::sync::Arc::new(verlet_history::InMemorySessionStore::new());
+    let host = crate::kernel::runtime_host::RuntimeHost::with_session_store(
+        std::sync::Arc::new(EchoRuntimeFactory),
+        store.clone(),
+    );
+    let thread = host
+        .start_thread(
+            coords("tenant_a", "user_1", "empty-bind-principal"),
+            verlet_runtime_contracts::ThreadTopology::root(),
+        )
+        .await
+        .unwrap();
+
+    let error = thread
+        .record_manifest_receipts_for_principal(
+            serde_json::json!({
+                "ref_uri": "agent://principal@0.1.0",
+                "manifest_hash": "snapshot-principal",
+                "source_hash": "sha256:source"
+            }),
+            serde_json::json!({
+                "ref_uri": "agent://principal@0.1.0",
+                "manifest_hash": "snapshot-principal",
+                "operation_bindings": [{
+                    "name": "search",
+                    "artifact_hash": "sha256:search"
+                }]
+            }),
+            "  ",
+        )
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("principal is required"));
+    let events = store
+        .read_events(
+            &verlet_history::EventStreamId::for_thread(&thread.context().coordinates),
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(events.iter().all(|event| {
+        !matches!(
+            event.kind,
+            verlet_history::EventKind::ManifestCompileCompleted
+                | verlet_history::EventKind::ManifestBindCompleted
+                | verlet_history::EventKind::BindingAttached
+        )
+    }));
+}
+
+#[tokio::test]
 async fn cancelled_manifest_receipt_caller_cannot_leave_a_half_witnessed_workspace() {
     let barrier = std::sync::Arc::new(AdmissionAppendBarrier::default());
     let store = std::sync::Arc::new(AdmissionTestStore::blocking_manifest(barrier.clone()));
@@ -5296,6 +5349,57 @@ async fn remote_manifest_receipt_rejects_a_workspace_before_witnessing_it() {
             .iter()
             .all(|event| event.kind != verlet_history::EventKind::ManifestBindCompleted)
     );
+}
+
+#[tokio::test]
+async fn remote_manifest_binding_preserves_the_resolved_principal() {
+    let store = std::sync::Arc::new(verlet_history::InMemorySessionStore::new());
+    let host = crate::kernel::runtime_host::RuntimeHost::with_session_store(
+        std::sync::Arc::new(EchoRuntimeFactory),
+        store.clone(),
+    );
+    let thread = host
+        .start_thread(
+            coords("tenant_a", "thread-user", "remote-principal-bind"),
+            verlet_runtime_contracts::ThreadTopology::root(),
+        )
+        .await
+        .unwrap();
+
+    thread
+        .record_remote_manifest_receipts_for_principal(
+            serde_json::json!({
+                "manifest_hash": "snapshot-remote-principal",
+                "source_hash": "sha256:source"
+            }),
+            serde_json::json!({
+                "manifest_hash": "snapshot-remote-principal",
+                "placement": {"target": "remote"},
+                "operation_bindings": [{
+                    "name": "search",
+                    "artifact_hash": "sha256:search"
+                }]
+            }),
+            "principal:remote-operator",
+        )
+        .await
+        .unwrap();
+
+    let events = store
+        .read_events(
+            &verlet_history::EventStreamId::for_thread(&thread.context().coordinates),
+            None,
+        )
+        .await
+        .unwrap();
+    let attached = events
+        .iter()
+        .find(|event| event.kind == verlet_history::EventKind::BindingAttached)
+        .unwrap();
+    let payload: verlet_history::BindingAttachedPayload =
+        serde_json::from_value(attached.payload.clone()).unwrap();
+    assert_eq!(payload.requested_by, "principal:remote-operator");
+    assert_eq!(payload.decided_by, "principal:remote-operator");
 }
 
 #[tokio::test]

--- a/crates/verlet-kernel/src/kernel/runtime_host/thread_handle.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/thread_handle.rs
@@ -51,7 +51,21 @@ impl crate::kernel::runtime_host::RuntimeThreadHandle {
         verlet_history::EventRecord,
         verlet_history::EventRecord,
     )> {
-        self.record_manifest_receipts_inner(compile_payload, bind_payload, false)
+        let principal_id = self.thread.context.coordinates.user_id.clone();
+        self.record_manifest_receipts_inner(compile_payload, bind_payload, &principal_id, false)
+            .await
+    }
+
+    pub(crate) async fn record_manifest_receipts_for_principal(
+        &self,
+        compile_payload: serde_json::Value,
+        bind_payload: serde_json::Value,
+        principal_id: &str,
+    ) -> crate::kernel::runtime_host::VerletResult<(
+        verlet_history::EventRecord,
+        verlet_history::EventRecord,
+    )> {
+        self.record_manifest_receipts_inner(compile_payload, bind_payload, principal_id, false)
             .await
     }
 
@@ -67,7 +81,8 @@ impl crate::kernel::runtime_host::RuntimeThreadHandle {
         verlet_history::EventRecord,
         verlet_history::EventRecord,
     )> {
-        self.record_manifest_receipts_inner(compile_payload, bind_payload, true)
+        let principal_id = self.thread.context.coordinates.user_id.clone();
+        self.record_manifest_receipts_inner(compile_payload, bind_payload, &principal_id, true)
             .await
     }
 
@@ -75,13 +90,34 @@ impl crate::kernel::runtime_host::RuntimeThreadHandle {
         &self,
         compile_payload: serde_json::Value,
         bind_payload: serde_json::Value,
+        principal_id: &str,
         remote_execution_authorized: bool,
     ) -> crate::kernel::runtime_host::VerletResult<(
         verlet_history::EventRecord,
         verlet_history::EventRecord,
     )> {
+        if principal_id.trim().is_empty() {
+            return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
+                "manifest bind principal is required".to_string(),
+            ));
+        }
         let coordinates = self.thread.context.coordinates.clone();
         let stream_id = verlet_history::EventStreamId::for_thread(&coordinates);
+        let operation_bindings = bind_payload
+            .get("operation_bindings")
+            .cloned()
+            .map(
+                serde_json::from_value::<
+                    Vec<crate::agent::manifest_bind::AgentManifestOperationBinding>,
+                >,
+            )
+            .transpose()
+            .map_err(|err| {
+                crate::kernel::runtime_host::VerletError::History(format!(
+                    "manifest operation binding payload codec failed: {err}"
+                ))
+            })?
+            .unwrap_or_default();
         let mut placement =
             bind_payload
                 .get("placement")
@@ -171,10 +207,46 @@ impl crate::kernel::runtime_host::RuntimeThreadHandle {
             verlet_history::EventKind::PlacementDecision,
             placement_payload,
         );
-        // Receipt and witness share one atomic store append. This closes the
+        let attachment_events = operation_bindings
+            .iter()
+            .map(|binding| {
+                let payload =
+                    crate::agent::manifest_bind::binding_attached_payload(binding, principal_id);
+                serde_json::to_value(payload)
+                    .map(|payload| {
+                        verlet_history::NewEventRecord::discharged(
+                            coordinates.clone(),
+                            verlet_history::EventKind::BindingAttached,
+                            payload,
+                            verlet_history::EventProvenance {
+                                source_streams: vec![stream_id.clone()],
+                                source_event_ids: vec![bind_event.id],
+                                discharged_by: Some(
+                                    crate::agent::manifest_bind::MANIFEST_BINDER_DISCHARGED_BY
+                                        .to_string(),
+                                ),
+                                function: Some(
+                                    crate::agent::manifest_bind::MANIFEST_BINDER_FUNCTION
+                                        .to_string(),
+                                ),
+                                ..verlet_history::EventProvenance::default()
+                            },
+                        )
+                    })
+                    .map_err(|err| {
+                        crate::kernel::runtime_host::VerletError::History(format!(
+                            "binding.attached payload codec failed: {err}"
+                        ))
+                    })
+            })
+            .collect::<crate::kernel::runtime_host::VerletResult<Vec<_>>>()?;
+        // Receipts and witnesses share one atomic store append. This closes the
         // crash/race window: callers never receive a bind receipt unless its
-        // effective placement fact committed in the same batch.
-        let mut records = vec![compile_event, bind_event, placement_event];
+        // effective binding and placement facts committed in the same batch.
+        let minimum_event_count = 3 + attachment_events.len();
+        let mut records = vec![compile_event, bind_event];
+        records.extend(attachment_events);
+        records.push(placement_event);
         if let Some(raw_coupling_set) = self
             .thread
             .context
@@ -232,8 +304,18 @@ impl crate::kernel::runtime_host::RuntimeThreadHandle {
         // start guards separately remove a thread cancelled during factory
         // construction, so no mounted runtime survives without this batch.
         let runtime_store = self.thread.services.runtime_store();
-        let append =
-            tokio::spawn(async move { runtime_store.append_events(&stream_id, records).await });
+        let expected_next_sequence = runtime_store
+            .read_events(&stream_id, None)
+            .await
+            .map_err(|err| crate::kernel::runtime_host::VerletError::History(err.to_string()))?
+            .last()
+            .map(|event| verlet_history::EventSequence::new(event.sequence.get() + 1))
+            .unwrap_or_else(|| verlet_history::EventSequence::new(1));
+        let append = tokio::spawn(async move {
+            runtime_store
+                .append_events_fenced(&stream_id, expected_next_sequence, records)
+                .await
+        });
         let events = append
             .await
             .map_err(|err| {
@@ -242,7 +324,7 @@ impl crate::kernel::runtime_host::RuntimeThreadHandle {
                 ))
             })?
             .map_err(|err| crate::kernel::runtime_host::VerletError::History(err.to_string()))?;
-        if events.len() < 3 {
+        if events.len() < minimum_event_count {
             return Err(crate::kernel::runtime_host::VerletError::History(format!(
                 "manifest receipt append returned {} record(s)",
                 events.len()

--- a/crates/verlet-kernel/src/kernel/runtime_host/thread_handle.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/thread_handle.rs
@@ -86,6 +86,19 @@ impl crate::kernel::runtime_host::RuntimeThreadHandle {
             .await
     }
 
+    pub(crate) async fn record_remote_manifest_receipts_for_principal(
+        &self,
+        compile_payload: serde_json::Value,
+        bind_payload: serde_json::Value,
+        principal_id: &str,
+    ) -> crate::kernel::runtime_host::VerletResult<(
+        verlet_history::EventRecord,
+        verlet_history::EventRecord,
+    )> {
+        self.record_manifest_receipts_inner(compile_payload, bind_payload, principal_id, true)
+            .await
+    }
+
     async fn record_manifest_receipts_inner(
         &self,
         compile_payload: serde_json::Value,

--- a/crates/verlet-kernel/src/kernel/thread_spawn_projector.rs
+++ b/crates/verlet-kernel/src/kernel/thread_spawn_projector.rs
@@ -668,6 +668,7 @@ impl ThreadSpawnProjector {
                             witness,
                             binding.compile_receipt,
                             binding.bind_receipt,
+                            binding.principal_id,
                         )
                         .await?
                 } else {
@@ -686,8 +687,14 @@ impl ThreadSpawnProjector {
                 }
             }
             crate::kernel::control_decision::PlacementTarget::Remote => {
-                let (compile_payload, bind_payload) = agent_binding
-                    .map(|binding| (Some(binding.compile_receipt), Some(binding.bind_receipt)))
+                let (compile_payload, bind_payload, binding_principal_id) = agent_binding
+                    .map(|binding| {
+                        (
+                            Some(binding.compile_receipt),
+                            Some(binding.bind_receipt),
+                            Some(binding.principal_id),
+                        )
+                    })
                     .unwrap_or_default();
                 self.host
                     .kernel_control()
@@ -701,6 +708,7 @@ impl ThreadSpawnProjector {
                         witness,
                         compile_payload,
                         bind_payload,
+                        binding_principal_id,
                     )
                     .await?
             }
@@ -1522,6 +1530,7 @@ mod tests {
                     workspace_origin: None,
                 })
                 .unwrap(),
+                principal_id: "user:forged-remote-workspace".to_string(),
             })
         }
     }

--- a/crates/verlet-kernel/src/lib.rs
+++ b/crates/verlet-kernel/src/lib.rs
@@ -59,6 +59,7 @@ pub mod daemon {
 
 pub mod kernel {
     pub(crate) mod admission;
+    pub mod binding_projector;
     pub mod compaction;
     pub mod context_compiler;
     pub mod control_decision;

--- a/crates/verlet-kernel/tests/lexicon_lint_baseline.txt
+++ b/crates/verlet-kernel/tests/lexicon_lint_baseline.txt
@@ -2,7 +2,7 @@
 # line edits do not churn the baseline. This file only shrinks.
 crates/verlet-kernel/src/adapters/app_server/connection.rs capsule 45
 crates/verlet-kernel/src/adapters/app_server.rs capsule 25
-crates/verlet-kernel/src/adapters/app_server/tests.rs capsule 118
+crates/verlet-kernel/src/adapters/app_server/tests.rs capsule 117
 crates/verlet-kernel/src/adapters/app_server/threads.rs capsule 10
 crates/verlet-kernel/src/adapters/mcp_server.rs capsule 28
 crates/verlet-kernel/src/adapters/mcp_server/tests.rs capsule 32

--- a/docs/app-server.md
+++ b/docs/app-server.md
@@ -639,15 +639,17 @@ manifest. Legacy explicit parameters lower as follows:
   at start time.
 
 Manifest-backed starts atomically emit `manifest.compile.completed`,
-`manifest.bind.completed`, and exactly one witnessed `placement.decision` on
-the thread event stream before the first turn. The placement fact is derived
-from the same effective binding stored on the bind receipt, including defaulted
-local, so the receipt cannot commit without its witness. The compile and bind
-events are discharged and include provenance. An `@latest` start includes the
-alias resolution receipt in the compile event payload. A remote child records
-the same bind receipt and unchanged `placement.decision` in its local stream
-before that stream converges to the parent store. Without a served sync backend,
-`remote` retains the missing-capability error; `sandbox` always does.
+`manifest.bind.completed`, one discharged `binding.attached` per operation
+binding, and exactly one witnessed `placement.decision` on the thread event
+stream before the first turn. The binding and placement facts are derived from
+the same effective binding stored on the bind receipt, including defaulted
+local, so the receipt cannot commit without its witnesses. The compile, bind,
+and attachment events are discharged and include provenance. An `@latest`
+start includes the alias resolution receipt in the compile event payload. A
+remote child records the same bind receipt, attachments, and unchanged
+`placement.decision` in its local stream before that stream converges to the
+parent store. Without a served sync backend, `remote` retains the
+missing-capability error; `sandbox` always does.
 When present, the effective workspace mount is part of that same
 `manifest.bind.completed` payload and atomic append. Thread lifecycle metadata
 stores the resolved mount for factory reconstruction. Missing or corrupt

--- a/docs/format-ids.md
+++ b/docs/format-ids.md
@@ -7,7 +7,7 @@ stored data or change interface hashes, so they never rename.
 
 The frozen families are:
 
-- event vocabulary version `cooldis.events/0.3`, event payload schema IDs under
+- event vocabulary version `cooldis.events/0.4`, event payload schema IDs under
   `cooldis.event.*`, and the `cooldis.stream.*`, `cooldis.context.*`, and
   `cooldis.debug.*` schema-ID namespaces;
 - operation names recorded in receipts, including `cooldis.thread_spawn`,

--- a/scripts/verlet-name-allowlist.tsv
+++ b/scripts/verlet-name-allowlist.tsv
@@ -1,5 +1,6 @@
 # path	reason
 @source-pattern	cooldis\.events/0\.3	Frozen event-kind vocabulary version.
+@source-pattern	cooldis\.events/0\.4	Frozen event-kind vocabulary version.
 @source-pattern	cooldis\.event\.	Frozen event payload schema-ID namespace.
 @source-pattern	cooldis\.stream\.	Frozen stream schema-ID namespace.
 @source-pattern	cooldis\.context\.[a-z0-9_.-]+/[0-9]+	Frozen context schema IDs.

--- a/scripts/verlet-name-allowlist.tsv
+++ b/scripts/verlet-name-allowlist.tsv
@@ -1,6 +1,6 @@
 # path	reason
 @source-pattern	cooldis\.events/0\.3	Frozen event-kind vocabulary version.
-@source-pattern	cooldis\.events/0\.4	Frozen event-kind vocabulary version.
+@source-pattern	(^|[^[:alnum:]_.-])cooldis\.events/0\.4([^[:alnum:]_.-]|$)	Frozen event-kind vocabulary version.
 @source-pattern	cooldis\.event\.	Frozen event payload schema-ID namespace.
 @source-pattern	cooldis\.stream\.	Frozen stream schema-ID namespace.
 @source-pattern	cooldis\.context\.[a-z0-9_.-]+/[0-9]+	Frozen context schema IDs.


### PR DESCRIPTION
## Summary

First implementation slice of the binding model (parent EMO-579): tool availability becomes journaled history. Additive only; catalog, router, and thread metadata remain the source of truth until the next slice.

- New frozen event vocabulary: `binding.attached` / `binding.detached` (schema ids `cooldis.event.binding.{attached,detached}/1`; `EVENT_KIND_SCHEMA_VERSION` bumped to `cooldis.events/0.4` per the established convention; a regression pins 0.3-kind journals still decode).
- Payloads carry the operation ref (content address), exposed operations, direct tools, attachment config, effect class, requester, decider, and an optional decision-event reference for the future policy router. Strict `deny_unknown_fields`, wire shapes pinned by parity tests against the kernel types.
- The manifest bind path emits one `binding.attached` per operation binding, in the same fenced append batch as the `manifest.bind.completed` receipt (discharged, with binder provenance citing the receipt). The resolved principal crosses app-server, daemon, spawn, and remote bootstrap seams; empty principals are rejected.
- `fold_thread_bindings`: a pure, deterministic projector deriving the active toolset from binding events, with typed anomalies (undecodable payloads, unknown or repeated detach references). Nothing consumes it in production yet.
- Review pass fixed three Medium bugs before this PR: rebind double-counting in the fold (generations now supersede), plain fork losing operation bindings entirely, and agent-bound spawn dropping the resolved principal.
- Known design gap, deliberately deferred to the next slice (EMO-585): a rebind that drops bindings emits no detach events yet, so the fold clears dropped tools only through generation supersede; explicit detach emission at rebind is specified there.

Linear: EMO-584 (implementation and review reports on the issue).

#### Test plan

- [x] `scripts/verify.sh` (lints, fmt, clippy, full workspace suite, both smokes)
- [x] `scripts/verify-linux.sh`
- [x] Full workspace tests green (kernel 1230 passed, 4 ignored)
- [x] Real lifecycle coverage: start, resume/rebind, fork, spawn (local + remote bootstrap)
- [x] Frozen wire shapes pinned; 0.3 journal compatibility regression
- [x] EMO-580/581 attachment enforcement and legacy metadata canaries green