### PR TITLE
app-server: enrich model list from provider APIs (EMO-583)

### DIFF
--- a/crates/verlet-kernel/src/adapters/app_server.rs
+++ b/crates/verlet-kernel/src/adapters/app_server.rs
@@ -11,6 +11,7 @@ pub mod connection;
 mod default_manifest;
 pub mod instance;
 pub mod lifecycle;
+pub(crate) mod live_models;
 pub(crate) mod model_catalog;
 mod orchestrator_boundary;
 mod subscriptions;
@@ -901,6 +902,7 @@ struct VerletAppServerInner {
     metadata_store: verlet_metadata::provider_store::SqliteMetadataStore,
     user_metadata_store: verlet_metadata::provider_store::SqliteMetadataStore,
     model_catalog: model_catalog::MergedModelCatalog,
+    live_models: std::sync::Arc<live_models::LiveModelCache>,
     process_manager: verlet_process::live::AsyncExecutionManager,
     process_dispatcher:
         tokio::sync::OnceCell<crate::kernel::process_handle_dispatch::ProcessHandleDispatcher>,
@@ -1377,6 +1379,7 @@ impl VerletAppServer {
                 metadata_store,
                 user_metadata_store,
                 model_catalog,
+                live_models: std::sync::Arc::new(live_models::LiveModelCache::new()),
                 process_manager,
                 process_dispatcher: tokio::sync::OnceCell::new(),
                 subscriptions: tokio::sync::Mutex::new(

--- a/crates/verlet-kernel/src/adapters/app_server/connection.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/connection.rs
@@ -5882,6 +5882,7 @@ impl crate::adapters::app_server::VerletAppServer {
             crate::adapters::app_server::model_catalog::StaticModelCatalog::new(catalog_entries);
         let auth_context = self.inner.instance_environment.provider_auth.resolve();
         let mut auth_statuses = std::collections::BTreeMap::new();
+        let mut live_entries = Vec::new();
         for provider in &providers {
             let status = verlet_metadata::provider_store::llm_provider_auth_status(
                 &self.inner.user_metadata_store,
@@ -5900,13 +5901,47 @@ impl crate::adapters::app_server::VerletAppServer {
                 None => "missing",
             };
             auth_statuses.insert(provider.provider_id.clone(), label);
+            match crate::adapters::app_server::live_models::resolve_refresh_credential(
+                &self.inner.user_metadata_store,
+                provider,
+                &auth_context,
+            )
+            .await
+            {
+                Ok(Some(credential)) => {
+                    live_entries.extend(self.inner.live_models.entries_and_refresh(
+                        &self.inner.tasks,
+                        provider,
+                        credential,
+                    ))
+                }
+                Ok(None) => {}
+                Err(error) => log::debug!(
+                    "live model auth unavailable for provider {}: {}",
+                    provider.provider_id,
+                    error
+                ),
+            }
         }
         let mut seen = std::collections::BTreeSet::new();
         Ok(catalog
             .entries()
             .into_iter()
-            .filter(|entry| seen.insert((entry.provider_id.clone(), entry.model_id.clone())))
-            .map(|entry| {
+            .map(|entry| (entry, false))
+            .chain(live_entries.into_iter().map(|model| {
+                (
+                    crate::adapters::app_server::model_catalog::ModelCatalogEntry {
+                        provider_id: model.provider_id,
+                        model_id: model.model_id,
+                        display_name: model.display_name,
+                        context_window: None,
+                        max_output_tokens: None,
+                    },
+                    true,
+                )
+            }))
+            .filter(|(entry, _)| seen.insert((entry.provider_id.clone(), entry.model_id.clone())))
+            .map(|(entry, live)| {
                 let is_active =
                     entry.provider_id == active.model_provider && entry.model_id == active.model;
                 let launch_only = entry.provider_id == self.inner.model_provider
@@ -5956,6 +5991,9 @@ impl crate::adapters::app_server::VerletAppServer {
                     "maxOutputTokens".to_string(),
                     serde_json::json!(entry.max_output_tokens),
                 );
+                if live {
+                    object.insert("origin".to_string(), serde_json::json!("live"));
+                }
                 if let Some(provider) = provider_records.get(&entry.provider_id)
                     && let Some(model) = provider
                         .models

--- a/crates/verlet-kernel/src/adapters/app_server/live_models.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/live_models.rs
@@ -547,14 +547,14 @@ mod tests {
     }
 
     async fn next_request(server: &mut RecordingHttpServer) -> String {
-        tokio::time::timeout(std::time::Duration::from_secs(2), server.requests.recv())
+        tokio::time::timeout(std::time::Duration::from_secs(30), server.requests.recv())
             .await
             .expect("model-list request timed out")
             .expect("model-list request channel closed")
     }
 
     async fn wait_until_idle(cache: &super::LiveModelCache, provider_id: &str) {
-        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        tokio::time::timeout(std::time::Duration::from_secs(30), async {
             while cache.is_refreshing_for_test(provider_id) {
                 tokio::task::yield_now().await;
             }

--- a/crates/verlet-kernel/src/adapters/app_server/live_models.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/live_models.rs
@@ -1,0 +1,681 @@
+//! In-memory live model-list enrichment for configured provider records.
+//!
+//! Reads never await network work. Missing or stale provider entries schedule
+//! one instance-owned refresh and immediately return the last cached models.
+
+const MAX_RESPONSE_BYTES: usize = 1024 * 1024;
+const MAX_MODELS: usize = 10_000;
+const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(4);
+pub(crate) const REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct LiveModel {
+    pub(crate) provider_id: String,
+    pub(crate) model_id: String,
+    pub(crate) display_name: String,
+}
+
+#[derive(Clone)]
+pub(crate) enum RefreshCredential {
+    ApiKey(String),
+    None,
+}
+
+impl std::fmt::Debug for RefreshCredential {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ApiKey(_) => formatter.write_str("ApiKey(<redacted>)"),
+            Self::None => formatter.write_str("None"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ProviderFingerprint {
+    api: verlet_history::ProviderApi,
+    base_url: String,
+}
+
+impl From<&verlet_metadata::provider_store::LlmProviderRecord> for ProviderFingerprint {
+    fn from(provider: &verlet_metadata::provider_store::LlmProviderRecord) -> Self {
+        Self {
+            api: provider.api.clone(),
+            base_url: provider.base_url.clone(),
+        }
+    }
+}
+
+struct CachedModels {
+    fingerprint: ProviderFingerprint,
+    models: Vec<LiveModel>,
+    checked_at: tokio::time::Instant,
+}
+
+pub(crate) struct LiveModelCache {
+    entries: std::sync::RwLock<std::collections::BTreeMap<String, CachedModels>>,
+    refreshing: std::sync::Mutex<std::collections::BTreeSet<String>>,
+    refresh_interval: std::time::Duration,
+    request_timeout: std::time::Duration,
+}
+
+impl Default for LiveModelCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LiveModelCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: std::sync::RwLock::new(std::collections::BTreeMap::new()),
+            refreshing: std::sync::Mutex::new(std::collections::BTreeSet::new()),
+            refresh_interval: REFRESH_INTERVAL,
+            request_timeout: REQUEST_TIMEOUT,
+        }
+    }
+
+    pub(crate) fn entries_and_refresh(
+        self: &std::sync::Arc<Self>,
+        tasks: &std::sync::Arc<super::lifecycle::InstanceTaskSet>,
+        provider: &verlet_metadata::provider_store::LlmProviderRecord,
+        credential: RefreshCredential,
+    ) -> Vec<LiveModel> {
+        let fingerprint = ProviderFingerprint::from(provider);
+        let now = tokio::time::Instant::now();
+        let (models, stale) = {
+            let entries = self
+                .entries
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            match entries.get(&provider.provider_id) {
+                Some(entry) if entry.fingerprint == fingerprint => {
+                    let stale = now
+                        .checked_duration_since(entry.checked_at)
+                        .is_none_or(|age| age >= self.refresh_interval);
+                    (entry.models.clone(), stale)
+                }
+                _ => (Vec::new(), true),
+            }
+        };
+        if stale && self.start_refresh(&provider.provider_id) {
+            let provider = provider.clone();
+            let refresh_id = provider.provider_id.clone();
+            let provider_id = refresh_id.clone();
+            let cache = std::sync::Arc::clone(self);
+            let request_timeout = self.request_timeout;
+            let accepted = tasks.spawn_cancellable(async move {
+                match fetch_models(&provider, &credential, request_timeout).await {
+                    Ok(models) => cache.finish_refresh(
+                        provider_id,
+                        fingerprint,
+                        Some(models),
+                        tokio::time::Instant::now(),
+                    ),
+                    Err(error) => {
+                        log::debug!(
+                            "live model refresh failed for provider {}: {}",
+                            provider.provider_id,
+                            error
+                        );
+                        cache.finish_refresh(
+                            provider_id,
+                            fingerprint,
+                            None,
+                            tokio::time::Instant::now(),
+                        );
+                    }
+                }
+            });
+            if !accepted {
+                self.clear_refresh(&refresh_id);
+            }
+        }
+        models
+    }
+
+    fn start_refresh(&self, provider_id: &str) -> bool {
+        self.refreshing
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(provider_id.to_string())
+    }
+
+    fn clear_refresh(&self, provider_id: &str) {
+        self.refreshing
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(provider_id);
+    }
+
+    fn finish_refresh(
+        &self,
+        provider_id: String,
+        fingerprint: ProviderFingerprint,
+        models: Option<Vec<LiveModel>>,
+        checked_at: tokio::time::Instant,
+    ) {
+        {
+            let mut entries = self
+                .entries
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            match models {
+                Some(models) => {
+                    entries.insert(
+                        provider_id.clone(),
+                        CachedModels {
+                            fingerprint,
+                            models,
+                            checked_at,
+                        },
+                    );
+                }
+                None => match entries.get_mut(&provider_id) {
+                    Some(entry) if entry.fingerprint == fingerprint => {
+                        entry.checked_at = checked_at;
+                    }
+                    _ => {
+                        entries.insert(
+                            provider_id.clone(),
+                            CachedModels {
+                                fingerprint,
+                                models: Vec::new(),
+                                checked_at,
+                            },
+                        );
+                    }
+                },
+            }
+        }
+        self.clear_refresh(&provider_id);
+    }
+
+    #[cfg(test)]
+    fn is_refreshing_for_test(&self, provider_id: &str) -> bool {
+        self.refreshing
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains(provider_id)
+    }
+
+    #[cfg(test)]
+    fn seed_for_test(
+        &self,
+        provider: &verlet_metadata::provider_store::LlmProviderRecord,
+        models: Vec<LiveModel>,
+        age: std::time::Duration,
+    ) {
+        self.entries
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(
+                provider.provider_id.clone(),
+                CachedModels {
+                    fingerprint: ProviderFingerprint::from(provider),
+                    models,
+                    checked_at: tokio::time::Instant::now() - age,
+                },
+            );
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum LiveModelAuthError {
+    #[error("credential lookup failed")]
+    CredentialLookup,
+    #[error("credential resolution failed")]
+    CredentialResolution,
+}
+
+pub(crate) async fn resolve_refresh_credential(
+    auth_store: &dyn verlet_metadata::provider_store::LlmProviderAuthStore,
+    provider: &verlet_metadata::provider_store::LlmProviderRecord,
+    auth_context: &verlet_metadata::provider_store::LlmProviderAuthContext,
+) -> Result<Option<RefreshCredential>, LiveModelAuthError> {
+    if !matches!(
+        provider.api,
+        verlet_history::ProviderApi::OpenAIChatCompletions
+            | verlet_history::ProviderApi::OpenAIResponses
+            | verlet_history::ProviderApi::AnthropicMessages
+    ) {
+        return Ok(None);
+    }
+    let stored = auth_store
+        .get_credential(&provider.provider_id)
+        .await
+        .map_err(|_| LiveModelAuthError::CredentialLookup)?;
+    if matches!(
+        stored,
+        Some(verlet_metadata::provider_store::LlmProviderCredential::OAuth { .. })
+    ) {
+        return Ok(None);
+    }
+    if matches!(
+        provider.auth,
+        verlet_metadata::provider_store::LlmProviderAuthConfig::None
+    ) {
+        return Ok(Some(RefreshCredential::None));
+    }
+    let Some(resolved) = verlet_metadata::provider_store::resolve_llm_provider_auth(
+        auth_store,
+        provider,
+        auth_context,
+    )
+    .await
+    .map_err(|_| LiveModelAuthError::CredentialResolution)?
+    else {
+        return Ok(None);
+    };
+    let eligible = match resolved.source {
+        verlet_metadata::provider_store::LlmProviderAuthSourceKind::Environment => true,
+        verlet_metadata::provider_store::LlmProviderAuthSourceKind::Stored => matches!(
+            stored,
+            Some(verlet_metadata::provider_store::LlmProviderCredential::ApiKey { .. })
+        ),
+        verlet_metadata::provider_store::LlmProviderAuthSourceKind::Runtime
+        | verlet_metadata::provider_store::LlmProviderAuthSourceKind::CatalogInline
+        | verlet_metadata::provider_store::LlmProviderAuthSourceKind::CatalogCommand
+        | verlet_metadata::provider_store::LlmProviderAuthSourceKind::None => false,
+    };
+    if !eligible {
+        return Ok(None);
+    }
+    if provider.auth_header {
+        Ok(Some(RefreshCredential::ApiKey(resolved.api_key)))
+    } else {
+        Ok(Some(RefreshCredential::None))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum LiveModelRefreshError {
+    #[error("HTTP client could not be constructed")]
+    Client,
+    #[error("HTTP request failed")]
+    Request,
+    #[error("HTTP status was not successful")]
+    HttpStatus,
+    #[error("HTTP response exceeded the size limit")]
+    ResponseTooLarge,
+    #[error("HTTP response was not a valid model list")]
+    InvalidResponse,
+    #[error("HTTP response exceeded the model-count limit")]
+    TooManyModels,
+}
+
+#[derive(serde::Deserialize)]
+struct ListModelsResponse {
+    data: Vec<ListModelsItem>,
+}
+
+#[derive(serde::Deserialize)]
+struct ListModelsItem {
+    id: String,
+    #[serde(default)]
+    display_name: Option<String>,
+}
+
+async fn fetch_models(
+    provider: &verlet_metadata::provider_store::LlmProviderRecord,
+    credential: &RefreshCredential,
+    request_timeout: std::time::Duration,
+) -> Result<Vec<LiveModel>, LiveModelRefreshError> {
+    let url = list_models_url(provider).ok_or(LiveModelRefreshError::Request)?;
+    let client = reqwest::Client::builder()
+        .timeout(request_timeout)
+        .redirect(reqwest::redirect::Policy::none())
+        .user_agent("verlet-live-models/0.1")
+        .build()
+        .map_err(|_| LiveModelRefreshError::Client)?;
+    let mut request = client.get(url);
+    match (&provider.api, credential) {
+        (
+            verlet_history::ProviderApi::OpenAIChatCompletions
+            | verlet_history::ProviderApi::OpenAIResponses,
+            RefreshCredential::ApiKey(key),
+        ) => {
+            request = request.bearer_auth(key);
+        }
+        (verlet_history::ProviderApi::AnthropicMessages, RefreshCredential::ApiKey(key)) => {
+            request = request.header("x-api-key", key);
+        }
+        (_, RefreshCredential::None) => {}
+        (verlet_history::ProviderApi::Other(_), RefreshCredential::ApiKey(_)) => {
+            return Err(LiveModelRefreshError::Request);
+        }
+    }
+    if matches!(provider.api, verlet_history::ProviderApi::AnthropicMessages) {
+        request = request.header("anthropic-version", verlet_provider::ANTHROPIC_API_VERSION);
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|_| LiveModelRefreshError::Request)?;
+    if !response.status().is_success() {
+        return Err(LiveModelRefreshError::HttpStatus);
+    }
+    let body = bounded_response_body(response).await?;
+    let response: ListModelsResponse =
+        serde_json::from_slice(&body).map_err(|_| LiveModelRefreshError::InvalidResponse)?;
+    if response.data.len() > MAX_MODELS {
+        return Err(LiveModelRefreshError::TooManyModels);
+    }
+    let mut models = std::collections::BTreeMap::new();
+    for item in response.data {
+        let model_id = item.id.trim();
+        if model_id.is_empty() {
+            continue;
+        }
+        let display_name = item
+            .display_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .unwrap_or(model_id);
+        models
+            .entry(model_id.to_string())
+            .or_insert_with(|| LiveModel {
+                provider_id: provider.provider_id.clone(),
+                model_id: model_id.to_string(),
+                display_name: display_name.to_string(),
+            });
+    }
+    Ok(models.into_values().collect())
+}
+
+fn list_models_url(
+    provider: &verlet_metadata::provider_store::LlmProviderRecord,
+) -> Option<String> {
+    let base_url = provider.base_url.trim_end_matches('/');
+    if base_url.is_empty() {
+        return None;
+    }
+    match provider.api {
+        verlet_history::ProviderApi::OpenAIChatCompletions
+        | verlet_history::ProviderApi::OpenAIResponses => Some(format!("{base_url}/models")),
+        verlet_history::ProviderApi::AnthropicMessages => {
+            if base_url.ends_with("/v1") {
+                Some(format!("{base_url}/models"))
+            } else {
+                Some(format!("{base_url}/v1/models"))
+            }
+        }
+        verlet_history::ProviderApi::Other(_) => None,
+    }
+}
+
+async fn bounded_response_body(
+    response: reqwest::Response,
+) -> Result<Vec<u8>, LiveModelRefreshError> {
+    use futures_util::StreamExt as _;
+
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_RESPONSE_BYTES as u64)
+    {
+        return Err(LiveModelRefreshError::ResponseTooLarge);
+    }
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|_| LiveModelRefreshError::Request)?;
+        if body.len().saturating_add(chunk.len()) > MAX_RESPONSE_BYTES {
+            return Err(LiveModelRefreshError::ResponseTooLarge);
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    struct HttpResponse {
+        status: &'static str,
+        body: String,
+        release: Option<std::sync::Arc<tokio::sync::Semaphore>>,
+    }
+
+    impl HttpResponse {
+        fn ok(body: impl Into<String>) -> Self {
+            Self {
+                status: "200 OK",
+                body: body.into(),
+                release: None,
+            }
+        }
+
+        fn gated(mut self, release: std::sync::Arc<tokio::sync::Semaphore>) -> Self {
+            self.release = Some(release);
+            self
+        }
+    }
+
+    struct RecordingHttpServer {
+        base_url: String,
+        requests: tokio::sync::mpsc::UnboundedReceiver<String>,
+        task: tokio::task::JoinHandle<()>,
+    }
+
+    impl Drop for RecordingHttpServer {
+        fn drop(&mut self) {
+            self.task.abort();
+        }
+    }
+
+    async fn spawn_http_sequence(responses: Vec<HttpResponse>) -> RecordingHttpServer {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
+        let task = tokio::spawn(async move {
+            let mut handlers = tokio::task::JoinSet::new();
+            for response in responses {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let request_tx = request_tx.clone();
+                handlers.spawn(async move {
+                    let mut request = Vec::new();
+                    loop {
+                        let mut chunk = [0_u8; 1024];
+                        let read = stream.read(&mut chunk).await.unwrap();
+                        assert!(read > 0, "request ended before its headers");
+                        request.extend_from_slice(&chunk[..read]);
+                        if request.windows(4).any(|bytes| bytes == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    request_tx
+                        .send(String::from_utf8(request).unwrap())
+                        .unwrap();
+                    if let Some(release) = response.release {
+                        let permit = release.acquire().await.unwrap();
+                        permit.forget();
+                    }
+                    let wire = format!(
+                        "HTTP/1.1 {}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        response.status,
+                        response.body.len(),
+                        response.body,
+                    );
+                    stream.write_all(wire.as_bytes()).await.unwrap();
+                });
+            }
+            while handlers.join_next().await.is_some() {}
+        });
+        RecordingHttpServer {
+            base_url: format!("http://{address}"),
+            requests: request_rx,
+            task,
+        }
+    }
+
+    async fn next_request(server: &mut RecordingHttpServer) -> String {
+        tokio::time::timeout(std::time::Duration::from_secs(2), server.requests.recv())
+            .await
+            .expect("model-list request timed out")
+            .expect("model-list request channel closed")
+    }
+
+    async fn wait_until_idle(cache: &super::LiveModelCache, provider_id: &str) {
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while cache.is_refreshing_for_test(provider_id) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("live-model refresh did not settle");
+    }
+
+    #[tokio::test]
+    async fn anthropic_fetch_uses_models_path_version_header_and_display_name() {
+        let mut server = spawn_http_sequence(vec![HttpResponse::ok(
+            r#"{"data":[{"id":"claude-live","display_name":"Claude Live"}]}"#,
+        )])
+        .await;
+        let provider = verlet_metadata::provider_store::LlmProviderRecord::new(
+            "anthropic-fixture",
+            verlet_history::ProviderApi::AnthropicMessages,
+            &server.base_url,
+        )
+        .with_auth_header(true);
+
+        let models = super::fetch_models(
+            &provider,
+            &super::RefreshCredential::ApiKey("anthropic-secret".to_string()),
+            std::time::Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].model_id, "claude-live");
+        assert_eq!(models[0].display_name, "Claude Live");
+        let request = next_request(&mut server).await;
+        let request_lower = request.to_ascii_lowercase();
+        assert!(request.starts_with("GET /v1/models HTTP/1.1"));
+        assert!(request_lower.contains("x-api-key: anthropic-secret"));
+        assert!(request_lower.contains("anthropic-version: 2023-06-01"));
+        assert!(!request_lower.contains("authorization:"));
+    }
+
+    #[tokio::test]
+    async fn refresh_errors_never_include_credentials_or_response_bodies() {
+        let mut server = spawn_http_sequence(vec![HttpResponse {
+            status: "500 Internal Server Error",
+            body: "response-body-secret".to_string(),
+            release: None,
+        }])
+        .await;
+        let provider = verlet_metadata::provider_store::LlmProviderRecord::new(
+            "redaction-fixture",
+            verlet_history::ProviderApi::OpenAIResponses,
+            format!("{}/v1", server.base_url),
+        )
+        .with_auth_header(true);
+
+        let error = super::fetch_models(
+            &provider,
+            &super::RefreshCredential::ApiKey("credential-secret".to_string()),
+            std::time::Duration::from_secs(2),
+        )
+        .await
+        .unwrap_err();
+
+        let message = error.to_string();
+        assert!(!message.contains("credential-secret"));
+        assert!(!message.contains("response-body-secret"));
+        assert_eq!(message, "HTTP status was not successful");
+        let request = next_request(&mut server).await;
+        assert!(request.starts_with("GET /v1/models HTTP/1.1"));
+    }
+
+    #[tokio::test]
+    async fn missing_cache_reads_are_immediate_and_single_flight() {
+        let release = std::sync::Arc::new(tokio::sync::Semaphore::new(0));
+        let mut server = spawn_http_sequence(vec![
+            HttpResponse::ok(r#"{"data":[{"id":"live-model"}]}"#)
+                .gated(std::sync::Arc::clone(&release)),
+            HttpResponse::ok(r#"{"data":[{"id":"unexpected-second-request"}]}"#),
+        ])
+        .await;
+        let provider = verlet_metadata::provider_store::LlmProviderRecord::new(
+            "single-flight-fixture",
+            verlet_history::ProviderApi::OpenAIChatCompletions,
+            format!("{}/v1", server.base_url),
+        )
+        .with_auth_header(true);
+        let cache = std::sync::Arc::new(super::LiveModelCache::new());
+        let tasks =
+            std::sync::Arc::new(crate::adapters::app_server::lifecycle::InstanceTaskSet::new());
+        let credential = super::RefreshCredential::ApiKey("fixture-key".to_string());
+
+        for _ in 0..16 {
+            assert!(
+                cache
+                    .entries_and_refresh(&tasks, &provider, credential.clone())
+                    .is_empty()
+            );
+        }
+        let request = next_request(&mut server).await;
+        assert!(request.starts_with("GET /v1/models HTTP/1.1"));
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), server.requests.recv(),)
+                .await
+                .is_err()
+        );
+
+        release.add_permits(1);
+        wait_until_idle(&cache, "single-flight-fixture").await;
+        let models = cache.entries_and_refresh(&tasks, &provider, credential);
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].model_id, "live-model");
+        tasks.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn expired_cache_entry_triggers_exactly_one_refresh() {
+        let release = std::sync::Arc::new(tokio::sync::Semaphore::new(0));
+        let mut server = spawn_http_sequence(vec![
+            HttpResponse::ok(r#"{"data":[{"id":"refreshed-model"}]}"#)
+                .gated(std::sync::Arc::clone(&release)),
+            HttpResponse::ok(r#"{"data":[{"id":"unexpected-second-request"}]}"#),
+        ])
+        .await;
+        let provider = verlet_metadata::provider_store::LlmProviderRecord::new(
+            "ttl-fixture",
+            verlet_history::ProviderApi::OpenAIChatCompletions,
+            format!("{}/v1", server.base_url),
+        )
+        .with_auth_header(true);
+        let cache = std::sync::Arc::new(super::LiveModelCache::new());
+        cache.seed_for_test(
+            &provider,
+            vec![super::LiveModel {
+                provider_id: provider.provider_id.clone(),
+                model_id: "stale-model".to_string(),
+                display_name: "Stale Model".to_string(),
+            }],
+            super::REFRESH_INTERVAL + std::time::Duration::from_secs(1),
+        );
+        let tasks =
+            std::sync::Arc::new(crate::adapters::app_server::lifecycle::InstanceTaskSet::new());
+        let credential = super::RefreshCredential::ApiKey("fixture-key".to_string());
+
+        for _ in 0..16 {
+            let models = cache.entries_and_refresh(&tasks, &provider, credential.clone());
+            assert_eq!(models[0].model_id, "stale-model");
+        }
+        let _request = next_request(&mut server).await;
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), server.requests.recv(),)
+                .await
+                .is_err()
+        );
+
+        release.add_permits(1);
+        wait_until_idle(&cache, "ttl-fixture").await;
+        let models = cache.entries_and_refresh(&tasks, &provider, credential);
+        assert_eq!(models[0].model_id, "refreshed-model");
+        tasks.shutdown().await;
+    }
+}

--- a/crates/verlet-kernel/src/adapters/app_server/live_models.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/live_models.rs
@@ -30,17 +30,41 @@ impl std::fmt::Debug for RefreshCredential {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+enum CredentialFingerprint {
+    ApiKey([u8; 32]),
+    None,
+}
+
+impl From<&RefreshCredential> for CredentialFingerprint {
+    fn from(credential: &RefreshCredential) -> Self {
+        match credential {
+            RefreshCredential::ApiKey(key) => {
+                use sha2::Digest as _;
+
+                Self::ApiKey(sha2::Sha256::digest(key.as_bytes()).into())
+            }
+            RefreshCredential::None => Self::None,
+        }
+    }
+}
+
+#[derive(Clone, Eq, PartialEq)]
 struct ProviderFingerprint {
     api: verlet_history::ProviderApi,
     base_url: String,
+    credential: CredentialFingerprint,
 }
 
-impl From<&verlet_metadata::provider_store::LlmProviderRecord> for ProviderFingerprint {
-    fn from(provider: &verlet_metadata::provider_store::LlmProviderRecord) -> Self {
+impl ProviderFingerprint {
+    fn new(
+        provider: &verlet_metadata::provider_store::LlmProviderRecord,
+        credential: &RefreshCredential,
+    ) -> Self {
         Self {
             api: provider.api.clone(),
             base_url: provider.base_url.clone(),
+            credential: CredentialFingerprint::from(credential),
         }
     }
 }
@@ -80,7 +104,7 @@ impl LiveModelCache {
         provider: &verlet_metadata::provider_store::LlmProviderRecord,
         credential: RefreshCredential,
     ) -> Vec<LiveModel> {
-        let fingerprint = ProviderFingerprint::from(provider);
+        let fingerprint = ProviderFingerprint::new(provider, &credential);
         let now = tokio::time::Instant::now();
         let (models, stale) = {
             let entries = self
@@ -103,7 +127,12 @@ impl LiveModelCache {
             let provider_id = refresh_id.clone();
             let cache = std::sync::Arc::clone(self);
             let request_timeout = self.request_timeout;
-            let accepted = tasks.spawn_cancellable(async move {
+            let refresh_marker = RefreshMarker {
+                cache: std::sync::Arc::clone(self),
+                provider_id: refresh_id,
+            };
+            tasks.spawn_cancellable(async move {
+                let _refresh_marker = refresh_marker;
                 match fetch_models(&provider, &credential, request_timeout).await {
                     Ok(models) => cache.finish_refresh(
                         provider_id,
@@ -126,9 +155,6 @@ impl LiveModelCache {
                     }
                 }
             });
-            if !accepted {
-                self.clear_refresh(&refresh_id);
-            }
         }
         models
     }
@@ -187,7 +213,6 @@ impl LiveModelCache {
                 },
             }
         }
-        self.clear_refresh(&provider_id);
     }
 
     #[cfg(test)]
@@ -202,6 +227,7 @@ impl LiveModelCache {
     fn seed_for_test(
         &self,
         provider: &verlet_metadata::provider_store::LlmProviderRecord,
+        credential: &RefreshCredential,
         models: Vec<LiveModel>,
         age: std::time::Duration,
     ) {
@@ -211,11 +237,22 @@ impl LiveModelCache {
             .insert(
                 provider.provider_id.clone(),
                 CachedModels {
-                    fingerprint: ProviderFingerprint::from(provider),
+                    fingerprint: ProviderFingerprint::new(provider, credential),
                     models,
                     checked_at: tokio::time::Instant::now() - age,
                 },
             );
+    }
+}
+
+struct RefreshMarker {
+    cache: std::sync::Arc<LiveModelCache>,
+    provider_id: String,
+}
+
+impl Drop for RefreshMarker {
+    fn drop(&mut self) {
+        self.cache.clear_refresh(&self.provider_id);
     }
 }
 
@@ -595,7 +632,6 @@ mod tests {
         let mut server = spawn_http_sequence(vec![
             HttpResponse::ok(r#"{"data":[{"id":"live-model"}]}"#)
                 .gated(std::sync::Arc::clone(&release)),
-            HttpResponse::ok(r#"{"data":[{"id":"unexpected-second-request"}]}"#),
         ])
         .await;
         let provider = verlet_metadata::provider_store::LlmProviderRecord::new(
@@ -618,11 +654,7 @@ mod tests {
         }
         let request = next_request(&mut server).await;
         assert!(request.starts_with("GET /v1/models HTTP/1.1"));
-        assert!(
-            tokio::time::timeout(std::time::Duration::from_millis(50), server.requests.recv(),)
-                .await
-                .is_err()
-        );
+        assert_eq!(tasks.task_count(), 1);
 
         release.add_permits(1);
         wait_until_idle(&cache, "single-flight-fixture").await;
@@ -638,7 +670,6 @@ mod tests {
         let mut server = spawn_http_sequence(vec![
             HttpResponse::ok(r#"{"data":[{"id":"refreshed-model"}]}"#)
                 .gated(std::sync::Arc::clone(&release)),
-            HttpResponse::ok(r#"{"data":[{"id":"unexpected-second-request"}]}"#),
         ])
         .await;
         let provider = verlet_metadata::provider_store::LlmProviderRecord::new(
@@ -650,6 +681,7 @@ mod tests {
         let cache = std::sync::Arc::new(super::LiveModelCache::new());
         cache.seed_for_test(
             &provider,
+            &super::RefreshCredential::ApiKey("fixture-key".to_string()),
             vec![super::LiveModel {
                 provider_id: provider.provider_id.clone(),
                 model_id: "stale-model".to_string(),
@@ -666,16 +698,135 @@ mod tests {
             assert_eq!(models[0].model_id, "stale-model");
         }
         let _request = next_request(&mut server).await;
-        assert!(
-            tokio::time::timeout(std::time::Duration::from_millis(50), server.requests.recv(),)
-                .await
-                .is_err()
-        );
+        assert_eq!(tasks.task_count(), 1);
 
         release.add_permits(1);
         wait_until_idle(&cache, "ttl-fixture").await;
         let models = cache.entries_and_refresh(&tasks, &provider, credential);
         assert_eq!(models[0].model_id, "refreshed-model");
+        tasks.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn failed_refresh_is_not_retried_before_the_ttl() {
+        let release = std::sync::Arc::new(tokio::sync::Semaphore::new(0));
+        let mut server = spawn_http_sequence(vec![
+            HttpResponse {
+                status: "500 Internal Server Error",
+                body: String::new(),
+                release: None,
+            },
+            HttpResponse::ok(r#"{"data":[]}"#).gated(std::sync::Arc::clone(&release)),
+        ])
+        .await;
+        let provider = verlet_metadata::provider_store::LlmProviderRecord::new(
+            "failed-refresh-fixture",
+            verlet_history::ProviderApi::OpenAIChatCompletions,
+            format!("{}/v1", server.base_url),
+        )
+        .with_auth_header(true);
+        let cache = std::sync::Arc::new(super::LiveModelCache::new());
+        let tasks =
+            std::sync::Arc::new(crate::adapters::app_server::lifecycle::InstanceTaskSet::new());
+        let credential = super::RefreshCredential::ApiKey("fixture-key".to_string());
+
+        cache.entries_and_refresh(&tasks, &provider, credential.clone());
+        let _request = next_request(&mut server).await;
+        wait_until_idle(&cache, "failed-refresh-fixture").await;
+
+        assert!(
+            cache
+                .entries_and_refresh(&tasks, &provider, credential)
+                .is_empty()
+        );
+        assert!(
+            !cache.is_refreshing_for_test("failed-refresh-fixture"),
+            "a failed refresh must advance checked_at and suppress retries until the TTL"
+        );
+        tasks.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn cancellation_clears_the_single_flight_marker() {
+        let release = std::sync::Arc::new(tokio::sync::Semaphore::new(0));
+        let mut server = spawn_http_sequence(vec![
+            HttpResponse::ok(r#"{"data":[]}"#).gated(std::sync::Arc::clone(&release)),
+        ])
+        .await;
+        let provider = verlet_metadata::provider_store::LlmProviderRecord::new(
+            "cancelled-refresh-fixture",
+            verlet_history::ProviderApi::OpenAIChatCompletions,
+            format!("{}/v1", server.base_url),
+        )
+        .with_auth_header(true);
+        let cache = std::sync::Arc::new(super::LiveModelCache::new());
+        let tasks =
+            std::sync::Arc::new(crate::adapters::app_server::lifecycle::InstanceTaskSet::new());
+
+        cache.entries_and_refresh(
+            &tasks,
+            &provider,
+            super::RefreshCredential::ApiKey("fixture-key".to_string()),
+        );
+        let _request = next_request(&mut server).await;
+        assert!(cache.is_refreshing_for_test("cancelled-refresh-fixture"));
+
+        tasks.shutdown().await;
+
+        assert!(!cache.is_refreshing_for_test("cancelled-refresh-fixture"));
+    }
+
+    #[tokio::test]
+    async fn credential_changes_do_not_serve_models_from_the_previous_credential() {
+        let mut server = spawn_http_sequence(vec![
+            HttpResponse::ok(r#"{"data":[{"id":"old-account-model"}]}"#),
+            HttpResponse::ok(r#"{"data":[{"id":"new-account-model"}]}"#),
+        ])
+        .await;
+        let provider = verlet_metadata::provider_store::LlmProviderRecord::new(
+            "credential-change-fixture",
+            verlet_history::ProviderApi::OpenAIChatCompletions,
+            format!("{}/v1", server.base_url),
+        )
+        .with_auth_header(true);
+        let cache = std::sync::Arc::new(super::LiveModelCache::new());
+        let tasks =
+            std::sync::Arc::new(crate::adapters::app_server::lifecycle::InstanceTaskSet::new());
+
+        cache.entries_and_refresh(
+            &tasks,
+            &provider,
+            super::RefreshCredential::ApiKey("old-account-key".to_string()),
+        );
+        let _request = next_request(&mut server).await;
+        wait_until_idle(&cache, "credential-change-fixture").await;
+        assert_eq!(
+            cache.entries_and_refresh(
+                &tasks,
+                &provider,
+                super::RefreshCredential::ApiKey("old-account-key".to_string()),
+            )[0]
+            .model_id,
+            "old-account-model"
+        );
+
+        let after_change = cache.entries_and_refresh(
+            &tasks,
+            &provider,
+            super::RefreshCredential::ApiKey("new-account-key".to_string()),
+        );
+        assert!(
+            after_change.is_empty(),
+            "models fetched with the previous credential must not cross the credential boundary"
+        );
+        let _request = next_request(&mut server).await;
+        wait_until_idle(&cache, "credential-change-fixture").await;
+        let models = cache.entries_and_refresh(
+            &tasks,
+            &provider,
+            super::RefreshCredential::ApiKey("new-account-key".to_string()),
+        );
+        assert_eq!(models[0].model_id, "new-account-model");
         tasks.shutdown().await;
     }
 }

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -3652,6 +3652,7 @@ async fn model_list_does_not_call_uncredentialed_or_oauth_provider_endpoints() {
             .any(|entry| entry["model"] == "oauth-catalog-model")
     );
     assert!(
+        // tight-timeout: an ineligible missing-auth provider must make no model-list request
         tokio::time::timeout(
             std::time::Duration::from_millis(100),
             missing_listener.accept(),
@@ -3660,6 +3661,7 @@ async fn model_list_does_not_call_uncredentialed_or_oauth_provider_endpoints() {
         .is_err()
     );
     assert!(
+        // tight-timeout: an OAuth provider must make no API-key model-list request
         tokio::time::timeout(
             std::time::Duration::from_millis(100),
             oauth_listener.accept(),
@@ -3777,6 +3779,7 @@ async fn slow_failing_live_endpoint_does_not_delay_or_break_model_list() {
         .unwrap();
     let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
+    // tight-timeout: model/list must return without waiting on a gated live endpoint
     let first = tokio::time::timeout(
         std::time::Duration::from_secs(1),
         app.dispatch_request(&connection, "model/list", None),
@@ -3793,6 +3796,7 @@ async fn slow_failing_live_endpoint_does_not_delay_or_break_model_list() {
     );
     let captured = request.await.unwrap();
     assert!(captured.starts_with("GET /v1/models HTTP/1.1"));
+    // tight-timeout: model/list must return while a live refresh remains in flight
     let second = tokio::time::timeout(
         std::time::Duration::from_secs(1),
         app.dispatch_request(&connection, "model/list", None),
@@ -18835,7 +18839,7 @@ async fn wait_for_model_list_entry(
     provider_id: &str,
     model_id: &str,
 ) -> serde_json::Value {
-    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+    tokio::time::timeout(std::time::Duration::from_secs(30), async {
         loop {
             let models = app
                 .dispatch_request(connection, "model/list", None)

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -18960,8 +18960,7 @@ async fn spawn_provider_sse_with_model_list_fixture(body: impl Into<String>) -> 
     let body = body.into();
     let request = tokio::spawn(async move {
         let mut turn_request = None;
-        let mut served_model_list = false;
-        while turn_request.is_none() || !served_model_list {
+        while turn_request.is_none() {
             let (mut stream, _) = listener.accept().await.unwrap();
             let request = read_provider_fixture_request(&mut stream).await;
             if request.starts_with("GET /v1/models HTTP/1.1") {
@@ -18972,7 +18971,6 @@ async fn spawn_provider_sse_with_model_list_fixture(body: impl Into<String>) -> 
                     list_body,
                 );
                 stream.write_all(response.as_bytes()).await.unwrap();
-                served_model_list = true;
             } else {
                 assert!(
                     request.starts_with("POST "),

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -3480,6 +3480,346 @@ async fn model_list_scopes_catalog_models_to_store_configured_providers() {
 }
 
 #[tokio::test]
+async fn model_list_unions_catalog_and_live_models_with_catalog_metadata_winning() {
+    let server =
+        spawn_provider_sse_fixture(r#"{"data":[{"id":"gpt-5.2"},{"id":"gpt-live-only"}]}"#).await;
+    let root = unique_test_root("app-server-model-list-live-union");
+    let config = test_config_at_root(&root);
+    let project_store =
+        verlet_metadata::provider_store::SqliteMetadataStore::open(config.metadata_store_path())
+            .await
+            .unwrap();
+    project_store
+        .upsert_provider(
+            verlet_metadata::provider_store::LlmProviderRecord::new(
+                "openai",
+                verlet_history::ProviderApi::OpenAIChatCompletions,
+                format!("{}/v1", server.base_url),
+            )
+            .with_auth_header(true)
+            .with_model(
+                verlet_metadata::provider_store::LlmProviderModelRecord::new("gpt-5.2")
+                    .with_display_name("Stored GPT 5.2")
+                    .with_context_window_tokens(777)
+                    .with_max_output_tokens(333),
+            ),
+        )
+        .await
+        .unwrap();
+    let user_store = verlet_metadata::provider_store::SqliteMetadataStore::open(
+        config.user_metadata_store_path(),
+    )
+    .await
+    .unwrap();
+    user_store
+        .set_credential(
+            "openai",
+            verlet_metadata::provider_store::LlmProviderCredential::ApiKey {
+                key: "live-list-secret".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    drop(project_store);
+    drop(user_store);
+
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    let first = app
+        .dispatch_request(&connection, "model/list", None)
+        .await
+        .unwrap();
+    assert!(
+        first["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|entry| entry["model"] != "gpt-live-only")
+    );
+
+    let request = server.request.await.unwrap();
+    let request_lower = request.to_ascii_lowercase();
+    assert!(request.starts_with("GET /v1/models HTTP/1.1"));
+    assert!(request_lower.contains("authorization: bearer live-list-secret"));
+    let models = wait_for_model_list_entry(&app, &connection, "openai", "gpt-live-only").await;
+    let data = models["data"].as_array().unwrap();
+    let stored = data
+        .iter()
+        .find(|entry| entry["providerId"] == "openai" && entry["model"] == "gpt-5.2")
+        .unwrap();
+    assert_eq!(
+        data.iter()
+            .filter(|entry| entry["providerId"] == "openai" && entry["model"] == "gpt-5.2")
+            .count(),
+        1
+    );
+    assert_eq!(stored["displayName"], "Stored GPT 5.2");
+    assert_eq!(stored["contextWindowTokens"], 777);
+    assert_eq!(stored["maxOutputTokens"], 333);
+    assert!(stored.get("origin").is_none());
+    let live = data
+        .iter()
+        .find(|entry| entry["providerId"] == "openai" && entry["model"] == "gpt-live-only")
+        .unwrap();
+    assert_eq!(live["origin"], "live");
+    assert_eq!(live["contextWindowTokens"], serde_json::Value::Null);
+    assert_eq!(live["maxOutputTokens"], serde_json::Value::Null);
+    assert!(
+        !serde_json::to_string(&models)
+            .unwrap()
+            .contains("live-list-secret")
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn model_list_does_not_call_uncredentialed_or_oauth_provider_endpoints() {
+    let missing_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let oauth_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let root = unique_test_root("app-server-model-list-live-ineligible-auth");
+    let config = test_config_at_root(&root);
+    let project_store =
+        verlet_metadata::provider_store::SqliteMetadataStore::open(config.metadata_store_path())
+            .await
+            .unwrap();
+    for provider in [
+        verlet_metadata::provider_store::LlmProviderRecord::new(
+            "missing-live-auth",
+            verlet_history::ProviderApi::OpenAIChatCompletions,
+            format!("http://{}/v1", missing_listener.local_addr().unwrap()),
+        )
+        .with_auth_header(true)
+        .with_model(
+            verlet_metadata::provider_store::LlmProviderModelRecord::new("missing-catalog-model"),
+        ),
+        verlet_metadata::provider_store::LlmProviderRecord::new(
+            "oauth-live-auth",
+            verlet_history::ProviderApi::OpenAIResponses,
+            format!("http://{}/v1", oauth_listener.local_addr().unwrap()),
+        )
+        .with_auth_header(true)
+        .with_model(
+            verlet_metadata::provider_store::LlmProviderModelRecord::new("oauth-catalog-model"),
+        ),
+    ] {
+        project_store.upsert_provider(provider).await.unwrap();
+    }
+    let user_store = verlet_metadata::provider_store::SqliteMetadataStore::open(
+        config.user_metadata_store_path(),
+    )
+    .await
+    .unwrap();
+    user_store
+        .set_credential(
+            "oauth-live-auth",
+            verlet_metadata::provider_store::LlmProviderCredential::OAuth {
+                access: "oauth-live-secret".to_string(),
+                refresh: "oauth-refresh-secret".to_string(),
+                expires_at_ms: verlet_history::now_ms() + 3_600_000,
+                account_id: None,
+                email: None,
+            },
+        )
+        .await
+        .unwrap();
+    drop(project_store);
+    drop(user_store);
+
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    let models = app
+        .dispatch_request(&connection, "model/list", None)
+        .await
+        .unwrap();
+    assert!(
+        models["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["model"] == "missing-catalog-model")
+    );
+    assert!(
+        models["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["model"] == "oauth-catalog-model")
+    );
+    assert!(
+        tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            missing_listener.accept(),
+        )
+        .await
+        .is_err()
+    );
+    assert!(
+        tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            oauth_listener.accept(),
+        )
+        .await
+        .is_err()
+    );
+    let encoded = serde_json::to_string(&models).unwrap();
+    assert!(!encoded.contains("oauth-live-secret"));
+    assert!(!encoded.contains("oauth-refresh-secret"));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn model_list_enriches_keyless_provider_without_authorization() {
+    let server = spawn_provider_sse_fixture(r#"{"data":[{"id":"keyless-live-model"}]}"#).await;
+    let root = unique_test_root("app-server-model-list-live-keyless");
+    let config = test_config_at_root(&root);
+    let project_store =
+        verlet_metadata::provider_store::SqliteMetadataStore::open(config.metadata_store_path())
+            .await
+            .unwrap();
+    project_store
+        .upsert_provider(
+            verlet_metadata::provider_store::LlmProviderRecord::new(
+                "keyless-live",
+                verlet_history::ProviderApi::OpenAIChatCompletions,
+                format!("{}/v1", server.base_url),
+            )
+            .with_auth(verlet_metadata::provider_store::LlmProviderAuthConfig::None)
+            .with_auth_header(false),
+        )
+        .await
+        .unwrap();
+    drop(project_store);
+
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    let first = app
+        .dispatch_request(&connection, "model/list", None)
+        .await
+        .unwrap();
+    assert!(first["data"].as_array().unwrap().iter().all(|entry| {
+        entry["providerId"] != "keyless-live" || entry["model"] != "keyless-live-model"
+    }));
+    let request = server.request.await.unwrap();
+    assert!(request.starts_with("GET /v1/models HTTP/1.1"));
+    assert!(!request.to_ascii_lowercase().contains("authorization:"));
+    let models =
+        wait_for_model_list_entry(&app, &connection, "keyless-live", "keyless-live-model").await;
+    let row = models["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["providerId"] == "keyless-live")
+        .unwrap();
+    assert_eq!(row["origin"], "live");
+    assert_eq!(row["authStatus"], "configured");
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn slow_failing_live_endpoint_does_not_delay_or_break_model_list() {
+    let fixture =
+        spawn_gated_model_list_fixture("500 Internal Server Error", "failure-response-secret")
+            .await;
+    let GatedModelListFixture {
+        base_url,
+        request,
+        release,
+        task,
+    } = fixture;
+    let root = unique_test_root("app-server-model-list-live-slow-failure");
+    let config = test_config_at_root(&root);
+    let project_store =
+        verlet_metadata::provider_store::SqliteMetadataStore::open(config.metadata_store_path())
+            .await
+            .unwrap();
+    project_store
+        .upsert_provider(
+            verlet_metadata::provider_store::LlmProviderRecord::new(
+                "slow-live",
+                verlet_history::ProviderApi::OpenAIChatCompletions,
+                format!("{base_url}/v1"),
+            )
+            .with_auth_header(true)
+            .with_model(
+                verlet_metadata::provider_store::LlmProviderModelRecord::new("slow-catalog-model"),
+            ),
+        )
+        .await
+        .unwrap();
+    let user_store = verlet_metadata::provider_store::SqliteMetadataStore::open(
+        config.user_metadata_store_path(),
+    )
+    .await
+    .unwrap();
+    user_store
+        .set_credential(
+            "slow-live",
+            verlet_metadata::provider_store::LlmProviderCredential::ApiKey {
+                key: "slow-live-secret".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    drop(project_store);
+    drop(user_store);
+
+    let app = crate::adapters::app_server::VerletAppServer::new_local(config)
+        .await
+        .unwrap();
+    let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    initialize_for_test(&connection).await;
+    let first = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        app.dispatch_request(&connection, "model/list", None),
+    )
+    .await
+    .expect("model/list waited for the live endpoint")
+    .unwrap();
+    assert!(
+        first["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["model"] == "slow-catalog-model")
+    );
+    let captured = request.await.unwrap();
+    assert!(captured.starts_with("GET /v1/models HTTP/1.1"));
+    let second = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        app.dispatch_request(&connection, "model/list", None),
+    )
+    .await
+    .expect("model/list waited for an in-flight live endpoint")
+    .unwrap();
+    assert!(
+        second["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["model"] == "slow-catalog-model")
+    );
+    release.add_permits(1);
+    task.await.unwrap();
+    let third = app
+        .dispatch_request(&connection, "model/list", None)
+        .await
+        .unwrap();
+    let encoded = serde_json::to_string(&third).unwrap();
+    assert!(!encoded.contains("slow-live-secret"));
+    assert!(!encoded.contains("failure-response-secret"));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
 async fn model_provider_catalog_merges_catalog_metadata_with_store_state() {
     const ENV_NAME: &str = "VERLET_CATALOG_MERGE_ENV_FIXTURE";
     let root = unique_test_root("app-server-provider-catalog-merge");
@@ -4359,7 +4699,7 @@ async fn model_list_suppresses_the_launch_row_when_another_model_is_active() {
 
 #[tokio::test]
 async fn model_select_routes_anthropic_store_provider_with_stored_key() {
-    let server = spawn_provider_sse_fixture(concat!(
+    let server = spawn_provider_sse_with_model_list_fixture(concat!(
         "event: message_start\n",
         "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":3}}}\n\n",
         "event: content_block_delta\n",
@@ -4515,7 +4855,7 @@ async fn model_select_routes_anthropic_store_provider_with_stored_key() {
 
 #[tokio::test]
 async fn model_select_routes_generic_openai_responses_store_provider() {
-    let server = spawn_provider_sse_fixture(concat!(
+    let server = spawn_provider_sse_with_model_list_fixture(concat!(
         "event: response.output_text.delta\n",
         "data: {\"type\":\"response.output_text.delta\",\"delta\":\"RESPONSES_STORE_OK\"}\n\n",
         "event: response.completed\n",
@@ -4696,7 +5036,7 @@ async fn model_select_routes_auth_free_responses_without_authorization() {
 /// routed turn that sends no Authorization header.
 #[tokio::test]
 async fn keyless_custom_provider_counts_configured_and_routes_without_authorization() {
-    let server = spawn_provider_sse_fixture(concat!(
+    let server = spawn_provider_sse_with_model_list_fixture(concat!(
         "data: {\"choices\":[{\"delta\":{\"content\":\"KEYLESS_OK\"},\"finish_reason\":null}]}\n\n",
         "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2}}\n\n",
         "data: [DONE]\n\n",
@@ -18489,6 +18829,80 @@ async fn assert_latest_assistant_coordinates(
     assert_eq!(model, expected_model);
 }
 
+async fn wait_for_model_list_entry(
+    app: &crate::adapters::app_server::VerletAppServer,
+    connection: &crate::adapters::app_server::connection::ConnectionState,
+    provider_id: &str,
+    model_id: &str,
+) -> serde_json::Value {
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            let models = app
+                .dispatch_request(connection, "model/list", None)
+                .await
+                .unwrap();
+            if models["data"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|entry| entry["providerId"] == provider_id && entry["model"] == model_id)
+            {
+                break models;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("live model did not reach model/list")
+}
+
+struct GatedModelListFixture {
+    base_url: String,
+    request: tokio::sync::oneshot::Receiver<String>,
+    release: std::sync::Arc<tokio::sync::Semaphore>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+async fn spawn_gated_model_list_fixture(
+    status: &'static str,
+    body: &'static str,
+) -> GatedModelListFixture {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let (request_tx, request_rx) = tokio::sync::oneshot::channel();
+    let release = std::sync::Arc::new(tokio::sync::Semaphore::new(0));
+    let task_release = std::sync::Arc::clone(&release);
+    let task = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = Vec::new();
+        loop {
+            let mut chunk = [0_u8; 1024];
+            let read = stream.read(&mut chunk).await.unwrap();
+            assert!(read > 0, "model-list request ended before its headers");
+            request.extend_from_slice(&chunk[..read]);
+            if request.windows(4).any(|bytes| bytes == b"\r\n\r\n") {
+                break;
+            }
+        }
+        request_tx
+            .send(String::from_utf8(request).unwrap())
+            .unwrap();
+        let permit = task_release.acquire().await.unwrap();
+        permit.forget();
+        let response = format!(
+            "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+            body.len(),
+        );
+        stream.write_all(response.as_bytes()).await.unwrap();
+    });
+    GatedModelListFixture {
+        base_url: format!("http://{address}"),
+        request: request_rx,
+        release,
+        task,
+    }
+}
+
 struct ProviderSseFixture {
     base_url: String,
     request: tokio::task::JoinHandle<String>,
@@ -18538,6 +18952,76 @@ async fn spawn_provider_sse_fixture(body: impl Into<String>) -> ProviderSseFixtu
         base_url: format!("http://{address}"),
         request,
     }
+}
+
+async fn spawn_provider_sse_with_model_list_fixture(body: impl Into<String>) -> ProviderSseFixture {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let body = body.into();
+    let request = tokio::spawn(async move {
+        let mut turn_request = None;
+        let mut served_model_list = false;
+        while turn_request.is_none() || !served_model_list {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request = read_provider_fixture_request(&mut stream).await;
+            if request.starts_with("GET /v1/models HTTP/1.1") {
+                let list_body = r#"{"data":[]}"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    list_body.len(),
+                    list_body,
+                );
+                stream.write_all(response.as_bytes()).await.unwrap();
+                served_model_list = true;
+            } else {
+                assert!(
+                    request.starts_with("POST "),
+                    "unexpected provider request: {request}"
+                );
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    body.len(),
+                    body,
+                );
+                stream.write_all(response.as_bytes()).await.unwrap();
+                turn_request = Some(request);
+            }
+        }
+        turn_request.unwrap()
+    });
+    ProviderSseFixture {
+        base_url: format!("http://{address}"),
+        request,
+    }
+}
+
+async fn read_provider_fixture_request(stream: &mut tokio::net::TcpStream) -> String {
+    let mut buffer = Vec::new();
+    let header_end = loop {
+        let mut chunk = [0_u8; 1024];
+        let read = stream.read(&mut chunk).await.unwrap();
+        assert!(read > 0, "provider request ended before its headers");
+        buffer.extend_from_slice(&chunk[..read]);
+        if let Some(index) = find_http_header_end(&buffer) {
+            break index;
+        }
+    };
+    let content_length = String::from_utf8_lossy(&buffer[..header_end])
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().unwrap())
+        })
+        .unwrap_or(0);
+    let request_end = header_end + 4 + content_length;
+    while buffer.len() < request_end {
+        let mut chunk = [0_u8; 1024];
+        let read = stream.read(&mut chunk).await.unwrap();
+        assert!(read > 0, "provider request ended before its body");
+        buffer.extend_from_slice(&chunk[..read]);
+    }
+    String::from_utf8(buffer[..request_end].to_vec()).unwrap()
 }
 
 fn unique_test_root(name: &str) -> std::path::PathBuf {

--- a/crates/verlet-provider/src/lib.rs
+++ b/crates/verlet-provider/src/lib.rs
@@ -13,6 +13,7 @@ use sha2::Digest as _;
 /// `openai_compatible` id is a fixture-only example for this public checkout.
 const ZHIPU_CONVENTION_CHAT_PROVIDERS: &[&str] = &["openai_compatible", "zhipu", "glm"];
 const BEDROCK_ANTHROPIC_VERSION: &str = "bedrock-2023-05-31";
+pub const ANTHROPIC_API_VERSION: &str = "2023-06-01";
 const AWS_SIGV4_ALGORITHM: &str = "AWS4-HMAC-SHA256";
 type HmacSha256 = hmac::Hmac<sha2::Sha256>;
 
@@ -830,7 +831,10 @@ impl ProviderEndpoint {
         Self {
             url: provider_endpoint_url(base_url.as_ref(), "messages"),
             auth: ProviderAuth::AnthropicApiKey { key: key.into() },
-            headers: vec![("anthropic-version".to_string(), "2023-06-01".to_string())],
+            headers: vec![(
+                "anthropic-version".to_string(),
+                ANTHROPIC_API_VERSION.to_string(),
+            )],
         }
     }
 

--- a/docs/app-server.md
+++ b/docs/app-server.md
@@ -748,6 +748,14 @@ selection, absent from the composed list, and either explicitly requested at
 launch or backed by a store record; the default offline echo pair therefore
 stays hidden on a fresh install, though submitting turns against it still
 works.
+For configured providers with a stored API key, an environment API key, or
+`auth: none`, the list is also enriched from the provider's own models API.
+Results are cached in memory per provider for one hour. A missing or stale
+entry starts a background refresh while `model/list` immediately serves cached
+or catalog data. Models contributed only by this live source carry
+`"origin": "live"`; catalog and store rows keep their existing shape. Live
+enrichment uses only the provider record's stored base URL and does not change
+the endpoint trust rules. OAuth providers are not queried by this path.
 Each entry includes `providerId`, `model`, `displayName`, `authStatus`
 (`configured`, `env`, or `missing`), and `active`. Compatibility fields such
 as `id` and `isDefault` remain present; `isDefault` follows the session's active


### PR DESCRIPTION
## Summary

`model/list` now unions in models from each configured provider's own list-models endpoint, so brand-new models are usable before the models.dev catalog picks them up.

- New in-memory live cache per provider: one-hour TTL, single-flight background refresh on the instance task set, four-second request timeout, no redirects, 1 MiB / 10k-model response caps. `model/list` never awaits network work.
- Eligibility: store-configured providers whose auth resolves to a stored API key, an environment key, or keyless (`auth: none`, no Authorization header). OAuth providers are skipped.
- Live-only rows carry an additive `origin: "live"` field and null limits; store/catalog rows keep their shape and win dedupe.
- Cache entries are fingerprinted by API family, base URL, and a credential digest, so endpoint or key changes cannot serve stale results. A drop guard clears the single-flight marker on cancellation.
- Endpoint trust rules from EMO-582 are unchanged: requests go only to the record's stored base URL.

Closes EMO-583.

## Verification

- `scripts/verify.sh` green locally (macOS), `scripts/verify-linux.sh` green (Linux lane)
- New tests: union/dedupe with catalog precedence, slow and failing endpoints never delay `model/list`, no requests without credentials, OAuth exclusion, keyless request carries no Authorization header, single-flight and TTL determinism, credential-change isolation, secret redaction
- Anthropic `/v1/models` path and `anthropic-version` header verified against current official docs