### PR TITLE
Derive thread toolsets from the bindings fold; delta emission at rebind (EMO-585)

### DIFF
--- a/crates/verlet-kernel/src/adapters/agent_loop.rs
+++ b/crates/verlet-kernel/src/adapters/agent_loop.rs
@@ -4437,7 +4437,10 @@ async fn prepare_tool_results(
     .unwrap_or_else(|| "unbound".to_string());
     let calls_with_snapshots = tool_calls
         .into_iter()
-        .map(|tool_call| (tool_call, active_snapshot_id.clone()))
+        .map(|tool_call| {
+            let attach_event_id = tool_router.attach_event_id_for_tool_name(&tool_call.name);
+            (tool_call, active_snapshot_id.clone(), attach_event_id)
+        })
         .collect::<Vec<_>>();
     let request_events = append_tool_call_requested_events(
         services,
@@ -4447,7 +4450,7 @@ async fn prepare_tool_results(
     )
     .await?;
     let mut witnessed_calls = Vec::with_capacity(calls_with_snapshots.len());
-    for ((tool_call, active_snapshot_id), request_event) in
+    for ((tool_call, active_snapshot_id, _), request_event) in
         calls_with_snapshots.into_iter().zip(request_events)
     {
         let holds = decode_witnessed_tool_holds(&request_event)?;
@@ -5738,7 +5741,11 @@ async fn append_turn_resumed_event(
 async fn append_tool_call_requested_events(
     services: &crate::kernel::runtime_host::runtime_services::RuntimeServices,
     turn_context: &crate::kernel::runtime_host::turn::TurnContext,
-    calls: &[(ProviderToolCall, String)],
+    calls: &[(
+        ProviderToolCall,
+        String,
+        Option<verlet_history::EventRecordId>,
+    )],
     assistant_entry_id: verlet_history::SessionEntryId,
 ) -> crate::kernel::runtime_host::VerletResult<Vec<verlet_history::EventRecord>> {
     let assistant_event_id =
@@ -5750,7 +5757,7 @@ async fn append_tool_call_requested_events(
                 ))
             })?;
     let mut records = Vec::with_capacity(calls.len());
-    for (tool_call, snapshot_id) in calls {
+    for (tool_call, snapshot_id, attach_event_id) in calls {
         let args_fingerprint =
             crate::agent::tool_universe::args_fingerprint(&tool_call.name, &tool_call.arguments)?;
         let mut payload =
@@ -5762,6 +5769,7 @@ async fn append_tool_call_requested_events(
                 snapshot_id: snapshot_id.clone(),
                 tool_name: tool_call.name.clone(),
                 arguments: tool_call.arguments.clone(),
+                attach_event_id: *attach_event_id,
                 args_fingerprint: Some(args_fingerprint),
                 holds: tool_holds::derive_tool_holds(&tool_call.name, &tool_call.arguments)
                     .into_iter()

--- a/crates/verlet-kernel/src/adapters/agent_loop/tests.rs
+++ b/crates/verlet-kernel/src/adapters/agent_loop/tests.rs
@@ -322,6 +322,7 @@ async fn append_recovery_request(
                     snapshot_id: "snapshot-recovery".to_string(),
                     tool_name: "recovery_tool".to_string(),
                     arguments,
+                    attach_event_id: None,
                     args_fingerprint: Some(fingerprint),
                     holds: Vec::new(),
                 })
@@ -824,6 +825,7 @@ async fn recovered_bash_rewrite_does_not_inherit_the_original_commands_lax_class
                 snapshot_id: "snapshot-recovery".to_string(),
                 tool_name: verlet_vbash::BASH_TOOL.to_string(),
                 arguments,
+                attach_event_id: None,
                 args_fingerprint: Some(fingerprint),
                 holds: Vec::new(),
             })
@@ -980,6 +982,7 @@ async fn turn_rerun_replays_witnessed_assistant_batch_without_redecode_mismatch(
                 arguments: arguments.clone(),
             },
             "snapshot-recovery".to_string(),
+            None,
         )],
         assistant_entry.entry_id,
     )
@@ -3931,6 +3934,7 @@ async fn persisted_round_accounting_rejects_a_request_without_an_assistant_sourc
                 snapshot_id: "unbound".to_string(),
                 tool_name: "thread_status".to_string(),
                 arguments: serde_json::json!({"task_name": "worker-a"}),
+                attach_event_id: None,
                 args_fingerprint: None,
                 holds: Vec::new(),
             })
@@ -4047,6 +4051,7 @@ async fn persisted_round_accounting_rejects_a_cross_turn_assistant_source() {
                     snapshot_id: "unbound".to_string(),
                     tool_name: "thread_status".to_string(),
                     arguments: serde_json::json!({"task_name": "worker-a"}),
+                    attach_event_id: None,
                     args_fingerprint: None,
                     holds: Vec::new(),
                 })
@@ -5612,6 +5617,7 @@ async fn detached_completion_retry_is_idempotent_before_and_after_a_store_failur
                             snapshot_id: "snapshot-1".to_string(),
                             tool_name: "thread_status".to_string(),
                             arguments: serde_json::json!({}),
+                            attach_event_id: None,
                             args_fingerprint: None,
                             holds: Vec::new(),
                         },
@@ -5872,6 +5878,7 @@ async fn legacy_completion_does_not_swallow_a_new_fingerprinted_completion() {
                     snapshot_id: "snapshot-recovery".to_string(),
                     tool_name: "recovery_tool".to_string(),
                     arguments: serde_json::json!({"input":"legacy"}),
+                    attach_event_id: None,
                     args_fingerprint: None,
                     holds: Vec::new(),
                 })
@@ -6082,6 +6089,7 @@ async fn resume_sweep_settles_only_dangling_calls_from_the_full_cancelled_turn_w
                 snapshot_id: "snapshot-cancelled".to_string(),
                 tool_name: "thread_status".to_string(),
                 arguments,
+                attach_event_id: None,
                 args_fingerprint: Some(fingerprint),
                 holds: Vec::new(),
             })
@@ -7996,6 +8004,7 @@ async fn kernel_thread_router() -> crate::agent::agent_tool_router::AgentToolRou
             tool_name: crate::operations::kernel_packages::THREAD_SPAWN_OPERATION.to_string(),
             registered_name: crate::operations::kernel_packages::VERLET_THREADS_PACKAGE.to_string(),
             operation_name: crate::operations::kernel_packages::THREAD_SPAWN_OPERATION.to_string(),
+            attach_event_id: None,
         },
     ])
 }

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -12580,8 +12580,20 @@ async fn thread_rebind_fork_creates_borrowed_prefix_manifest_child() {
 
 #[tokio::test]
 async fn thread_rebind_fork_rejects_active_source_thread() {
-    let app = test_app().await;
-    let (connection, _outbound_rx) = test_connection(app.clone()).await;
+    let root = unique_test_root("rebind-fork-running-turn");
+    let workspace = root.join("workspace");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let client = std::sync::Arc::new(BlockingProviderClient::default());
+    let provider_client: std::sync::Arc<dyn verlet_provider::ProviderClient> = client.clone();
+    let app = test_app_with_provider_root(
+        &root,
+        &workspace,
+        provider_client,
+        // lexicon-allow: capsule - existing app-server test fixture config type
+        crate::adapters::app_server::CapsuleBindingsConfig::default(),
+    )
+    .await;
+    let (connection, mut outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
 
     let thread_start = app
@@ -12589,13 +12601,23 @@ async fn thread_rebind_fork_rejects_active_source_thread() {
         .await
         .unwrap();
     let source_thread_id = thread_start["thread"]["id"].as_str().unwrap().to_string();
-    {
-        let mut state = app.inner.state.write().await;
-        let source = state.threads.get_mut(&source_thread_id).unwrap();
-        source.active_turn_id = Some("active-turn".to_string());
-    }
+    let turn_id =
+        start_text_turn(&app, &connection, &source_thread_id, "keep this turn bound").await;
+    tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        client.wait_for_request(),
+    )
+    .await
+    .expect("provider request did not start");
+    assert_eq!(
+        app.handle_for_thread(&source_thread_id)
+            .await
+            .unwrap()
+            .status(),
+        verlet_runtime_contracts::ThreadStatus::Running
+    );
 
-    let err = app
+    let result = app
         .dispatch_request(
             &connection,
             "thread/rebindFork",
@@ -12604,13 +12626,16 @@ async fn thread_rebind_fork_rejects_active_source_thread() {
                 "agentRef": crate::adapters::app_server::default_manifest::DEFAULT_AGENT_REF,
             })),
         )
-        .await
-        .unwrap_err();
+        .await;
+    client.release_request();
+    let err = result.unwrap_err();
 
     assert!(
         err.message
             .contains("requires the source thread to be idle")
     );
+    wait_for_turn_completed_notification(&mut outbound_rx, &source_thread_id, &turn_id).await;
+    let _ = std::fs::remove_dir_all(root);
 }
 
 #[tokio::test]
@@ -19874,6 +19899,40 @@ struct SequencedStreamCapsuleClient {
 
 struct BurstStreamClient {
     deltas: Vec<String>,
+}
+
+#[derive(Default)]
+struct BlockingProviderClient {
+    request_started: tokio::sync::Notify,
+    release_request: tokio::sync::Notify,
+}
+
+impl BlockingProviderClient {
+    async fn wait_for_request(&self) {
+        self.request_started.notified().await;
+    }
+
+    fn release_request(&self) {
+        self.release_request.notify_one();
+    }
+}
+
+#[async_trait::async_trait]
+impl verlet_provider::ProviderClient for BlockingProviderClient {
+    async fn complete(
+        &self,
+        _request: &verlet_provider::ProviderRequest,
+    ) -> verlet_provider::ProviderResult<verlet_provider::ProviderResponse> {
+        self.request_started.notify_one();
+        self.release_request.notified().await;
+        Ok(verlet_provider::ProviderResponse {
+            content: vec![verlet_history::CanonicalContent::text(
+                "blocking request completed",
+            )],
+            usage: verlet_history::CanonicalUsage::default(),
+            stop_reason: verlet_history::CanonicalStopReason::EndTurn,
+        })
+    }
 }
 
 #[derive(Default)]

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -11917,11 +11917,14 @@ streaming = false
         "gpt-test",
     );
     runtime_config.max_tokens = 128;
-    let runtime_factory = crate::adapters::app_server::runtime_factory_from_provider_parts(
-        runtime_config,
-        provider_client,
-        capsule_bindings,
-    );
+    let runtime_factory =
+        crate::adapters::app_server::runtime_factory_from_provider_parts_with_app_paths(
+            runtime_config,
+            provider_client,
+            capsule_bindings,
+            None,
+            &config,
+        );
     let app =
         crate::adapters::app_server::VerletAppServer::with_runtime_factory(config, runtime_factory)
             .await
@@ -11972,6 +11975,64 @@ streaming = false
         verlet_agent::manifest_schema::EffectClass::Idempotent,
         "the runtime lookup must read the class from the real top-level bind receipt shape"
     );
