### PR TITLE
Tolerate hooks that exit without reading stdin (EMO-569)

### DIFF
--- a/crates/verlet-kernel/src/agent/hooks.rs
+++ b/crates/verlet-kernel/src/agent/hooks.rs
@@ -607,11 +607,17 @@ impl CommandHookHandler {
             ))
         })?;
         if let Some(mut stdin) = child.stdin.take() {
-            stdin.write_all(input.as_bytes()).await.map_err(|err| {
-                crate::kernel::runtime_host::VerletError::RuntimeExecution(format!(
-                    "failed to write hook stdin: {err}"
-                ))
-            })?;
+            // A hook may exit without reading stdin; the resulting broken pipe
+            // is not a failure. The exit status and stdout decide the outcome.
+            match stdin.write_all(input.as_bytes()).await {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => {}
+                Err(err) => {
+                    return Err(crate::kernel::runtime_host::VerletError::RuntimeExecution(
+                        format!("failed to write hook stdin: {err}"),
+                    ));
+                }
+            }
         }
         let output = tokio::time::timeout(
             std::time::Duration::from_millis(self.timeout_ms),

--- a/crates/verlet-kernel/src/agent/hooks/tests.rs
+++ b/crates/verlet-kernel/src/agent/hooks/tests.rs
@@ -37,6 +37,44 @@ async fn command_hook_handler_reads_json_stdin_and_returns_pre_tool_output() {
     assert_eq!(outcome.additional_contexts, vec!["ctx"]);
 }
 
+#[tokio::test]
+async fn command_hook_handler_tolerates_hook_that_never_reads_stdin() {
+    let hook = crate::agent::hooks::CommandHookHandler::new(
+        "no-stdin",
+        crate::agent::hooks::HookEventName::PreToolUse,
+        r#"printf '%s' '{"additional_context":"ignored stdin"}'"#,
+    )
+    .with_matcher("echo_search");
+    let coordinates =
+        verlet_runtime_contracts::ThreadCoordinates::new("tenant_a", "user_1", "session_1");
+    let turn_context = crate::kernel::runtime_host::turn::TurnContext::new(
+        verlet_runtime_contracts::ThreadContext::root(coordinates),
+        "turn-1",
+        &crate::kernel::runtime_host::turn::TurnInput::text("hello"),
+        tokio_util::sync::CancellationToken::new(),
+    );
+    // Larger than any pipe buffer, so the stdin write cannot complete before
+    // the hook exits and the broken pipe is guaranteed rather than a race.
+    let request = crate::agent::hooks::PreToolUseHookRequest {
+        turn_context: turn_context.snapshot(),
+        call_id: "call_1".to_string(),
+        tool_name: "echo_search".to_string(),
+        arguments: serde_json::json!({"input": "x".repeat(4 * 1024 * 1024)}),
+    };
+    let outcome = crate::agent::hooks::HookPipeline::new()
+        .with_command_handler(hook)
+        .run_pre_tool_use(request, |_| {})
+        .await;
+
+    assert_eq!(
+        outcome.records[0].status,
+        crate::agent::hooks::HookRunStatus::Completed,
+        "hook records: {:?}",
+        outcome.records
+    );
+    assert_eq!(outcome.additional_contexts, vec!["ignored stdin"]);
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn command_hook_handler_prefers_injected_shell() {


### PR DESCRIPTION
Stop-the-line fix for red main: the ubuntu Verify leg failed twice in a row on agent::hooks::tests::command_hook_handler_prefers_injected_shell with "failed to write hook stdin: Broken pipe". A hook may legitimately exit without reading stdin; the runner treated the resulting EPIPE as a hard failure, so any non-stdin-reading hook could fail nondeterministically. Second flake mode on this test after the ETXTBSY fix in #93.

The runner now tolerates BrokenPipe when writing hook stdin; the exit status and stdout decide the outcome. New regression test forces the broken pipe deterministically with a payload larger than the pipe buffer.

This lands the fix already written in the anchor's working tree for EMO-569, unchanged.

Verification: scripts/verify.sh and scripts/verify-linux.sh both green locally.