### PR TITLE
build: inherit version and edition from [workspace.package]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5878,7 +5878,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-abi"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-agent"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5901,7 +5901,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-chat"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "crossterm",
  "futures-util",
@@ -5912,7 +5912,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5921,7 +5921,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5930,7 +5930,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-history"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -5944,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-history-sqlite"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -5957,7 +5957,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-io-core"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -5969,7 +5969,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-io-pgqrs"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5984,7 +5984,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-io-telegram"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -5997,7 +5997,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-metadata"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "futures-executor",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-operations"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-process"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-provider"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -6073,7 +6073,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-runtime-contracts"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6083,7 +6083,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-sqlite"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "tempfile",
  "thiserror 2.0.18",
@@ -6094,7 +6094,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-trace-ab"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6102,7 +6102,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-vbash"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bashkit",
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-vfs"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bashkit",
@@ -6129,7 +6129,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-wasm"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "bashkit",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ members = [
 default-members = ["crates/verlet-kernel"]
 resolver = "3"
 
+[workspace.package]
+edition = "2024"
+version = "0.4.0"
+
 [workspace.dependencies]
 async-trait = "0.1"
 base64 = "0.22"

--- a/crates/verlet-abi/Cargo.toml
+++ b/crates/verlet-abi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-abi"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/verlet-agent/Cargo.toml
+++ b/crates/verlet-agent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-agent"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/verlet-chat/Cargo.toml
+++ b/crates/verlet-chat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-chat"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/verlet-guest-sdk-macros/Cargo.toml
+++ b/crates/verlet-guest-sdk-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-guest-sdk-macros"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/verlet-guest-sdk/Cargo.toml
+++ b/crates/verlet-guest-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-guest-sdk"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/verlet-history-sqlite/Cargo.toml
+++ b/crates/verlet-history-sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-history-sqlite"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/verlet-history/Cargo.toml
+++ b/crates/verlet-history/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-history"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/verlet-io-core/Cargo.toml
+++ b/crates/verlet-io-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-io-core"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/verlet-io-pgqrs/Cargo.toml
+++ b/crates/verlet-io-pgqrs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-io-pgqrs"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [features]

--- a/crates/verlet-io-telegram/Cargo.toml
+++ b/crates/verlet-io-telegram/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-io-telegram"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/verlet-kernel/Cargo.toml
+++ b/crates/verlet-kernel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet"
-version = "0.4.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 autobins = false
 

--- a/crates/verlet-metadata/Cargo.toml
+++ b/crates/verlet-metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-metadata"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/verlet-operations/Cargo.toml
+++ b/crates/verlet-operations/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-operations"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/verlet-process/Cargo.toml
+++ b/crates/verlet-process/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-process"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/verlet-provider/Cargo.toml
+++ b/crates/verlet-provider/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-provider"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/verlet-runtime-contracts/Cargo.toml
+++ b/crates/verlet-runtime-contracts/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-runtime-contracts"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/verlet-sqlite/Cargo.toml
+++ b/crates/verlet-sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-sqlite"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 license = "Apache-2.0"
 description = "Engine-owner crate for verlet SQLite stores (ADR 0005): configuration, connections, migrations, DST IO hook"
 

--- a/crates/verlet-vbash/Cargo.toml
+++ b/crates/verlet-vbash/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-vbash"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/verlet-vfs/Cargo.toml
+++ b/crates/verlet-vfs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-vfs"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/verlet-wasm/Cargo.toml
+++ b/crates/verlet-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-wasm"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/tools/file-read/Cargo.lock
+++ b/tools/file-read/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tools/http-fetch/Cargo.lock
+++ b/tools/http-fetch/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tools/json-query/Cargo.lock
+++ b/tools/json-query/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tools/trace-ab/Cargo.toml
+++ b/tools/trace-ab/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verlet-trace-ab"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 [dependencies]


### PR DESCRIPTION
Declares `version = "0.4.0"` and `edition = "2024"` once in the root `[workspace.package]`, and points all 21 members at it with `version.workspace = true` / `edition.workspace = true`.

Members were previously split between 0.1.0 and 0.4.0 (verlet-kernel). They now all report 0.4.0. Path dependencies carry no version field, so nothing else changed.

`tools/{http-fetch,file-read,json-query}` declare their own `[workspace]` and are not members here, so they keep literal values.

Based on #119, which moves verlet-sqlite to edition 2024. Without it, inheriting the edition would flip that crate to 2024 without its source changes.

Gates: `cargo fmt --check` clean, `cargo clippy --workspace --all-targets` unchanged from the base branch, `cargo nextest run --workspace` has one failure (`nonzero_daemon_lease_epoch_reaches_client_stream_and_ingress_witness_handles`) that reproduces on the base branch with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)