+    let pre_binding_event_stream = events
+        .iter()
+        .filter(|event| {
+            !matches!(
+                event.kind,
+                verlet_history::EventKind::BindingAttached
+                    | verlet_history::EventKind::BindingDetached
+            )
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let receipt_bindings =
+        crate::adapters::app_server::threads::thread_operation_bindings_from_events(
+            &pre_binding_event_stream,
+        )
+        .unwrap()
+        .expect("a pre-EMO-584 bind receipt should remain authoritative");
+    assert_eq!(receipt_bindings.len(), 1);
+    assert_eq!(receipt_bindings[0].binding.operations, ["profile"]);
+    assert_eq!(receipt_bindings[0].attach_event_id, None);
+
+    let mut corrupted_lifecycle = lifecycle.clone();
+    let mut cached_bindings =
+        serde_json::from_str::<Vec<crate::agent::manifest_bind::AgentManifestOperationBinding>>(
+            &corrupted_lifecycle.metadata
+                [crate::adapters::app_server::THREAD_AGENT_OPERATION_BINDINGS_METADATA],
+        )
+        .unwrap();
+    let analytics = cached_bindings
+        .iter_mut()
+        .find(|binding| binding.name == "analytics")
+        .unwrap();
+    analytics.operations = vec!["summarize".to_string()];
+    corrupted_lifecycle.metadata.insert(
+        crate::adapters::app_server::THREAD_AGENT_OPERATION_BINDINGS_METADATA.to_string(),
+        serde_json::to_string(&cached_bindings).unwrap(),
+    );
+    app.inner
+        .metadata_store
+        .upsert_thread_lifecycle(corrupted_lifecycle)
+        .await
+        .unwrap();
+    app.inner
+        .supervisor
+        .shutdown_thread_at(&lifecycle.coordinates)
+        .await
+        .unwrap();
+    app.inner.state.write().await.threads.remove(&thread_id);
+    app.dispatch_request(
+        &connection,
+        "thread/resume",
+        Some(serde_json::json!({
+            "threadId": thread_id,
+            "excludeTurns": true,
+        })),
+    )
+    .await
+    .unwrap();
 
     app.dispatch_request(
         &connection,

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -496,6 +496,11 @@ fn assert_binding_fold_matches_latest_bind(
         bind.payload.clone(),
     )
     .unwrap();
+    let bind_event_ids = events
+        .iter()
+        .filter(|event| event.kind == verlet_history::EventKind::ManifestBindCompleted)
+        .map(|event| event.id)
+        .collect::<std::collections::HashSet<_>>();
     let folded = crate::kernel::binding_projector::fold_thread_bindings(events);
 
     assert!(folded.anomalies.is_empty());
@@ -518,7 +523,10 @@ fn assert_binding_fold_matches_latest_bind(
             .iter()
             .find(|event| event.id == binding.attach_event_id)
             .expect("active binding must retain its attach event");
-        assert_eq!(event.provenance.source_event_ids, vec![bind.id]);
+        assert!(matches!(
+            event.provenance.source_event_ids.as_slice(),
+            [bind_event_id] if bind_event_ids.contains(bind_event_id)
+        ));
         assert_eq!(binding.payload.requested_by, expected_principal);
         assert_eq!(binding.payload.decided_by, expected_principal);
     }
@@ -13327,6 +13335,11 @@ async fn app_server_manifest_bindings_expose_tools_and_replay_across_lifecycle()
         Some(record.active_artifact_hash.as_str())
     );
     assert_eq!(exa_binding["operations"], serde_json::json!(["search"]));
+    let original_attach_event_ids = events
+        .iter()
+        .filter(|event| event.kind == verlet_history::EventKind::BindingAttached)
+        .map(|event| event.id)
+        .collect::<Vec<_>>();
     assert_binding_fold_matches_latest_bind(
         &events,
         connection.resolved_principal.principal_id.as_str(),
@@ -13356,7 +13369,24 @@ async fn app_server_manifest_bindings_expose_tools_and_replay_across_lifecycle()
             .count(),
         2
     );
-    assert_binding_fold_matches_latest_bind(&resumed_events, &lifecycle.coordinates.user_id);
+    assert!(resumed_events[events.len()..].iter().all(|event| {
+        !matches!(
+            event.kind,
+            verlet_history::EventKind::BindingAttached | verlet_history::EventKind::BindingDetached
+        )
+    }));
+    assert_eq!(
+        crate::kernel::binding_projector::fold_thread_bindings(&resumed_events)
+            .active
+            .iter()
+            .map(|binding| binding.attach_event_id)
+            .collect::<Vec<_>>(),
+        original_attach_event_ids
+    );
+    assert_binding_fold_matches_latest_bind(
+        &resumed_events,
+        connection.resolved_principal.principal_id.as_str(),
+    );
     let expected_fork_bindings =
         crate::adapters::app_server::threads::thread_manifest_operation_bindings(
             app.handle_for_thread(&thread_id).await.unwrap().context(),

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -11446,11 +11446,14 @@ streaming = false
         "gpt-test",
     );
     runtime_config.max_tokens = 128;
-    let runtime_factory = crate::adapters::app_server::runtime_factory_from_provider_parts(
-        runtime_config,
-        provider_client,
-        capsule_bindings,
-    );
+    let runtime_factory =
+        crate::adapters::app_server::runtime_factory_from_provider_parts_with_app_paths(
+            runtime_config,
+            provider_client,
+            capsule_bindings,
+            None,
+            &config,
+        );
     let app =
         crate::adapters::app_server::VerletAppServer::with_runtime_factory(config, runtime_factory)
             .await
@@ -11467,6 +11470,29 @@ streaming = false
         .await
         .unwrap();
     let thread_id = thread["thread"]["id"].as_str().unwrap().to_string();
+    let lifecycle = app
+        .inner
+        .metadata_store
+        .get_thread_lifecycle(verlet_runtime_contracts::ThreadId::parse_str(&thread_id).unwrap())
+        .await
+        .unwrap()
+        .unwrap();
+    app.inner
+        .supervisor
+        .shutdown_thread_at(&lifecycle.coordinates)
+        .await
+        .unwrap();
+    app.inner.state.write().await.threads.remove(&thread_id);
+    app.dispatch_request(
+        &connection,
+        "thread/resume",
+        Some(serde_json::json!({
+            "threadId": thread_id,
+            "excludeTurns": true,
+        })),
+    )
+    .await
+    .unwrap();
     app.dispatch_request(
         &connection,
         "turn/start",
@@ -11997,6 +12023,106 @@ streaming = false
     assert_eq!(receipt_bindings[0].binding.operations, ["profile"]);
     assert_eq!(receipt_bindings[0].attach_event_id, None);
 
+    let mut anomalous_events = events.clone();
+    anomalous_events
+        .iter_mut()
+        .find(|event| event.kind == verlet_history::EventKind::BindingAttached)
+        .unwrap()
+        .payload = serde_json::json!({"name": "missing-required-fields"});
+    let error = crate::adapters::app_server::threads::thread_operation_bindings_from_events(
+        &anomalous_events,
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("binding history is anomalous"));
+
+    let mut detached_events = events.clone();
+    let mut next_sequence = detached_events.last().unwrap().sequence.get() + 1;
+    for attach_event_id in events
+        .iter()
+        .filter(|event| event.kind == verlet_history::EventKind::BindingAttached)
+        .map(|event| event.id)
+    {
+        let detached = verlet_history::NewEventRecord::witnessed(
+            lifecycle.coordinates.clone(),
+            verlet_history::EventKind::BindingDetached,
+            serde_json::to_value(verlet_history::BindingDetachedPayload {
+                attach_event_id,
+                requested_by: "principal:test".to_string(),
+                decided_by: "principal:test".to_string(),
+                decision_event_id: None,
+            })
+            .unwrap(),
+        );
+        detached_events.push(verlet_history::EventRecord::from_new(
+            stream_id.clone(),
+            verlet_history::EventSequence::new(next_sequence),
+            detached,
+        ));
+        next_sequence += 1;
+    }
+    let empty_fold = crate::adapters::app_server::threads::thread_operation_bindings_from_events(
+        &detached_events,
+    )
+    .unwrap()
+    .expect("binding events must remain authoritative after detaching every binding");
+    assert!(empty_fold.is_empty());
+
+    let old_analytics_attach = events
+        .iter()
+        .find(|event| {
+            event.kind == verlet_history::EventKind::BindingAttached
+                && event.payload["name"] == "analytics"
+        })
+        .unwrap();
+    let mut changed_events = events.clone();
+    let detach = verlet_history::NewEventRecord::witnessed(
+        lifecycle.coordinates.clone(),
+        verlet_history::EventKind::BindingDetached,
+        serde_json::to_value(verlet_history::BindingDetachedPayload {
+            attach_event_id: old_analytics_attach.id,
+            requested_by: "principal:test".to_string(),
+            decided_by: "principal:test".to_string(),
+            decision_event_id: None,
+        })
+        .unwrap(),
+    );
+    changed_events.push(verlet_history::EventRecord::from_new(
+        stream_id.clone(),
+        verlet_history::EventSequence::new(next_sequence),
+        detach,
+    ));
+    let mut changed_payload = serde_json::from_value::<verlet_history::BindingAttachedPayload>(
+        old_analytics_attach.payload.clone(),
+    )
+    .unwrap();
+    changed_payload.operations = vec!["summarize".to_string()];
+    let attach = verlet_history::NewEventRecord::witnessed(
+        lifecycle.coordinates.clone(),
+        verlet_history::EventKind::BindingAttached,
+        serde_json::to_value(changed_payload).unwrap(),
+    );
+    let new_analytics_attach = attach.id;
+    changed_events.push(verlet_history::EventRecord::from_new(
+        stream_id.clone(),
+        verlet_history::EventSequence::new(next_sequence + 1),
+        attach,
+    ));
+    let changed_bindings =
+        crate::adapters::app_server::threads::thread_operation_bindings_from_events(
+            &changed_events,
+        )
+        .unwrap()
+        .unwrap();
+    let changed_analytics = changed_bindings
+        .iter()
+        .find(|binding| binding.binding.name == "analytics")
+        .unwrap();
+    assert_eq!(changed_analytics.binding.operations, ["summarize"]);
+    assert_eq!(
+        changed_analytics.attach_event_id,
+        Some(new_analytics_attach)
+    );
+
     let mut corrupted_lifecycle = lifecycle.clone();
     let mut cached_bindings =
         serde_json::from_str::<Vec<crate::agent::manifest_bind::AgentManifestOperationBinding>>(
@@ -12054,6 +12180,79 @@ streaming = false
     assert_bash_tool_describes(&requests[0], "profile");
     assert_bash_tool_omits(&requests[0], "summarize");
     let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn bound_agent_metadata_cache_replaces_changed_and_empty_binding_sets() {
+    let app = test_app().await;
+    let mut bound = app
+        .bind_app_server_agent_ref(
+            crate::adapters::app_server::default_manifest::DEFAULT_AGENT_REF,
+            &crate::agent::manifest_bind::AgentManifestModelProfileSelection::default(),
+            &crate::agent::manifest_bind::AgentManifestBindOverrides::default(),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(!bound.operation_bindings.is_empty());
+    let mut metadata = std::collections::BTreeMap::new();
+    crate::adapters::app_server::threads::append_bound_agent_metadata(
+        &mut metadata,
+        &bound,
+        None,
+        None,
+    )
+    .unwrap();
+
+    let retained = bound.operation_bindings[0].clone();
+    bound.operation_bindings = vec![retained.clone()];
+    bound.bind_receipt.operation_bindings = vec![retained.clone()];
+    crate::adapters::app_server::threads::append_bound_agent_metadata(
+        &mut metadata,
+        &bound,
+        None,
+        None,
+    )
+    .unwrap();
+    let changed =
+        serde_json::from_str::<Vec<crate::agent::manifest_bind::AgentManifestOperationBinding>>(
+            &metadata[crate::adapters::app_server::THREAD_AGENT_OPERATION_BINDINGS_METADATA],
+        )
+        .unwrap();
+    assert_eq!(changed, [retained]);
+
+    bound.operation_bindings.clear();
+    bound.bind_receipt.operation_bindings.clear();
+    bound.bind_receipt.tool_ids.clear();
+    crate::adapters::app_server::threads::append_bound_agent_metadata(
+        &mut metadata,
+        &bound,
+        None,
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        metadata[crate::adapters::app_server::THREAD_AGENT_OPERATION_BINDINGS_METADATA],
+        "[]"
+    );
+    assert!(
+        !metadata
+            .contains_key(crate::adapters::app_server::THREAD_AGENT_SYSTEM_INSTRUCTION_METADATA)
+    );
+    let context = verlet_runtime_contracts::ThreadContext::with_topology_and_metadata(
+        verlet_runtime_contracts::ThreadCoordinates::new("tenant", "user", "empty-cache"),
+        verlet_runtime_contracts::ThreadTopology::root(),
+        metadata,
+    );
+    let mut config = crate::adapters::agent_loop::AgentLoopConfig::new(
+        verlet_history::ProviderApi::OpenAIResponses,
+        "openai",
+        "gpt-test",
+    );
+    crate::adapters::app_server::threads::apply_manifest_runtime_metadata(&context, &mut config)
+        .unwrap();
+    assert!(config.system.is_empty());
 }
 
 #[test]

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -11967,6 +11967,7 @@ streaming = false
         snapshot_id: bind.payload["manifest_hash"].as_str().unwrap().to_string(),
         tool_name: verlet_vbash::BASH_TOOL.to_string(),
         arguments: serde_json::json!({"command":"profile customer-1"}),
+        attach_event_id: None,
         args_fingerprint: None,
         holds: Vec::new(),
     };
@@ -13351,20 +13352,39 @@ async fn model_provider_capabilities_read_reports_bedrock_streaming() {
 async fn app_server_manifest_bindings_expose_tools_and_replay_across_lifecycle() {
     let registry_root = unique_test_root("capsule-global-registry");
     let record = publish_echo_operation(&registry_root, "search", "search", "search").await;
-    let client = std::sync::Arc::new(BashCallingCapsuleClient::new(
-        "search",
-        "search",
-        "command -v search && printf verlet | search",
-        "search:verlet",
-    ));
+    let client = std::sync::Arc::new(DirectOperationCallingClient::new("search", "search:verlet"));
     let provider_client: std::sync::Arc<dyn verlet_provider::ProviderClient> = client.clone();
-    let app = test_app_with_provider_and_capsule_bindings(
-        provider_client,
-        crate::adapters::app_server::CapsuleBindingsConfig::default()
-            .with_registry_root(&registry_root)
-            .with_global_operation_name("search"),
-    )
-    .await;
+    let app_root = unique_test_root("binding-attach-receipt");
+    let workspace = app_root.join("workspace");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let binding_config = crate::adapters::app_server::CapsuleBindingsConfig::default()
+        .with_registry_root(&registry_root)
+        .with_global_operation_name("search");
+    let listen =
+        crate::adapters::app_server::AppServerListenAddr::Unix(app_root.join("app-server.sock"));
+    let mut config = crate::adapters::app_server::VerletAppServerConfig::local(listen, &workspace)
+        .with_capsule_bindings(binding_config.clone());
+    config.runtime_home = app_root.join("runtime");
+    config.state_home = app_root.join("state");
+    config.agent_registry_root = app_root.join("agents");
+    let mut runtime_config = crate::adapters::agent_loop::AgentLoopConfig::new(
+        verlet_history::ProviderApi::OpenAIResponses,
+        "openai",
+        "gpt-test",
+    );
+    runtime_config.max_tokens = 128;
+    let runtime_factory =
+        crate::adapters::app_server::runtime_factory_from_provider_parts_with_app_paths(
+            runtime_config,
+            provider_client,
+            binding_config,
+            None,
+            &config,
+        );
+    let app =
+        crate::adapters::app_server::VerletAppServer::with_runtime_factory(config, runtime_factory)
+            .await
+            .unwrap();
     let mut principal = operator_principal(&app);
     principal.principal_id = crate::daemon::identity::PrincipalId::new("principal:binding-review");
     let (connection, _outbound_rx) = test_connection_for_principal(app.clone(), principal).await;
@@ -13520,6 +13540,26 @@ async fn app_server_manifest_bindings_expose_tools_and_replay_across_lifecycle()
     let requests = client.requests();
     assert!(tool_names(&requests[0]).contains(&"search".to_string()));
     assert_bash_tool_describes(&requests[0], "search");
+    let completed_events = session_store.read_events(&stream_id, None).await.unwrap();
+    let search_attach = completed_events
+        .iter()
+        .find(|event| {
+            event.kind == verlet_history::EventKind::BindingAttached
+                && event.payload["name"].as_str() == Some("search")
+        })
+        .expect("search should have a binding attachment");
+    let search_request = completed_events
+        .iter()
+        .filter(|event| event.kind == verlet_history::EventKind::ToolCallRequested)
+        .find_map(|event| {
+            serde_json::from_value::<crate::kernel::control_decision::ToolCallRequestedPayload>(
+                event.payload.clone(),
+            )
+            .ok()
+            .filter(|payload| payload.tool_name == "search")
+        })
+        .expect("the operation-backed search call should be witnessed");
+    assert_eq!(search_request.attach_event_id, Some(search_attach.id));
 
     let spawned = app
         .dispatch_request(
@@ -13569,6 +13609,7 @@ async fn app_server_manifest_bindings_expose_tools_and_replay_across_lifecycle()
         .as_slice(),
         expected_fork_bindings.as_slice()
     );
+    let _ = std::fs::remove_dir_all(app_root);
     let _ = std::fs::remove_dir_all(registry_root);
 }
 
@@ -20222,6 +20263,68 @@ struct BashCallingCapsuleClient {
     expected_output: String,
 }
 
+struct DirectOperationCallingClient {
+    requests: std::sync::Mutex<Vec<verlet_provider::ProviderRequest>>,
+    tool_name: String,
+    expected_output: String,
+}
+
+impl DirectOperationCallingClient {
+    fn new(tool_name: &str, expected_output: &str) -> Self {
+        Self {
+            requests: std::sync::Mutex::new(Vec::new()),
+            tool_name: tool_name.to_string(),
+            expected_output: expected_output.to_string(),
+        }
+    }
+
+    fn requests(&self) -> Vec<verlet_provider::ProviderRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl verlet_provider::ProviderClient for DirectOperationCallingClient {
+    async fn complete(
+        &self,
+        request: &verlet_provider::ProviderRequest,
+    ) -> verlet_provider::ProviderResult<verlet_provider::ProviderResponse> {
+        self.requests.lock().unwrap().push(request.clone());
+        let has_tool_result = request
+            .messages
+            .iter()
+            .any(|message| matches!(message, verlet_history::CanonicalMessage::ToolResult { .. }));
+        if !has_tool_result {
+            assert!(tool_names(request).contains(&self.tool_name));
+            return Ok(verlet_provider::ProviderResponse {
+                content: vec![verlet_history::CanonicalContent::tool_call(
+                    "call_direct_operation_1",
+                    self.tool_name.clone(),
+                    serde_json::json!({"input": "verlet"}),
+                )],
+                usage: verlet_history::CanonicalUsage::default(),
+                stop_reason: verlet_history::CanonicalStopReason::ToolUse,
+            });
+        }
+
+        let text = text_from_canonical_messages(&request.messages);
+        assert!(text.contains(&self.expected_output));
+        Ok(verlet_provider::ProviderResponse {
+            content: vec![verlet_history::CanonicalContent::text(
+                "direct operation completed",
+            )],
+            usage: verlet_history::CanonicalUsage::default(),
+            stop_reason: verlet_history::CanonicalStopReason::EndTurn,
+        })
+    }
+}
+
+impl ProviderRequestRecorder for DirectOperationCallingClient {
+    fn recorded_request_count(&self) -> usize {
+        self.requests.lock().unwrap().len()
+    }
+}
+
 // lexicon-allow: capsule - existing test client name
 impl BashCallingCapsuleClient {
     fn new(
@@ -20237,10 +20340,6 @@ impl BashCallingCapsuleClient {
             command: command.to_string(),
             expected_output: expected_output.to_string(),
         }
-    }
-
-    fn requests(&self) -> Vec<verlet_provider::ProviderRequest> {
-        self.requests.lock().unwrap().clone()
     }
 }
 

--- a/crates/verlet-kernel/src/adapters/app_server/threads.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/threads.rs
@@ -1517,6 +1517,8 @@ pub(super) fn append_bound_agent_metadata(
             crate::adapters::app_server::THREAD_AGENT_SYSTEM_INSTRUCTION_METADATA.to_string(),
             instruction,
         );
+    } else {
+        metadata.remove(crate::adapters::app_server::THREAD_AGENT_SYSTEM_INSTRUCTION_METADATA);
     }
     metadata.insert(
         crate::adapters::app_server::THREAD_AGENT_RUNTIME_STREAMING_METADATA.to_string(),
@@ -1547,18 +1549,16 @@ pub(super) fn append_bound_agent_metadata(
             auto_at_text_bytes.to_string(),
         );
     }
-    if !bound.operation_bindings.is_empty() {
-        let encoded = serde_json::to_string(&bound.operation_bindings).map_err(|err| {
-            crate::adapters::app_server::connection::jsonrpc_error(
-                -32602,
-                format!("failed to encode manifest operation bindings: {err}"),
-            )
-        })?;
-        metadata.insert(
-            crate::adapters::app_server::THREAD_AGENT_OPERATION_BINDINGS_METADATA.to_string(),
-            encoded,
-        );
-    }
+    let encoded = serde_json::to_string(&bound.operation_bindings).map_err(|err| {
+        crate::adapters::app_server::connection::jsonrpc_error(
+            -32602,
+            format!("failed to encode manifest operation bindings: {err}"),
+        )
+    })?;
+    metadata.insert(
+        crate::adapters::app_server::THREAD_AGENT_OPERATION_BINDINGS_METADATA.to_string(),
+        encoded,
+    );
     if !bound.skill_packages.is_empty() {
         let encoded = serde_json::to_string(&bound.skill_packages).map_err(|err| {
             crate::adapters::app_server::connection::jsonrpc_error(
@@ -1669,14 +1669,9 @@ fn manifest_tool_use_system_instruction(
 fn legacy_manifest_tool_use_system_instruction(
     context: &verlet_runtime_contracts::ThreadContext,
 ) -> Option<String> {
-    let has_tool_metadata = context
-        .metadata
-        .get(crate::adapters::app_server::THREAD_AGENT_OPERATION_BINDINGS_METADATA)
-        .is_some_and(|value| !value.trim().is_empty())
-        || context
-            .metadata
-            .get(crate::adapters::app_server::THREAD_AGENT_TOOL_UNIVERSES_METADATA)
-            .is_some_and(|value| !value.trim().is_empty());
+    let has_tool_metadata = thread_manifest_operation_bindings(context)
+        .is_ok_and(|bindings| !bindings.is_empty())
+        || thread_manifest_tool_universes(context).is_ok_and(|bindings| !bindings.is_empty());
     if !has_tool_metadata {
         return None;
     }
@@ -2007,7 +2002,11 @@ pub(super) fn thread_operation_bindings_from_events(
             verlet_history::EventKind::BindingAttached | verlet_history::EventKind::BindingDetached
         )
     }) {
-        let bindings = crate::kernel::binding_projector::fold_thread_bindings(events)
+        let folded = crate::kernel::binding_projector::fold_thread_bindings(events);
+        if let Some(message) = folded.anomaly_message() {
+            return Err(crate::kernel::runtime_host::VerletError::History(message));
+        }
+        let bindings = folded
             .active
             .into_iter()
             .map(|binding| ThreadOperationBinding {

--- a/crates/verlet-kernel/src/adapters/app_server/threads.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/threads.rs
@@ -1,4 +1,4 @@
-use verlet_history::SessionStore as _;
+use verlet_history::{EventStore as _, SessionStore as _};
 use verlet_metadata::provider_store::ThreadMetadataStore as _;
 
 const THREAD_REMOTE_PLACEMENT_PROJECTION_METADATA: &str = "cooldis.remote_placement_projection";
@@ -1998,6 +1998,55 @@ pub(super) fn thread_manifest_operation_bindings(
         })
 }
 
+pub(super) fn thread_operation_bindings_from_events(
+    events: &[verlet_history::EventRecord],
+) -> crate::kernel::runtime_host::VerletResult<Option<Vec<ThreadOperationBinding>>> {
+    if events.iter().any(|event| {
+        matches!(
+            event.kind,
+            verlet_history::EventKind::BindingAttached | verlet_history::EventKind::BindingDetached
+        )
+    }) {
+        let bindings = crate::kernel::binding_projector::fold_thread_bindings(events)
+            .active
+            .into_iter()
+            .map(|binding| ThreadOperationBinding {
+                binding: crate::agent::manifest_bind::operation_binding_from_attached_payload(
+                    binding.payload,
+                ),
+                attach_event_id: Some(binding.attach_event_id),
+            })
+            .collect();
+        return Ok(Some(bindings));
+    }
+
+    let Some(bind_event) = events
+        .iter()
+        .filter(|event| event.kind == verlet_history::EventKind::ManifestBindCompleted)
+        .max_by_key(|event| event.sequence.get())
+    else {
+        return Ok(None);
+    };
+    let receipt = serde_json::from_value::<crate::agent::manifest_bind::AgentManifestBindReceipt>(
+        bind_event.payload.clone(),
+    )
+    .map_err(|err| {
+        crate::kernel::runtime_host::VerletError::History(format!(
+            "manifest.bind.completed payload is invalid: {err}"
+        ))
+    })?;
+    Ok(Some(
+        receipt
+            .operation_bindings
+            .into_iter()
+            .map(|binding| ThreadOperationBinding {
+                binding,
+                attach_event_id: None,
+            })
+            .collect(),
+    ))
+}
+
 pub(super) fn thread_manifest_workspace_mount(
     context: &verlet_runtime_contracts::ThreadContext,
 ) -> crate::kernel::runtime_host::VerletResult<
@@ -2126,6 +2175,12 @@ struct ThreadOperationCatalog {
     /// The per-thread workspace VFS installed into catalog-loaded operations and
     /// virtual bash so filesystem surfaces do not drift into separate trees.
     workspace_vfs: std::sync::Arc<verlet_vfs::VerletVfs>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct ThreadOperationBinding {
+    pub(super) binding: crate::agent::manifest_bind::AgentManifestOperationBinding,
+    pub(super) attach_event_id: Option<verlet_history::EventRecordId>,
 }
 
 #[async_trait::async_trait]
@@ -2436,11 +2491,43 @@ impl CapsuleBindingRuntimeFactory {
         Ok(files)
     }
 
+    async fn operation_bindings_for_thread(
+        &self,
+        context: &verlet_runtime_contracts::ThreadContext,
+    ) -> crate::kernel::runtime_host::VerletResult<Vec<ThreadOperationBinding>> {
+        if let Some(session_store_path) = &self.session_store_path {
+            let store = verlet_history_sqlite::SqliteSessionStore::open(session_store_path)
+                .await
+                .map_err(|err| crate::kernel::runtime_host::VerletError::History(err.to_string()))?
+                .with_lease_epoch(self.lease_epoch);
+            let events = store
+                .read_events(
+                    &verlet_history::EventStreamId::for_thread(&context.coordinates),
+                    None,
+                )
+                .await
+                .map_err(|err| {
+                    crate::kernel::runtime_host::VerletError::History(err.to_string())
+                })?;
+            if let Some(bindings) = thread_operation_bindings_from_events(&events)? {
+                return Ok(bindings);
+            }
+        }
+
+        Ok(thread_manifest_operation_bindings(context)?
+            .into_iter()
+            .map(|binding| ThreadOperationBinding {
+                binding,
+                attach_event_id: None,
+            })
+            .collect())
+    }
+
     async fn operation_catalog_for_thread(
         &self,
         context: &verlet_runtime_contracts::ThreadContext,
     ) -> crate::kernel::runtime_host::VerletResult<Option<ThreadOperationCatalog>> {
-        let manifest_operation_bindings = thread_manifest_operation_bindings(context)?;
+        let manifest_operation_bindings = self.operation_bindings_for_thread(context).await?;
         let workspace = thread_manifest_workspace_mount(context)?;
         if manifest_operation_bindings.is_empty() && workspace.is_none() {
             return Ok(None);
@@ -2466,7 +2553,11 @@ impl CapsuleBindingRuntimeFactory {
             verlet_operations::operation_store::LocalOperationRegistry::new(&registry_root);
         let mut records = Vec::new();
         let mut tool_aliases = Vec::new();
-        for binding in manifest_operation_bindings {
+        for thread_binding in manifest_operation_bindings {
+            let ThreadOperationBinding {
+                binding,
+                attach_event_id: _,
+            } = thread_binding;
             let crate::agent::manifest_bind::AgentManifestOperationBinding {
                 name,
                 artifact_hash,

--- a/crates/verlet-kernel/src/adapters/app_server/threads.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/threads.rs
@@ -2556,7 +2556,7 @@ impl CapsuleBindingRuntimeFactory {
         for thread_binding in manifest_operation_bindings {
             let ThreadOperationBinding {
                 binding,
-                attach_event_id: _,
+                attach_event_id,
             } = thread_binding;
             let crate::agent::manifest_bind::AgentManifestOperationBinding {
                 name,
@@ -2566,13 +2566,6 @@ impl CapsuleBindingRuntimeFactory {
                 operations,
                 direct_tools,
             } = binding;
-            tool_aliases.extend(direct_tools.into_iter().map(|direct_tool| {
-                crate::agent::agent_tool_router::OperationToolAlias {
-                    tool_name: direct_tool.tool_name,
-                    registered_name: name.clone(),
-                    operation_name: direct_tool.operation,
-                }
-            }));
             let record = registry
                 .load_version_record(&name, &artifact_hash)
                 .map_err(|err| {
@@ -2581,6 +2574,41 @@ impl CapsuleBindingRuntimeFactory {
                         name, artifact_hash
                     ))
                 })?;
+            let is_kernel = matches!(
+                &record.source,
+                verlet_operations::operation_store::PublishedOperationSource::Kernel { .. }
+            );
+            let alias_attach_event_id = if is_kernel { None } else { attach_event_id };
+            tool_aliases.extend(direct_tools.into_iter().map(|direct_tool| {
+                crate::agent::agent_tool_router::OperationToolAlias {
+                    tool_name: direct_tool.tool_name,
+                    registered_name: name.clone(),
+                    operation_name: direct_tool.operation,
+                    attach_event_id: alias_attach_event_id,
+                }
+            }));
+            if !is_kernel {
+                tool_aliases.extend(
+                    record
+                        .manifest
+                        .operations
+                        .iter()
+                        .filter(|operation| {
+                            operations.is_empty() || operations.contains(&operation.name)
+                        })
+                        .map(
+                            |operation| crate::agent::agent_tool_router::OperationToolAlias {
+                                tool_name: verlet_operations::projection_tool_name(
+                                    &name,
+                                    &operation.name,
+                                ),
+                                registered_name: name.clone(),
+                                operation_name: operation.name.clone(),
+                                attach_event_id: alias_attach_event_id,
+                            },
+                        ),
+                );
+            }
             let record = if operations.is_empty() {
                 crate::operations::plugins::LocalPluginCatalogRecord::whole_record(record)
             } else {

--- a/crates/verlet-kernel/src/agent/agent_tool_router.rs
+++ b/crates/verlet-kernel/src/agent/agent_tool_router.rs
@@ -91,6 +91,7 @@ pub struct OperationToolAlias {
     pub tool_name: String,
     pub registered_name: String,
     pub operation_name: String,
+    pub attach_event_id: Option<verlet_history::EventRecordId>,
 }
 
 #[async_trait::async_trait]
@@ -173,6 +174,15 @@ impl AgentToolRouter {
         &self,
     ) -> std::sync::Arc<verlet_operations::operation_registry::OperationRegistry> {
         std::sync::Arc::clone(&self.operation_registry)
+    }
+
+    pub fn attach_event_id_for_tool_name(
+        &self,
+        tool_name: &str,
+    ) -> Option<verlet_history::EventRecordId> {
+        self.tool_aliases
+            .get(tool_name)
+            .and_then(|alias| alias.attach_event_id)
     }
 
     pub async fn tool_definitions(&self) -> Vec<verlet_provider::ToolDefinition> {

--- a/crates/verlet-kernel/src/agent/agent_tool_router/tests.rs
+++ b/crates/verlet-kernel/src/agent/agent_tool_router/tests.rs
@@ -632,8 +632,41 @@ async fn router_with_kernel_process_operation(
             tool_name: crate::operations::kernel_packages::PROCESS_EXEC_OPERATION.to_string(),
             registered_name: crate::operations::kernel_packages::VERLET_PROCESS_PACKAGE.to_string(),
             operation_name: crate::operations::kernel_packages::PROCESS_EXEC_OPERATION.to_string(),
+            attach_event_id: None,
         },
     ])
+}
+
+#[test]
+fn router_attach_provenance_is_only_present_on_fold_derived_aliases() {
+    let attach_event_id = verlet_history::EventRecordId::from_uuid(uuid::Uuid::from_u128(42));
+    let router = crate::agent::agent_tool_router::AgentToolRouter::new(std::sync::Arc::new(
+        verlet_operations::operation_registry::OperationRegistry::new(),
+    ))
+    .with_tool_aliases([
+        crate::agent::agent_tool_router::OperationToolAlias {
+            tool_name: "bound_operation".to_string(),
+            registered_name: "bound".to_string(),
+            operation_name: "run".to_string(),
+            attach_event_id: Some(attach_event_id),
+        },
+        crate::agent::agent_tool_router::OperationToolAlias {
+            tool_name: "kernel_operation".to_string(),
+            registered_name: "kernel".to_string(),
+            operation_name: "run".to_string(),
+            attach_event_id: None,
+        },
+    ]);
+
+    assert_eq!(
+        router.attach_event_id_for_tool_name("bound_operation"),
+        Some(attach_event_id)
+    );
+    assert_eq!(
+        router.attach_event_id_for_tool_name("kernel_operation"),
+        None
+    );
+    assert_eq!(router.attach_event_id_for_tool_name("static_tool"), None);
 }
 
 async fn router_with_kernel_notify_operation() -> crate::agent::agent_tool_router::AgentToolRouter {
@@ -660,11 +693,13 @@ async fn router_with_kernel_notify_operation() -> crate::agent::agent_tool_route
             registered_name: crate::operations::kernel_packages::VERLET_NOTIFY_PACKAGE.to_string(),
             operation_name: crate::operations::kernel_packages::NOTIFY_PREVIEW_OPERATION
                 .to_string(),
+            attach_event_id: None,
         },
         crate::agent::agent_tool_router::OperationToolAlias {
             tool_name: crate::operations::kernel_packages::CHANNEL_EMIT_OPERATION.to_string(),
             registered_name: crate::operations::kernel_packages::VERLET_NOTIFY_PACKAGE.to_string(),
             operation_name: crate::operations::kernel_packages::CHANNEL_EMIT_OPERATION.to_string(),
+            attach_event_id: None,
         },
     ])
 }
@@ -710,6 +745,7 @@ async fn router_with_kernel_thread_operations(
                 registered_name: crate::operations::kernel_packages::VERLET_THREADS_PACKAGE
                     .to_string(),
                 operation_name: operation.to_string(),
+                attach_event_id: None,
             },
         ),
     )
@@ -848,6 +884,7 @@ fn kernel_identity_router(
             tool_name: "identify-thread".to_string(),
             registered_name: "thread-identity".to_string(),
             operation_name: "identify-thread".to_string(),
+            attach_event_id: None,
         }])
 }
 

--- a/crates/verlet-kernel/src/agent/manifest_bind.rs
+++ b/crates/verlet-kernel/src/agent/manifest_bind.rs
@@ -3331,6 +3331,46 @@ pub(crate) fn binding_attached_payload(
     }
 }
 
+pub(crate) fn operation_binding_from_attached_payload(
+    payload: verlet_history::BindingAttachedPayload,
+) -> AgentManifestOperationBinding {
+    fn effect_class(
+        effect_class: verlet_history::BindingEffectClass,
+    ) -> verlet_agent::manifest_schema::EffectClass {
+        match effect_class {
+            verlet_history::BindingEffectClass::Pure => {
+                verlet_agent::manifest_schema::EffectClass::Pure
+            }
+            verlet_history::BindingEffectClass::Idempotent => {
+                verlet_agent::manifest_schema::EffectClass::Idempotent
+            }
+            verlet_history::BindingEffectClass::AtMostOnce => {
+                verlet_agent::manifest_schema::EffectClass::AtMostOnce
+            }
+        }
+    }
+
+    AgentManifestOperationBinding {
+        name: payload.name,
+        artifact_hash: payload.artifact_hash,
+        effect_class: effect_class(payload.effect_class),
+        attachment_config: verlet_wasm::WasmAttachmentConfig {
+            allowed_secrets: payload.attachment_config.allowed_secrets,
+            allowed_private_network: payload.attachment_config.allowed_private_network,
+        },
+        operations: payload.operations,
+        direct_tools: payload
+            .direct_tools
+            .into_iter()
+            .map(|direct_tool| AgentManifestDirectToolBinding {
+                tool_name: direct_tool.tool_name,
+                operation: direct_tool.operation,
+                effect_class: effect_class(direct_tool.effect_class),
+            })
+            .collect(),
+    }
+}
+
 /// Apply caller overrides onto the manifest's runtime defaults, enforcing
 /// the deny-by-default allowlist. Returns the effective defaults plus the
 /// list of keys actually overridden, for the bind receipt.

--- a/crates/verlet-kernel/src/agent/manifest_bind/tests.rs
+++ b/crates/verlet-kernel/src/agent/manifest_bind/tests.rs
@@ -793,6 +793,36 @@ fn binding_effect_class_matches_manifest_wire_values() {
     }
 }
 
+#[test]
+fn binding_attached_payload_round_trips_catalog_binding_fields() {
+    let binding = crate::agent::manifest_bind::AgentManifestOperationBinding {
+        name: "analytics".to_string(),
+        artifact_hash: "a".repeat(64),
+        effect_class: verlet_agent::manifest_schema::EffectClass::Pure,
+        attachment_config: verlet_wasm::WasmAttachmentConfig {
+            allowed_secrets: std::collections::BTreeSet::from(["SEARCH_TOKEN".to_string()]),
+            allowed_private_network: std::collections::BTreeMap::from([(
+                "https://example.com".to_string(),
+                std::collections::BTreeSet::from(["GET".to_string()]),
+            )]),
+        },
+        operations: vec!["profile".to_string()],
+        direct_tools: vec![
+            crate::agent::manifest_bind::AgentManifestDirectToolBinding {
+                tool_name: "analytics_profile".to_string(),
+                operation: "profile".to_string(),
+                effect_class: verlet_agent::manifest_schema::EffectClass::Idempotent,
+            },
+        ],
+    };
+
+    let attached = crate::agent::manifest_bind::binding_attached_payload(&binding, "principal");
+    assert_eq!(
+        crate::agent::manifest_bind::operation_binding_from_attached_payload(attached),
+        binding
+    );
+}
+
 #[tokio::test]
 async fn protocol_tool_import_pin_drift_fails_bind_with_both_hashes() {
     let witnessed = witnessed_tool("verlet_mcp_echo", "string");

--- a/crates/verlet-kernel/src/kernel/binding_projector.rs
+++ b/crates/verlet-kernel/src/kernel/binding_projector.rs
@@ -30,16 +30,124 @@ pub struct ThreadBindingsFold {
     pub anomalies: Vec<ThreadBindingAnomaly>,
 }
 
+pub(crate) fn binding_payload_identity_matches(
+    left: &verlet_history::BindingAttachedPayload,
+    right: &verlet_history::BindingAttachedPayload,
+) -> bool {
+    left.name == right.name
+        && left.artifact_hash == right.artifact_hash
+        && left.operations == right.operations
+        && left.direct_tools == right.direct_tools
+        && left.attachment_config == right.attachment_config
+        && left.effect_class == right.effect_class
+}
+
+#[derive(Default)]
+struct BindingBatchObservation {
+    attached_count: usize,
+    attached_payloads: Vec<verlet_history::BindingAttachedPayload>,
+    has_detach: bool,
+}
+
+fn full_reemission_bind_batches(
+    events: &[verlet_history::EventRecord],
+) -> std::collections::HashMap<verlet_history::EventRecordId, usize> {
+    let expected = events
+        .iter()
+        .filter(|event| event.kind == verlet_history::EventKind::ManifestBindCompleted)
+        .filter_map(|event| {
+            let bindings = serde_json::from_value::<
+                Vec<crate::agent::manifest_bind::AgentManifestOperationBinding>,
+            >(event.payload.get("operation_bindings")?.clone())
+            .ok()?;
+            let payloads = bindings
+                .iter()
+                .map(|binding| crate::agent::manifest_bind::binding_attached_payload(binding, ""))
+                .collect::<Vec<_>>();
+            Some((event.id, payloads))
+        })
+        .collect::<std::collections::HashMap<_, _>>();
+    let mut observed = std::collections::HashMap::<_, BindingBatchObservation>::new();
+    for event in events {
+        let Some(bind_event_id) = event.provenance.source_event_ids.first().copied() else {
+            continue;
+        };
+        if !expected.contains_key(&bind_event_id) {
+            continue;
+        }
+        match event.kind {
+            verlet_history::EventKind::BindingAttached => {
+                let observation = observed.entry(bind_event_id).or_default();
+                observation.attached_count += 1;
+                if let Ok(payload) = serde_json::from_value::<verlet_history::BindingAttachedPayload>(
+                    event.payload.clone(),
+                ) {
+                    observation.attached_payloads.push(payload);
+                }
+            }
+            verlet_history::EventKind::BindingDetached => {
+                observed.entry(bind_event_id).or_default().has_detach = true;
+            }
+            _ => {}
+        }
+    }
+
+    expected
+        .into_iter()
+        .filter_map(|(bind_event_id, expected_payloads)| {
+            let observation = observed.get(&bind_event_id);
+            let attached_count = observation.map_or(0, |batch| batch.attached_count);
+            if observation.is_some_and(|batch| batch.has_detach)
+                || attached_count != expected_payloads.len()
+            {
+                return None;
+            }
+            let decoded = observation
+                .map(|batch| batch.attached_payloads.as_slice())
+                .unwrap_or_default();
+            if decoded.len() == attached_count {
+                let mut matched = vec![false; decoded.len()];
+                for expected_payload in &expected_payloads {
+                    let Some((index, _)) = decoded.iter().enumerate().find(|(index, actual)| {
+                        !matched[*index]
+                            && binding_payload_identity_matches(expected_payload, actual)
+                    }) else {
+                        return None;
+                    };
+                    matched[index] = true;
+                }
+            }
+            Some((bind_event_id, attached_count))
+        })
+        .collect()
+}
+
 pub fn fold_thread_bindings(events: &[verlet_history::EventRecord]) -> ThreadBindingsFold {
     let mut folded = ThreadBindingsFold::default();
     let mut inactive = std::collections::HashSet::new();
-    let mut active_bind_batch_id = None;
+    // EMO-584 briefly wrote each bind receipt followed by a complete attached
+    // snapshot and no detaches. Only receipt-proven full snapshots retain
+    // generation semantics; every delta-era batch folds strictly by attach id.
+    let full_reemission_batches = full_reemission_bind_batches(events);
+    let mut applied_full_reemission_batches = std::collections::HashSet::new();
 
     for event in events {
         match event.kind {
+            verlet_history::EventKind::ManifestBindCompleted
+                if full_reemission_batches.get(&event.id) == Some(&0) =>
+            {
+                inactive.extend(
+                    folded
+                        .active
+                        .drain(..)
+                        .map(|binding| binding.attach_event_id),
+                );
+                applied_full_reemission_batches.insert(event.id);
+            }
             verlet_history::EventKind::BindingAttached => {
                 if let Some(bind_batch_id) = event.provenance.source_event_ids.first().copied()
-                    && active_bind_batch_id != Some(bind_batch_id)
+                    && full_reemission_batches.contains_key(&bind_batch_id)
+                    && applied_full_reemission_batches.insert(bind_batch_id)
                 {
                     inactive.extend(
                         folded
@@ -47,19 +155,11 @@ pub fn fold_thread_bindings(events: &[verlet_history::EventRecord]) -> ThreadBin
                             .drain(..)
                             .map(|binding| binding.attach_event_id),
                     );
-                    active_bind_batch_id = Some(bind_batch_id);
                 }
                 match serde_json::from_value::<verlet_history::BindingAttachedPayload>(
                     event.payload.clone(),
                 ) {
                     Ok(payload) => {
-                        if let Some(index) = folded.active.iter().position(|binding| {
-                            binding.payload.name == payload.name
-                                && binding.payload.artifact_hash == payload.artifact_hash
-                        }) {
-                            let superseded = folded.active.remove(index);
-                            inactive.insert(superseded.attach_event_id);
-                        }
                         folded.active.push(ThreadBinding {
                             attach_event_id: event.id,
                             payload,
@@ -172,6 +272,19 @@ mod tests {
         event
     }
 
+    fn bind_event(
+        sequence: i64,
+        id: u128,
+        operation_bindings: serde_json::Value,
+    ) -> verlet_history::EventRecord {
+        event(
+            sequence,
+            id,
+            verlet_history::EventKind::ManifestBindCompleted,
+            serde_json::json!({"operation_bindings": operation_bindings}),
+        )
+    }
+
     fn detach_event(
         sequence: i64,
         id: u128,
@@ -246,15 +359,33 @@ mod tests {
 
     #[test]
     fn repeated_bind_batches_replace_same_operation_artifacts_in_stream_order() {
-        let first_search = attach_event_for_bind(1, 400, "search-tools", 900);
-        let first_files = attach_event_for_bind(2, 300, "file-tools", 900);
-        let mut rebound_search = attach_event_for_bind(3, 200, "search-tools", 901);
+        let first_bind = bind_event(
+            1,
+            900,
+            serde_json::json!([
+                {"name": "search-tools", "artifact_hash": "sha256:search-tools"},
+                {"name": "file-tools", "artifact_hash": "sha256:file-tools"}
+            ]),
+        );
+        let first_search = attach_event_for_bind(2, 400, "search-tools", 900);
+        let first_files = attach_event_for_bind(3, 300, "file-tools", 900);
+        let second_bind = bind_event(
+            4,
+            901,
+            serde_json::json!([
+                {"name": "search-tools", "artifact_hash": "sha256:search-tools-v2"},
+                {"name": "file-tools", "artifact_hash": "sha256:file-tools"}
+            ]),
+        );
+        let mut rebound_search = attach_event_for_bind(5, 200, "search-tools", 901);
         rebound_search.payload["artifact_hash"] = serde_json::json!("sha256:search-tools-v2");
-        let rebound_files = attach_event_for_bind(4, 100, "file-tools", 901);
+        let rebound_files = attach_event_for_bind(6, 100, "file-tools", 901);
 
         let folded = super::fold_thread_bindings(&[
+            first_bind,
             first_search,
             first_files,
+            second_bind,
             rebound_search.clone(),
             rebound_files.clone(),
         ]);
@@ -270,6 +401,128 @@ mod tests {
                 (rebound_search.id, "search-tools"),
                 (rebound_files.id, "file-tools"),
             ]
+        );
+    }
+
+    #[test]
+    fn emo_584_full_reemission_fixture_folds_to_the_latest_complete_generation() {
+        let first_bind = bind_event(
+            1,
+            900,
+            serde_json::json!([
+                {"name": "search-tools", "artifact_hash": "sha256:search-tools"},
+                {"name": "file-tools", "artifact_hash": "sha256:file-tools"}
+            ]),
+        );
+        let first_search = attach_event_for_bind(2, 400, "search-tools", 900);
+        let first_files = attach_event_for_bind(3, 300, "file-tools", 900);
+        let second_bind = bind_event(
+            4,
+            901,
+            serde_json::json!([
+                {"name": "search-tools", "artifact_hash": "sha256:search-tools-v2"},
+                {"name": "file-tools", "artifact_hash": "sha256:file-tools"}
+            ]),
+        );
+        let mut rebound_search = attach_event_for_bind(5, 200, "search-tools", 901);
+        rebound_search.payload["artifact_hash"] = serde_json::json!("sha256:search-tools-v2");
+        let rebound_files = attach_event_for_bind(6, 100, "file-tools", 901);
+
+        let folded = super::fold_thread_bindings(&[
+            first_bind,
+            first_search,
+            first_files,
+            second_bind,
+            rebound_search.clone(),
+            rebound_files.clone(),
+        ]);
+
+        assert!(folded.anomalies.is_empty());
+        assert_eq!(
+            folded
+                .active
+                .iter()
+                .map(|binding| binding.attach_event_id)
+                .collect::<Vec<_>>(),
+            vec![rebound_search.id, rebound_files.id]
+        );
+    }
+
+    #[test]
+    fn add_only_delta_after_historical_generations_preserves_prior_attach_ids() {
+        let first_bind = bind_event(
+            1,
+            900,
+            serde_json::json!([
+                {"name": "search-tools", "artifact_hash": "sha256:search-tools"},
+                {"name": "file-tools", "artifact_hash": "sha256:file-tools"}
+            ]),
+        );
+        let first_search = attach_event_for_bind(2, 400, "search-tools", 900);
+        let first_files = attach_event_for_bind(3, 300, "file-tools", 900);
+        let delta_bind = bind_event(
+            4,
+            901,
+            serde_json::json!([
+                {"name": "clock-tools", "artifact_hash": "sha256:clock-tools"},
+                {"name": "search-tools", "artifact_hash": "sha256:search-tools"},
+                {"name": "file-tools", "artifact_hash": "sha256:file-tools"}
+            ]),
+        );
+        let added_clock = attach_event_for_bind(5, 200, "clock-tools", 901);
+
+        let folded = super::fold_thread_bindings(&[
+            first_bind,
+            first_search.clone(),
+            first_files.clone(),
+            delta_bind,
+            added_clock.clone(),
+        ]);
+
+        assert!(folded.anomalies.is_empty());
+        assert_eq!(
+            folded
+                .active
+                .iter()
+                .map(|binding| binding.attach_event_id)
+                .collect::<Vec<_>>(),
+            vec![first_search.id, first_files.id, added_clock.id]
+        );
+    }
+
+    #[test]
+    fn emo_584_empty_reemission_retires_the_prior_generation() {
+        let first_bind = bind_event(
+            1,
+            900,
+            serde_json::json!([
+                {"name": "search-tools", "artifact_hash": "sha256:search-tools"}
+            ]),
+        );
+        let first_search = attach_event_for_bind(2, 400, "search-tools", 900);
+        let empty_bind = bind_event(3, 901, serde_json::json!([]));
+
+        let folded = super::fold_thread_bindings(&[first_bind, first_search, empty_bind]);
+
+        assert!(folded.anomalies.is_empty());
+        assert!(folded.active.is_empty());
+    }
+
+    #[test]
+    fn ordinary_attaches_remain_distinct_until_their_ids_are_detached() {
+        let first = attach_event(1, 1, "search-tools");
+        let second = attach_event(2, 2, "search-tools");
+
+        let folded = super::fold_thread_bindings(&[first.clone(), second.clone()]);
+
+        assert!(folded.anomalies.is_empty());
+        assert_eq!(
+            folded
+                .active
+                .iter()
+                .map(|binding| binding.attach_event_id)
+                .collect::<Vec<_>>(),
+            vec![first.id, second.id]
         );
     }
 
@@ -361,9 +614,23 @@ mod tests {
 
     #[test]
     fn undecodable_new_bind_batch_retires_the_previous_batch() {
-        let old = attach_event_for_bind(1, 1, "search-tools", 900);
+        let old_bind = bind_event(
+            1,
+            900,
+            serde_json::json!([
+                {"name": "search-tools", "artifact_hash": "sha256:search-tools"}
+            ]),
+        );
+        let old = attach_event_for_bind(2, 1, "search-tools", 900);
+        let new_bind = bind_event(
+            3,
+            901,
+            serde_json::json!([
+                {"name": "search-tools", "artifact_hash": "sha256:search-tools-v2"}
+            ]),
+        );
         let mut bad_attach = event(
-            2,
+            4,
             2,
             verlet_history::EventKind::BindingAttached,
             serde_json::json!({"name": "missing-fields"}),
@@ -372,7 +639,7 @@ mod tests {
             uuid::Uuid::from_u128(901),
         )];
 
-        let folded = super::fold_thread_bindings(&[old, bad_attach.clone()]);
+        let folded = super::fold_thread_bindings(&[old_bind, old, new_bind, bad_attach.clone()]);
 
         assert!(folded.active.is_empty());
         assert!(matches!(

--- a/crates/verlet-kernel/src/kernel/binding_projector.rs
+++ b/crates/verlet-kernel/src/kernel/binding_projector.rs
@@ -30,7 +30,14 @@ pub struct ThreadBindingsFold {
     pub anomalies: Vec<ThreadBindingAnomaly>,
 }
 
-pub(crate) fn binding_payload_identity_matches(
+impl ThreadBindingsFold {
+    pub(crate) fn anomaly_message(&self) -> Option<String> {
+        (!self.anomalies.is_empty())
+            .then(|| format!("thread binding history is anomalous: {:?}", self.anomalies))
+    }
+}
+
+fn binding_payload_identity_matches(
     left: &verlet_history::BindingAttachedPayload,
     right: &verlet_history::BindingAttachedPayload,
 ) -> bool {
@@ -42,10 +49,42 @@ pub(crate) fn binding_payload_identity_matches(
         && left.effect_class == right.effect_class
 }
 
+pub(crate) struct ThreadBindingDelta {
+    pub removed_attach_event_ids: Vec<verlet_history::EventRecordId>,
+    pub added_bindings: Vec<verlet_history::BindingAttachedPayload>,
+}
+
+pub(crate) fn reconcile_thread_bindings(
+    active: &[ThreadBinding],
+    desired: Vec<verlet_history::BindingAttachedPayload>,
+) -> ThreadBindingDelta {
+    let mut unmatched_active = vec![true; active.len()];
+    let mut added_bindings = Vec::new();
+    for desired_binding in desired {
+        if let Some((index, _)) = active.iter().enumerate().find(|(index, active_binding)| {
+            unmatched_active[*index]
+                && binding_payload_identity_matches(&active_binding.payload, &desired_binding)
+        }) {
+            unmatched_active[index] = false;
+        } else {
+            added_bindings.push(desired_binding);
+        }
+    }
+    let removed_attach_event_ids = active
+        .iter()
+        .zip(unmatched_active)
+        .filter_map(|(binding, unmatched)| unmatched.then_some(binding.attach_event_id))
+        .collect();
+    ThreadBindingDelta {
+        removed_attach_event_ids,
+        added_bindings,
+    }
+}
+
 #[derive(Default)]
 struct BindingBatchObservation {
     attached_count: usize,
-    attached_payloads: Vec<verlet_history::BindingAttachedPayload>,
+    attached_bindings: Vec<crate::agent::manifest_bind::AgentManifestOperationBinding>,
     has_detach: bool,
 }
 
@@ -56,15 +95,12 @@ fn full_reemission_bind_batches(
         .iter()
         .filter(|event| event.kind == verlet_history::EventKind::ManifestBindCompleted)
         .filter_map(|event| {
-            let bindings = serde_json::from_value::<
+            let mut bindings = serde_json::from_value::<
                 Vec<crate::agent::manifest_bind::AgentManifestOperationBinding>,
             >(event.payload.get("operation_bindings")?.clone())
             .ok()?;
-            let payloads = bindings
-                .iter()
-                .map(|binding| crate::agent::manifest_bind::binding_attached_payload(binding, ""))
-                .collect::<Vec<_>>();
-            Some((event.id, payloads))
+            bindings.sort();
+            Some((event.id, bindings))
         })
         .collect::<std::collections::HashMap<_, _>>();
     let mut observed = std::collections::HashMap::<_, BindingBatchObservation>::new();
@@ -82,7 +118,11 @@ fn full_reemission_bind_batches(
                 if let Ok(payload) = serde_json::from_value::<verlet_history::BindingAttachedPayload>(
                     event.payload.clone(),
                 ) {
-                    observation.attached_payloads.push(payload);
+                    observation.attached_bindings.push(
+                        crate::agent::manifest_bind::operation_binding_from_attached_payload(
+                            payload,
+                        ),
+                    );
                 }
             }
             verlet_history::EventKind::BindingDetached => {
@@ -94,30 +134,22 @@ fn full_reemission_bind_batches(
 
     expected
         .into_iter()
-        .filter_map(|(bind_event_id, expected_payloads)| {
+        .filter_map(|(bind_event_id, expected_bindings)| {
             let observation = observed.get(&bind_event_id);
             let attached_count = observation.map_or(0, |batch| batch.attached_count);
             if observation.is_some_and(|batch| batch.has_detach)
-                || attached_count != expected_payloads.len()
+                || attached_count != expected_bindings.len()
             {
                 return None;
             }
-            let decoded = observation
-                .map(|batch| batch.attached_payloads.as_slice())
+            let mut attached_bindings = observation
+                .map(|batch| batch.attached_bindings.clone())
                 .unwrap_or_default();
-            if decoded.len() == attached_count {
-                let mut matched = vec![false; decoded.len()];
-                for expected_payload in &expected_payloads {
-                    let Some((index, _)) = decoded.iter().enumerate().find(|(index, actual)| {
-                        !matched[*index]
-                            && binding_payload_identity_matches(expected_payload, actual)
-                    }) else {
-                        return None;
-                    };
-                    matched[index] = true;
-                }
+            if attached_bindings.len() != attached_count {
+                return None;
             }
-            Some((bind_event_id, attached_count))
+            attached_bindings.sort();
+            (attached_bindings == expected_bindings).then_some((bind_event_id, attached_count))
         })
         .collect()
 }
@@ -302,6 +334,19 @@ mod tests {
             })
             .unwrap(),
         )
+    }
+
+    fn detach_event_for_bind(
+        sequence: i64,
+        id: u128,
+        attach_event_id: verlet_history::EventRecordId,
+        bind_id: u128,
+    ) -> verlet_history::EventRecord {
+        let mut event = detach_event(sequence, id, attach_event_id);
+        event.provenance.source_event_ids = vec![verlet_history::EventRecordId::from_uuid(
+            uuid::Uuid::from_u128(bind_id),
+        )];
+        event
     }
 
     #[test]
@@ -491,6 +536,97 @@ mod tests {
     }
 
     #[test]
+    fn modern_changed_delta_is_not_mistaken_for_a_full_reemission() {
+        let first_bind = bind_event(
+            1,
+            900,
+            serde_json::json!([
+                {"name": "search-tools", "artifact_hash": "sha256:search-tools"},
+                {"name": "file-tools", "artifact_hash": "sha256:file-tools"}
+            ]),
+        );
+        let first_search = attach_event_for_bind(2, 400, "search-tools", 900);
+        let first_files = attach_event_for_bind(3, 300, "file-tools", 900);
+        let second_bind = bind_event(
+            4,
+            901,
+            serde_json::json!([
+                {"name": "search-tools", "artifact_hash": "sha256:search-tools-v2"},
+                {"name": "file-tools", "artifact_hash": "sha256:file-tools"}
+            ]),
+        );
+        let mut second_search = attach_event_for_bind(5, 200, "search-tools", 901);
+        second_search.payload["artifact_hash"] = serde_json::json!("sha256:search-tools-v2");
+        let detach_first_search = detach_event_for_bind(6, 100, first_search.id, 901);
+
+        let folded = super::fold_thread_bindings(&[
+            first_bind,
+            first_search,
+            first_files.clone(),
+            second_bind,
+            second_search.clone(),
+            detach_first_search,
+        ]);
+
+        assert!(folded.anomalies.is_empty());
+        assert_eq!(
+            folded
+                .active
+                .iter()
+                .map(|binding| binding.attach_event_id)
+                .collect::<Vec<_>>(),
+            vec![first_files.id, second_search.id]
+        );
+    }
+
+    #[test]
+    fn many_emo_584_full_reemissions_keep_only_the_latest_generation() {
+        let mut events = Vec::new();
+        let mut sequence = 1;
+        let mut expected_ids = Vec::new();
+        for generation in 0..12_u128 {
+            let bind_id = 1_000 + generation;
+            let search_name = format!("search-tools-{generation}");
+            let file_name = format!("file-tools-{generation}");
+            events.push(bind_event(
+                sequence,
+                bind_id,
+                serde_json::json!([
+                    {
+                        "name": search_name,
+                        "artifact_hash": format!("sha256:search-tools-{generation}")
+                    },
+                    {
+                        "name": file_name,
+                        "artifact_hash": format!("sha256:file-tools-{generation}")
+                    }
+                ]),
+            ));
+            sequence += 1;
+            let search =
+                attach_event_for_bind(sequence, 2_000 + generation * 2, &search_name, bind_id);
+            sequence += 1;
+            let files =
+                attach_event_for_bind(sequence, 2_001 + generation * 2, &file_name, bind_id);
+            sequence += 1;
+            expected_ids = vec![search.id, files.id];
+            events.extend([search, files]);
+        }
+
+        let folded = super::fold_thread_bindings(&events);
+
+        assert!(folded.anomalies.is_empty());
+        assert_eq!(
+            folded
+                .active
+                .iter()
+                .map(|binding| binding.attach_event_id)
+                .collect::<Vec<_>>(),
+            expected_ids
+        );
+    }
+
+    #[test]
     fn emo_584_empty_reemission_retires_the_prior_generation() {
         let first_bind = bind_event(
             1,
@@ -613,7 +749,7 @@ mod tests {
     }
 
     #[test]
-    fn undecodable_new_bind_batch_retires_the_previous_batch() {
+    fn undecodable_attach_cannot_prove_a_full_reemission_batch() {
         let old_bind = bind_event(
             1,
             900,
@@ -641,7 +777,16 @@ mod tests {
 
         let folded = super::fold_thread_bindings(&[old_bind, old, new_bind, bad_attach.clone()]);
 
-        assert!(folded.active.is_empty());
+        assert_eq!(
+            folded
+                .active
+                .iter()
+                .map(|binding| binding.attach_event_id)
+                .collect::<Vec<_>>(),
+            vec![verlet_history::EventRecordId::from_uuid(
+                uuid::Uuid::from_u128(1)
+            )]
+        );
         assert!(matches!(
             folded.anomalies.as_slice(),
             [super::ThreadBindingAnomaly::UndecodableAttached { event_id, .. }]

--- a/crates/verlet-kernel/src/kernel/control_decision.rs
+++ b/crates/verlet-kernel/src/kernel/control_decision.rs
@@ -12,6 +12,8 @@ pub struct ToolCallRequestedPayload {
     pub tool_name: String,
     pub arguments: serde_json::Value,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attach_event_id: Option<verlet_history::EventRecordId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub args_fingerprint: Option<String>,
     /// Kernel-derived resource holds for this invocation. Empty when decoding
     /// events written before hold scheduling existed.
@@ -970,6 +972,7 @@ mod tests {
             .unwrap();
         assert!(legacy_request.holds.is_empty());
         assert_eq!(legacy_request.args_fingerprint, None);
+        assert_eq!(legacy_request.attach_event_id, None);
         assert!(
             crate::kernel::control_decision::tool_invocation_fingerprint_matches(
                 "snapshot-a",
@@ -1009,6 +1012,9 @@ mod tests {
                 snapshot_id: legacy_request.snapshot_id.clone(),
                 tool_name: legacy_request.tool_name.clone(),
                 arguments: legacy_request.arguments.clone(),
+                attach_event_id: Some(verlet_history::EventRecordId::from_uuid(
+                    uuid::Uuid::from_u128(42),
+                )),
                 args_fingerprint: Some(format!("sha256:{}", "a".repeat(64))),
                 holds: vec![serde_json::json!({
                     "key": {"kind": "kernel_thread", "task_name": "worker-a"},
@@ -1016,6 +1022,10 @@ mod tests {
                 })],
             })
             .unwrap();
+        assert_eq!(
+            new_request["attach_event_id"],
+            serde_json::json!(uuid::Uuid::from_u128(42).to_string())
+        );
         let decoded_by_old_reader: LegacyToolCallRequestedPayload =
             serde_json::from_value(new_request).unwrap();
         assert_eq!(decoded_by_old_reader.subject, legacy_request.subject);
@@ -1623,6 +1633,7 @@ mod tests {
                                 snapshot_id: snapshot_id.clone(),
                                 tool_name: "bash".to_string(),
                                 arguments: serde_json::json!({"cmd": "rm -rf /"}),
+                                attach_event_id: None,
                                 args_fingerprint: None,
                                 holds: Vec::new(),
                             },

--- a/crates/verlet-kernel/src/kernel/runtime_host/tests.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/tests.rs
@@ -5344,6 +5344,223 @@ async fn manifest_rebind_emits_only_changed_binding_deltas_in_the_fenced_batch()
             ("search".to_string(), "sha256:search-b".to_string()),
         ]
     );
+    let folded = crate::kernel::binding_projector::fold_thread_bindings(&events);
+    let rebound_search = folded
+        .active
+        .iter()
+        .find(|binding| binding.payload.name == "search")
+        .unwrap();
+    assert_eq!(rebound_search.payload.artifact_hash, "sha256:search-b");
+    assert!(
+        delta[4..6]
+            .iter()
+            .any(|event| event.id == rebound_search.attach_event_id)
+    );
+}
+
+#[tokio::test]
+async fn manifest_bind_fence_conflict_never_appends_a_stale_binding_diff() {
+    let barrier = std::sync::Arc::new(AdmissionAppendBarrier::default());
+    let store = std::sync::Arc::new(AdmissionTestStore::blocking_manifest(barrier.clone()));
+    let host = crate::kernel::runtime_host::RuntimeHost::with_session_store(
+        std::sync::Arc::new(EchoRuntimeFactory),
+        store.clone(),
+    );
+    let thread = host
+        .start_thread(
+            coords("tenant_a", "user_1", "binding-fence-conflict"),
+            verlet_runtime_contracts::ThreadTopology::root(),
+        )
+        .await
+        .unwrap();
+    let coordinates = thread.context().coordinates.clone();
+    let stream_id = verlet_history::EventStreamId::for_thread(&coordinates);
+    let recorder = tokio::spawn(async move {
+        thread
+            .record_manifest_receipts(
+                serde_json::json!({"manifest_hash": "snapshot-stale"}),
+                serde_json::json!({
+                    "manifest_hash": "snapshot-stale",
+                    "operation_bindings": [
+                        {"name": "search", "artifact_hash": "sha256:search"}
+                    ]
+                }),
+            )
+            .await
+    });
+
+    barrier.wait_for_entries(1).await;
+    let concurrent = verlet_history::NewEventRecord::witnessed(
+        coordinates,
+        verlet_history::EventKind::TurnSubmitted,
+        serde_json::json!({"turn_id": "turn-concurrent"}),
+    );
+    store
+        .append_events(&stream_id, vec![concurrent])
+        .await
+        .unwrap();
+    barrier.release();
+
+    let error = recorder.await.unwrap().unwrap_err();
+    assert!(error.to_string().contains("fenced append"));
+    let events = store.read_events(&stream_id, None).await.unwrap();
+    assert!(events.iter().any(|event| {
+        event.kind == verlet_history::EventKind::TurnSubmitted
+            && event.payload["turn_id"] == "turn-concurrent"
+    }));
+    assert!(events.iter().all(|event| {
+        !matches!(
+            event.kind,
+            verlet_history::EventKind::ManifestCompileCompleted
+                | verlet_history::EventKind::ManifestBindCompleted
+                | verlet_history::EventKind::BindingAttached
+                | verlet_history::EventKind::BindingDetached
+                | verlet_history::EventKind::PlacementDecision
+        )
+    }));
+}
+
+#[tokio::test]
+async fn manifest_rebind_matches_duplicate_bindings_one_for_one() {
+    let store = std::sync::Arc::new(verlet_history::InMemorySessionStore::new());
+    let host = crate::kernel::runtime_host::RuntimeHost::with_session_store(
+        std::sync::Arc::new(EchoRuntimeFactory),
+        store.clone(),
+    );
+    let thread = host
+        .start_thread(
+            coords("tenant_a", "user_1", "binding-duplicates"),
+            verlet_runtime_contracts::ThreadTopology::root(),
+        )
+        .await
+        .unwrap();
+    let duplicate = serde_json::json!({
+        "name": "search",
+        "artifact_hash": "sha256:search"
+    });
+    thread
+        .record_manifest_receipts(
+            serde_json::json!({"manifest_hash": "snapshot-a"}),
+            serde_json::json!({
+                "manifest_hash": "snapshot-a",
+                "operation_bindings": [duplicate.clone(), duplicate.clone()]
+            }),
+        )
+        .await
+        .unwrap();
+    let stream_id = verlet_history::EventStreamId::for_thread(&thread.context().coordinates);
+    let before_unchanged = store.read_events(&stream_id, None).await.unwrap();
+
+    thread
+        .record_manifest_receipts(
+            serde_json::json!({"manifest_hash": "snapshot-b"}),
+            serde_json::json!({
+                "manifest_hash": "snapshot-b",
+                "operation_bindings": [duplicate.clone(), duplicate.clone()]
+            }),
+        )
+        .await
+        .unwrap();
+    let after_unchanged = store.read_events(&stream_id, None).await.unwrap();
+    assert!(
+        after_unchanged[before_unchanged.len()..]
+            .iter()
+            .all(|event| !matches!(
+                event.kind,
+                verlet_history::EventKind::BindingAttached
+                    | verlet_history::EventKind::BindingDetached
+            ))
+    );
+
+    thread
+        .record_manifest_receipts(
+            serde_json::json!({"manifest_hash": "snapshot-c"}),
+            serde_json::json!({
+                "manifest_hash": "snapshot-c",
+                "operation_bindings": [duplicate]
+            }),
+        )
+        .await
+        .unwrap();
+    let after_removal = store.read_events(&stream_id, None).await.unwrap();
+    let removal_delta = &after_removal[after_unchanged.len()..];
+    assert_eq!(
+        removal_delta
+            .iter()
+            .filter(|event| event.kind == verlet_history::EventKind::BindingDetached)
+            .count(),
+        1
+    );
+    assert_eq!(
+        removal_delta
+            .iter()
+            .filter(|event| event.kind == verlet_history::EventKind::BindingAttached)
+            .count(),
+        0
+    );
+    let folded = crate::kernel::binding_projector::fold_thread_bindings(&after_removal);
+    assert!(folded.anomalies.is_empty());
+    assert_eq!(folded.active.len(), 1);
+}
+
+#[tokio::test]
+async fn manifest_rebind_rejects_an_anomalous_binding_fold() {
+    let store = std::sync::Arc::new(verlet_history::InMemorySessionStore::new());
+    let host = crate::kernel::runtime_host::RuntimeHost::with_session_store(
+        std::sync::Arc::new(EchoRuntimeFactory),
+        store.clone(),
+    );
+    let thread = host
+        .start_thread(
+            coords("tenant_a", "user_1", "binding-anomaly"),
+            verlet_runtime_contracts::ThreadTopology::root(),
+        )
+        .await
+        .unwrap();
+    let stream_id = verlet_history::EventStreamId::for_thread(&thread.context().coordinates);
+    store
+        .append_events(
+            &stream_id,
+            vec![verlet_history::NewEventRecord::witnessed(
+                thread.context().coordinates.clone(),
+                verlet_history::EventKind::BindingAttached,
+                serde_json::json!({"name": "missing-required-fields"}),
+            )],
+        )
+        .await
+        .unwrap();
+
+    let error = thread
+        .record_manifest_receipts(
+            serde_json::json!({"manifest_hash": "snapshot-a"}),
+            serde_json::json!({
+                "manifest_hash": "snapshot-a",
+                "operation_bindings": [
+                    {"name": "search", "artifact_hash": "sha256:search"}
+                ]
+            }),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("binding history is anomalous"));
+    let events = store.read_events(&stream_id, None).await.unwrap();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.kind == verlet_history::EventKind::BindingAttached)
+            .count(),
+        1
+    );
+    assert!(events.iter().all(|event| {
+        !matches!(
+            event.kind,
+            verlet_history::EventKind::ManifestCompileCompleted
+                | verlet_history::EventKind::ManifestBindCompleted
+                | verlet_history::EventKind::BindingDetached
+                | verlet_history::EventKind::PlacementDecision
+        )
+    }));
 }
 
 #[tokio::test]

--- a/crates/verlet-kernel/src/kernel/runtime_host/tests.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/tests.rs
@@ -5227,6 +5227,191 @@ async fn manifest_binding_rejects_an_empty_principal_before_append() {
 }
 
 #[tokio::test]
+async fn manifest_rebind_emits_only_changed_binding_deltas_in_the_fenced_batch() {
+    let store = std::sync::Arc::new(verlet_history::InMemorySessionStore::new());
+    let host = crate::kernel::runtime_host::RuntimeHost::with_session_store(
+        std::sync::Arc::new(EchoRuntimeFactory),
+        store.clone(),
+    );
+    let thread = host
+        .start_thread(
+            coords("tenant_a", "user_1", "binding-delta"),
+            verlet_runtime_contracts::ThreadTopology::root(),
+        )
+        .await
+        .unwrap();
+
+    thread
+        .record_manifest_receipts(
+            serde_json::json!({
+                "manifest_hash": "snapshot-a",
+                "source_hash": "sha256:source-a"
+            }),
+            serde_json::json!({
+                "manifest_hash": "snapshot-a",
+                "operation_bindings": [
+                    {"name": "files", "artifact_hash": "sha256:files"},
+                    {"name": "logs", "artifact_hash": "sha256:logs"},
+                    {"name": "search", "artifact_hash": "sha256:search-a"}
+                ]
+            }),
+        )
+        .await
+        .unwrap();
+    let stream_id = verlet_history::EventStreamId::for_thread(&thread.context().coordinates);
+    let before = store.read_events(&stream_id, None).await.unwrap();
+    let first_attaches = before
+        .iter()
+        .filter(|event| event.kind == verlet_history::EventKind::BindingAttached)
+        .map(|event| {
+            let payload: verlet_history::BindingAttachedPayload =
+                serde_json::from_value(event.payload.clone()).unwrap();
+            (payload.name, event.id)
+        })
+        .collect::<std::collections::BTreeMap<_, _>>();
+
+    thread
+        .record_manifest_receipts(
+            serde_json::json!({
+                "manifest_hash": "snapshot-b",
+                "source_hash": "sha256:source-b"
+            }),
+            serde_json::json!({
+                "manifest_hash": "snapshot-b",
+                "operation_bindings": [
+                    {"name": "clock", "artifact_hash": "sha256:clock"},
+                    {"name": "files", "artifact_hash": "sha256:files"},
+                    {"name": "search", "artifact_hash": "sha256:search-b"}
+                ]
+            }),
+        )
+        .await
+        .unwrap();
+
+    let events = store.read_events(&stream_id, None).await.unwrap();
+    let delta = &events[before.len()..];
+    assert_eq!(
+        delta.iter().map(|event| event.kind).collect::<Vec<_>>(),
+        vec![
+            verlet_history::EventKind::ManifestCompileCompleted,
+            verlet_history::EventKind::ManifestBindCompleted,
+            verlet_history::EventKind::BindingDetached,
+            verlet_history::EventKind::BindingDetached,
+            verlet_history::EventKind::BindingAttached,
+            verlet_history::EventKind::BindingAttached,
+            verlet_history::EventKind::PlacementDecision,
+        ]
+    );
+    let bind_id = delta[1].id;
+    assert!(
+        delta[2..6]
+            .iter()
+            .all(|event| event.provenance.source_event_ids == vec![bind_id])
+    );
+    let detached = delta[2..4]
+        .iter()
+        .map(|event| {
+            serde_json::from_value::<verlet_history::BindingDetachedPayload>(event.payload.clone())
+                .unwrap()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        detached
+            .iter()
+            .map(|payload| payload.attach_event_id)
+            .collect::<std::collections::HashSet<_>>(),
+        ["logs", "search"]
+            .into_iter()
+            .map(|name| first_attaches[name])
+            .collect()
+    );
+    assert!(detached.iter().all(|payload| {
+        payload.requested_by == "user_1"
+            && payload.decided_by == "user_1"
+            && payload.decision_event_id.is_none()
+    }));
+    assert_eq!(
+        delta[4..6]
+            .iter()
+            .map(|event| {
+                let payload: verlet_history::BindingAttachedPayload =
+                    serde_json::from_value(event.payload.clone()).unwrap();
+                (payload.name, payload.artifact_hash)
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            ("clock".to_string(), "sha256:clock".to_string()),
+            ("search".to_string(), "sha256:search-b".to_string()),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn manifest_rebind_to_zero_operations_detaches_every_active_binding() {
+    let store = std::sync::Arc::new(verlet_history::InMemorySessionStore::new());
+    let host = crate::kernel::runtime_host::RuntimeHost::with_session_store(
+        std::sync::Arc::new(EchoRuntimeFactory),
+        store.clone(),
+    );
+    let thread = host
+        .start_thread(
+            coords("tenant_a", "user_1", "binding-delta-empty"),
+            verlet_runtime_contracts::ThreadTopology::root(),
+        )
+        .await
+        .unwrap();
+
+    thread
+        .record_manifest_receipts(
+            serde_json::json!({"manifest_hash": "snapshot-a"}),
+            serde_json::json!({
+                "manifest_hash": "snapshot-a",
+                "operation_bindings": [
+                    {"name": "files", "artifact_hash": "sha256:files"},
+                    {"name": "search", "artifact_hash": "sha256:search"}
+                ]
+            }),
+        )
+        .await
+        .unwrap();
+    let stream_id = verlet_history::EventStreamId::for_thread(&thread.context().coordinates);
+    let before = store.read_events(&stream_id, None).await.unwrap();
+
+    thread
+        .record_manifest_receipts(
+            serde_json::json!({"manifest_hash": "snapshot-b"}),
+            serde_json::json!({
+                "manifest_hash": "snapshot-b",
+                "operation_bindings": []
+            }),
+        )
+        .await
+        .unwrap();
+
+    let events = store.read_events(&stream_id, None).await.unwrap();
+    let delta = &events[before.len()..];
+    assert_eq!(
+        delta
+            .iter()
+            .filter(|event| event.kind == verlet_history::EventKind::BindingDetached)
+            .count(),
+        2
+    );
+    assert_eq!(
+        delta
+            .iter()
+            .filter(|event| event.kind == verlet_history::EventKind::BindingAttached)
+            .count(),
+        0
+    );
+    assert!(
+        crate::kernel::binding_projector::fold_thread_bindings(&events)
+            .active
+            .is_empty()
+    );
+}
+
+#[tokio::test]
 async fn cancelled_manifest_receipt_caller_cannot_leave_a_half_witnessed_workspace() {
     let barrier = std::sync::Arc::new(AdmissionAppendBarrier::default());
     let store = std::sync::Arc::new(AdmissionTestStore::blocking_manifest(barrier.clone()));

--- a/crates/verlet-kernel/src/kernel/runtime_host/thread_handle.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/thread_handle.rs
@@ -1,3 +1,15 @@
+fn binding_payload_identity_matches(
+    left: &verlet_history::BindingAttachedPayload,
+    right: &verlet_history::BindingAttachedPayload,
+) -> bool {
+    left.name == right.name
+        && left.artifact_hash == right.artifact_hash
+        && left.operations == right.operations
+        && left.direct_tools == right.direct_tools
+        && left.attachment_config == right.attachment_config
+        && left.effect_class == right.effect_class
+}
+
 impl crate::kernel::runtime_host::RuntimeThreadHandle {
     pub fn context(&self) -> &verlet_runtime_contracts::ThreadContext {
         &self.thread.context
@@ -131,6 +143,52 @@ impl crate::kernel::runtime_host::RuntimeThreadHandle {
                 ))
             })?
             .unwrap_or_default();
+        let runtime_store = self.thread.services.runtime_store();
+        let existing_events = runtime_store
+            .read_events(&stream_id, None)
+            .await
+            .map_err(|err| crate::kernel::runtime_host::VerletError::History(err.to_string()))?;
+        let expected_next_sequence = existing_events
+            .last()
+            .map(|event| verlet_history::EventSequence::new(event.sequence.get() + 1))
+            .unwrap_or_else(|| verlet_history::EventSequence::new(1));
+        let folded = crate::kernel::binding_projector::fold_thread_bindings(&existing_events);
+        let desired_bindings = operation_bindings
+            .iter()
+            .map(|binding| {
+                crate::agent::manifest_bind::binding_attached_payload(binding, principal_id)
+            })
+            .collect::<Vec<_>>();
+        let mut matched_active = vec![false; folded.active.len()];
+        let mut matched_desired = vec![false; desired_bindings.len()];
+        for (desired_index, desired) in desired_bindings.iter().enumerate() {
+            if let Some((active_index, _)) =
+                folded
+                    .active
+                    .iter()
+                    .enumerate()
+                    .find(|(active_index, active)| {
+                        !matched_active[*active_index]
+                            && binding_payload_identity_matches(&active.payload, desired)
+                    })
+            {
+                matched_active[active_index] = true;
+                matched_desired[desired_index] = true;
+            }
+        }
+        let removed_attach_event_ids = folded
+            .active
+            .iter()
+            .enumerate()
+            .filter_map(|(index, binding)| {
+                (!matched_active[index]).then_some(binding.attach_event_id)
+            })
+            .collect::<Vec<_>>();
+        let added_bindings = desired_bindings
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, binding)| (!matched_desired[index]).then_some(binding))
+            .collect::<Vec<_>>();
         let mut placement =
             bind_payload
                 .get("placement")
@@ -220,11 +278,46 @@ impl crate::kernel::runtime_host::RuntimeThreadHandle {
             verlet_history::EventKind::PlacementDecision,
             placement_payload,
         );
-        let attachment_events = operation_bindings
-            .iter()
-            .map(|binding| {
-                let payload =
-                    crate::agent::manifest_bind::binding_attached_payload(binding, principal_id);
+        let detachment_events = removed_attach_event_ids
+            .into_iter()
+            .map(|attach_event_id| {
+                let payload = verlet_history::BindingDetachedPayload {
+                    attach_event_id,
+                    requested_by: principal_id.to_string(),
+                    decided_by: principal_id.to_string(),
+                    decision_event_id: None,
+                };
+                serde_json::to_value(payload)
+                    .map(|payload| {
+                        verlet_history::NewEventRecord::discharged(
+                            coordinates.clone(),
+                            verlet_history::EventKind::BindingDetached,
+                            payload,
+                            verlet_history::EventProvenance {
+                                source_streams: vec![stream_id.clone()],
+                                source_event_ids: vec![bind_event.id],
+                                discharged_by: Some(
+                                    crate::agent::manifest_bind::MANIFEST_BINDER_DISCHARGED_BY
+                                        .to_string(),
+                                ),
+                                function: Some(
+                                    crate::agent::manifest_bind::MANIFEST_BINDER_FUNCTION
+                                        .to_string(),
+                                ),
+                                ..verlet_history::EventProvenance::default()
+                            },
+                        )
+                    })
+                    .map_err(|err| {
+                        crate::kernel::runtime_host::VerletError::History(format!(
+                            "binding.detached payload codec failed: {err}"
+                        ))
+                    })
+            })
+            .collect::<crate::kernel::runtime_host::VerletResult<Vec<_>>>()?;
+        let attachment_events = added_bindings
+            .into_iter()
+            .map(|payload| {
                 serde_json::to_value(payload)
                     .map(|payload| {
                         verlet_history::NewEventRecord::discharged(
@@ -256,8 +349,9 @@ impl crate::kernel::runtime_host::RuntimeThreadHandle {
         // Receipts and witnesses share one atomic store append. This closes the
         // crash/race window: callers never receive a bind receipt unless its
         // effective binding and placement facts committed in the same batch.
-        let minimum_event_count = 3 + attachment_events.len();
+        let minimum_event_count = 3 + detachment_events.len() + attachment_events.len();
         let mut records = vec![compile_event, bind_event];
+        records.extend(detachment_events);
         records.extend(attachment_events);
         records.push(placement_event);
         if let Some(raw_coupling_set) = self
@@ -316,14 +410,6 @@ impl crate::kernel::runtime_host::RuntimeThreadHandle {
         // RPC task that initiated the bind is cancelled. The runtime-host
         // start guards separately remove a thread cancelled during factory
         // construction, so no mounted runtime survives without this batch.
-        let runtime_store = self.thread.services.runtime_store();
-        let expected_next_sequence = runtime_store
-            .read_events(&stream_id, None)
-            .await
-            .map_err(|err| crate::kernel::runtime_host::VerletError::History(err.to_string()))?
-            .last()
-            .map(|event| verlet_history::EventSequence::new(event.sequence.get() + 1))
-            .unwrap_or_else(|| verlet_history::EventSequence::new(1));
         let append = tokio::spawn(async move {
             runtime_store
                 .append_events_fenced(&stream_id, expected_next_sequence, records)

--- a/crates/verlet-kernel/src/kernel/runtime_host/thread_handle.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/thread_handle.rs
@@ -1,15 +1,3 @@
-fn binding_payload_identity_matches(
-    left: &verlet_history::BindingAttachedPayload,
-    right: &verlet_history::BindingAttachedPayload,
-) -> bool {
-    left.name == right.name
-        && left.artifact_hash == right.artifact_hash
-        && left.operations == right.operations
-        && left.direct_tools == right.direct_tools
-        && left.attachment_config == right.attachment_config
-        && left.effect_class == right.effect_class
-}
-
 impl crate::kernel::runtime_host::RuntimeThreadHandle {
     pub fn context(&self) -> &verlet_runtime_contracts::ThreadContext {
         &self.thread.context
@@ -169,7 +157,10 @@ impl crate::kernel::runtime_host::RuntimeThreadHandle {
                     .enumerate()
                     .find(|(active_index, active)| {
                         !matched_active[*active_index]
-                            && binding_payload_identity_matches(&active.payload, desired)
+                            && crate::kernel::binding_projector::binding_payload_identity_matches(
+                                &active.payload,
+                                desired,
+                            )
                     })
             {
                 matched_active[active_index] = true;

--- a/crates/verlet-kernel/src/kernel/runtime_host/thread_handle.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/thread_handle.rs
@@ -141,45 +141,22 @@ impl crate::kernel::runtime_host::RuntimeThreadHandle {
             .map(|event| verlet_history::EventSequence::new(event.sequence.get() + 1))
             .unwrap_or_else(|| verlet_history::EventSequence::new(1));
         let folded = crate::kernel::binding_projector::fold_thread_bindings(&existing_events);
+        if let Some(message) = folded.anomaly_message() {
+            return Err(crate::kernel::runtime_host::VerletError::History(message));
+        }
         let desired_bindings = operation_bindings
             .iter()
             .map(|binding| {
                 crate::agent::manifest_bind::binding_attached_payload(binding, principal_id)
             })
             .collect::<Vec<_>>();
-        let mut matched_active = vec![false; folded.active.len()];
-        let mut matched_desired = vec![false; desired_bindings.len()];
-        for (desired_index, desired) in desired_bindings.iter().enumerate() {
-            if let Some((active_index, _)) =
-                folded
-                    .active
-                    .iter()
-                    .enumerate()
-                    .find(|(active_index, active)| {
-                        !matched_active[*active_index]
-                            && crate::kernel::binding_projector::binding_payload_identity_matches(
-                                &active.payload,
-                                desired,
-                            )
-                    })
-            {
-                matched_active[active_index] = true;
-                matched_desired[desired_index] = true;
-            }
-        }
-        let removed_attach_event_ids = folded
-            .active
-            .iter()
-            .enumerate()
-            .filter_map(|(index, binding)| {
-                (!matched_active[index]).then_some(binding.attach_event_id)
-            })
-            .collect::<Vec<_>>();
-        let added_bindings = desired_bindings
-            .into_iter()
-            .enumerate()
-            .filter_map(|(index, binding)| (!matched_desired[index]).then_some(binding))
-            .collect::<Vec<_>>();
+        let crate::kernel::binding_projector::ThreadBindingDelta {
+            removed_attach_event_ids,
+            added_bindings,
+        } = crate::kernel::binding_projector::reconcile_thread_bindings(
+            &folded.active,
+            desired_bindings,
+        );
         let mut placement =
             bind_payload
                 .get("placement")

--- a/crates/verlet-kernel/tests/lexicon_lint_baseline.txt
+++ b/crates/verlet-kernel/tests/lexicon_lint_baseline.txt
@@ -2,7 +2,7 @@
 # line edits do not churn the baseline. This file only shrinks.
 crates/verlet-kernel/src/adapters/app_server/connection.rs capsule 45
 crates/verlet-kernel/src/adapters/app_server.rs capsule 25
-crates/verlet-kernel/src/adapters/app_server/tests.rs capsule 117
+crates/verlet-kernel/src/adapters/app_server/tests.rs capsule 116
 crates/verlet-kernel/src/adapters/app_server/threads.rs capsule 10
 crates/verlet-kernel/src/adapters/mcp_server.rs capsule 28
 crates/verlet-kernel/src/adapters/mcp_server/tests.rs capsule 32

--- a/crates/verlet-kernel/tests/runtime_loop_scenarios.rs
+++ b/crates/verlet-kernel/tests/runtime_loop_scenarios.rs
@@ -1453,6 +1453,7 @@ async fn kernel_thread_router() -> verlet::agent::agent_tool_router::AgentToolRo
             registered_name: verlet::operations::kernel_packages::VERLET_THREADS_PACKAGE
                 .to_string(),
             operation_name: verlet::operations::kernel_packages::THREAD_SPAWN_OPERATION.to_string(),
+            attach_event_id: None,
         },
     ])
 }


### PR DESCRIPTION
## Summary

Second implementation slice of the binding model (parent EMO-579, builds on #111): the journaled binding events become the source of truth for a thread's toolset.

- Rebinds emit deltas in the receipt's fenced batch: dropped bindings get `binding.detached`, changed ones detach and re-attach, unchanged ones emit nothing (their original attach event stays the binding's identity), and rebind-to-zero detaches everything. An unchanged resume appends no binding events, so restarts stop growing the journal.
- `fold_thread_bindings` folds plain attach/detach semantics for current streams; a narrow read-time rule (exact decoded multiset equality against the batch's receipt) recognizes the transitional full re-emission batches written between #111 and this PR.
- `operation_catalog_for_thread` derives from binding history, then bind receipts (pre-#111 streams), then legacy metadata. The metadata key remains a write-through cache that cannot override the fold; corrupted history fails closed instead of silently changing the toolset.
- Operation-backed `tool.call.requested` events cite the admitting `binding.attached` event id; kernel and static tools cite none. Unchanged resume cites the original attach event; changed rebind cites the new one.
- Rebind stays idle-only; a regression pins the turn-boundary law against a genuinely running provider turn. No snapshot machinery added.
- Review pass fixed two Highs before this PR (corrupt attach payloads could be misread as a legacy snapshot and retire authority; fold anomalies were silently swallowed by catalog and rebind paths) plus stale cache state after rebind-to-zero.
- Known design item deferred with the policy router work: per-operation attach provenance for operations invoked inside bash scripts (the outer bash request correctly cites none).

Linear: EMO-585 (implementation and review reports on the issue).

#### Test plan

- [x] `scripts/verify.sh` (lints, fmt, clippy, full workspace suite, both smokes)
- [x] `scripts/verify-linux.sh`
- [x] Full workspace tests green (kernel 1246 passed, 4 ignored)
- [x] Lifecycle coverage: start, turn with citation, unchanged resume (no new events), changed rebind (delta), rebind-to-zero (all detached, empty catalog, fresh cache), fork, bash-through-resume
- [x] Adversarial coverage: fence race fails closed, duplicate bindings, corrupt payloads fail closed, 12-generation legacy fold
- [x] EMO-580/581/584 canaries green; frozen wire fixtures byte-identical
