### PR TITLE
Apply the AGENTS.md Rust rules across the workspace

### DIFF
--- a/crates/verlet-chat/src/app.rs
+++ b/crates/verlet-chat/src/app.rs
@@ -2,21 +2,11 @@
 //!
 //! Ported from tuika's `codex` example (`examples/codex/app.rs`) and rewired
 //! for a real host: instead of driving a scripted agent, [`App::handle`]
-//! emits [`Action`]s for the host to execute, and the host feeds results back
+//! emits [`crate::Action`]s for the host to execute, and the host feeds results back
 //! through [`App::apply`]. Both are synchronous; every UI behavior is testable
 //! by calling them in sequence.
 
-use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
-
-use tuika::components::MarkdownState;
-use tuika::prelude::*;
-
 pub(crate) mod setup;
-
-use crate::cells::{Cell, ExecStatus, Tone, short_id};
-use crate::{Action, ChatEvent, ModelRow, SessionMeta};
-use setup::SetupStep;
 
 /// Whether the event loop should keep running.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -98,21 +88,21 @@ pub fn parse_slash_command(input: &str) -> Result<Option<SlashCommand>, String> 
 
 /// The composer's trigger characters: `/` opens command completion when it
 /// starts the message.
-pub(crate) fn triggers() -> [Trigger; 1] {
-    [Trigger::new('/').anchor(TriggerAnchor::BufferStart)]
+pub(crate) fn triggers() -> [tuika::components::Trigger; 1] {
+    [tuika::components::Trigger::new('/').anchor(tuika::components::TriggerAnchor::BufferStart)]
 }
 
 /// The slash-completion popup state.
 pub(crate) struct Popup {
-    pub state: SelectState,
+    pub state: tuika::components::SelectState,
 }
 
 /// The `/models` picker: a modal list over the composer. Opened by
-/// [`ChatEvent::Models`], closed by Enter (emits [`Action::SelectModel`])
+/// [`crate::ChatEvent::Models`], closed by Enter (emits [`crate::Action::SelectModel`])
 /// or Esc. While open it consumes every key event.
 pub(crate) struct ModelPicker {
-    pub rows: Vec<ModelRow>,
-    pub state: SelectState,
+    pub rows: Vec<crate::ModelRow>,
+    pub state: tuika::components::SelectState,
 }
 
 /// The whole application.
@@ -121,14 +111,14 @@ pub struct App {
     /// Milliseconds per frame, set by the runner's tick interval; the
     /// `Working (12s …)` timer counts in frames so tests stay deterministic.
     pub frame_ms: u64,
-    pub cells: Vec<Cell>,
-    pub composer: TextInputState,
-    pub scroll: ScrollState,
+    pub cells: Vec<crate::cells::Cell>,
+    pub composer: tuika::components::TextInputState,
+    pub scroll: tuika::components::ScrollState,
     pub(crate) popup: Option<Popup>,
     pub(crate) picker: Option<ModelPicker>,
-    pub(crate) setup: Option<SetupStep>,
+    pub(crate) setup: Option<crate::app::setup::SetupStep>,
     /// A model choice waiting on credentials: re-issued as
-    /// [`Action::SelectModel`] once the provider's credential lands.
+    /// [`crate::Action::SelectModel`] once the provider's credential lands.
     pub(crate) pending_selection: Option<(String, String)>,
     /// First-run gate: no configured providers yet. The footer nags until a
     /// credential lands or a model is selected.
@@ -136,7 +126,7 @@ pub struct App {
     /// Submitted keys retained until one host reply so late generic errors
     /// can be redacted after the user leaves the input step.
     pub(crate) pending_key_redactions: Vec<(String, String)>,
-    pub meta: SessionMeta,
+    pub meta: crate::SessionMeta,
     /// Turn state label for the footer: "idle", "running", "steered", ...
     pub turn_state: String,
     turn_active: bool,
@@ -155,19 +145,19 @@ pub struct App {
     pub content_h: usize,
     pub viewport_h: usize,
     /// Host work queued by `handle`; the runner drains it after every event.
-    actions: Vec<Action>,
+    actions: Vec<crate::Action>,
     quit_requested: bool,
 }
 
 impl App {
-    pub fn new(meta: SessionMeta) -> Self {
+    pub fn new(meta: crate::SessionMeta) -> Self {
         let banner = banner_cell(&meta);
         Self {
             frame: 0,
             frame_ms: 60,
             cells: vec![banner],
-            composer: TextInputState::new(),
-            scroll: ScrollState::new(),
+            composer: tuika::components::TextInputState::new(),
+            scroll: tuika::components::ScrollState::new(),
             popup: None,
             picker: None,
             setup: None,
@@ -207,14 +197,14 @@ impl App {
     }
 
     /// Host work queued since the last drain.
-    pub fn drain_actions(&mut self) -> Vec<Action> {
+    pub fn drain_actions(&mut self) -> Vec<crate::Action> {
         std::mem::take(&mut self.actions)
     }
 
     /// Where the terminal cursor belongs, given the composer's painted rect.
     /// While a modal window owns the input surface the composer is dimmed
     /// underneath it, so no terminal caret is shown.
-    pub fn cursor(&self, composer_rect: Rect) -> Option<(u16, u16)> {
+    pub fn cursor(&self, composer_rect: ratatui::layout::Rect) -> Option<(u16, u16)> {
         if composer_rect.width == 0 || self.setup_visible() || self.picker.is_some() {
             return None;
         }
@@ -237,7 +227,7 @@ impl App {
 
     /// Route one translated event. The order here *is* the focus model: the
     /// transcript's scroll keys first, then the picker, then the composer.
-    pub fn handle(&mut self, event: &Event) -> Flow {
+    pub fn handle(&mut self, event: &tuika::event::Event) -> Flow {
         let flow = self.route(event);
         if self.quit_requested {
             return Flow::Quit;
@@ -245,7 +235,7 @@ impl App {
         flow
     }
 
-    fn route(&mut self, event: &Event) -> Flow {
+    fn route(&mut self, event: &tuika::event::Event) -> Flow {
         // The setup wizard and the model picker own the whole input surface
         // while open. Keep them ahead of transcript scrolling, paste
         // handling, global controls, and slash completion so none of those
@@ -262,38 +252,38 @@ impl App {
             let _ = self.scroll.handle(event, self.content_h, self.viewport_h);
             return Flow::Continue;
         }
-        if matches!(event, Event::Paste(_)) {
+        if matches!(event, tuika::event::Event::Paste(_)) {
             let _ = self.composer.handle(event);
             self.sync_popup();
             return Flow::Continue;
         }
-        let Event::Key(key) = event else {
+        let tuika::event::Event::Key(key) = event else {
             return Flow::Continue;
         };
 
-        if key.ctrl && key.code == KeyCode::Char('c') {
+        if key.ctrl && key.code == tuika::event::KeyCode::Char('c') {
             return self.interrupt_or_quit();
         }
-        if key.ctrl && key.code == KeyCode::Char('d') && self.composer.is_empty() {
+        if key.ctrl && key.code == tuika::event::KeyCode::Char('d') && self.composer.is_empty() {
             return Flow::Quit;
         }
         if self.popup.is_some() && self.handle_popup(event, *key) {
             return Flow::Continue;
         }
-        if key.plain() && key.code == KeyCode::Esc {
+        if key.plain() && key.code == tuika::event::KeyCode::Esc {
             if self.turn_active {
-                self.actions.push(Action::Interrupt);
+                self.actions.push(crate::Action::Interrupt);
             }
             return Flow::Continue;
         }
         // `Up` on an empty composer recalls the previous prompt.
-        if key.plain() && key.code == KeyCode::Up && self.composer.is_empty() {
+        if key.plain() && key.code == tuika::event::KeyCode::Up && self.composer.is_empty() {
             self.recall();
             return Flow::Continue;
         }
 
         match self.composer.handle(event) {
-            InputOutcome::Submitted => {
+            tuika::event::InputOutcome::Submitted => {
                 let text = self.composer.text().trim().to_string();
                 self.composer.clear();
                 self.popup = None;
@@ -308,30 +298,39 @@ impl App {
     }
 
     /// Events that belong to the transcript rather than to any focused surface.
-    fn scrolling(&self, event: &Event) -> bool {
+    fn scrolling(&self, event: &tuika::event::Event) -> bool {
         match event {
-            Event::Mouse(m) => matches!(m.kind, MouseKind::ScrollUp | MouseKind::ScrollDown),
-            Event::Key(k) => k.plain() && matches!(k.code, KeyCode::PageUp | KeyCode::PageDown),
+            tuika::event::Event::Mouse(m) => matches!(
+                m.kind,
+                tuika::event::MouseKind::ScrollUp | tuika::event::MouseKind::ScrollDown
+            ),
+            tuika::event::Event::Key(k) => {
+                k.plain()
+                    && matches!(
+                        k.code,
+                        tuika::event::KeyCode::PageUp | tuika::event::KeyCode::PageDown
+                    )
+            }
             _ => false,
         }
     }
 
     fn interrupt_or_quit(&mut self) -> Flow {
         if self.turn_active {
-            self.actions.push(Action::Interrupt);
+            self.actions.push(crate::Action::Interrupt);
             return Flow::Continue;
         }
         Flow::Quit
     }
 
     /// Returns true when the popup consumed the event.
-    fn handle_popup(&mut self, event: &Event, key: Key) -> bool {
+    fn handle_popup(&mut self, event: &tuika::event::Event, key: tuika::event::Key) -> bool {
         let items = self.popup_items();
         let Some(popup) = self.popup.as_mut() else {
             return false;
         };
         // Tab completes the highlighted row in place, without running it.
-        if key.plain() && key.code == KeyCode::Tab {
+        if key.plain() && key.code == tuika::event::KeyCode::Tab {
             let completion = popup
                 .state
                 .selected()
@@ -343,7 +342,7 @@ impl App {
             return true;
         }
         match popup.state.handle(event, items.len()) {
-            InputOutcome::Submitted => {
+            tuika::event::InputOutcome::Submitted => {
                 let label = popup
                     .state
                     .selected()
@@ -362,7 +361,7 @@ impl App {
                 }
                 true
             }
-            InputOutcome::Cancelled => {
+            tuika::event::InputOutcome::Cancelled => {
                 self.popup = None;
                 true
             }
@@ -374,12 +373,12 @@ impl App {
     /// Enter selects (already-active rows just close), Esc dismisses,
     /// arrows move; anything else is swallowed so the composer underneath
     /// stays untouched.
-    fn handle_picker(&mut self, event: &Event) {
+    fn handle_picker(&mut self, event: &tuika::event::Event) {
         let Some(picker) = self.picker.as_mut() else {
             return;
         };
         match picker.state.handle(event, picker.rows.len()) {
-            InputOutcome::Submitted => {
+            tuika::event::InputOutcome::Submitted => {
                 let row = picker
                     .state
                     .selected()
@@ -391,7 +390,7 @@ impl App {
                 };
                 if row.active {
                     self.notice(
-                        Tone::Info,
+                        crate::cells::Tone::Info,
                         format!("{}/{} is already active", row.provider_id, row.model),
                         Vec::new(),
                     );
@@ -404,12 +403,12 @@ impl App {
                     self.setup_for_model(row.provider_id, row.model);
                     return;
                 }
-                self.actions.push(Action::SelectModel {
+                self.actions.push(crate::Action::SelectModel {
                     provider_id: row.provider_id,
                     model: row.model,
                 });
             }
-            InputOutcome::Cancelled => {
+            tuika::event::InputOutcome::Cancelled => {
                 self.picker = None;
             }
             _ => {}
@@ -431,7 +430,7 @@ impl App {
             }
             (None, Some(_)) => {
                 self.popup = Some(Popup {
-                    state: SelectState::new(),
+                    state: tuika::components::SelectState::new(),
                 });
             }
         }
@@ -447,15 +446,18 @@ impl App {
     }
 
     /// The composer's `/` token as a styled range, colored in the input.
-    pub fn composer_highlights(&self, theme: &Theme) -> Vec<tuika::components::TextSpan> {
+    pub fn composer_highlights(
+        &self,
+        theme: &tuika::style::Theme,
+    ) -> Vec<tuika::components::TextSpan> {
         self.composer
             .tokens(&triggers())
             .iter()
-            .map(|token: &Token| {
+            .map(|token: &tuika::components::Token| {
                 token.span(
-                    Style::default()
+                    ratatui::style::Style::default()
                         .fg(theme.accent_alt)
-                        .add_modifier(Modifier::BOLD),
+                        .add_modifier(ratatui::style::Modifier::BOLD),
                 )
             })
             .collect()
@@ -480,10 +482,10 @@ impl App {
         match parse_slash_command(text) {
             Ok(Some(command)) => self.slash(command),
             Ok(None) => {
-                self.cells.push(Cell::User(text.to_string()));
-                self.actions.push(Action::Submit(text.to_string()));
+                self.cells.push(crate::cells::Cell::User(text.to_string()));
+                self.actions.push(crate::Action::Submit(text.to_string()));
             }
-            Err(message) => self.notice(Tone::Error, message, Vec::new()),
+            Err(message) => self.notice(crate::cells::Tone::Error, message, Vec::new()),
         }
         self.follow();
     }
@@ -498,15 +500,15 @@ impl App {
                         format!("{label}{hint} — {blurb}")
                     })
                     .collect();
-                self.notice(Tone::Info, "Commands".to_string(), body);
+                self.notice(crate::cells::Tone::Info, "Commands".to_string(), body);
             }
             SlashCommand::Quit => self.quit_requested = true,
             SlashCommand::Interrupt => {
                 if self.turn_active {
-                    self.actions.push(Action::Interrupt);
+                    self.actions.push(crate::Action::Interrupt);
                 } else {
                     self.notice(
-                        Tone::Info,
+                        crate::cells::Tone::Info,
                         "no active turn to interrupt".to_string(),
                         vec![],
                     );
@@ -516,7 +518,11 @@ impl App {
                 self.cells.clear();
                 self.active_answer = None;
                 self.active_thinking = None;
-                self.notice(Tone::Info, "transcript cleared".to_string(), Vec::new());
+                self.notice(
+                    crate::cells::Tone::Info,
+                    "transcript cleared".to_string(),
+                    Vec::new(),
+                );
             }
             SlashCommand::Status => {
                 let mut rows = self.meta_rows();
@@ -524,42 +530,45 @@ impl App {
                 if self.total_tokens > 0 {
                     rows.push(("tokens".into(), self.total_tokens.to_string()));
                 }
-                self.cells.push(Cell::Config {
+                self.cells.push(crate::cells::Cell::Config {
                     title: "Session".into(),
                     rows,
                 });
             }
             SlashCommand::New => {
                 if self.ensure_idle("/new") {
-                    self.actions.push(Action::NewThread);
+                    self.actions.push(crate::Action::NewThread);
                 }
             }
-            SlashCommand::Sessions => self.actions.push(Action::ListSessions),
+            SlashCommand::Sessions => self.actions.push(crate::Action::ListSessions),
             SlashCommand::Resume(id) => {
                 if self.ensure_idle("/resume") {
-                    self.actions.push(Action::Resume(id));
+                    self.actions.push(crate::Action::Resume(id));
                 }
             }
-            SlashCommand::Rename(name) => self.actions.push(Action::Rename(name)),
+            SlashCommand::Rename(name) => self.actions.push(crate::Action::Rename(name)),
             SlashCommand::Fork => {
                 if self.ensure_idle("/fork") {
-                    self.actions.push(Action::Fork);
+                    self.actions.push(crate::Action::Fork);
                 }
             }
             SlashCommand::Compact => {
                 if self.ensure_idle("/compact") {
-                    self.actions.push(Action::Compact);
+                    self.actions.push(crate::Action::Compact);
                 }
             }
             SlashCommand::Models => {
                 if matches!(
                     self.setup,
-                    Some(SetupStep::AwaitModels { .. } | SetupStep::AwaitCatalog { .. })
+                    Some(
+                        crate::app::setup::SetupStep::AwaitModels { .. }
+                            | crate::app::setup::SetupStep::AwaitCatalog { .. }
+                    )
                 ) {
                     self.setup = None;
                     self.pending_selection = None;
                 }
-                self.actions.push(Action::ListModels);
+                self.actions.push(crate::Action::ListModels);
             }
             SlashCommand::Setup => self.open_setup_home(),
         }
@@ -568,7 +577,7 @@ impl App {
     fn ensure_idle(&mut self, command: &str) -> bool {
         if self.turn_active {
             self.notice(
-                Tone::Error,
+                crate::cells::Tone::Error,
                 format!("{command} is unavailable during an active turn; use /interrupt"),
                 Vec::new(),
             );
@@ -578,35 +587,36 @@ impl App {
     }
 
     /// Fold one host event into the transcript and status state.
-    pub fn apply(&mut self, event: ChatEvent) {
+    pub fn apply(&mut self, event: crate::ChatEvent) {
         match event {
-            ChatEvent::AnswerDelta(delta) => {
+            crate::ChatEvent::AnswerDelta(delta) => {
                 if delta.is_empty() {
                     return;
                 }
                 let index = match self.active_answer {
                     Some(index) => index,
                     None => {
-                        self.cells
-                            .push(Cell::Answer(Box::new(MarkdownState::new())));
+                        self.cells.push(crate::cells::Cell::Answer(Box::new(
+                            tuika::components::MarkdownState::new(),
+                        )));
                         let index = self.cells.len() - 1;
                         self.active_answer = Some(index);
                         index
                     }
                 };
-                if let Some(Cell::Answer(state)) = self.cells.get_mut(index) {
+                if let Some(crate::cells::Cell::Answer(state)) = self.cells.get_mut(index) {
                     state.push_str(&delta);
                 }
                 self.follow();
             }
-            ChatEvent::ThinkingDelta(delta) => {
+            crate::ChatEvent::ThinkingDelta(delta) => {
                 if delta.is_empty() {
                     return;
                 }
                 let index = match self.active_thinking {
                     Some(index) => index,
                     None => {
-                        self.cells.push(Cell::Reasoning {
+                        self.cells.push(crate::cells::Cell::Reasoning {
                             body: String::new(),
                         });
                         let index = self.cells.len() - 1;
@@ -614,48 +624,48 @@ impl App {
                         index
                     }
                 };
-                if let Some(Cell::Reasoning { body }) = self.cells.get_mut(index) {
+                if let Some(crate::cells::Cell::Reasoning { body }) = self.cells.get_mut(index) {
                     body.push_str(&delta);
                 }
                 self.follow();
             }
-            ChatEvent::ToolStarted { id, title } => {
+            crate::ChatEvent::ToolStarted { id, title } => {
                 // A tool call interleaves with the streamed answer: close the
                 // streaming cells so later deltas open fresh ones below.
                 self.active_answer = None;
                 self.active_thinking = None;
-                self.cells.push(Cell::Exec {
+                self.cells.push(crate::cells::Cell::Exec {
                     id,
                     title,
                     output: Vec::new(),
-                    status: ExecStatus::Running,
+                    status: crate::cells::ExecStatus::Running,
                 });
                 self.follow();
             }
-            ChatEvent::ToolOutputDelta { id, delta } => {
+            crate::ChatEvent::ToolOutputDelta { id, delta } => {
                 if delta.is_empty() {
                     return;
                 }
-                if let Some(Cell::Exec { output, .. }) = self.find_exec(&id) {
+                if let Some(crate::cells::Cell::Exec { output, .. }) = self.find_exec(&id) {
                     append_output_lines(output, &delta);
                 }
                 self.follow();
             }
-            ChatEvent::ToolCompleted {
+            crate::ChatEvent::ToolCompleted {
                 id,
                 success,
                 output,
             } => {
-                if let Some(Cell::Exec {
+                if let Some(crate::cells::Cell::Exec {
                     output: rows,
                     status,
                     ..
                 }) = self.find_exec(&id)
                 {
                     *status = if success {
-                        ExecStatus::Ok
+                        crate::cells::ExecStatus::Ok
                     } else {
-                        ExecStatus::Failed
+                        crate::cells::ExecStatus::Failed
                     };
                     if !output.is_empty() {
                         rows.clear();
@@ -664,27 +674,27 @@ impl App {
                 }
                 self.follow();
             }
-            ChatEvent::TurnStarted { turn_id } => {
+            crate::ChatEvent::TurnStarted { turn_id } => {
                 self.turn_active = true;
                 self.turn_started = Some(self.frame);
-                self.turn_state = format!("running {}", short_id(&turn_id));
+                self.turn_state = format!("running {}", crate::cells::short_id(&turn_id));
                 self.total_tokens = 0;
                 self.active_answer = None;
                 self.active_thinking = None;
             }
-            ChatEvent::TurnSteered => {
+            crate::ChatEvent::TurnSteered => {
                 self.turn_state = "steered".to_string();
             }
-            ChatEvent::TurnCompleted { error } => {
+            crate::ChatEvent::TurnCompleted { error } => {
                 if let Some(message) = error {
-                    self.notice(Tone::Error, message, Vec::new());
+                    self.notice(crate::cells::Tone::Error, message, Vec::new());
                 }
                 self.finish_turn();
             }
-            ChatEvent::Usage { total_tokens } => {
+            crate::ChatEvent::Usage { total_tokens } => {
                 self.total_tokens = self.total_tokens.saturating_add(total_tokens);
             }
-            ChatEvent::ThreadSwitched {
+            crate::ChatEvent::ThreadSwitched {
                 thread_id,
                 name,
                 cwd,
@@ -698,29 +708,33 @@ impl App {
                 self.finish_turn();
                 self.total_tokens = 0;
                 self.notice(
-                    Tone::Info,
-                    format!("{reason} {}", short_id(&self.meta.thread_id)),
+                    crate::cells::Tone::Info,
+                    format!("{reason} {}", crate::cells::short_id(&self.meta.thread_id)),
                     Vec::new(),
                 );
             }
-            ChatEvent::ThreadRenamed { name } => {
+            crate::ChatEvent::ThreadRenamed { name } => {
                 self.meta.thread_name = Some(name.clone());
-                self.notice(Tone::Info, format!("renamed thread {name}"), Vec::new());
+                self.notice(
+                    crate::cells::Tone::Info,
+                    format!("renamed thread {name}"),
+                    Vec::new(),
+                );
             }
-            ChatEvent::Sessions(rows) => {
-                self.cells.push(Cell::Sessions(rows));
+            crate::ChatEvent::Sessions(rows) => {
+                self.cells.push(crate::cells::Cell::Sessions(rows));
                 self.follow();
             }
-            ChatEvent::Models(rows) => {
+            crate::ChatEvent::Models(rows) => {
                 let rows = match self.setup.take() {
-                    Some(SetupStep::AwaitModels { provider_id }) => {
-                        let scoped: Vec<ModelRow> = rows
+                    Some(crate::app::setup::SetupStep::AwaitModels { provider_id }) => {
+                        let scoped: Vec<crate::ModelRow> = rows
                             .into_iter()
                             .filter(|row| row.provider_id == provider_id)
                             .collect();
                         if scoped.is_empty() {
                             self.notice(
-                                Tone::Error,
+                                crate::cells::Tone::Error,
                                 format!("no models available for {provider_id}"),
                                 Vec::new(),
                             );
@@ -740,14 +754,18 @@ impl App {
                 self.popup = None;
                 self.picker = None;
                 if rows.is_empty() {
-                    self.notice(Tone::Error, "no models available".to_string(), Vec::new());
+                    self.notice(
+                        crate::cells::Tone::Error,
+                        "no models available".to_string(),
+                        Vec::new(),
+                    );
                     return;
                 }
-                let mut state = SelectState::new();
+                let mut state = tuika::components::SelectState::new();
                 state.select(rows.iter().position(|row| row.active).or(Some(0)));
                 self.picker = Some(ModelPicker { rows, state });
             }
-            ChatEvent::ModelSelected { provider_id, model } => {
+            crate::ChatEvent::ModelSelected { provider_id, model } => {
                 self.pending_selection = None;
                 if provider_id != "local" {
                     self.needs_provider = false;
@@ -759,36 +777,40 @@ impl App {
                     Vec::new()
                 };
                 self.notice(
-                    Tone::Info,
+                    crate::cells::Tone::Info,
                     format!("model set to {provider_id}/{model}"),
                     body,
                 );
             }
-            ChatEvent::ProviderCatalog { providers } => self.apply_provider_catalog(providers),
-            ChatEvent::CustomProviderResult { provider_id, error } => {
+            crate::ChatEvent::ProviderCatalog { providers } => {
+                self.apply_provider_catalog(providers)
+            }
+            crate::ChatEvent::CustomProviderResult { provider_id, error } => {
                 self.apply_custom_provider_result(provider_id, error);
             }
-            ChatEvent::NoConfiguredProviders => self.apply_no_configured_providers(),
-            ChatEvent::LoginDeviceCode {
+            crate::ChatEvent::NoConfiguredProviders => self.apply_no_configured_providers(),
+            crate::ChatEvent::LoginDeviceCode {
                 verification_uri,
                 user_code,
             } => self.apply_device_code(verification_uri, user_code),
-            ChatEvent::CredentialResult { provider_id, error } => {
+            crate::ChatEvent::CredentialResult { provider_id, error } => {
                 self.apply_credential_result(provider_id, error);
             }
-            ChatEvent::CredentialCleared { provider_id } => {
+            crate::ChatEvent::CredentialCleared { provider_id } => {
                 self.apply_credential_cleared(provider_id);
             }
-            ChatEvent::ThreadStatus(status) => {
+            crate::ChatEvent::ThreadStatus(status) => {
                 if !self.turn_active {
                     self.turn_state = status;
                 }
             }
-            ChatEvent::Info { title, body } => self.notice(Tone::Info, title, body),
-            ChatEvent::Error { title, body } => self.apply_error(title, body),
-            ChatEvent::ResyncStarted => {
+            crate::ChatEvent::Info { title, body } => {
+                self.notice(crate::cells::Tone::Info, title, body)
+            }
+            crate::ChatEvent::Error { title, body } => self.apply_error(title, body),
+            crate::ChatEvent::ResyncStarted => {
                 self.notice(
-                    Tone::Warn,
+                    crate::cells::Tone::Warn,
                     "stream lagged; transcript tail may be incomplete".to_string(),
                     vec!["the server is rebuilding the turn".to_string()],
                 );
@@ -805,15 +827,15 @@ impl App {
     }
 
     /// The most recent exec cell with this tool-call id.
-    fn find_exec(&mut self, id: &str) -> Option<&mut Cell> {
-        self.cells
-            .iter_mut()
-            .rev()
-            .find(|cell| matches!(cell, Cell::Exec { id: cell_id, .. } if cell_id == id))
+    fn find_exec(&mut self, id: &str) -> Option<&mut crate::cells::Cell> {
+        self.cells.iter_mut().rev().find(
+            |cell| matches!(cell, crate::cells::Cell::Exec { id: cell_id, .. } if cell_id == id),
+        )
     }
 
-    fn notice(&mut self, tone: Tone, title: String, body: Vec<String>) {
-        self.cells.push(Cell::Notice { tone, title, body });
+    fn notice(&mut self, tone: crate::cells::Tone, title: String, body: Vec<String>) {
+        self.cells
+            .push(crate::cells::Cell::Notice { tone, title, body });
         self.follow();
     }
 
@@ -826,7 +848,7 @@ impl App {
                 "thread".into(),
                 format!(
                     "{} {}",
-                    short_id(&self.meta.thread_id),
+                    crate::cells::short_id(&self.meta.thread_id),
                     self.meta.thread_name.as_deref().unwrap_or("unnamed")
                 ),
             ),
@@ -842,7 +864,12 @@ impl App {
     ///
     /// Rebuilding every frame is the model working as intended: only the
     /// streaming answer holds a cache, and ratatui diffs the resulting cells.
-    pub fn transcript(&mut self, width: u16, theme: &Theme, sheet: &StyleSheet) -> Vec<Element> {
+    pub fn transcript(
+        &mut self,
+        width: u16,
+        theme: &tuika::style::Theme,
+        sheet: &tuika::style::StyleSheet,
+    ) -> Vec<tuika::view::Element> {
         self.cells
             .iter_mut()
             .map(|cell| cell.view(width, theme, sheet))
@@ -881,14 +908,14 @@ fn append_output_lines(rows: &mut Vec<String>, delta: &str) {
     }
 }
 
-fn banner_cell(meta: &SessionMeta) -> Cell {
-    Cell::Banner {
+fn banner_cell(meta: &crate::SessionMeta) -> crate::cells::Cell {
+    crate::cells::Cell::Banner {
         version: meta.version.clone(),
         rows: vec![
             ("connection".into(), meta.connection_label.clone()),
             ("directory".into(), meta.cwd.clone()),
             ("model".into(), meta.model_label.clone()),
-            ("thread".into(), short_id(&meta.thread_id)),
+            ("thread".into(), crate::cells::short_id(&meta.thread_id)),
         ],
         tips: [
             ("/help", "list the available commands"),

--- a/crates/verlet-chat/src/app/setup.rs
+++ b/crates/verlet-chat/src/app/setup.rs
@@ -4,16 +4,10 @@
 //! `ui.rs`) whose home screen is an overview of configured providers, with a
 //! searchable catalog picker and a custom-provider form behind it. The pi
 //! coding agent's `/login` dialog is the UX reference. Presentation-only
-//! discipline holds: `SetupStep` is the window's state, these `impl App`
-//! methods are its transitions, and every side effect is an [`Action`] for
+//! discipline holds: `SetupStep` is the window's state, these `impl crate::app::App`
+//! methods are its transitions, and every side effect is an [`crate::Action`] for
 //! the host to execute. The window owns the whole input surface while it has
 //! a visible step; Esc backs out one level at a time and closes from home.
-
-use tuika::prelude::*;
-
-use super::App;
-use crate::cells::Tone;
-use crate::{Action, CatalogProviderRow, CustomProviderSpec, LoginMethod};
 
 /// What a catalog fetch was for, so [`crate::ChatEvent::ProviderCatalog`]
 /// knows which screen to open when the rows arrive.
@@ -117,7 +111,7 @@ impl CustomForm {
     /// Prefill from an existing custom provider for editing. The key field
     /// starts empty: an empty key on submit means "leave the credential
     /// alone".
-    pub(crate) fn from_row(row: &CatalogProviderRow) -> Self {
+    pub(crate) fn from_row(row: &crate::CatalogProviderRow) -> Self {
         let api_index = API_FAMILIES
             .iter()
             .position(|(value, _)| *value == row.api)
@@ -155,7 +149,7 @@ impl CustomForm {
 
     /// Validate and build the submission. Ok also carries the API key text
     /// (possibly empty, meaning "no key follow-up").
-    pub(crate) fn build_spec(&self) -> Result<CustomProviderSpec, String> {
+    pub(crate) fn build_spec(&self) -> Result<crate::CustomProviderSpec, String> {
         let display_name = self.name.trim();
         if display_name.is_empty() {
             return Err("name is required".to_string());
@@ -182,7 +176,7 @@ impl CustomForm {
             (false, false) => Some((header_name.to_string(), header_value.to_string())),
             _ => return Err("header name and value must both be set (or both empty)".to_string()),
         };
-        Ok(CustomProviderSpec {
+        Ok(crate::CustomProviderSpec {
             provider_id: provider_id.to_string(),
             display_name: display_name.to_string(),
             api: API_FAMILIES[self.api_index.min(API_FAMILIES.len() - 1)]
@@ -204,37 +198,37 @@ pub(crate) enum SetupStep {
     AwaitCatalog { intent: CatalogIntent },
     /// The provider overview plus the `Connect` / `Add custom` actions.
     Home {
-        rows: Vec<CatalogProviderRow>,
-        state: SelectState,
+        rows: Vec<crate::CatalogProviderRow>,
+        state: tuika::components::SelectState,
     },
     /// Actions for one configured provider.
     ProviderMenu {
-        rows: Vec<CatalogProviderRow>,
-        provider: CatalogProviderRow,
-        state: SelectState,
+        rows: Vec<crate::CatalogProviderRow>,
+        provider: crate::CatalogProviderRow,
+        state: tuika::components::SelectState,
         /// A delete is in flight; only Esc works.
         busy: bool,
         error: Option<String>,
     },
     /// The searchable catalog picker ("Connect a provider").
     Catalog {
-        rows: Vec<CatalogProviderRow>,
+        rows: Vec<crate::CatalogProviderRow>,
         filter: String,
-        state: SelectState,
+        state: tuika::components::SelectState,
     },
     /// OAuth sign-in method choice (browser / device code).
     Credential {
-        rows: Vec<CatalogProviderRow>,
-        provider: CatalogProviderRow,
+        rows: Vec<crate::CatalogProviderRow>,
+        provider: crate::CatalogProviderRow,
         origin: CredentialOrigin,
-        state: SelectState,
+        state: tuika::components::SelectState,
         error: Option<String>,
     },
     /// Masked API-key entry. `busy` is set between submitting the key and
     /// the host's [`crate::ChatEvent::CredentialResult`].
     KeyInput {
-        rows: Vec<CatalogProviderRow>,
-        provider: CatalogProviderRow,
+        rows: Vec<crate::CatalogProviderRow>,
+        provider: crate::CatalogProviderRow,
         origin: CredentialOrigin,
         value: String,
         busy: bool,
@@ -243,16 +237,16 @@ pub(crate) enum SetupStep {
     /// An OAuth login is running in the host. Device logins fill
     /// `device_code` with `(verification_uri, user_code)` when it arrives.
     LoginWait {
-        rows: Vec<CatalogProviderRow>,
-        provider: CatalogProviderRow,
+        rows: Vec<crate::CatalogProviderRow>,
+        provider: crate::CatalogProviderRow,
         origin: CredentialOrigin,
-        method: LoginMethod,
+        method: crate::LoginMethod,
         device_code: Option<(String, String)>,
     },
     /// The custom-provider form. `editing` carries the original provider id
     /// when this is an edit rather than a create.
     CustomForm {
-        rows: Vec<CatalogProviderRow>,
+        rows: Vec<crate::CatalogProviderRow>,
         form: Box<CustomForm>,
         editing: Option<String>,
         busy: CustomBusy,
@@ -285,7 +279,7 @@ pub(crate) enum MenuAction {
 }
 
 /// The actions for one configured provider on the overview.
-pub(crate) fn provider_menu_options(provider: &CatalogProviderRow) -> Vec<MenuOption> {
+pub(crate) fn provider_menu_options(provider: &crate::CatalogProviderRow) -> Vec<MenuOption> {
     let mut options = vec![MenuOption {
         action: MenuAction::PickModel,
         label: "Pick a model",
@@ -362,7 +356,7 @@ pub(crate) fn oauth_options() -> Vec<MenuOption> {
 
 /// The rows the home overview lists: configured or custom providers, in
 /// catalog order (the server sorts configured first).
-pub(crate) fn overview_rows(rows: &[CatalogProviderRow]) -> Vec<&CatalogProviderRow> {
+pub(crate) fn overview_rows(rows: &[crate::CatalogProviderRow]) -> Vec<&crate::CatalogProviderRow> {
     rows.iter()
         .filter(|row| row.configured || row.custom)
         .collect()
@@ -375,7 +369,7 @@ pub(crate) const HOME_ACTIONS: [(&str, &str); 2] = [
 ];
 
 /// The status suffix for a catalog row, pi-style.
-pub(crate) fn catalog_status(row: &CatalogProviderRow) -> String {
+pub(crate) fn catalog_status(row: &crate::CatalogProviderRow) -> String {
     if row.configured {
         if row.auth_label.is_empty() {
             "✓ configured".to_string()
@@ -391,7 +385,7 @@ pub(crate) fn catalog_status(row: &CatalogProviderRow) -> String {
 
 /// The one-line summary for an overview row: auth source, model count, and
 /// base URL for custom entries.
-pub(crate) fn overview_status(row: &CatalogProviderRow) -> String {
+pub(crate) fn overview_status(row: &crate::CatalogProviderRow) -> String {
     let mut status = catalog_status(row);
     if row.custom {
         status.push_str(&format!(" · {}", row.base_url));
@@ -415,9 +409,9 @@ pub(crate) fn fuzzy_matches(haystack: &str, query: &str) -> bool {
 
 /// Catalog rows matching `filter`, substring matches (on name or id) first.
 pub(crate) fn filtered_catalog<'a>(
-    rows: &'a [CatalogProviderRow],
+    rows: &'a [crate::CatalogProviderRow],
     filter: &str,
-) -> Vec<&'a CatalogProviderRow> {
+) -> Vec<&'a crate::CatalogProviderRow> {
     let query = filter.trim().to_lowercase();
     if query.is_empty() {
         return rows.iter().collect();
@@ -506,14 +500,14 @@ pub(crate) fn validate_base_url(url: &str) -> Result<(), String> {
     Ok(())
 }
 
-impl App {
+impl crate::app::App {
     /// `/setup` and `/providers`: fetch the catalog and open the overview.
     pub(crate) fn open_setup_home(&mut self) {
         self.pending_selection = None;
         self.setup = Some(SetupStep::AwaitCatalog {
             intent: CatalogIntent::Home,
         });
-        self.actions.push(Action::FetchProviderCatalog);
+        self.actions.push(crate::Action::FetchProviderCatalog);
     }
 
     /// First-run gate: no configured providers, open the catalog picker.
@@ -523,7 +517,7 @@ impl App {
             self.setup = Some(SetupStep::AwaitCatalog {
                 intent: CatalogIntent::Catalog,
             });
-            self.actions.push(Action::FetchProviderCatalog);
+            self.actions.push(crate::Action::FetchProviderCatalog);
         }
     }
 
@@ -535,11 +529,11 @@ impl App {
         self.setup = Some(SetupStep::AwaitCatalog {
             intent: CatalogIntent::ForModel { provider_id },
         });
-        self.actions.push(Action::FetchProviderCatalog);
+        self.actions.push(crate::Action::FetchProviderCatalog);
     }
 
     /// Fold an arrived catalog into the window.
-    pub(crate) fn apply_provider_catalog(&mut self, rows: Vec<CatalogProviderRow>) {
+    pub(crate) fn apply_provider_catalog(&mut self, rows: Vec<crate::CatalogProviderRow>) {
         if rows.iter().any(|row| row.configured) {
             self.needs_provider = false;
         }
@@ -555,7 +549,7 @@ impl App {
                     else {
                         self.pending_selection = None;
                         self.notice(
-                            Tone::Error,
+                            crate::cells::Tone::Error,
                             format!("provider {provider_id} is no longer available"),
                             Vec::new(),
                         );
@@ -671,9 +665,9 @@ impl App {
         }
     }
 
-    fn open_home(&mut self, rows: Vec<CatalogProviderRow>) {
+    fn open_home(&mut self, rows: Vec<crate::CatalogProviderRow>) {
         self.popup = None;
-        let mut state = SelectState::new();
+        let mut state = tuika::components::SelectState::new();
         let selected = overview_rows(&rows)
             .iter()
             .position(|row| row.active)
@@ -682,19 +676,19 @@ impl App {
         self.setup = Some(SetupStep::Home { rows, state });
     }
 
-    fn open_catalog(&mut self, rows: Vec<CatalogProviderRow>) {
+    fn open_catalog(&mut self, rows: Vec<crate::CatalogProviderRow>) {
         self.popup = None;
         if rows.is_empty() {
             self.setup = None;
             self.pending_selection = None;
             self.notice(
-                Tone::Error,
+                crate::cells::Tone::Error,
                 "no providers available".to_string(),
                 Vec::new(),
             );
             return;
         }
-        let mut state = SelectState::new();
+        let mut state = tuika::components::SelectState::new();
         state.select(Some(0));
         self.setup = Some(SetupStep::Catalog {
             rows,
@@ -707,13 +701,13 @@ impl App {
     /// providers, the sign-in method choice for OAuth ones.
     fn open_credential_entry(
         &mut self,
-        rows: Vec<CatalogProviderRow>,
-        provider: CatalogProviderRow,
+        rows: Vec<crate::CatalogProviderRow>,
+        provider: crate::CatalogProviderRow,
         origin: CredentialOrigin,
     ) {
         self.popup = None;
         if provider.auth_kind == "oauth" {
-            let mut state = SelectState::new();
+            let mut state = tuika::components::SelectState::new();
             state.select(Some(0));
             self.setup = Some(SetupStep::Credential {
                 rows,
@@ -744,7 +738,7 @@ impl App {
         )
     }
 
-    pub(crate) fn handle_setup(&mut self, event: &Event) {
+    pub(crate) fn handle_setup(&mut self, event: &tuika::event::Event) {
         let Some(step) = self.setup.take() else {
             return;
         };
@@ -799,21 +793,21 @@ impl App {
 
     fn handle_home(
         &mut self,
-        event: &Event,
-        rows: Vec<CatalogProviderRow>,
-        mut state: SelectState,
+        event: &tuika::event::Event,
+        rows: Vec<crate::CatalogProviderRow>,
+        mut state: tuika::components::SelectState,
     ) {
         let overview_len = overview_rows(&rows).len();
         let total = overview_len + HOME_ACTIONS.len();
         match state.handle(event, total) {
-            InputOutcome::Submitted => {
+            tuika::event::InputOutcome::Submitted => {
                 let Some(index) = state.selected() else {
                     self.setup = Some(SetupStep::Home { rows, state });
                     return;
                 };
                 if index < overview_len {
                     let provider = overview_rows(&rows)[index].clone();
-                    let mut menu_state = SelectState::new();
+                    let mut menu_state = tuika::components::SelectState::new();
                     menu_state.select(Some(0));
                     self.setup = Some(SetupStep::ProviderMenu {
                         rows,
@@ -834,7 +828,7 @@ impl App {
                     });
                 }
             }
-            InputOutcome::Cancelled => {
+            tuika::event::InputOutcome::Cancelled => {
                 self.setup = None;
                 self.pending_selection = None;
             }
@@ -844,16 +838,17 @@ impl App {
 
     fn handle_provider_menu(
         &mut self,
-        event: &Event,
-        rows: Vec<CatalogProviderRow>,
-        provider: CatalogProviderRow,
-        mut state: SelectState,
+        event: &tuika::event::Event,
+        rows: Vec<crate::CatalogProviderRow>,
+        provider: crate::CatalogProviderRow,
+        mut state: tuika::components::SelectState,
         busy: bool,
         error: Option<String>,
     ) {
         // While the delete is in flight only Esc (back to home) works.
         if busy {
-            if matches!(event, Event::Key(key) if key.plain() && key.code == KeyCode::Esc) {
+            if matches!(event, tuika::event::Event::Key(key) if key.plain() && key.code == tuika::event::KeyCode::Esc)
+            {
                 self.open_home(rows);
             } else {
                 self.setup = Some(SetupStep::ProviderMenu {
@@ -868,7 +863,7 @@ impl App {
         }
         let options = provider_menu_options(&provider);
         match state.handle(event, options.len()) {
-            InputOutcome::Submitted => {
+            tuika::event::InputOutcome::Submitted => {
                 let action = state
                     .selected()
                     .and_then(|index| options.get(index))
@@ -879,7 +874,7 @@ impl App {
                         self.setup = Some(SetupStep::AwaitModels {
                             provider_id: provider.provider_id,
                         });
-                        self.actions.push(Action::ListModels);
+                        self.actions.push(crate::Action::ListModels);
                     }
                     MenuAction::ReplaceKey => {
                         self.setup = Some(SetupStep::KeyInput {
@@ -893,11 +888,11 @@ impl App {
                     }
                     MenuAction::BrowserLogin | MenuAction::DeviceLogin => {
                         let method = if action == MenuAction::BrowserLogin {
-                            LoginMethod::Browser
+                            crate::LoginMethod::Browser
                         } else {
-                            LoginMethod::Device
+                            crate::LoginMethod::Device
                         };
-                        self.actions.push(Action::StartLogin {
+                        self.actions.push(crate::Action::StartLogin {
                             provider_id: provider.provider_id.clone(),
                             method,
                         });
@@ -910,7 +905,7 @@ impl App {
                         });
                     }
                     MenuAction::ClearSaved => {
-                        self.actions.push(Action::ClearCredential {
+                        self.actions.push(crate::Action::ClearCredential {
                             provider_id: provider.provider_id.clone(),
                         });
                         self.setup = Some(SetupStep::ProviderMenu {
@@ -932,7 +927,7 @@ impl App {
                         });
                     }
                     MenuAction::DeleteCustom => {
-                        self.actions.push(Action::DeleteCustomProvider {
+                        self.actions.push(crate::Action::DeleteCustomProvider {
                             provider_id: provider.provider_id.clone(),
                         });
                         self.setup = Some(SetupStep::ProviderMenu {
@@ -946,7 +941,7 @@ impl App {
                     MenuAction::Back => self.open_home(rows),
                 }
             }
-            InputOutcome::Cancelled => self.open_home(rows),
+            tuika::event::InputOutcome::Cancelled => self.open_home(rows),
             _ => {
                 self.setup = Some(SetupStep::ProviderMenu {
                     rows,
@@ -961,15 +956,15 @@ impl App {
 
     fn handle_catalog(
         &mut self,
-        event: &Event,
-        rows: Vec<CatalogProviderRow>,
+        event: &tuika::event::Event,
+        rows: Vec<crate::CatalogProviderRow>,
         mut filter: String,
-        mut state: SelectState,
+        mut state: tuika::components::SelectState,
     ) {
         // Typing edits the filter; the select list only sees navigation keys.
-        if let Event::Key(key) = event {
+        if let tuika::event::Event::Key(key) = event {
             match key.code {
-                KeyCode::Char(ch) if !key.ctrl && !key.alt => {
+                tuika::event::KeyCode::Char(ch) if !key.ctrl && !key.alt => {
                     filter.push(ch);
                     state.select(Some(0));
                     self.setup = Some(SetupStep::Catalog {
@@ -979,7 +974,7 @@ impl App {
                     });
                     return;
                 }
-                KeyCode::Backspace => {
+                tuika::event::KeyCode::Backspace => {
                     filter.pop();
                     state.select(Some(0));
                     self.setup = Some(SetupStep::Catalog {
@@ -994,7 +989,7 @@ impl App {
         }
         let filtered_len = filtered_catalog(&rows, &filter).len();
         match state.handle(event, filtered_len) {
-            InputOutcome::Submitted => {
+            tuika::event::InputOutcome::Submitted => {
                 let provider = state
                     .selected()
                     .and_then(|index| filtered_catalog(&rows, &filter).get(index).copied())
@@ -1009,7 +1004,7 @@ impl App {
                 };
                 self.open_credential_entry(rows, provider, CredentialOrigin::Catalog);
             }
-            InputOutcome::Cancelled => self.open_home(rows),
+            tuika::event::InputOutcome::Cancelled => self.open_home(rows),
             _ => {
                 self.setup = Some(SetupStep::Catalog {
                     rows,
@@ -1022,16 +1017,16 @@ impl App {
 
     fn handle_credential(
         &mut self,
-        event: &Event,
-        rows: Vec<CatalogProviderRow>,
-        provider: CatalogProviderRow,
+        event: &tuika::event::Event,
+        rows: Vec<crate::CatalogProviderRow>,
+        provider: crate::CatalogProviderRow,
         origin: CredentialOrigin,
-        mut state: SelectState,
+        mut state: tuika::components::SelectState,
         error: Option<String>,
     ) {
         let options = oauth_options();
         match state.handle(event, options.len()) {
-            InputOutcome::Submitted => {
+            tuika::event::InputOutcome::Submitted => {
                 let action = state
                     .selected()
                     .and_then(|index| options.get(index))
@@ -1040,11 +1035,11 @@ impl App {
                 match action {
                     MenuAction::BrowserLogin | MenuAction::DeviceLogin => {
                         let method = if action == MenuAction::BrowserLogin {
-                            LoginMethod::Browser
+                            crate::LoginMethod::Browser
                         } else {
-                            LoginMethod::Device
+                            crate::LoginMethod::Device
                         };
-                        self.actions.push(Action::StartLogin {
+                        self.actions.push(crate::Action::StartLogin {
                             provider_id: provider.provider_id.clone(),
                             method,
                         });
@@ -1059,7 +1054,7 @@ impl App {
                     _ => self.credential_back(rows, provider, origin),
                 }
             }
-            InputOutcome::Cancelled => self.credential_back(rows, provider, origin),
+            tuika::event::InputOutcome::Cancelled => self.credential_back(rows, provider, origin),
             _ => {
                 self.setup = Some(SetupStep::Credential {
                     rows,
@@ -1075,13 +1070,13 @@ impl App {
     /// Esc from a credential-flow step: back to where the flow started.
     fn credential_back(
         &mut self,
-        rows: Vec<CatalogProviderRow>,
-        provider: CatalogProviderRow,
+        rows: Vec<crate::CatalogProviderRow>,
+        provider: crate::CatalogProviderRow,
         origin: CredentialOrigin,
     ) {
         match origin {
             CredentialOrigin::Catalog => {
-                let mut state = SelectState::new();
+                let mut state = tuika::components::SelectState::new();
                 state.select(
                     rows.iter()
                         .position(|row| row.provider_id == provider.provider_id)
@@ -1094,7 +1089,7 @@ impl App {
                 });
             }
             CredentialOrigin::Menu => {
-                let mut state = SelectState::new();
+                let mut state = tuika::components::SelectState::new();
                 state.select(Some(0));
                 self.setup = Some(SetupStep::ProviderMenu {
                     rows,
@@ -1110,9 +1105,9 @@ impl App {
     #[allow(clippy::too_many_arguments)]
     fn handle_key_input(
         &mut self,
-        event: &Event,
-        rows: Vec<CatalogProviderRow>,
-        provider: CatalogProviderRow,
+        event: &tuika::event::Event,
+        rows: Vec<crate::CatalogProviderRow>,
+        provider: crate::CatalogProviderRow,
         origin: CredentialOrigin,
         mut value: String,
         busy: bool,
@@ -1121,7 +1116,8 @@ impl App {
         // While the key is being saved only Esc (back out) works; typing
         // into a submitted form would race the host's answer.
         if busy {
-            if matches!(event, Event::Key(key) if key.plain() && key.code == KeyCode::Esc) {
+            if matches!(event, tuika::event::Event::Key(key) if key.plain() && key.code == tuika::event::KeyCode::Esc)
+            {
                 self.pending_selection = None;
                 self.credential_back(rows, provider, origin);
             } else {
@@ -1136,7 +1132,7 @@ impl App {
             }
             return;
         }
-        if let Event::Paste(pasted) = event {
+        if let tuika::event::Event::Paste(pasted) = event {
             value.push_str(pasted.trim());
             self.setup = Some(SetupStep::KeyInput {
                 rows,
@@ -1148,7 +1144,7 @@ impl App {
             });
             return;
         }
-        let Event::Key(key) = event else {
+        let tuika::event::Event::Key(key) = event else {
             self.setup = Some(SetupStep::KeyInput {
                 rows,
                 provider,
@@ -1160,8 +1156,8 @@ impl App {
             return;
         };
         match key.code {
-            KeyCode::Esc => self.credential_back(rows, provider, origin),
-            KeyCode::Enter => {
+            tuika::event::KeyCode::Esc => self.credential_back(rows, provider, origin),
+            tuika::event::KeyCode::Enter => {
                 let trimmed = value.trim().to_string();
                 if trimmed.is_empty() {
                     self.setup = Some(SetupStep::KeyInput {
@@ -1174,7 +1170,7 @@ impl App {
                     });
                     return;
                 }
-                self.actions.push(Action::SetProviderKey {
+                self.actions.push(crate::Action::SetProviderKey {
                     provider_id: provider.provider_id.clone(),
                     api_key: trimmed.clone(),
                 });
@@ -1188,7 +1184,7 @@ impl App {
                     error: None,
                 });
             }
-            KeyCode::Backspace => {
+            tuika::event::KeyCode::Backspace => {
                 value.pop();
                 self.setup = Some(SetupStep::KeyInput {
                     rows,
@@ -1199,7 +1195,7 @@ impl App {
                     error: None,
                 });
             }
-            KeyCode::Char(ch) if !key.ctrl => {
+            tuika::event::KeyCode::Char(ch) if !key.ctrl => {
                 value.push(ch);
                 self.setup = Some(SetupStep::KeyInput {
                     rows,
@@ -1225,17 +1221,18 @@ impl App {
 
     fn handle_login_wait(
         &mut self,
-        event: &Event,
-        rows: Vec<CatalogProviderRow>,
-        provider: CatalogProviderRow,
+        event: &tuika::event::Event,
+        rows: Vec<crate::CatalogProviderRow>,
+        provider: crate::CatalogProviderRow,
         origin: CredentialOrigin,
-        method: LoginMethod,
+        method: crate::LoginMethod,
         device_code: Option<(String, String)>,
     ) {
-        if matches!(event, Event::Key(key) if key.plain() && key.code == KeyCode::Esc) {
-            self.actions.push(Action::CancelLogin);
+        if matches!(event, tuika::event::Event::Key(key) if key.plain() && key.code == tuika::event::KeyCode::Esc)
+        {
+            self.actions.push(crate::Action::CancelLogin);
             self.pending_selection = None;
-            let mut state = SelectState::new();
+            let mut state = tuika::components::SelectState::new();
             state.select(Some(0));
             self.setup = Some(SetupStep::Credential {
                 rows,
@@ -1257,8 +1254,8 @@ impl App {
 
     fn handle_custom_form(
         &mut self,
-        event: &Event,
-        rows: Vec<CatalogProviderRow>,
+        event: &tuika::event::Event,
+        rows: Vec<crate::CatalogProviderRow>,
         mut form: Box<CustomForm>,
         editing: Option<String>,
         busy: CustomBusy,
@@ -1266,7 +1263,8 @@ impl App {
     ) {
         // A submitted form only honors Esc until the host answers.
         if busy != CustomBusy::Idle {
-            if matches!(event, Event::Key(key) if key.plain() && key.code == KeyCode::Esc) {
+            if matches!(event, tuika::event::Event::Key(key) if key.plain() && key.code == tuika::event::KeyCode::Esc)
+            {
                 self.open_home(rows);
             } else {
                 self.setup = Some(SetupStep::CustomForm {
@@ -1279,7 +1277,7 @@ impl App {
             }
             return;
         }
-        if let Event::Paste(pasted) = event {
+        if let tuika::event::Event::Paste(pasted) = event {
             let field = form.focused();
             if let Some(value) = form.field_mut(field) {
                 value.push_str(pasted.trim());
@@ -1296,7 +1294,7 @@ impl App {
             });
             return;
         }
-        let Event::Key(key) = event else {
+        let tuika::event::Event::Key(key) = event else {
             self.setup = Some(SetupStep::CustomForm {
                 rows,
                 form,
@@ -1307,8 +1305,8 @@ impl App {
             return;
         };
         match key.code {
-            KeyCode::Esc => self.open_home(rows),
-            KeyCode::Up | KeyCode::BackTab => {
+            tuika::event::KeyCode::Esc => self.open_home(rows),
+            tuika::event::KeyCode::Up | tuika::event::KeyCode::BackTab => {
                 form.focus = form.focus.checked_sub(1).unwrap_or(CUSTOM_FIELDS - 1);
                 self.setup = Some(SetupStep::CustomForm {
                     rows,
@@ -1318,7 +1316,7 @@ impl App {
                     error,
                 });
             }
-            KeyCode::Down | KeyCode::Tab => {
+            tuika::event::KeyCode::Down | tuika::event::KeyCode::Tab => {
                 form.focus = (form.focus + 1) % CUSTOM_FIELDS;
                 self.setup = Some(SetupStep::CustomForm {
                     rows,
@@ -1328,9 +1326,11 @@ impl App {
                     error,
                 });
             }
-            KeyCode::Left | KeyCode::Right if form.focused() == CustomField::Api => {
+            tuika::event::KeyCode::Left | tuika::event::KeyCode::Right
+                if form.focused() == CustomField::Api =>
+            {
                 let len = API_FAMILIES.len();
-                form.api_index = if key.code == KeyCode::Right {
+                form.api_index = if key.code == tuika::event::KeyCode::Right {
                     (form.api_index + 1) % len
                 } else {
                     form.api_index.checked_sub(1).unwrap_or(len - 1)
@@ -1343,7 +1343,7 @@ impl App {
                     error,
                 });
             }
-            KeyCode::Enter => match form.build_spec() {
+            tuika::event::KeyCode::Enter => match form.build_spec() {
                 Ok(spec) => {
                     if !form.api_key.trim().is_empty() {
                         self.push_key_redaction(
@@ -1351,7 +1351,8 @@ impl App {
                             form.api_key.trim().to_string(),
                         );
                     }
-                    self.actions.push(Action::UpsertCustomProvider { spec });
+                    self.actions
+                        .push(crate::Action::UpsertCustomProvider { spec });
                     self.setup = Some(SetupStep::CustomForm {
                         rows,
                         form,
@@ -1370,7 +1371,7 @@ impl App {
                     });
                 }
             },
-            KeyCode::Backspace => {
+            tuika::event::KeyCode::Backspace => {
                 let field = form.focused();
                 if let Some(value) = form.field_mut(field) {
                     value.pop();
@@ -1388,7 +1389,7 @@ impl App {
                     error: None,
                 });
             }
-            KeyCode::Char(ch) if !key.ctrl => {
+            tuika::event::KeyCode::Char(ch) if !key.ctrl => {
                 let field = form.focused();
                 if let Some(value) = form.field_mut(field) {
                     value.push(ch);
@@ -1459,7 +1460,7 @@ impl App {
             }) if provider.provider_id == provider_id => {
                 if let Some(message) = error {
                     let message = self.redact_secrets(&message);
-                    let mut state = SelectState::new();
+                    let mut state = tuika::components::SelectState::new();
                     state.select(Some(0));
                     self.setup = Some(SetupStep::Credential {
                         rows,
@@ -1505,14 +1506,14 @@ impl App {
                 }
                 match error {
                     Some(_) => self.notice(
-                        Tone::Error,
+                        crate::cells::Tone::Error,
                         format!("{provider_id}: credential failed"),
                         Vec::new(),
                     ),
                     None => {
                         self.needs_provider = false;
                         self.notice(
-                            Tone::Info,
+                            crate::cells::Tone::Info,
                             format!("{provider_id}: credential saved"),
                             Vec::new(),
                         )
@@ -1529,14 +1530,14 @@ impl App {
     /// the refreshed catalog has not arrived yet.
     fn custom_form_row(
         &self,
-        rows: &[CatalogProviderRow],
+        rows: &[crate::CatalogProviderRow],
         form: &CustomForm,
-    ) -> CatalogProviderRow {
+    ) -> crate::CatalogProviderRow {
         let provider_id = form.id.trim();
         rows.iter()
             .find(|row| row.provider_id == provider_id)
             .cloned()
-            .unwrap_or_else(|| CatalogProviderRow {
+            .unwrap_or_else(|| crate::CatalogProviderRow {
                 provider_id: provider_id.to_string(),
                 display_name: form.name.trim().to_string(),
                 base_url: form.base_url.trim().to_string(),
@@ -1555,9 +1556,13 @@ impl App {
     }
 
     /// A credential landed for `provider`: report it, then continue.
-    fn finish_credential(&mut self, rows: Vec<CatalogProviderRow>, provider: CatalogProviderRow) {
+    fn finish_credential(
+        &mut self,
+        rows: Vec<crate::CatalogProviderRow>,
+        provider: crate::CatalogProviderRow,
+    ) {
         self.notice(
-            Tone::Info,
+            crate::cells::Tone::Info,
             format!("{}: credential saved", provider.provider_id),
             Vec::new(),
         );
@@ -1569,15 +1574,15 @@ impl App {
     /// is unusable, or open the picker scoped to the provider.
     fn continue_after_configure(
         &mut self,
-        rows: Vec<CatalogProviderRow>,
-        provider: CatalogProviderRow,
+        rows: Vec<crate::CatalogProviderRow>,
+        provider: crate::CatalogProviderRow,
     ) {
         let model_was_unusable = self.model_unusable();
         self.needs_provider = false;
         if let Some((pending_provider, model)) = self.pending_selection.take() {
             if pending_provider == provider.provider_id {
                 self.setup = None;
-                self.actions.push(Action::SelectModel {
+                self.actions.push(crate::Action::SelectModel {
                     provider_id: pending_provider,
                     model,
                 });
@@ -1587,7 +1592,7 @@ impl App {
         }
         if model_was_unusable && let Some(model) = provider.default_model.clone() {
             self.setup = None;
-            self.actions.push(Action::SelectModel {
+            self.actions.push(crate::Action::SelectModel {
                 provider_id: provider.provider_id,
                 model,
             });
@@ -1597,7 +1602,7 @@ impl App {
         self.setup = Some(SetupStep::AwaitModels {
             provider_id: provider.provider_id,
         });
-        self.actions.push(Action::ListModels);
+        self.actions.push(crate::Action::ListModels);
     }
 
     /// Whether the active model cannot serve real turns: the first-run gate
@@ -1634,7 +1639,7 @@ impl App {
                     let api_key = form.api_key.trim().to_string();
                     if api_key.is_empty() {
                         self.notice(
-                            Tone::Info,
+                            crate::cells::Tone::Info,
                             format!("{provider_id}: provider saved"),
                             Vec::new(),
                         );
@@ -1642,7 +1647,7 @@ impl App {
                         // No key to save: continue as a configured provider.
                         self.continue_after_configure(rows, provider);
                     } else {
-                        self.actions.push(Action::SetProviderKey {
+                        self.actions.push(crate::Action::SetProviderKey {
                             provider_id: provider_id.clone(),
                             api_key,
                         });
@@ -1675,7 +1680,7 @@ impl App {
                 }
                 None => {
                     self.notice(
-                        Tone::Info,
+                        crate::cells::Tone::Info,
                         format!("{provider_id}: provider deleted"),
                         Vec::new(),
                     );
@@ -1683,19 +1688,19 @@ impl App {
                     self.setup = Some(SetupStep::AwaitCatalog {
                         intent: CatalogIntent::Home,
                     });
-                    self.actions.push(Action::FetchProviderCatalog);
+                    self.actions.push(crate::Action::FetchProviderCatalog);
                 }
             },
             step => {
                 self.setup = step;
                 match error {
                     Some(_) => self.notice(
-                        Tone::Error,
+                        crate::cells::Tone::Error,
                         format!("{provider_id}: provider change failed"),
                         Vec::new(),
                     ),
                     None => self.notice(
-                        Tone::Info,
+                        crate::cells::Tone::Info,
                         format!("{provider_id}: provider saved"),
                         Vec::new(),
                     ),
@@ -1706,7 +1711,7 @@ impl App {
 
     pub(crate) fn apply_device_code(&mut self, verification_uri: String, user_code: String) {
         if let Some(SetupStep::LoginWait {
-            method: LoginMethod::Device,
+            method: crate::LoginMethod::Device,
             device_code,
             ..
         }) = self.setup.as_mut()
@@ -1717,7 +1722,7 @@ impl App {
 
     pub(crate) fn apply_credential_cleared(&mut self, provider_id: String) {
         self.notice(
-            Tone::Info,
+            crate::cells::Tone::Info,
             format!("{provider_id}: credential cleared"),
             Vec::new(),
         );
@@ -1726,10 +1731,10 @@ impl App {
             Some(SetupStep::ProviderMenu { provider, .. })
                 if provider.provider_id == provider_id =>
             {
-                self.actions.push(Action::FetchProviderCatalog);
+                self.actions.push(crate::Action::FetchProviderCatalog);
             }
             Some(SetupStep::Home { .. } | SetupStep::Catalog { .. }) => {
-                self.actions.push(Action::FetchProviderCatalog);
+                self.actions.push(crate::Action::FetchProviderCatalog);
             }
             _ => {}
         }
@@ -1794,7 +1799,7 @@ impl App {
                 origin,
                 ..
             }) => {
-                let mut state = SelectState::new();
+                let mut state = tuika::components::SelectState::new();
                 state.select(Some(0));
                 self.setup = Some(SetupStep::Credential {
                     rows,
@@ -1843,7 +1848,7 @@ impl App {
             }
             step => self.setup = step,
         }
-        self.notice(Tone::Error, title, body);
+        self.notice(crate::cells::Tone::Error, title, body);
     }
 }
 

--- a/crates/verlet-chat/src/cells.rs
+++ b/crates/verlet-chat/src/cells.rs
@@ -6,15 +6,8 @@
 //! the session banner and `/status` are bordered panels, laid out rather than
 //! drawn as glyphs in strings. So a cell renders to an `Element`, not to
 //! lines, and the transcript is an `ItemScroll` over those elements. A
-//! streamed answer keeps a [`MarkdownState`] so only its in-flight tail
-//! re-parses.
-
-use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
-
-use tuika::components::MarkdownState;
-use tuika::components::text::wrap_lines;
-use tuika::prelude::*;
+//! streamed answer keeps a [`tuika::components::MarkdownState`] so only its
+//! in-flight tail re-parses.
 
 /// Rows of tool output kept inline before the middle is elided.
 const MAX_OUTPUT_ROWS: usize = 6;
@@ -64,7 +57,7 @@ pub enum Cell {
     ///
     /// Boxed because `MarkdownState` carries the parse/flatten caches and
     /// would otherwise dominate the size of every other variant.
-    Answer(Box<MarkdownState>),
+    Answer(Box<tuika::components::MarkdownState>),
     /// A local notice: interruptions, errors, slash-command acknowledgements.
     Notice {
         tone: Tone,
@@ -77,7 +70,12 @@ pub enum Cell {
 
 impl Cell {
     /// Render this cell as a transcript item, laid out to `width`.
-    pub fn view(&mut self, width: u16, theme: &Theme, sheet: &StyleSheet) -> Element {
+    pub fn view(
+        &mut self,
+        width: u16,
+        theme: &tuika::style::Theme,
+        sheet: &tuika::style::StyleSheet,
+    ) -> tuika::view::Element {
         match self {
             Cell::Banner {
                 version,
@@ -85,12 +83,19 @@ impl Cell {
                 tips,
             } => banner(version, rows, tips, theme),
             Cell::Config { title, rows } => config(title, rows, theme),
-            other => element(Text::new(other.lines(width, theme, sheet))),
+            other => tuika::view::element(tuika::components::Text::new(
+                other.lines(width, theme, sheet),
+            )),
         }
     }
 
     /// Render a line-shaped cell to transcript rows, wrapped to `width`.
-    fn lines(&mut self, width: u16, theme: &Theme, sheet: &StyleSheet) -> Vec<Line<'static>> {
+    fn lines(
+        &mut self,
+        width: u16,
+        theme: &tuika::style::Theme,
+        sheet: &tuika::style::StyleSheet,
+    ) -> Vec<ratatui::text::Line<'static>> {
         match self {
             Cell::User(text) => user(text, width, theme),
             Cell::Reasoning { body } => reasoning(body, width, theme),
@@ -111,54 +116,76 @@ impl Cell {
 
 /// Wrap `child` so it takes only the width it measures, instead of stretching
 /// to the transcript's.
-fn shrink_to_fit(child: Element) -> Element {
-    element(Flex::column().align(Align::Start).auto(child))
+fn shrink_to_fit(child: tuika::view::Element) -> tuika::view::Element {
+    tuika::view::element(
+        tuika::components::Flex::column()
+            .align(tuika::layout::Align::Start)
+            .auto(child),
+    )
 }
 
 /// `• ` — the marker in front of every reported event.
-fn bullet(theme: &Theme) -> Span<'static> {
-    Span::styled("• ", Style::default().fg(theme.accent))
+fn bullet(theme: &tuika::style::Theme) -> ratatui::text::Span<'static> {
+    ratatui::text::Span::styled("• ", ratatui::style::Style::default().fg(theme.accent))
 }
 
 /// A cell header: the bullet plus a bold title and optional trailing detail.
-fn header(title: &str, detail: Option<Span<'static>>, theme: &Theme) -> Line<'static> {
+fn header(
+    title: &str,
+    detail: Option<ratatui::text::Span<'static>>,
+    theme: &tuika::style::Theme,
+) -> ratatui::text::Line<'static> {
     let mut spans = vec![
         bullet(theme),
-        Span::styled(
+        ratatui::text::Span::styled(
             title.to_string(),
-            Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+            ratatui::style::Style::default()
+                .fg(theme.text)
+                .add_modifier(ratatui::style::Modifier::BOLD),
         ),
     ];
     spans.extend(detail);
-    Line::from(spans)
+    ratatui::text::Line::from(spans)
 }
 
 /// Indent detail rows under a header: `  └ ` on the first, `    ` on the rest.
-fn detail(rows: Vec<Line<'static>>, theme: &Theme) -> Vec<Line<'static>> {
+fn detail(
+    rows: Vec<ratatui::text::Line<'static>>,
+    theme: &tuika::style::Theme,
+) -> Vec<ratatui::text::Line<'static>> {
     rows.into_iter()
         .enumerate()
         .map(|(i, line)| {
             let lead = if i == 0 { "  └ " } else { "    " };
-            let mut spans = vec![Span::styled(lead, Style::default().fg(theme.dim))];
+            let mut spans = vec![ratatui::text::Span::styled(
+                lead,
+                ratatui::style::Style::default().fg(theme.dim),
+            )];
             spans.extend(line.spans);
-            Line::from(spans)
+            ratatui::text::Line::from(spans)
         })
         .collect()
 }
 
 /// Prefix every row with `pad` columns of blank.
-fn indent(rows: Vec<Line<'static>>, pad: usize) -> Vec<Line<'static>> {
+fn indent(
+    rows: Vec<ratatui::text::Line<'static>>,
+    pad: usize,
+) -> Vec<ratatui::text::Line<'static>> {
     rows.into_iter()
         .map(|line| {
-            let mut spans = vec![Span::raw(" ".repeat(pad))];
+            let mut spans = vec![ratatui::text::Span::raw(" ".repeat(pad))];
             spans.extend(line.spans);
-            Line::from(spans)
+            ratatui::text::Line::from(spans)
         })
         .collect()
 }
 
 /// `label:` / `value` rows, aligned on the widest label.
-fn kv_rows(rows: &[(String, String)], theme: &Theme) -> Vec<Line<'static>> {
+fn kv_rows(
+    rows: &[(String, String)],
+    theme: &tuika::style::Theme,
+) -> Vec<ratatui::text::Line<'static>> {
     let pad = rows
         .iter()
         .map(|(k, _)| k.chars().count())
@@ -166,12 +193,15 @@ fn kv_rows(rows: &[(String, String)], theme: &Theme) -> Vec<Line<'static>> {
         .unwrap_or(0);
     rows.iter()
         .map(|(k, v)| {
-            Line::from(vec![
-                Span::styled(
+            ratatui::text::Line::from(vec![
+                ratatui::text::Span::styled(
                     format!("{k}:{:width$} ", "", width = pad - k.chars().count()),
                     theme.muted_style(),
                 ),
-                Span::styled(v.clone(), Style::default().fg(theme.text)),
+                ratatui::text::Span::styled(
+                    v.clone(),
+                    ratatui::style::Style::default().fg(theme.text),
+                ),
             ])
         })
         .collect()
@@ -181,21 +211,23 @@ fn banner(
     version: &str,
     rows: &[(String, String)],
     tips: &[(String, String)],
-    theme: &Theme,
-) -> Element {
-    let mut panel = vec![Line::from(vec![
-        Span::styled(
+    theme: &tuika::style::Theme,
+) -> tuika::view::Element {
+    let mut panel = vec![ratatui::text::Line::from(vec![
+        ratatui::text::Span::styled(
             ">_ ",
-            Style::default()
+            ratatui::style::Style::default()
                 .fg(theme.accent)
-                .add_modifier(Modifier::BOLD),
+                .add_modifier(ratatui::style::Modifier::BOLD),
         ),
-        Span::styled(
+        ratatui::text::Span::styled(
             format!("Verlet chat (v{version})"),
-            Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+            ratatui::style::Style::default()
+                .fg(theme.text)
+                .add_modifier(ratatui::style::Modifier::BOLD),
         ),
     ])];
-    panel.push(Line::default());
+    panel.push(ratatui::text::Line::default());
     panel.extend(kv_rows(rows, theme));
 
     let pad = tips
@@ -204,74 +236,99 @@ fn banner(
         .max()
         .unwrap_or(0);
     let mut tip_rows = vec![
-        Line::default(),
-        Line::from(Span::styled(
+        ratatui::text::Line::default(),
+        ratatui::text::Line::from(ratatui::text::Span::styled(
             "Describe a task, or try one of these commands:",
             theme.muted_style(),
         )),
-        Line::default(),
+        ratatui::text::Line::default(),
     ];
     tip_rows.extend(tips.iter().map(|(cmd, blurb)| {
-        Line::from(vec![
-            Span::styled(
+        ratatui::text::Line::from(vec![
+            ratatui::text::Span::styled(
                 format!("{cmd}{:width$}  ", "", width = pad - cmd.chars().count()),
-                Style::default().fg(theme.accent_alt),
+                ratatui::style::Style::default().fg(theme.accent_alt),
             ),
-            Span::styled(blurb.clone(), theme.muted_style()),
+            ratatui::text::Span::styled(blurb.clone(), theme.muted_style()),
         ])
     }));
 
-    element(
-        Flex::column()
-            .auto(shrink_to_fit(element(
-                Boxed::new(element(Text::new(panel)))
-                    .border(BorderStyle::Rounded)
-                    .border_color(theme.border)
-                    .padding(Padding::symmetric(1, 0)),
+    tuika::view::element(
+        tuika::components::Flex::column()
+            .auto(shrink_to_fit(tuika::view::element(
+                tuika::components::Boxed::new(tuika::view::element(tuika::components::Text::new(
+                    panel,
+                )))
+                .border(tuika::style::BorderStyle::Rounded)
+                .border_color(theme.border)
+                .padding(tuika::geometry::Padding::symmetric(1, 0)),
             )))
-            .auto(element(Text::new(tip_rows))),
+            .auto(tuika::view::element(tuika::components::Text::new(tip_rows))),
     )
 }
 
-fn config(title: &str, rows: &[(String, String)], theme: &Theme) -> Element {
-    let panel = Boxed::new(element(Text::new(kv_rows(rows, theme))))
-        .title(Line::from(Span::styled(
-            format!(" {title} "),
-            Style::default()
-                .fg(theme.accent)
-                .add_modifier(Modifier::BOLD),
-        )))
-        .border(BorderStyle::Rounded)
-        .border_color(theme.border)
-        .padding(Padding::symmetric(1, 0));
-    shrink_to_fit(element(panel))
+fn config(
+    title: &str,
+    rows: &[(String, String)],
+    theme: &tuika::style::Theme,
+) -> tuika::view::Element {
+    let panel = tuika::components::Boxed::new(tuika::view::element(tuika::components::Text::new(
+        kv_rows(rows, theme),
+    )))
+    .title(ratatui::text::Line::from(ratatui::text::Span::styled(
+        format!(" {title} "),
+        ratatui::style::Style::default()
+            .fg(theme.accent)
+            .add_modifier(ratatui::style::Modifier::BOLD),
+    )))
+    .border(tuika::style::BorderStyle::Rounded)
+    .border_color(theme.border)
+    .padding(tuika::geometry::Padding::symmetric(1, 0));
+    shrink_to_fit(tuika::view::element(panel))
 }
 
-fn user(text: &str, width: u16, theme: &Theme) -> Vec<Line<'static>> {
-    let body: Vec<Line<'static>> = text
+fn user(text: &str, width: u16, theme: &tuika::style::Theme) -> Vec<ratatui::text::Line<'static>> {
+    let body: Vec<ratatui::text::Line<'static>> = text
         .lines()
-        .map(|l| Line::from(Span::styled(l.to_string(), Style::default().fg(theme.text))))
+        .map(|l| {
+            ratatui::text::Line::from(ratatui::text::Span::styled(
+                l.to_string(),
+                ratatui::style::Style::default().fg(theme.text),
+            ))
+        })
         .collect();
-    wrap_lines(&body, width.saturating_sub(2))
+    tuika::components::text::wrap_lines(&body, width.saturating_sub(2))
         .into_iter()
         .enumerate()
         .map(|(i, line)| {
             let lead = if i == 0 { "› " } else { "  " };
-            let mut spans = vec![Span::styled(lead, Style::default().fg(theme.accent_alt))];
+            let mut spans = vec![ratatui::text::Span::styled(
+                lead,
+                ratatui::style::Style::default().fg(theme.accent_alt),
+            )];
             spans.extend(line.spans);
-            Line::from(spans)
+            ratatui::text::Line::from(spans)
         })
         .collect()
 }
 
-fn reasoning(body: &str, width: u16, theme: &Theme) -> Vec<Line<'static>> {
-    let style = theme.muted_style().add_modifier(Modifier::ITALIC);
-    let rows: Vec<Line<'static>> = body
+fn reasoning(
+    body: &str,
+    width: u16,
+    theme: &tuika::style::Theme,
+) -> Vec<ratatui::text::Line<'static>> {
+    let style = theme
+        .muted_style()
+        .add_modifier(ratatui::style::Modifier::ITALIC);
+    let rows: Vec<ratatui::text::Line<'static>> = body
         .split('\n')
-        .map(|l| Line::from(Span::styled(l.to_string(), style)))
+        .map(|l| ratatui::text::Line::from(ratatui::text::Span::styled(l.to_string(), style)))
         .collect();
     let mut out = vec![header("Thinking", None, theme)];
-    out.extend(indent(wrap_lines(&rows, width.saturating_sub(2)), 2));
+    out.extend(indent(
+        tuika::components::text::wrap_lines(&rows, width.saturating_sub(2)),
+        2,
+    ));
     out
 }
 
@@ -280,22 +337,24 @@ fn exec(
     output: &[String],
     status: ExecStatus,
     width: u16,
-    theme: &Theme,
-) -> Vec<Line<'static>> {
+    theme: &tuika::style::Theme,
+) -> Vec<ratatui::text::Line<'static>> {
     let trailing = match status {
         ExecStatus::Running => None,
         ExecStatus::Ok => None,
-        ExecStatus::Failed => Some(Span::styled(
+        ExecStatus::Failed => Some(ratatui::text::Span::styled(
             "  (failed)".to_string(),
-            Style::default().fg(theme.accent),
+            ratatui::style::Style::default().fg(theme.accent),
         )),
     };
-    let mut out = vec![Line::from({
+    let mut out = vec![ratatui::text::Line::from({
         let mut spans = vec![
             bullet(theme),
-            Span::styled(
+            ratatui::text::Span::styled(
                 title.to_string(),
-                Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+                ratatui::style::Style::default()
+                    .fg(theme.text)
+                    .add_modifier(ratatui::style::Modifier::BOLD),
             ),
         ];
         spans.extend(trailing);
@@ -306,17 +365,22 @@ fn exec(
     // being clipped at the viewport edge.
     let source = output
         .iter()
-        .map(|line| Line::from(Span::styled(line.clone(), theme.muted_style())))
+        .map(|line| {
+            ratatui::text::Line::from(ratatui::text::Span::styled(
+                line.clone(),
+                theme.muted_style(),
+            ))
+        })
         .collect::<Vec<_>>();
-    let wrapped = wrap_lines(&source, width.saturating_sub(4));
-    let mut rows: Vec<Line<'static>> = Vec::new();
+    let wrapped = tuika::components::text::wrap_lines(&source, width.saturating_sub(4));
+    let mut rows: Vec<ratatui::text::Line<'static>> = Vec::new();
     if wrapped.len() > MAX_OUTPUT_ROWS {
         let head = MAX_OUTPUT_ROWS / 2;
         let tail = wrapped.len() - (MAX_OUTPUT_ROWS - head);
         rows.extend_from_slice(&wrapped[..head]);
-        rows.push(Line::from(Span::styled(
+        rows.push(ratatui::text::Line::from(ratatui::text::Span::styled(
             format!("… +{} lines", tail - head),
-            Style::default().fg(theme.dim),
+            ratatui::style::Style::default().fg(theme.dim),
         )));
         rows.extend_from_slice(&wrapped[tail..]);
     } else {
@@ -327,18 +391,18 @@ fn exec(
 }
 
 fn answer(
-    state: &mut MarkdownState,
+    state: &mut tuika::components::MarkdownState,
     width: u16,
-    theme: &Theme,
-    sheet: &StyleSheet,
-) -> Vec<Line<'static>> {
+    theme: &tuika::style::Theme,
+    sheet: &tuika::style::StyleSheet,
+) -> Vec<ratatui::text::Line<'static>> {
     // The markdown is wrapped two columns narrow so the bullet gutter fits.
     let body = state
         .lines(
             width.saturating_sub(2),
             theme,
             sheet,
-            CodeHighlighter::Plain,
+            tuika::highlight::CodeHighlighter::Plain,
         )
         .to_vec();
     indent(body, 2)
@@ -351,7 +415,7 @@ fn answer(
             // Replace the first row's indent with the bullet.
             let mut spans = vec![bullet(theme)];
             spans.extend(line.spans.into_iter().skip(1));
-            Line::from(spans)
+            ratatui::text::Line::from(spans)
         })
         .collect()
 }
@@ -361,33 +425,43 @@ fn notice(
     title: &str,
     body: &[String],
     width: u16,
-    theme: &Theme,
-) -> Vec<Line<'static>> {
+    theme: &tuika::style::Theme,
+) -> Vec<ratatui::text::Line<'static>> {
     let (glyph, color) = match tone {
         Tone::Info => ("• ", theme.accent),
         Tone::Warn => ("⚠ ", theme.accent_alt),
         Tone::Error => ("✗ ", theme.accent),
     };
-    let mut out = vec![Line::from(vec![
-        Span::styled(glyph, Style::default().fg(color)),
-        Span::styled(
+    let mut out = vec![ratatui::text::Line::from(vec![
+        ratatui::text::Span::styled(glyph, ratatui::style::Style::default().fg(color)),
+        ratatui::text::Span::styled(
             title.to_string(),
-            Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+            ratatui::style::Style::default()
+                .fg(theme.text)
+                .add_modifier(ratatui::style::Modifier::BOLD),
         ),
     ])];
-    let rows: Vec<Line<'static>> = body
+    let rows: Vec<ratatui::text::Line<'static>> = body
         .iter()
-        .map(|l| Line::from(Span::styled(l.clone(), theme.muted_style())))
+        .map(|l| {
+            ratatui::text::Line::from(ratatui::text::Span::styled(l.clone(), theme.muted_style()))
+        })
         .collect();
-    out.extend(indent(wrap_lines(&rows, width.saturating_sub(2)), 2));
+    out.extend(indent(
+        tuika::components::text::wrap_lines(&rows, width.saturating_sub(2)),
+        2,
+    ));
     out
 }
 
-fn sessions(rows: &[crate::SessionRow], theme: &Theme) -> Vec<Line<'static>> {
+fn sessions(
+    rows: &[crate::SessionRow],
+    theme: &tuika::style::Theme,
+) -> Vec<ratatui::text::Line<'static>> {
     let mut out = vec![header("Sessions", None, theme)];
     if rows.is_empty() {
         out.extend(detail(
-            vec![Line::from(Span::styled(
+            vec![ratatui::text::Line::from(ratatui::text::Span::styled(
                 "no sessions".to_string(),
                 theme.muted_style(),
             ))],
@@ -400,21 +474,27 @@ fn sessions(rows: &[crate::SessionRow], theme: &Theme) -> Vec<Line<'static>> {
         .map(|row| {
             let marker = if row.current { "* " } else { "  " };
             let mut spans = vec![
-                Span::styled(marker.to_string(), Style::default().fg(theme.accent)),
-                Span::styled(
-                    format!("{} ", short_id(&row.id)),
-                    Style::default().fg(theme.accent_alt),
+                ratatui::text::Span::styled(
+                    marker.to_string(),
+                    ratatui::style::Style::default().fg(theme.accent),
                 ),
-                Span::styled(format!("{} ", row.name), Style::default().fg(theme.text)),
-                Span::styled(format!("[{}]", row.status), theme.muted_style()),
+                ratatui::text::Span::styled(
+                    format!("{} ", short_id(&row.id)),
+                    ratatui::style::Style::default().fg(theme.accent_alt),
+                ),
+                ratatui::text::Span::styled(
+                    format!("{} ", row.name),
+                    ratatui::style::Style::default().fg(theme.text),
+                ),
+                ratatui::text::Span::styled(format!("[{}]", row.status), theme.muted_style()),
             ];
             if !row.preview.is_empty() {
-                spans.push(Span::styled(
+                spans.push(ratatui::text::Span::styled(
                     format!(" - {}", row.preview),
-                    Style::default().fg(theme.dim),
+                    ratatui::style::Style::default().fg(theme.dim),
                 ));
             }
-            Line::from(spans)
+            ratatui::text::Line::from(spans)
         })
         .collect();
     out.extend(detail(body, theme));

--- a/crates/verlet-chat/src/lib.rs
+++ b/crates/verlet-chat/src/lib.rs
@@ -5,7 +5,7 @@
 //! notifications into [`ChatEvent`]s; the UI translates keystrokes into
 //! [`Action`]s for the host to execute. Everything in between — transcript
 //! cells, composer, slash popup, layout — is a synchronous state machine
-//! ([`App`]) that tests can drive without a terminal or a runtime.
+//! ([`app::App`]) that tests can drive without a terminal or a runtime.
 //!
 //! Built on [tuika](https://github.com/everruns/tuika), pinned to an exact
 //! version in the workspace manifest: tuika is pre-1.0 and minor releases may
@@ -14,20 +14,15 @@
 //! deliberately stays close to it, so upstream improvements remain easy to
 //! diff against.
 
-mod app;
-mod cells;
-mod runner;
+pub mod app;
+pub mod cells;
+pub mod runner;
 #[cfg(test)]
 mod tests;
-mod theme;
+pub mod theme;
 mod ui;
 
-pub use app::{App, COMMANDS, SlashCommand, parse_slash_command};
-pub use cells::{Cell, ExecStatus, Tone};
-pub use runner::{RunnerError, run_ui};
-pub use theme::chat_theme;
-
-/// What the host must execute on the UI's behalf. Emitted by [`App::handle`],
+/// What the host must execute on the UI's behalf. Emitted by [`app::App::handle`],
 /// drained by the host loop.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Action {

--- a/crates/verlet-chat/src/runner.rs
+++ b/crates/verlet-chat/src/runner.rs
@@ -1,23 +1,13 @@
 //! The async event loop: terminal in, actions out, host events folded back.
 //!
-//! The host owns the [`App`] and the channels; this loop owns the terminal.
-//! It multiplexes three sources — terminal input, host [`ChatEvent`]s, and an
-//! animation tick — and redraws after each. The tick only runs while a turn
-//! is in flight (the spinner and elapsed timer are the only animated parts),
-//! so an idle chat performs no timer-driven redraws and otherwise wakes for
-//! input or host events only.
-
-use std::io;
+//! The host owns the [`crate::app::App`] and the channels; this loop owns the
+//! terminal. It multiplexes three sources — terminal input, host
+//! [`crate::ChatEvent`]s, and an animation tick — and redraws after each. The
+//! tick only runs while a turn is in flight (the spinner and elapsed timer are
+//! the only animated parts), so an idle chat performs no timer-driven redraws
+//! and otherwise wakes for input or host events only.
 
 use futures_util::StreamExt as _;
-use ratatui::backend::CrosstermBackend;
-use ratatui::{Terminal, TerminalOptions, Viewport};
-
-use tuika::probe::RectProbe;
-use tuika::{StyleSheet, TerminalSession, paint, translate_event};
-
-use crate::app::{App, Flow};
-use crate::{Action, ChatEvent, theme};
 
 /// Frame budget for the animation tick, and the clock `Working (12s …)`
 /// counts in.
@@ -35,37 +25,37 @@ impl std::fmt::Display for RunnerError {
 
 impl std::error::Error for RunnerError {}
 
-impl From<io::Error> for RunnerError {
-    fn from(err: io::Error) -> Self {
+impl From<std::io::Error> for RunnerError {
+    fn from(err: std::io::Error) -> Self {
         RunnerError(format!("terminal failure: {err}"))
     }
 }
 
 /// Run the chat UI until the user quits or the host closes the event channel.
 ///
-/// The host executes the [`Action`]s it receives and reports outcomes as
-/// [`ChatEvent`]s; this function never blocks on the host — a slow RPC just
-/// means the working row keeps spinning.
+/// The host executes the [`crate::Action`]s it receives and reports outcomes
+/// as [`crate::ChatEvent`]s; this function never blocks on the host — a slow
+/// RPC just means the working row keeps spinning.
 pub async fn run_ui(
-    app: &mut App,
+    app: &mut crate::app::App,
     no_color: bool,
-    actions: tokio::sync::mpsc::UnboundedSender<Action>,
-    mut events: tokio::sync::mpsc::UnboundedReceiver<ChatEvent>,
+    actions: tokio::sync::mpsc::UnboundedSender<crate::Action>,
+    mut events: tokio::sync::mpsc::UnboundedReceiver<crate::ChatEvent>,
 ) -> Result<(), RunnerError> {
-    let theme = theme::chat_theme(no_color);
-    let sheet = StyleSheet::from_theme(&theme);
-    let probe = RectProbe::new();
+    let theme = crate::theme::chat_theme(no_color);
+    let sheet = tuika::style::StyleSheet::from_theme(&theme);
+    let probe = tuika::probe::RectProbe::new();
     app.frame_ms = FRAME_MS;
 
-    let _session = TerminalSession::enter()?;
-    crossterm::execute!(io::stdout(), crossterm::event::EnableBracketedPaste)?;
+    let _session = tuika::host::TerminalSession::enter()?;
+    crossterm::execute!(std::io::stdout(), crossterm::event::EnableBracketedPaste)?;
     // Restore on every exit path; TerminalSession's own Drop handles the rest.
     let _paste_guard = PasteGuard;
 
-    let mut terminal = Terminal::with_options(
-        CrosstermBackend::new(io::stdout()),
-        TerminalOptions {
-            viewport: Viewport::Fullscreen,
+    let mut terminal = ratatui::Terminal::with_options(
+        ratatui::backend::CrosstermBackend::new(std::io::stdout()),
+        ratatui::TerminalOptions {
+            viewport: ratatui::Viewport::Fullscreen,
         },
     )?;
     let mut input = crossterm::event::EventStream::new();
@@ -81,7 +71,7 @@ pub async fn run_ui(
         terminal.draw(|f| {
             let area = f.area();
             let scene = crate::ui::build(app, area, &theme, &sheet, &probe);
-            paint(f.buffer_mut(), area, &theme, &scene, &[]);
+            tuika::host::paint(f.buffer_mut(), area, &theme, &scene, &[]);
             // The composer's rect is only known after layout; the probe
             // reports where it landed, and the real terminal caret goes there.
             if let Some(pos) = app.cursor(probe.rect()) {
@@ -93,8 +83,8 @@ pub async fn run_ui(
             maybe_event = input.next() => {
                 match maybe_event {
                     Some(Ok(raw)) => {
-                        if let Some(event) = translate_event(raw)
-                            && app.handle(&event) == Flow::Quit
+                        if let Some(event) = tuika::host::translate_event(raw)
+                            && app.handle(&event) == crate::app::Flow::Quit
                         {
                             break;
                         }
@@ -138,6 +128,6 @@ struct PasteGuard;
 
 impl Drop for PasteGuard {
     fn drop(&mut self) {
-        let _ = crossterm::execute!(io::stdout(), crossterm::event::DisableBracketedPaste);
+        let _ = crossterm::execute!(std::io::stdout(), crossterm::event::DisableBracketedPaste);
     }
 }

--- a/crates/verlet-chat/src/tests.rs
+++ b/crates/verlet-chat/src/tests.rs
@@ -1,8 +1,5 @@
-use crate::app::{App, Flow};
-use crate::{Action, ChatEvent, SessionMeta, parse_slash_command};
-
-fn meta() -> SessionMeta {
-    SessionMeta {
+fn meta() -> crate::SessionMeta {
+    crate::SessionMeta {
         connection_label: "local/private".to_string(),
         cwd: "/work".to_string(),
         model_label: "provider/model".to_string(),
@@ -12,15 +9,15 @@ fn meta() -> SessionMeta {
     }
 }
 
-fn app() -> App {
-    App::new(meta())
+fn app() -> crate::app::App {
+    crate::app::App::new(meta())
 }
 
 fn key(code: tuika::KeyCode) -> tuika::Event {
     tuika::Event::Key(tuika::Key::new(code))
 }
 
-fn type_text(app: &mut App, text: &str) {
+fn type_text(app: &mut crate::app::App, text: &str) {
     for ch in text.chars() {
         let _ = app.handle(&key(tuika::KeyCode::Char(ch)));
     }
@@ -28,29 +25,33 @@ fn type_text(app: &mut App, text: &str) {
 
 #[test]
 fn slash_parser_accepts_chat_session_commands() {
-    use crate::SlashCommand;
     assert_eq!(
-        parse_slash_command("/help").unwrap(),
-        Some(SlashCommand::Help)
-    );
-    assert_eq!(parse_slash_command("/q").unwrap(), Some(SlashCommand::Quit));
-    assert_eq!(
-        parse_slash_command("/resume 019abc").unwrap(),
-        Some(SlashCommand::Resume("019abc".to_string()))
+        crate::app::parse_slash_command("/help").unwrap(),
+        Some(crate::app::SlashCommand::Help)
     );
     assert_eq!(
-        parse_slash_command("/rename customer debug").unwrap(),
-        Some(SlashCommand::Rename("customer debug".to_string()))
+        crate::app::parse_slash_command("/q").unwrap(),
+        Some(crate::app::SlashCommand::Quit)
     );
-    assert_eq!(parse_slash_command("hello").unwrap(), None);
+    assert_eq!(
+        crate::app::parse_slash_command("/resume 019abc").unwrap(),
+        Some(crate::app::SlashCommand::Resume("019abc".to_string()))
+    );
+    assert_eq!(
+        crate::app::parse_slash_command("/rename customer debug").unwrap(),
+        Some(crate::app::SlashCommand::Rename(
+            "customer debug".to_string()
+        ))
+    );
+    assert_eq!(crate::app::parse_slash_command("hello").unwrap(), None);
 }
 
 #[test]
 fn slash_parser_rejects_unknown_or_incomplete_commands() {
-    assert!(parse_slash_command("/wat").is_err());
-    assert!(parse_slash_command("/resume").is_err());
-    assert!(parse_slash_command("/rename").is_err());
-    assert!(parse_slash_command("/").is_err());
+    assert!(crate::app::parse_slash_command("/wat").is_err());
+    assert!(crate::app::parse_slash_command("/resume").is_err());
+    assert!(crate::app::parse_slash_command("/rename").is_err());
+    assert!(crate::app::parse_slash_command("/").is_err());
 }
 
 #[test]
@@ -59,55 +60,55 @@ fn submitting_a_prompt_queues_the_action_and_echoes_the_user_cell() {
     app.submit("hello there");
     assert_eq!(
         app.drain_actions(),
-        vec![Action::Submit("hello there".to_string())]
+        vec![crate::Action::Submit("hello there".to_string())]
     );
     assert!(
         app.cells
             .iter()
-            .any(|cell| matches!(cell, crate::Cell::User(text) if text == "hello there"))
+            .any(|cell| matches!(cell, crate::cells::Cell::User(text) if text == "hello there"))
     );
 }
 
 #[test]
 fn idle_gated_commands_refuse_during_an_active_turn() {
     let mut app = app();
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
     for command in ["/new", "/fork", "/compact", "/resume abc"] {
         app.submit(command);
         assert_eq!(app.drain_actions(), Vec::new(), "{command} must be gated");
     }
-    app.apply(ChatEvent::TurnCompleted { error: None });
+    app.apply(crate::ChatEvent::TurnCompleted { error: None });
     app.submit("/new");
-    assert_eq!(app.drain_actions(), vec![Action::NewThread]);
+    assert_eq!(app.drain_actions(), vec![crate::Action::NewThread]);
 }
 
 #[test]
 fn deltas_stream_into_one_cell_and_close_on_turn_completion() {
     let mut app = app();
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
-    app.apply(ChatEvent::ThinkingDelta("mm".to_string()));
-    app.apply(ChatEvent::AnswerDelta("first ".to_string()));
-    app.apply(ChatEvent::AnswerDelta("second".to_string()));
+    app.apply(crate::ChatEvent::ThinkingDelta("mm".to_string()));
+    app.apply(crate::ChatEvent::AnswerDelta("first ".to_string()));
+    app.apply(crate::ChatEvent::AnswerDelta("second".to_string()));
     let answers = app
         .cells
         .iter()
-        .filter(|cell| matches!(cell, crate::Cell::Answer(_)))
+        .filter(|cell| matches!(cell, crate::cells::Cell::Answer(_)))
         .count();
     assert_eq!(answers, 1, "deltas must append to one streaming cell");
 
-    app.apply(ChatEvent::TurnCompleted { error: None });
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnCompleted { error: None });
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-2".to_string(),
     });
-    app.apply(ChatEvent::AnswerDelta("third".to_string()));
+    app.apply(crate::ChatEvent::AnswerDelta("third".to_string()));
     let answers = app
         .cells
         .iter()
-        .filter(|cell| matches!(cell, crate::Cell::Answer(_)))
+        .filter(|cell| matches!(cell, crate::cells::Cell::Answer(_)))
         .count();
     assert_eq!(answers, 2, "a new turn opens a new answer cell");
 }
@@ -115,13 +116,13 @@ fn deltas_stream_into_one_cell_and_close_on_turn_completion() {
 #[test]
 fn empty_deltas_do_not_open_transcript_cells_or_output_rows() {
     let mut app = app();
-    app.apply(ChatEvent::AnswerDelta(String::new()));
-    app.apply(ChatEvent::ThinkingDelta(String::new()));
-    app.apply(ChatEvent::ToolStarted {
+    app.apply(crate::ChatEvent::AnswerDelta(String::new()));
+    app.apply(crate::ChatEvent::ThinkingDelta(String::new()));
+    app.apply(crate::ChatEvent::ToolStarted {
         id: "call-1".to_string(),
         title: "build".to_string(),
     });
-    app.apply(ChatEvent::ToolOutputDelta {
+    app.apply(crate::ChatEvent::ToolOutputDelta {
         id: "call-1".to_string(),
         delta: String::new(),
     });
@@ -129,34 +130,34 @@ fn empty_deltas_do_not_open_transcript_cells_or_output_rows() {
     assert!(
         !app.cells
             .iter()
-            .any(|cell| matches!(cell, crate::Cell::Answer(_)))
+            .any(|cell| matches!(cell, crate::cells::Cell::Answer(_)))
     );
     assert!(
         !app.cells
             .iter()
-            .any(|cell| matches!(cell, crate::Cell::Reasoning { .. }))
+            .any(|cell| matches!(cell, crate::cells::Cell::Reasoning { .. }))
     );
     assert!(app.cells.iter().any(|cell| matches!(
         cell,
-        crate::Cell::Exec { output, .. } if output.is_empty()
+        crate::cells::Cell::Exec { output, .. } if output.is_empty()
     )));
 }
 
 #[test]
 fn tool_events_target_their_cell_by_id() {
     let mut app = app();
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
-    app.apply(ChatEvent::ToolStarted {
+    app.apply(crate::ChatEvent::ToolStarted {
         id: "call-1".to_string(),
         title: "cargo test".to_string(),
     });
-    app.apply(ChatEvent::ToolOutputDelta {
+    app.apply(crate::ChatEvent::ToolOutputDelta {
         id: "call-1".to_string(),
         delta: "running 3 tests\nok\n".to_string(),
     });
-    app.apply(ChatEvent::ToolCompleted {
+    app.apply(crate::ChatEvent::ToolCompleted {
         id: "call-1".to_string(),
         success: true,
         output: String::new(),
@@ -165,32 +166,32 @@ fn tool_events_target_their_cell_by_id() {
         .cells
         .iter()
         .find_map(|cell| match cell {
-            crate::Cell::Exec { output, status, .. } => Some((output.clone(), *status)),
+            crate::cells::Cell::Exec { output, status, .. } => Some((output.clone(), *status)),
             _ => None,
         })
         .expect("exec cell");
     assert_eq!(exec.0, vec!["running 3 tests", "ok", ""]);
-    assert_eq!(exec.1, crate::ExecStatus::Ok);
+    assert_eq!(exec.1, crate::cells::ExecStatus::Ok);
 }
 
 #[test]
 fn a_tool_call_splits_the_streamed_answer() {
     let mut app = app();
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
-    app.apply(ChatEvent::AnswerDelta("before".to_string()));
-    app.apply(ChatEvent::ToolStarted {
+    app.apply(crate::ChatEvent::AnswerDelta("before".to_string()));
+    app.apply(crate::ChatEvent::ToolStarted {
         id: "call-1".to_string(),
         title: "read file".to_string(),
     });
-    app.apply(ChatEvent::AnswerDelta("after".to_string()));
+    app.apply(crate::ChatEvent::AnswerDelta("after".to_string()));
     let kinds: Vec<&str> = app
         .cells
         .iter()
         .map(|cell| match cell {
-            crate::Cell::Answer(_) => "answer",
-            crate::Cell::Exec { .. } => "exec",
+            crate::cells::Cell::Answer(_) => "answer",
+            crate::cells::Cell::Exec { .. } => "exec",
             _ => "other",
         })
         .filter(|kind| *kind != "other")
@@ -201,14 +202,20 @@ fn a_tool_call_splits_the_streamed_answer() {
 #[test]
 fn escape_interrupts_only_while_a_turn_is_active() {
     let mut app = app();
-    assert_eq!(app.handle(&key(tuika::KeyCode::Esc)), Flow::Continue);
+    assert_eq!(
+        app.handle(&key(tuika::KeyCode::Esc)),
+        crate::app::Flow::Continue
+    );
     assert_eq!(app.drain_actions(), Vec::new());
 
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
-    assert_eq!(app.handle(&key(tuika::KeyCode::Esc)), Flow::Continue);
-    assert_eq!(app.drain_actions(), vec![Action::Interrupt]);
+    assert_eq!(
+        app.handle(&key(tuika::KeyCode::Esc)),
+        crate::app::Flow::Continue
+    );
+    assert_eq!(app.drain_actions(), vec![crate::Action::Interrupt]);
 }
 
 #[test]
@@ -220,13 +227,13 @@ fn ctrl_c_interrupts_then_quits() {
         alt: false,
         shift: false,
     });
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
-    assert_eq!(app.handle(&ctrl_c), Flow::Continue);
-    assert_eq!(app.drain_actions(), vec![Action::Interrupt]);
-    app.apply(ChatEvent::TurnCompleted { error: None });
-    assert_eq!(app.handle(&ctrl_c), Flow::Quit);
+    assert_eq!(app.handle(&ctrl_c), crate::app::Flow::Continue);
+    assert_eq!(app.drain_actions(), vec![crate::Action::Interrupt]);
+    app.apply(crate::ChatEvent::TurnCompleted { error: None });
+    assert_eq!(app.handle(&ctrl_c), crate::app::Flow::Quit);
 }
 
 #[test]
@@ -242,7 +249,7 @@ fn typing_slash_opens_the_completion_popup_and_enter_runs_the_pick() {
     assert!(
         app.cells.iter().any(|cell| matches!(
             cell,
-            crate::Cell::Notice { title, .. } if title == "Commands"
+            crate::cells::Cell::Notice { title, .. } if title == "Commands"
         )),
         "/help ran"
     );
@@ -272,18 +279,18 @@ fn enter_with_no_popup_matches_submits_the_unknown_command() {
     assert!(app.composer.is_empty());
     assert!(app.cells.iter().any(|cell| matches!(
         cell,
-        crate::Cell::Notice { tone: crate::Tone::Error, title, .. }
+        crate::cells::Cell::Notice { tone: crate::cells::Tone::Error, title, .. }
             if title.contains("unknown slash command /wat")
     )));
 }
 
 /// Render the app at 80x24 and return the glyph grid.
-fn render(app: &mut App, no_color: bool) -> String {
+fn render(app: &mut crate::app::App, no_color: bool) -> String {
     render_at(app, no_color, 80, 24)
 }
 
-fn render_at(app: &mut App, no_color: bool, width: u16, height: u16) -> String {
-    let theme = crate::chat_theme(no_color);
+fn render_at(app: &mut crate::app::App, no_color: bool, width: u16, height: u16) -> String {
+    let theme = crate::theme::chat_theme(no_color);
     let sheet = tuika::StyleSheet::from_theme(&theme);
     let probe = tuika::probe::RectProbe::new();
     let scene = crate::ui::build(
@@ -311,7 +318,7 @@ fn shift_enter_inserts_a_newline_and_enter_submits() {
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     assert_eq!(
         app.drain_actions(),
-        vec![Action::Submit("first\nsecond".to_string())]
+        vec![crate::Action::Submit("first\nsecond".to_string())]
     );
 }
 
@@ -323,7 +330,7 @@ fn paste_inserts_text_without_submitting() {
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     assert_eq!(
         app.drain_actions(),
-        vec![Action::Submit("pasted\ntext".to_string())]
+        vec![crate::Action::Submit("pasted\ntext".to_string())]
     );
 }
 
@@ -342,7 +349,7 @@ fn up_on_an_empty_composer_recalls_earlier_prompts() {
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     assert_eq!(
         app.drain_actions(),
-        vec![Action::Submit("first prompt".to_string())]
+        vec![crate::Action::Submit("first prompt".to_string())]
     );
 }
 
@@ -356,9 +363,9 @@ fn ctrl_d_quits_only_on_an_empty_composer() {
         shift: false,
     });
     type_text(&mut app, "draft");
-    assert_eq!(app.handle(&ctrl_d), Flow::Continue);
+    assert_eq!(app.handle(&ctrl_d), crate::app::Flow::Continue);
     app.composer.clear();
-    assert_eq!(app.handle(&ctrl_d), Flow::Quit);
+    assert_eq!(app.handle(&ctrl_d), crate::app::Flow::Quit);
 }
 
 #[test]
@@ -403,25 +410,25 @@ fn confirming_an_argument_command_from_the_popup_completes_instead_of_running() 
 #[test]
 fn submit_during_an_active_turn_still_queues_and_steered_updates_the_label() {
     let mut app = app();
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
     app.submit("also check the docs");
     assert_eq!(
         app.drain_actions(),
-        vec![Action::Submit("also check the docs".to_string())]
+        vec![crate::Action::Submit("also check the docs".to_string())]
     );
-    app.apply(ChatEvent::TurnSteered);
+    app.apply(crate::ChatEvent::TurnSteered);
     assert_eq!(app.turn_state, "steered");
 }
 
 #[test]
 fn rpc_error_notice_does_not_finish_an_unrelated_active_turn() {
     let mut app = app();
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
-    app.apply(ChatEvent::Error {
+    app.apply(crate::ChatEvent::Error {
         title: "request `thread/list` was refused".to_string(),
         body: Vec::new(),
     });
@@ -433,11 +440,11 @@ fn rpc_error_notice_does_not_finish_an_unrelated_active_turn() {
 #[test]
 fn thread_switched_resets_turn_state_and_token_count() {
     let mut app = app();
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
-    app.apply(ChatEvent::Usage { total_tokens: 500 });
-    app.apply(ChatEvent::ThreadSwitched {
+    app.apply(crate::ChatEvent::Usage { total_tokens: 500 });
+    app.apply(crate::ChatEvent::ThreadSwitched {
         thread_id: "thread-99999999".to_string(),
         name: Some("fresh".to_string()),
         cwd: None,
@@ -453,12 +460,12 @@ fn thread_switched_resets_turn_state_and_token_count() {
 #[test]
 fn a_new_turn_resets_previous_turn_usage() {
     let mut app = app();
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
-    app.apply(ChatEvent::Usage { total_tokens: 500 });
-    app.apply(ChatEvent::TurnCompleted { error: None });
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::Usage { total_tokens: 500 });
+    app.apply(crate::ChatEvent::TurnCompleted { error: None });
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-2".to_string(),
     });
 
@@ -468,11 +475,11 @@ fn a_new_turn_resets_previous_turn_usage() {
 #[test]
 fn usage_accumulates_across_model_requests_in_one_turn() {
     let mut app = app();
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
-    app.apply(ChatEvent::Usage { total_tokens: 120 });
-    app.apply(ChatEvent::Usage { total_tokens: 80 });
+    app.apply(crate::ChatEvent::Usage { total_tokens: 120 });
+    app.apply(crate::ChatEvent::Usage { total_tokens: 80 });
 
     assert_eq!(app.total_tokens, 200);
 }
@@ -480,16 +487,16 @@ fn usage_accumulates_across_model_requests_in_one_turn() {
 #[test]
 fn status_command_reports_state_and_tokens() {
     let mut app = app();
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
-    app.apply(ChatEvent::Usage { total_tokens: 1234 });
+    app.apply(crate::ChatEvent::Usage { total_tokens: 1234 });
     app.submit("/status");
     let rows = app
         .cells
         .iter()
         .find_map(|cell| match cell {
-            crate::Cell::Config { title, rows } if title == "Session" => Some(rows.clone()),
+            crate::cells::Cell::Config { title, rows } if title == "Session" => Some(rows.clone()),
             _ => None,
         })
         .expect("status panel");
@@ -504,23 +511,23 @@ fn status_command_reports_state_and_tokens() {
 #[test]
 fn clear_empties_the_transcript_and_streams_reopen_after() {
     let mut app = app();
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
-    app.apply(ChatEvent::AnswerDelta("half an answer".to_string()));
+    app.apply(crate::ChatEvent::AnswerDelta("half an answer".to_string()));
     app.submit("/clear");
     assert!(
         !app.cells
             .iter()
-            .any(|cell| matches!(cell, crate::Cell::Answer(_))),
+            .any(|cell| matches!(cell, crate::cells::Cell::Answer(_))),
         "clear must drop the transcript"
     );
     // A delta after /clear must open a fresh cell, not write into the dropped one.
-    app.apply(ChatEvent::AnswerDelta("more".to_string()));
+    app.apply(crate::ChatEvent::AnswerDelta("more".to_string()));
     assert_eq!(
         app.cells
             .iter()
-            .filter(|cell| matches!(cell, crate::Cell::Answer(_)))
+            .filter(|cell| matches!(cell, crate::cells::Cell::Answer(_)))
             .count(),
         1
     );
@@ -533,7 +540,7 @@ fn interrupt_command_when_idle_is_a_notice_not_an_action() {
     assert_eq!(app.drain_actions(), Vec::new());
     assert!(app.cells.iter().any(|cell| matches!(
         cell,
-        crate::Cell::Notice { title, .. } if title == "no active turn to interrupt"
+        crate::cells::Cell::Notice { title, .. } if title == "no active turn to interrupt"
     )));
 }
 
@@ -544,7 +551,7 @@ fn unknown_slash_command_reports_an_error_notice() {
     assert_eq!(app.drain_actions(), Vec::new());
     assert!(app.cells.iter().any(|cell| matches!(
         cell,
-        crate::Cell::Notice { tone: crate::Tone::Error, title, .. }
+        crate::cells::Cell::Notice { tone: crate::cells::Tone::Error, title, .. }
             if title.contains("unknown slash command /frobnicate")
     )));
 }
@@ -557,12 +564,14 @@ fn help_lists_every_command() {
         .cells
         .iter()
         .find_map(|cell| match cell {
-            crate::Cell::Notice { title, body, .. } if title == "Commands" => Some(body.clone()),
+            crate::cells::Cell::Notice { title, body, .. } if title == "Commands" => {
+                Some(body.clone())
+            }
             _ => None,
         })
         .expect("help notice");
-    assert_eq!(body.len(), crate::COMMANDS.len());
-    for (label, _, _) in crate::COMMANDS {
+    assert_eq!(body.len(), crate::app::COMMANDS.len());
+    for (label, _, _) in crate::app::COMMANDS {
         assert!(
             body.iter().any(|line| line.starts_with(*label)),
             "missing {label}"
@@ -573,15 +582,15 @@ fn help_lists_every_command() {
 #[test]
 fn partial_output_deltas_join_across_line_boundaries() {
     let mut app = app();
-    app.apply(ChatEvent::ToolStarted {
+    app.apply(crate::ChatEvent::ToolStarted {
         id: "call-1".to_string(),
         title: "build".to_string(),
     });
-    app.apply(ChatEvent::ToolOutputDelta {
+    app.apply(crate::ChatEvent::ToolOutputDelta {
         id: "call-1".to_string(),
         delta: "Compil".to_string(),
     });
-    app.apply(ChatEvent::ToolOutputDelta {
+    app.apply(crate::ChatEvent::ToolOutputDelta {
         id: "call-1".to_string(),
         delta: "ing verlet\nFinished".to_string(),
     });
@@ -589,7 +598,7 @@ fn partial_output_deltas_join_across_line_boundaries() {
         .cells
         .iter()
         .find_map(|cell| match cell {
-            crate::Cell::Exec { output, .. } => Some(output.clone()),
+            crate::cells::Cell::Exec { output, .. } => Some(output.clone()),
             _ => None,
         })
         .expect("exec cell");
@@ -599,7 +608,7 @@ fn partial_output_deltas_join_across_line_boundaries() {
 #[test]
 fn renders_exec_cells_with_elision_and_failure_marker() {
     let mut app = app();
-    app.apply(ChatEvent::ToolStarted {
+    app.apply(crate::ChatEvent::ToolStarted {
         id: "call-1".to_string(),
         title: "cargo test".to_string(),
     });
@@ -607,7 +616,7 @@ fn renders_exec_cells_with_elision_and_failure_marker() {
         .map(|i| format!("line {i}"))
         .collect::<Vec<_>>()
         .join("\n");
-    app.apply(ChatEvent::ToolCompleted {
+    app.apply(crate::ChatEvent::ToolCompleted {
         id: "call-1".to_string(),
         success: false,
         output: long_output,
@@ -624,8 +633,10 @@ fn renders_exec_cells_with_elision_and_failure_marker() {
 #[test]
 fn renders_thinking_sessions_and_notice_tones() {
     let mut app = app();
-    app.apply(ChatEvent::ThinkingDelta("weighing options".to_string()));
-    app.apply(ChatEvent::Sessions(vec![
+    app.apply(crate::ChatEvent::ThinkingDelta(
+        "weighing options".to_string(),
+    ));
+    app.apply(crate::ChatEvent::Sessions(vec![
         crate::SessionRow {
             id: "thread-12345678".to_string(),
             name: "alpha".to_string(),
@@ -641,11 +652,11 @@ fn renders_thinking_sessions_and_notice_tones() {
             current: false,
         },
     ]));
-    app.apply(ChatEvent::Error {
+    app.apply(crate::ChatEvent::Error {
         title: "boom".to_string(),
         body: vec!["details".to_string()],
     });
-    app.apply(ChatEvent::ResyncStarted);
+    app.apply(crate::ChatEvent::ResyncStarted);
     let grid = render(&mut app, false);
     assert!(grid.contains("Thinking"), "thinking header:\n{grid}");
     assert!(grid.contains("weighing options"), "thinking body:\n{grid}");
@@ -664,13 +675,13 @@ fn renders_thinking_sessions_and_notice_tones() {
 #[test]
 fn renders_markdown_answers_with_code() {
     let mut app = app();
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
-    app.apply(ChatEvent::AnswerDelta(
+    app.apply(crate::ChatEvent::AnswerDelta(
         "Fix the guard:\n\n```rust\nlet x = 1;\n```\n\nDone.".to_string(),
     ));
-    app.apply(ChatEvent::TurnCompleted { error: None });
+    app.apply(crate::ChatEvent::TurnCompleted { error: None });
     let grid = render(&mut app, false);
     assert!(grid.contains("Fix the guard:"), "prose:\n{grid}");
     assert!(grid.contains("let x = 1;"), "code block body:\n{grid}");
@@ -699,7 +710,7 @@ fn model_rows() -> Vec<crate::ModelRow> {
 #[test]
 fn models_event_opens_the_picker_preselecting_the_active_row() {
     let mut app = app();
-    app.apply(ChatEvent::Models(model_rows()));
+    app.apply(crate::ChatEvent::Models(model_rows()));
     let grid = render(&mut app, true);
     assert!(grid.contains("Select a model"), "picker title:\n{grid}");
     assert!(grid.contains("Model A"), "display name row:\n{grid}");
@@ -728,19 +739,19 @@ fn configured_model_rows() -> Vec<crate::ModelRow> {
 #[test]
 fn picker_selection_emits_select_model_and_esc_dismisses() {
     let mut app = app();
-    app.apply(ChatEvent::Models(configured_model_rows()));
+    app.apply(crate::ChatEvent::Models(configured_model_rows()));
     let _ = app.handle(&key(tuika::KeyCode::Down));
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     assert_eq!(
         app.drain_actions(),
-        vec![Action::SelectModel {
+        vec![crate::Action::SelectModel {
             provider_id: "provider".to_string(),
             model: "model-b".to_string(),
         }]
     );
 
     // Reopen, then Esc closes without selecting and without interrupting.
-    app.apply(ChatEvent::Models(model_rows()));
+    app.apply(crate::ChatEvent::Models(model_rows()));
     let _ = app.handle(&key(tuika::KeyCode::Esc));
     assert_eq!(app.drain_actions(), Vec::new());
     let grid = render(&mut app, true);
@@ -750,7 +761,7 @@ fn picker_selection_emits_select_model_and_esc_dismisses() {
 #[test]
 fn picker_swallows_typing_and_model_selected_updates_the_footer_label() {
     let mut app = app();
-    app.apply(ChatEvent::Models(model_rows()));
+    app.apply(crate::ChatEvent::Models(model_rows()));
     type_text(&mut app, "stray keys");
     assert!(
         app.composer.is_empty(),
@@ -758,7 +769,7 @@ fn picker_swallows_typing_and_model_selected_updates_the_footer_label() {
     );
     let _ = app.handle(&key(tuika::KeyCode::Esc));
 
-    app.apply(ChatEvent::ModelSelected {
+    app.apply(crate::ChatEvent::ModelSelected {
         provider_id: "provider".to_string(),
         model: "model-b".to_string(),
     });
@@ -779,10 +790,10 @@ fn picker_is_modal_over_paste_scrolling_and_global_control_keys() {
     app.viewport_h = 10;
     app.scroll.jump_to_bottom(app.content_h, app.viewport_h);
     let scroll_offset = app.scroll.offset();
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
-    app.apply(ChatEvent::Models(model_rows()));
+    app.apply(crate::ChatEvent::Models(model_rows()));
 
     let _ = app.handle(&tuika::Event::Paste("must not leak".to_string()));
     let _ = app.handle(&key(tuika::KeyCode::PageUp));
@@ -794,7 +805,7 @@ fn picker_is_modal_over_paste_scrolling_and_global_control_keys() {
                 alt: false,
                 shift: false,
             })),
-            Flow::Continue
+            crate::app::Flow::Continue
         );
     }
 
@@ -818,7 +829,7 @@ fn models_event_replaces_popup_and_picker_and_empty_result_closes_stale_picker()
     let mut replacement = model_rows();
     replacement[0].active = false;
     replacement[1].active = false;
-    app.apply(ChatEvent::Models(replacement.clone()));
+    app.apply(crate::ChatEvent::Models(replacement.clone()));
     assert!(
         app.popup_items().is_empty(),
         "picker must win focus over popup"
@@ -826,17 +837,17 @@ fn models_event_replaces_popup_and_picker_and_empty_result_closes_stale_picker()
     assert_eq!(app.picker.as_ref().unwrap().state.selected(), Some(0));
 
     replacement[0].display_name = "Replacement".to_string();
-    app.apply(ChatEvent::Models(replacement));
+    app.apply(crate::ChatEvent::Models(replacement));
     assert_eq!(
         app.picker.as_ref().unwrap().rows[0].display_name,
         "Replacement"
     );
 
-    app.apply(ChatEvent::Models(Vec::new()));
+    app.apply(crate::ChatEvent::Models(Vec::new()));
     assert!(app.picker.is_none());
     assert!(app.cells.iter().any(|cell| matches!(
         cell,
-        crate::Cell::Notice { tone: crate::Tone::Error, title, .. }
+        crate::cells::Cell::Notice { tone: crate::cells::Tone::Error, title, .. }
             if title == "no models available"
     )));
 }
@@ -844,33 +855,36 @@ fn models_event_replaces_popup_and_picker_and_empty_result_closes_stale_picker()
 #[test]
 fn missing_auth_selection_routes_into_the_setup_window() {
     let mut app = app();
-    app.apply(ChatEvent::Models(model_rows()));
+    app.apply(crate::ChatEvent::Models(model_rows()));
     let _ = app.handle(&key(tuika::KeyCode::Down));
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     // No doomed SelectModel: the UI fetches the provider catalog to open the
     // credential step for `provider` instead.
-    assert_eq!(app.drain_actions(), vec![Action::FetchProviderCatalog]);
+    assert_eq!(
+        app.drain_actions(),
+        vec![crate::Action::FetchProviderCatalog]
+    );
     assert!(app.picker.is_none());
 }
 
 #[test]
 fn rejected_selection_keeps_model_and_active_turn_consistent() {
     let mut app = app();
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
     // Authenticated on the client's view, but the server still rejects the
     // switch (stale key, unreachable endpoint).
-    app.apply(ChatEvent::Models(configured_model_rows()));
+    app.apply(crate::ChatEvent::Models(configured_model_rows()));
     let _ = app.handle(&key(tuika::KeyCode::Down));
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     assert!(matches!(
         app.drain_actions().as_slice(),
-        [Action::SelectModel { provider_id, model }]
+        [crate::Action::SelectModel { provider_id, model }]
             if provider_id == "provider" && model == "model-b"
     ));
 
-    app.apply(ChatEvent::Error {
+    app.apply(crate::ChatEvent::Error {
         title: "model/select rejected: authentication required".to_string(),
         body: Vec::new(),
     });
@@ -880,7 +894,7 @@ fn rejected_selection_keeps_model_and_active_turn_consistent() {
     assert!(app.picker.is_none());
     assert!(app.cells.iter().any(|cell| matches!(
         cell,
-        crate::Cell::Notice { tone: crate::Tone::Error, title, .. }
+        crate::cells::Cell::Notice { tone: crate::cells::Tone::Error, title, .. }
             if title.contains("authentication required")
     )));
 }
@@ -888,10 +902,10 @@ fn rejected_selection_keeps_model_and_active_turn_consistent() {
 #[test]
 fn selection_during_active_turn_uses_server_echo_and_explains_deferred_effect() {
     let mut app = app();
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
-    app.apply(ChatEvent::ModelSelected {
+    app.apply(crate::ChatEvent::ModelSelected {
         provider_id: "echoed-provider".to_string(),
         model: "echoed-model".to_string(),
     });
@@ -899,7 +913,7 @@ fn selection_during_active_turn_uses_server_echo_and_explains_deferred_effect() 
     assert_eq!(app.meta.model_label, "echoed-provider/echoed-model");
     assert!(app.cells.iter().any(|cell| matches!(
         cell,
-        crate::Cell::Notice { title, body, .. }
+        crate::cells::Cell::Notice { title, body, .. }
             if title == "model set to echoed-provider/echoed-model"
                 && body == &["applies to turns after the current one".to_string()]
     )));
@@ -908,7 +922,7 @@ fn selection_during_active_turn_uses_server_echo_and_explains_deferred_effect() 
 #[test]
 fn long_and_wide_model_rows_fit_one_line_at_eighty_columns() {
     let mut app = app();
-    app.apply(ChatEvent::Models(vec![crate::ModelRow {
+    app.apply(crate::ChatEvent::Models(vec![crate::ModelRow {
         provider_id: "provider-with-a-very-long-identifier".repeat(2),
         model: "model-with-a-very-long-identifier".repeat(2),
         display_name: "模型🙂 with an extremely long display name ".repeat(3),
@@ -935,7 +949,7 @@ fn long_and_wide_model_rows_fit_one_line_at_eighty_columns() {
 fn model_picker_build_is_safe_at_zero_and_tiny_terminal_sizes() {
     for (width, height) in [(0, 0), (1, 1), (20, 4)] {
         let mut app = app();
-        app.apply(ChatEvent::Models(model_rows()));
+        app.apply(crate::ChatEvent::Models(model_rows()));
         let _ = render_at(&mut app, true, width, height);
     }
 }
@@ -944,7 +958,7 @@ fn model_picker_build_is_safe_at_zero_and_tiny_terminal_sizes() {
 fn long_transcripts_follow_the_tail() {
     let mut app = app();
     for i in 0..40 {
-        app.apply(ChatEvent::Info {
+        app.apply(crate::ChatEvent::Info {
             title: format!("notice number {i}"),
             body: Vec::new(),
         });
@@ -952,7 +966,7 @@ fn long_transcripts_follow_the_tail() {
     // First render measures geometry; second applies the follow offset the
     // append re-armed against it.
     let _ = render(&mut app, false);
-    app.apply(ChatEvent::Info {
+    app.apply(crate::ChatEvent::Info {
         title: "the last notice".to_string(),
         body: Vec::new(),
     });
@@ -979,7 +993,7 @@ fn transcript_updates_preserve_manual_scrollback() {
     let offset = app.scroll.offset();
     assert!(!app.scroll.is_stuck_to_bottom());
 
-    app.apply(ChatEvent::Info {
+    app.apply(crate::ChatEvent::Info {
         title: "new output".to_string(),
         body: Vec::new(),
     });
@@ -991,11 +1005,11 @@ fn transcript_updates_preserve_manual_scrollback() {
 #[test]
 fn long_single_line_tool_output_wraps_instead_of_clipping_the_tail() {
     let mut app = app();
-    app.apply(ChatEvent::ToolStarted {
+    app.apply(crate::ChatEvent::ToolStarted {
         id: "call-1".to_string(),
         title: "emit".to_string(),
     });
-    app.apply(ChatEvent::ToolCompleted {
+    app.apply(crate::ChatEvent::ToolCompleted {
         id: "call-1".to_string(),
         success: true,
         output: format!("HEAD {} TAIL", "x".repeat(180)),
@@ -1015,23 +1029,23 @@ fn wide_character_input_submits_losslessly() {
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     assert_eq!(
         app.drain_actions(),
-        vec![Action::Submit("你🙂é".to_string())]
+        vec![crate::Action::Submit("你🙂é".to_string())]
     );
 }
 
 #[test]
 fn zero_size_terminal_build_is_safe() {
     let mut app = app();
-    app.apply(ChatEvent::ToolStarted {
+    app.apply(crate::ChatEvent::ToolStarted {
         id: "call-1".to_string(),
         title: "emit".to_string(),
     });
-    app.apply(ChatEvent::ToolCompleted {
+    app.apply(crate::ChatEvent::ToolCompleted {
         id: "call-1".to_string(),
         success: true,
         output: "long output".repeat(20),
     });
-    let theme = crate::chat_theme(false);
+    let theme = crate::theme::chat_theme(false);
     let sheet = tuika::StyleSheet::from_theme(&theme);
     let probe = tuika::probe::RectProbe::new();
     let _ = crate::ui::build(
@@ -1046,7 +1060,7 @@ fn zero_size_terminal_build_is_safe() {
 #[test]
 fn footer_shows_thread_and_turn_state() {
     let mut app = app();
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-abcdefgh-rest".to_string(),
     });
     let grid = render(&mut app, false);
@@ -1058,7 +1072,7 @@ fn footer_shows_thread_and_turn_state() {
 #[test]
 fn renders_a_welcome_screen_snapshot() {
     let mut app = app();
-    let theme = crate::chat_theme(false);
+    let theme = crate::theme::chat_theme(false);
     let sheet = tuika::StyleSheet::from_theme(&theme);
     let probe = tuika::probe::RectProbe::new();
     let scene = crate::ui::build(
@@ -1084,13 +1098,13 @@ fn renders_a_turn_in_flight_snapshot() {
     let mut app = app();
     app.submit("why does the test fail?");
     let _ = app.drain_actions();
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
-    app.apply(ChatEvent::AnswerDelta(
+    app.apply(crate::ChatEvent::AnswerDelta(
         "Looking at the *snapshot*…".to_string(),
     ));
-    let theme = crate::chat_theme(false);
+    let theme = crate::theme::chat_theme(false);
     let sheet = tuika::StyleSheet::from_theme(&theme);
     let probe = tuika::probe::RectProbe::new();
     let scene = crate::ui::build(
@@ -1175,17 +1189,20 @@ fn catalog_rows() -> Vec<crate::CatalogProviderRow> {
 }
 
 /// `/setup` then the catalog answer: lands on the provider overview.
-fn open_home(app: &mut App) {
+fn open_home(app: &mut crate::app::App) {
     app.submit("/setup");
-    assert_eq!(app.drain_actions(), vec![Action::FetchProviderCatalog]);
-    app.apply(ChatEvent::ProviderCatalog {
+    assert_eq!(
+        app.drain_actions(),
+        vec![crate::Action::FetchProviderCatalog]
+    );
+    app.apply(crate::ChatEvent::ProviderCatalog {
         providers: catalog_rows(),
     });
 }
 
 /// Overview has 2 configured rows (anthropic, local-llm); "Connect a
 /// provider" sits right under them.
-fn open_catalog(app: &mut App) {
+fn open_catalog(app: &mut crate::app::App) {
     open_home(app);
     let _ = app.handle(&key(tuika::KeyCode::Down));
     let _ = app.handle(&key(tuika::KeyCode::Down));
@@ -1222,7 +1239,10 @@ fn setup_command_opens_the_provider_overview() {
 fn providers_alias_matches_setup() {
     let mut app = app();
     app.submit("/providers");
-    assert_eq!(app.drain_actions(), vec![Action::FetchProviderCatalog]);
+    assert_eq!(
+        app.drain_actions(),
+        vec![crate::Action::FetchProviderCatalog]
+    );
 }
 
 #[test]
@@ -1240,8 +1260,8 @@ fn overview_enter_opens_the_provider_menu_and_scoped_models() {
     );
 
     let _ = app.handle(&key(tuika::KeyCode::Enter));
-    assert_eq!(app.drain_actions(), vec![Action::ListModels]);
-    app.apply(ChatEvent::Models(vec![
+    assert_eq!(app.drain_actions(), vec![crate::Action::ListModels]);
+    app.apply(crate::ChatEvent::Models(vec![
         crate::ModelRow {
             provider_id: "anthropic".to_string(),
             model: "model-a".to_string(),
@@ -1291,7 +1311,7 @@ fn catalog_picker_searches_and_routes_to_key_entry() {
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     assert_eq!(
         app.drain_actions(),
-        vec![Action::SetProviderKey {
+        vec![crate::Action::SetProviderKey {
             provider_id: "openai".to_string(),
             api_key: "sk-secret-123".to_string(),
         }]
@@ -1300,14 +1320,14 @@ fn catalog_picker_searches_and_routes_to_key_entry() {
     assert!(grid.contains("saving…"), "busy hint:\n{grid}");
 
     // Success with a usable current model: the picker opens scoped.
-    app.apply(ChatEvent::CredentialResult {
+    app.apply(crate::ChatEvent::CredentialResult {
         provider_id: "openai".to_string(),
         error: None,
     });
-    assert_eq!(app.drain_actions(), vec![Action::ListModels]);
+    assert_eq!(app.drain_actions(), vec![crate::Action::ListModels]);
     assert!(app.cells.iter().any(|cell| matches!(
         cell,
-        crate::Cell::Notice { title, .. } if title == "openai: credential saved"
+        crate::cells::Cell::Notice { title, .. } if title == "openai: credential saved"
     )));
 }
 
@@ -1321,13 +1341,13 @@ fn credential_success_auto_selects_the_default_model_when_current_is_unusable() 
     type_text(&mut app, "sk-key");
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     let _ = app.drain_actions();
-    app.apply(ChatEvent::CredentialResult {
+    app.apply(crate::ChatEvent::CredentialResult {
         provider_id: "openai".to_string(),
         error: None,
     });
     assert_eq!(
         app.drain_actions(),
-        vec![Action::SelectModel {
+        vec![crate::Action::SelectModel {
             provider_id: "openai".to_string(),
             model: "gpt-best".to_string(),
         }]
@@ -1351,7 +1371,7 @@ fn empty_and_failed_key_submissions_surface_errors_in_place() {
     type_text(&mut app, "sk-bad");
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     let _ = app.drain_actions();
-    app.apply(ChatEvent::CredentialResult {
+    app.apply(crate::ChatEvent::CredentialResult {
         provider_id: "openai".to_string(),
         error: Some("provider rejected the key".to_string()),
     });
@@ -1381,7 +1401,7 @@ fn oauth_provider_offers_sign_in_and_shows_the_device_code() {
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     assert_eq!(
         app.drain_actions(),
-        vec![Action::StartLogin {
+        vec![crate::Action::StartLogin {
             provider_id: "openai-codex".to_string(),
             method: crate::LoginMethod::Device,
         }]
@@ -1392,7 +1412,7 @@ fn oauth_provider_offers_sign_in_and_shows_the_device_code() {
         "wait body:\n{grid}"
     );
 
-    app.apply(ChatEvent::LoginDeviceCode {
+    app.apply(crate::ChatEvent::LoginDeviceCode {
         verification_uri: "https://auth.example/device".to_string(),
         user_code: "ABCD-1234".to_string(),
     });
@@ -1405,7 +1425,7 @@ fn oauth_provider_offers_sign_in_and_shows_the_device_code() {
 
     // Esc cancels the login and lands back on the method choice.
     let _ = app.handle(&key(tuika::KeyCode::Esc));
-    assert_eq!(app.drain_actions(), vec![Action::CancelLogin]);
+    assert_eq!(app.drain_actions(), vec![crate::Action::CancelLogin]);
     let grid = render(&mut app, true);
     assert!(grid.contains("sign-in canceled"), "cancel notice:\n{grid}");
     assert!(
@@ -1418,7 +1438,7 @@ fn oauth_provider_offers_sign_in_and_shows_the_device_code() {
 fn login_success_reissues_the_selection_that_started_the_window() {
     let mut app = app();
     // Enter on a "needs login" model row routes into the window.
-    app.apply(ChatEvent::Models(vec![crate::ModelRow {
+    app.apply(crate::ChatEvent::Models(vec![crate::ModelRow {
         provider_id: "openai-codex".to_string(),
         model: "gpt-5.6-sol".to_string(),
         display_name: "GPT 5.6 sol".to_string(),
@@ -1426,10 +1446,13 @@ fn login_success_reissues_the_selection_that_started_the_window() {
         active: false,
     }]));
     let _ = app.handle(&key(tuika::KeyCode::Enter));
-    assert_eq!(app.drain_actions(), vec![Action::FetchProviderCatalog]);
+    assert_eq!(
+        app.drain_actions(),
+        vec![crate::Action::FetchProviderCatalog]
+    );
 
     // The catalog answer lands directly on the provider's sign-in step.
-    app.apply(ChatEvent::ProviderCatalog {
+    app.apply(crate::ChatEvent::ProviderCatalog {
         providers: catalog_rows(),
     });
     let grid = render(&mut app, true);
@@ -1441,13 +1464,13 @@ fn login_success_reissues_the_selection_that_started_the_window() {
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     assert_eq!(
         app.drain_actions(),
-        vec![Action::StartLogin {
+        vec![crate::Action::StartLogin {
             provider_id: "openai-codex".to_string(),
             method: crate::LoginMethod::Browser,
         }]
     );
     // A stale device code for a browser login must not corrupt the wait.
-    app.apply(ChatEvent::LoginDeviceCode {
+    app.apply(crate::ChatEvent::LoginDeviceCode {
         verification_uri: "https://stale.example/device".to_string(),
         user_code: "STALE".to_string(),
     });
@@ -1459,13 +1482,13 @@ fn login_success_reissues_the_selection_that_started_the_window() {
             ..
         })
     ));
-    app.apply(ChatEvent::CredentialResult {
+    app.apply(crate::ChatEvent::CredentialResult {
         provider_id: "openai-codex".to_string(),
         error: None,
     });
     assert_eq!(
         app.drain_actions(),
-        vec![Action::SelectModel {
+        vec![crate::Action::SelectModel {
             provider_id: "openai-codex".to_string(),
             model: "gpt-5.6-sol".to_string(),
         }]
@@ -1499,7 +1522,7 @@ fn esc_backs_out_level_by_level_and_closes_from_home() {
 fn window_swallows_composer_input_while_open() {
     let mut app = app();
     open_home(&mut app);
-    app.apply(ChatEvent::TurnStarted {
+    app.apply(crate::ChatEvent::TurnStarted {
         turn_id: "turn-1".to_string(),
     });
     type_text(&mut app, "hello");
@@ -1522,9 +1545,12 @@ fn window_swallows_composer_input_while_open() {
 #[test]
 fn first_run_gate_opens_the_catalog_and_nags_until_configured() {
     let mut app = app();
-    app.apply(ChatEvent::NoConfiguredProviders);
-    assert_eq!(app.drain_actions(), vec![Action::FetchProviderCatalog]);
-    app.apply(ChatEvent::ProviderCatalog {
+    app.apply(crate::ChatEvent::NoConfiguredProviders);
+    assert_eq!(
+        app.drain_actions(),
+        vec![crate::Action::FetchProviderCatalog]
+    );
+    app.apply(crate::ChatEvent::ProviderCatalog {
         providers: catalog_rows()
             .into_iter()
             .map(|mut row| {
@@ -1548,7 +1574,7 @@ fn first_run_gate_opens_the_catalog_and_nags_until_configured() {
     );
 
     // A saved credential clears the nag (out-of-band here).
-    app.apply(ChatEvent::CredentialResult {
+    app.apply(crate::ChatEvent::CredentialResult {
         provider_id: "openai".to_string(),
         error: None,
     });
@@ -1563,7 +1589,7 @@ fn first_run_gate_opens_the_catalog_and_nags_until_configured() {
 fn first_run_gate_does_not_reopen_over_an_active_window() {
     let mut app = app();
     open_home(&mut app);
-    app.apply(ChatEvent::NoConfiguredProviders);
+    app.apply(crate::ChatEvent::NoConfiguredProviders);
     assert_eq!(app.drain_actions(), Vec::new());
     let grid = render(&mut app, true);
     assert!(grid.contains("Connect a provider"), "home kept:\n{grid}");
@@ -1627,7 +1653,7 @@ fn custom_form_derives_the_id_validates_and_submits() {
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     assert_eq!(
         app.drain_actions(),
-        vec![Action::UpsertCustomProvider {
+        vec![crate::Action::UpsertCustomProvider {
             spec: crate::CustomProviderSpec {
                 provider_id: "my-llm-server".to_string(),
                 display_name: "My LLM Server".to_string(),
@@ -1643,13 +1669,13 @@ fn custom_form_derives_the_id_validates_and_submits() {
     assert!(grid.contains("saving provider…"), "busy:\n{grid}");
 
     // Upsert success chains into the key save.
-    app.apply(ChatEvent::CustomProviderResult {
+    app.apply(crate::ChatEvent::CustomProviderResult {
         provider_id: "my-llm-server".to_string(),
         error: None,
     });
     assert_eq!(
         app.drain_actions(),
-        vec![Action::SetProviderKey {
+        vec![crate::Action::SetProviderKey {
             provider_id: "my-llm-server".to_string(),
             api_key: "sk-custom-secret".to_string(),
         }]
@@ -1658,11 +1684,11 @@ fn custom_form_derives_the_id_validates_and_submits() {
     assert!(grid.contains("saving key…"), "key busy:\n{grid}");
 
     // Key success finishes into the provider's model list.
-    app.apply(ChatEvent::CredentialResult {
+    app.apply(crate::ChatEvent::CredentialResult {
         provider_id: "my-llm-server".to_string(),
         error: None,
     });
-    assert_eq!(app.drain_actions(), vec![Action::ListModels]);
+    assert_eq!(app.drain_actions(), vec![crate::Action::ListModels]);
 }
 
 #[test]
@@ -1686,7 +1712,7 @@ fn keyless_custom_provider_finishes_without_a_key_save() {
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     assert_eq!(
         app.drain_actions(),
-        vec![Action::UpsertCustomProvider {
+        vec![crate::Action::UpsertCustomProvider {
             spec: crate::CustomProviderSpec {
                 provider_id: "ollama".to_string(),
                 display_name: "Ollama".to_string(),
@@ -1698,14 +1724,14 @@ fn keyless_custom_provider_finishes_without_a_key_save() {
             },
         }]
     );
-    app.apply(ChatEvent::CustomProviderResult {
+    app.apply(crate::ChatEvent::CustomProviderResult {
         provider_id: "ollama".to_string(),
         error: None,
     });
     // No key follow-up; the unusable echo model auto-selects the default.
     assert_eq!(
         app.drain_actions(),
-        vec![Action::SelectModel {
+        vec![crate::Action::SelectModel {
             provider_id: "ollama".to_string(),
             model: "llama-local".to_string(),
         }]
@@ -1733,7 +1759,7 @@ fn custom_form_upsert_errors_render_inline_and_redact() {
     type_text(&mut app, "m1");
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     let _ = app.drain_actions();
-    app.apply(ChatEvent::CustomProviderResult {
+    app.apply(crate::ChatEvent::CustomProviderResult {
         provider_id: "broken".to_string(),
         error: Some("record for sk-broken-secret was rejected".to_string()),
     });
@@ -1786,23 +1812,26 @@ fn provider_menu_edits_and_deletes_custom_providers() {
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     assert_eq!(
         app.drain_actions(),
-        vec![Action::DeleteCustomProvider {
+        vec![crate::Action::DeleteCustomProvider {
             provider_id: "local-llm".to_string(),
         }]
     );
     let grid = render(&mut app, true);
     assert!(grid.contains("deleting…"), "delete busy:\n{grid}");
 
-    app.apply(ChatEvent::CustomProviderResult {
+    app.apply(crate::ChatEvent::CustomProviderResult {
         provider_id: "local-llm".to_string(),
         error: None,
     });
-    assert_eq!(app.drain_actions(), vec![Action::FetchProviderCatalog]);
+    assert_eq!(
+        app.drain_actions(),
+        vec![crate::Action::FetchProviderCatalog]
+    );
     let without_custom: Vec<crate::CatalogProviderRow> = catalog_rows()
         .into_iter()
         .filter(|row| row.provider_id != "local-llm")
         .collect();
-    app.apply(ChatEvent::ProviderCatalog {
+    app.apply(crate::ChatEvent::ProviderCatalog {
         providers: without_custom,
     });
     let grid = render(&mut app, true);
@@ -1812,14 +1841,14 @@ fn provider_menu_edits_and_deletes_custom_providers() {
     );
     assert!(app.cells.iter().any(|cell| matches!(
         cell,
-        crate::Cell::Notice { title, .. } if title == "local-llm: provider deleted"
+        crate::cells::Cell::Notice { title, .. } if title == "local-llm: provider deleted"
     )));
 }
 
 #[test]
 fn stale_credential_results_report_out_of_band_without_reopening_the_window() {
     let mut app = app();
-    app.apply(ChatEvent::CredentialResult {
+    app.apply(crate::ChatEvent::CredentialResult {
         provider_id: "openai".to_string(),
         error: Some("boom".to_string()),
     });
@@ -1827,7 +1856,7 @@ fn stale_credential_results_report_out_of_band_without_reopening_the_window() {
     assert!(!grid.contains("Providers"), "window stayed shut:\n{grid}");
     assert!(app.cells.iter().any(|cell| matches!(
         cell,
-        crate::Cell::Notice { tone: crate::Tone::Error, title, .. }
+        crate::cells::Cell::Notice { tone: crate::cells::Tone::Error, title, .. }
             if title == "openai: credential failed"
     )));
 }
@@ -1835,7 +1864,7 @@ fn stale_credential_results_report_out_of_band_without_reopening_the_window() {
 #[test]
 fn setup_request_errors_release_invisible_wait_states() {
     let mut app = app();
-    app.apply(ChatEvent::Models(vec![crate::ModelRow {
+    app.apply(crate::ChatEvent::Models(vec![crate::ModelRow {
         provider_id: "missing-provider".to_string(),
         model: "model-a".to_string(),
         display_name: "Model A".to_string(),
@@ -1844,7 +1873,7 @@ fn setup_request_errors_release_invisible_wait_states() {
     }]));
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     let _ = app.drain_actions();
-    app.apply(ChatEvent::Error {
+    app.apply(crate::ChatEvent::Error {
         title: "provider catalog failed".to_string(),
         body: Vec::new(),
     });
@@ -1855,12 +1884,12 @@ fn setup_request_errors_release_invisible_wait_states() {
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     let _ = app.drain_actions();
-    app.apply(ChatEvent::Error {
+    app.apply(crate::ChatEvent::Error {
         title: "model catalog failed".to_string(),
         body: Vec::new(),
     });
     assert!(app.setup.is_none());
-    app.apply(ChatEvent::Models(vec![
+    app.apply(crate::ChatEvent::Models(vec![
         crate::ModelRow {
             provider_id: "anthropic".to_string(),
             model: "model-a".to_string(),
@@ -1890,7 +1919,7 @@ fn setup_action_errors_return_busy_steps_to_interactive_state() {
     type_text(&mut app, "sk-secret");
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     let _ = app.drain_actions();
-    app.apply(ChatEvent::Error {
+    app.apply(crate::ChatEvent::Error {
         title: "saving sk-secret failed".to_string(),
         body: vec!["sk-secret was rejected".to_string()],
     });
@@ -1901,19 +1930,19 @@ fn setup_action_errors_return_busy_steps_to_interactive_state() {
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     assert_eq!(
         app.drain_actions(),
-        vec![Action::SetProviderKey {
+        vec![crate::Action::SetProviderKey {
             provider_id: "openai".to_string(),
             api_key: "sk-retry".to_string(),
         }]
     );
 
-    let mut oauth_app = App::new(meta());
+    let mut oauth_app = crate::app::App::new(meta());
     open_catalog(&mut oauth_app);
     type_text(&mut oauth_app, "codex");
     let _ = oauth_app.handle(&key(tuika::KeyCode::Enter));
     let _ = oauth_app.handle(&key(tuika::KeyCode::Enter));
     let _ = oauth_app.drain_actions();
-    oauth_app.apply(ChatEvent::Error {
+    oauth_app.apply(crate::ChatEvent::Error {
         title: "login failed".to_string(),
         body: Vec::new(),
     });
@@ -1937,7 +1966,7 @@ fn credential_failure_never_renders_the_submitted_secret() {
     type_text(&mut app, "sk-do-not-render");
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     let _ = app.drain_actions();
-    app.apply(ChatEvent::CredentialResult {
+    app.apply(crate::ChatEvent::CredentialResult {
         provider_id: "openai".to_string(),
         error: Some("provider echoed sk-do-not-render".to_string()),
     });
@@ -1948,7 +1977,7 @@ fn credential_failure_never_renders_the_submitted_secret() {
         "redacted error missing:\n{grid}"
     );
 
-    let mut late_app = App::new(meta());
+    let mut late_app = crate::app::App::new(meta());
     open_catalog(&mut late_app);
     type_text(&mut late_app, "openai");
     let _ = late_app.handle(&key(tuika::KeyCode::Enter));
@@ -1956,7 +1985,7 @@ fn credential_failure_never_renders_the_submitted_secret() {
     let _ = late_app.handle(&key(tuika::KeyCode::Enter));
     let _ = late_app.drain_actions();
     let _ = late_app.handle(&key(tuika::KeyCode::Esc));
-    late_app.apply(ChatEvent::Error {
+    late_app.apply(crate::ChatEvent::Error {
         title: "saving sk-late-error failed".to_string(),
         body: vec!["rejected sk-late-error".to_string()],
     });
@@ -1975,20 +2004,20 @@ fn catalog_events_do_not_clobber_open_credential_input() {
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     type_text(&mut app, "sk-kept");
 
-    app.apply(ChatEvent::ProviderCatalog {
+    app.apply(crate::ChatEvent::ProviderCatalog {
         providers: catalog_rows(),
     });
-    app.apply(ChatEvent::Models(vec![crate::ModelRow {
+    app.apply(crate::ChatEvent::Models(vec![crate::ModelRow {
         provider_id: "anthropic".to_string(),
         model: "model-a".to_string(),
         display_name: "Must Not Open".to_string(),
         auth_status: "configured".to_string(),
         active: true,
     }]));
-    app.apply(ChatEvent::CredentialCleared {
+    app.apply(crate::ChatEvent::CredentialCleared {
         provider_id: "anthropic".to_string(),
     });
-    app.apply(ChatEvent::CredentialResult {
+    app.apply(crate::ChatEvent::CredentialResult {
         provider_id: "anthropic".to_string(),
         error: None,
     });
@@ -2006,7 +2035,7 @@ fn catalog_events_do_not_clobber_open_credential_input() {
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     assert_eq!(
         app.drain_actions(),
-        vec![Action::SetProviderKey {
+        vec![crate::Action::SetProviderKey {
             provider_id: "openai".to_string(),
             api_key: "sk-kept".to_string(),
         }]
@@ -2022,8 +2051,8 @@ fn manual_models_command_supersedes_the_window_model_scope() {
     let _ = app.drain_actions();
 
     app.submit("/models");
-    assert_eq!(app.drain_actions(), vec![Action::ListModels]);
-    app.apply(ChatEvent::Models(vec![
+    assert_eq!(app.drain_actions(), vec![crate::Action::ListModels]);
+    app.apply(crate::ChatEvent::Models(vec![
         crate::ModelRow {
             provider_id: "anthropic".to_string(),
             model: "model-a".to_string(),
@@ -2050,7 +2079,7 @@ fn manual_models_command_supersedes_the_window_model_scope() {
 #[test]
 fn missing_awaited_provider_and_canceled_login_clear_pending_selection() {
     let mut app = app();
-    app.apply(ChatEvent::Models(vec![crate::ModelRow {
+    app.apply(crate::ChatEvent::Models(vec![crate::ModelRow {
         provider_id: "gone".to_string(),
         model: "model-a".to_string(),
         display_name: "Model A".to_string(),
@@ -2059,13 +2088,13 @@ fn missing_awaited_provider_and_canceled_login_clear_pending_selection() {
     }]));
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     let _ = app.drain_actions();
-    app.apply(ChatEvent::ProviderCatalog {
+    app.apply(crate::ChatEvent::ProviderCatalog {
         providers: catalog_rows(),
     });
     assert!(app.pending_selection.is_none());
 
-    let mut cancel_app = App::new(meta());
-    cancel_app.apply(ChatEvent::Models(vec![crate::ModelRow {
+    let mut cancel_app = crate::app::App::new(meta());
+    cancel_app.apply(crate::ChatEvent::Models(vec![crate::ModelRow {
         provider_id: "openai-codex".to_string(),
         model: "gpt-5.6-sol".to_string(),
         display_name: "GPT 5.6 sol".to_string(),
@@ -2074,7 +2103,7 @@ fn missing_awaited_provider_and_canceled_login_clear_pending_selection() {
     }]));
     let _ = cancel_app.handle(&key(tuika::KeyCode::Enter));
     let _ = cancel_app.drain_actions();
-    cancel_app.apply(ChatEvent::ProviderCatalog {
+    cancel_app.apply(crate::ChatEvent::ProviderCatalog {
         providers: catalog_rows(),
     });
     let _ = cancel_app.handle(&key(tuika::KeyCode::Enter));
@@ -2082,7 +2111,7 @@ fn missing_awaited_provider_and_canceled_login_clear_pending_selection() {
     let _ = cancel_app.handle(&key(tuika::KeyCode::Esc));
     let _ = cancel_app.drain_actions();
     assert!(cancel_app.pending_selection.is_none());
-    cancel_app.apply(ChatEvent::CredentialResult {
+    cancel_app.apply(crate::ChatEvent::CredentialResult {
         provider_id: "openai-codex".to_string(),
         error: None,
     });
@@ -2090,8 +2119,8 @@ fn missing_awaited_provider_and_canceled_login_clear_pending_selection() {
     // reported out of band without driving the flow forward.
     assert_eq!(cancel_app.drain_actions(), Vec::new());
 
-    let mut key_app = App::new(meta());
-    key_app.apply(ChatEvent::Models(vec![crate::ModelRow {
+    let mut key_app = crate::app::App::new(meta());
+    key_app.apply(crate::ChatEvent::Models(vec![crate::ModelRow {
         provider_id: "openai".to_string(),
         model: "gpt-key".to_string(),
         display_name: "GPT key".to_string(),
@@ -2100,7 +2129,7 @@ fn missing_awaited_provider_and_canceled_login_clear_pending_selection() {
     }]));
     let _ = key_app.handle(&key(tuika::KeyCode::Enter));
     let _ = key_app.drain_actions();
-    key_app.apply(ChatEvent::ProviderCatalog {
+    key_app.apply(crate::ChatEvent::ProviderCatalog {
         providers: catalog_rows(),
     });
     type_text(&mut key_app, "sk-key");
@@ -2115,7 +2144,7 @@ fn long_and_wide_provider_rows_preserve_the_active_marker() {
     let mut app = app();
     app.submit("/setup");
     let _ = app.drain_actions();
-    app.apply(ChatEvent::ProviderCatalog {
+    app.apply(crate::ChatEvent::ProviderCatalog {
         providers: vec![crate::CatalogProviderRow {
             provider_id: "provider".to_string(),
             display_name: "模型🙂 provider with a very long display name".repeat(2),
@@ -2146,23 +2175,26 @@ fn clearing_a_credential_refreshes_the_open_window() {
     let _ = app.handle(&key(tuika::KeyCode::Enter));
     assert_eq!(
         app.drain_actions(),
-        vec![Action::ClearCredential {
+        vec![crate::Action::ClearCredential {
             provider_id: "anthropic".to_string(),
         }]
     );
-    app.apply(ChatEvent::CredentialCleared {
+    app.apply(crate::ChatEvent::CredentialCleared {
         provider_id: "anthropic".to_string(),
     });
-    assert_eq!(app.drain_actions(), vec![Action::FetchProviderCatalog]);
+    assert_eq!(
+        app.drain_actions(),
+        vec![crate::Action::FetchProviderCatalog]
+    );
     assert!(app.cells.iter().any(|cell| matches!(
         cell,
-        crate::Cell::Notice { title, .. } if title == "anthropic: credential cleared"
+        crate::cells::Cell::Notice { title, .. } if title == "anthropic: credential cleared"
     )));
     // The refreshed catalog demotes the provider; the menu falls back home.
     let mut rows = catalog_rows();
     rows[0].configured = false;
     rows[0].auth_label = String::new();
-    app.apply(ChatEvent::ProviderCatalog { providers: rows });
+    app.apply(crate::ChatEvent::ProviderCatalog { providers: rows });
     let grid = render(&mut app, true);
     assert!(
         grid.contains("API key"),
@@ -2182,7 +2214,7 @@ fn setup_window_build_is_safe_at_zero_and_tiny_terminal_sizes() {
         let _ = app.handle(&key(tuika::KeyCode::Enter));
         let _ = render_at(&mut app, true, width, height);
 
-        let mut form_app = App::new(meta());
+        let mut form_app = crate::app::App::new(meta());
         open_home(&mut form_app);
         for _ in 0..3 {
             let _ = form_app.handle(&key(tuika::KeyCode::Down));
@@ -2194,28 +2226,26 @@ fn setup_window_build_is_safe_at_zero_and_tiny_terminal_sizes() {
 
 #[test]
 fn base_url_validation_accepts_https_and_local_http_only() {
-    use crate::app::setup::validate_base_url;
-    assert!(validate_base_url("https://api.example.com/v1").is_ok());
-    assert!(validate_base_url("http://localhost:8080/v1").is_ok());
-    assert!(validate_base_url("http://127.0.0.1:11434").is_ok());
-    assert!(validate_base_url("http://[::1]:8080/v1").is_ok());
-    assert!(validate_base_url("http://example.com/v1").is_err());
-    assert!(validate_base_url("ftp://example.com").is_err());
-    assert!(validate_base_url("https://").is_err());
-    assert!(validate_base_url("").is_err());
+    assert!(crate::app::setup::validate_base_url("https://api.example.com/v1").is_ok());
+    assert!(crate::app::setup::validate_base_url("http://localhost:8080/v1").is_ok());
+    assert!(crate::app::setup::validate_base_url("http://127.0.0.1:11434").is_ok());
+    assert!(crate::app::setup::validate_base_url("http://[::1]:8080/v1").is_ok());
+    assert!(crate::app::setup::validate_base_url("http://example.com/v1").is_err());
+    assert!(crate::app::setup::validate_base_url("ftp://example.com").is_err());
+    assert!(crate::app::setup::validate_base_url("https://").is_err());
+    assert!(crate::app::setup::validate_base_url("").is_err());
 }
 
 #[test]
 fn fuzzy_filter_matches_subsequences_and_ranks_substrings_first() {
-    use crate::app::setup::filtered_catalog;
     let rows = catalog_rows();
-    let hits = filtered_catalog(&rows, "oai");
+    let hits = crate::app::setup::filtered_catalog(&rows, "oai");
     assert!(
         hits.iter().any(|row| row.provider_id == "openai"),
         "subsequence match failed"
     );
-    let hits = filtered_catalog(&rows, "openai");
+    let hits = crate::app::setup::filtered_catalog(&rows, "openai");
     assert_eq!(hits[0].provider_id, "openai");
-    let hits = filtered_catalog(&rows, "zzz");
+    let hits = crate::app::setup::filtered_catalog(&rows, "zzz");
     assert!(hits.is_empty());
 }

--- a/crates/verlet-chat/src/theme.rs
+++ b/crates/verlet-chat/src/theme.rs
@@ -1,48 +1,44 @@
 //! The chat palette.
 
-use ratatui::style::Color;
-
-use tuika::prelude::*;
-
 /// The Verlet chat theme. With `no_color` (the `NO_COLOR` convention) every
 /// slot collapses to the terminal's default foreground/background so the UI
 /// degrades to structure-only styling.
-pub fn chat_theme(no_color: bool) -> Theme {
+pub fn chat_theme(no_color: bool) -> tuika::style::Theme {
     if no_color {
-        return Theme {
-            background: Color::Reset,
-            surface: Color::Reset,
-            text: Color::Reset,
-            muted: Color::Reset,
-            dim: Color::Reset,
-            accent: Color::Reset,
-            accent_alt: Color::Reset,
-            border: Color::Reset,
-            border_focused: Color::Reset,
-            selection_bg: Color::Reset,
-            selection_fg: Color::Reset,
-            code: CodeTheme::default(),
+        return tuika::style::Theme {
+            background: ratatui::style::Color::Reset,
+            surface: ratatui::style::Color::Reset,
+            text: ratatui::style::Color::Reset,
+            muted: ratatui::style::Color::Reset,
+            dim: ratatui::style::Color::Reset,
+            accent: ratatui::style::Color::Reset,
+            accent_alt: ratatui::style::Color::Reset,
+            border: ratatui::style::Color::Reset,
+            border_focused: ratatui::style::Color::Reset,
+            selection_bg: ratatui::style::Color::Reset,
+            selection_fg: ratatui::style::Color::Reset,
+            code: tuika::style::CodeTheme::default(),
         };
     }
     // A dark, low-chroma palette: near-black ground, teal for the UI's own
     // marks, violet for user-entered tokens, muted gray for machine output.
-    Theme {
-        background: Color::Rgb(13, 14, 16),
-        surface: Color::Rgb(23, 25, 28),
-        text: Color::Rgb(223, 226, 230),
-        muted: Color::Rgb(142, 148, 158),
-        dim: Color::Rgb(88, 94, 104),
-        accent: Color::Rgb(94, 187, 209),
-        accent_alt: Color::Rgb(197, 154, 231),
-        border: Color::Rgb(60, 66, 74),
-        border_focused: Color::Rgb(94, 187, 209),
-        selection_bg: Color::Rgb(35, 44, 52),
-        selection_fg: Color::Rgb(235, 238, 242),
-        code: CodeTheme {
-            link: Color::Rgb(122, 172, 240),
-            string: Color::Rgb(140, 200, 140),
-            heading: Color::Rgb(223, 226, 230),
-            ..CodeTheme::default()
+    tuika::style::Theme {
+        background: ratatui::style::Color::Rgb(13, 14, 16),
+        surface: ratatui::style::Color::Rgb(23, 25, 28),
+        text: ratatui::style::Color::Rgb(223, 226, 230),
+        muted: ratatui::style::Color::Rgb(142, 148, 158),
+        dim: ratatui::style::Color::Rgb(88, 94, 104),
+        accent: ratatui::style::Color::Rgb(94, 187, 209),
+        accent_alt: ratatui::style::Color::Rgb(197, 154, 231),
+        border: ratatui::style::Color::Rgb(60, 66, 74),
+        border_focused: ratatui::style::Color::Rgb(94, 187, 209),
+        selection_bg: ratatui::style::Color::Rgb(35, 44, 52),
+        selection_fg: ratatui::style::Color::Rgb(235, 238, 242),
+        code: tuika::style::CodeTheme {
+            link: ratatui::style::Color::Rgb(122, 172, 240),
+            string: ratatui::style::Color::Rgb(140, 200, 140),
+            heading: ratatui::style::Color::Rgb(223, 226, 230),
+            ..tuika::style::CodeTheme::default()
         },
     }
 }

--- a/crates/verlet-chat/src/ui.rs
+++ b/crates/verlet-chat/src/ui.rs
@@ -5,25 +5,8 @@
 //! screen is one column. The transcript grows; everything below it is
 //! measured first and pinned — the composer never moves, and new output
 //! pushes the history up instead of the input down. The setup window and the
-//! model picker render as a centered [`Dialog`] overlay that dims the base
+//! model picker render as a centered [`tuika::components::Dialog`] overlay that dims the base
 //! tree underneath.
-
-use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
-
-use tuika::components::Dialog;
-use tuika::prelude::*;
-use tuika::probe::RectProbe;
-
-use crate::app::App;
-use crate::app::setup::{
-    API_FAMILIES, CUSTOM_FIELD_ORDER, CustomBusy, CustomField, CustomForm, HOME_ACTIONS, SetupStep,
-    catalog_status, filtered_catalog, oauth_options, overview_rows, overview_status,
-    provider_menu_options,
-};
-use crate::cells::short_id;
-use crate::{CatalogProviderRow, LoginMethod};
 
 /// Columns of blank kept down each side of the UI.
 pub const GUTTER: u16 = 1;
@@ -40,16 +23,16 @@ const MODAL_WIDTH: u16 = 72;
 /// Columns a select list spends on its `› ` selection marker.
 const SELECT_MARKER_W: u16 = 2;
 
-/// Build the frame. Takes `&mut App` because the transcript's streaming
+/// Build the frame. Takes `&mut crate::app::App` because the transcript's streaming
 /// markdown re-renders through its own cache, and because the scroll offset
 /// is reconciled against this frame's geometry.
 pub fn build(
-    app: &mut App,
-    area: Rect,
-    theme: &Theme,
-    sheet: &StyleSheet,
-    probe: &RectProbe,
-) -> Scene {
+    app: &mut crate::app::App,
+    area: ratatui::layout::Rect,
+    theme: &tuika::style::Theme,
+    sheet: &tuika::style::StyleSheet,
+    probe: &tuika::probe::RectProbe,
+) -> tuika::scene::Scene {
     let width = area.width.saturating_sub(GUTTER * 2);
 
     // Measure the pinned bottom stack first; the transcript takes what is left.
@@ -74,17 +57,20 @@ pub fn build(
     // them — same width, same scrollbar setting — so the offset can't drift
     // from the paint.
     let items = app.transcript(width, theme, sheet);
-    let ctx = RenderCtx::new(theme).with_sheet(*sheet);
-    app.content_h = ItemScroll::measure_height(&items, width, TRANSCRIPT_GAP, true, &ctx);
+    let ctx = tuika::view::RenderCtx::new(theme).with_sheet(*sheet);
+    app.content_h =
+        tuika::components::ItemScroll::measure_height(&items, width, TRANSCRIPT_GAP, true, &ctx);
     app.viewport_h = transcript_h as usize;
     app.scroll.clamp(app.content_h, app.viewport_h);
 
-    let mut root = Flex::column()
-        .padding(Padding::symmetric(GUTTER, 0))
-        .background(Style::default().bg(theme.background))
+    let mut root = tuika::components::Flex::column()
+        .padding(tuika::geometry::Padding::symmetric(GUTTER, 0))
+        .background(ratatui::style::Style::default().bg(theme.background))
         .grow(
             1,
-            element(ItemScroll::new(items, &app.scroll).gap(TRANSCRIPT_GAP)),
+            tuika::view::element(
+                tuika::components::ItemScroll::new(items, &app.scroll).gap(TRANSCRIPT_GAP),
+            ),
         );
     if working_h > 0 {
         root = root.fixed(working_h, working(app, theme));
@@ -95,7 +81,7 @@ pub fn build(
     root = root.fixed(body_h, composer(app, theme, probe));
     root = root.fixed(1, footer(app, theme));
 
-    let mut scene = Scene::new(element(root));
+    let mut scene = tuika::scene::Scene::new(tuika::view::element(root));
     if let Some(dialog) = modal(app, area, theme) {
         scene = scene.dialog(dialog);
     }
@@ -104,13 +90,15 @@ pub fn build(
 
 /// `⠹ Working (12s • Esc to interrupt)` — the row shown under the transcript
 /// while a turn is in flight.
-fn working(app: &App, theme: &Theme) -> Element {
-    let label = Line::from(vec![
-        Span::styled(
+fn working(app: &crate::app::App, theme: &tuika::style::Theme) -> tuika::view::Element {
+    let label = ratatui::text::Line::from(vec![
+        ratatui::text::Span::styled(
             "Working",
-            Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+            ratatui::style::Style::default()
+                .fg(theme.text)
+                .add_modifier(ratatui::style::Modifier::BOLD),
         ),
-        Span::styled(
+        ratatui::text::Span::styled(
             // While the picker or the setup window is open it owns Esc
             // (dismiss, not interrupt), so the interrupt hint would lie.
             if app.picker.is_some() || app.setup_visible() {
@@ -121,59 +109,72 @@ fn working(app: &App, theme: &Theme) -> Element {
             theme.muted_style(),
         ),
     ]);
-    let row = view! {
+    let row = tuika::view! {
         row(gap = 1) {
-            fixed(1) { node(Spinner::new(app.frame).color(theme.accent)) }
-            grow(1) { node(Text::new(vec![label])) }
+            fixed(1) { node(tuika::components::Spinner::new(app.frame).color(theme.accent)) }
+            grow(1) { node(tuika::components::Text::new(vec![label])) }
         }
     };
-    element(Flex::column().fixed(1, element(Spacer)).fixed(1, row))
+    tuika::view::element(
+        tuika::components::Flex::column()
+            .fixed(1, tuika::view::element(tuika::components::Spacer))
+            .fixed(1, row),
+    )
 }
 
 /// The slash-command completion picker.
-fn popup(app: &App, items: &[(String, String)], theme: &Theme) -> Element {
+fn popup(
+    app: &crate::app::App,
+    items: &[(String, String)],
+    theme: &tuika::style::Theme,
+) -> tuika::view::Element {
     let pad = items
         .iter()
         .map(|(label, _)| label.chars().count())
         .max()
         .unwrap_or(0);
-    let rows: Vec<Line<'static>> = items
+    let rows: Vec<ratatui::text::Line<'static>> = items
         .iter()
         .map(|(label, blurb)| {
-            Line::from(vec![
-                Span::styled(
+            ratatui::text::Line::from(vec![
+                ratatui::text::Span::styled(
                     format!(
                         "{label}{:width$}  ",
                         "",
                         width = pad - label.chars().count()
                     ),
-                    Style::default().fg(theme.accent_alt),
+                    ratatui::style::Style::default().fg(theme.accent_alt),
                 ),
-                Span::styled(blurb.clone(), theme.muted_style()),
+                ratatui::text::Span::styled(blurb.clone(), theme.muted_style()),
             ])
         })
         .collect();
     let Some(state) = app.popup.as_ref().map(|popup| popup.state) else {
-        return element(Spacer);
+        return tuika::view::element(tuika::components::Spacer);
     };
-    let list = SelectList::new(rows, &state).viewport(MAX_POPUP_ROWS as u16);
-    element(
-        Flex::column()
-            .fixed(1, element(Spacer))
-            .grow(1, element(list)),
+    let list = tuika::components::SelectList::new(rows, &state).viewport(MAX_POPUP_ROWS as u16);
+    tuika::view::element(
+        tuika::components::Flex::column()
+            .fixed(1, tuika::view::element(tuika::components::Spacer))
+            .grow(1, tuika::view::element(list)),
     )
 }
 
 /// The modal window, when one is open: the setup screens or the model
 /// picker, composed as a centered dialog over the dimmed base tree.
-fn modal(app: &App, area: Rect, theme: &Theme) -> Option<Dialog> {
+fn modal(
+    app: &crate::app::App,
+    area: ratatui::layout::Rect,
+    theme: &tuika::style::Theme,
+) -> Option<tuika::components::Dialog> {
     let width = MODAL_WIDTH.min(area.width.saturating_sub(4)).max(24);
     let content_w = width.saturating_sub(4);
-    let (title, content, content_h, hints): (String, Element, u16, Vec<(&str, &str)>) =
+    let (title, content, content_h, hints): (String, tuika::view::Element, u16, Vec<(&str, &str)>) =
         if let Some(step) = app.setup.as_ref() {
             match step {
-                SetupStep::AwaitCatalog { .. } | SetupStep::AwaitModels { .. } => return None,
-                SetupStep::Home { rows, state } => {
+                crate::app::setup::SetupStep::AwaitCatalog { .. }
+                | crate::app::setup::SetupStep::AwaitModels { .. } => return None,
+                crate::app::setup::SetupStep::Home { rows, state } => {
                     let (content, rows_h) = setup_home(rows, state, theme, content_w);
                     (
                         "Providers".to_string(),
@@ -182,7 +183,7 @@ fn modal(app: &App, area: Rect, theme: &Theme) -> Option<Dialog> {
                         vec![("↑↓", "move"), ("⏎", "select"), ("esc", "close")],
                     )
                 }
-                SetupStep::ProviderMenu {
+                crate::app::setup::SetupStep::ProviderMenu {
                     provider,
                     state,
                     busy,
@@ -198,7 +199,7 @@ fn modal(app: &App, area: Rect, theme: &Theme) -> Option<Dialog> {
                         vec![("↑↓", "move"), ("⏎", "select"), ("esc", "back")],
                     )
                 }
-                SetupStep::Catalog {
+                crate::app::setup::SetupStep::Catalog {
                     rows,
                     filter,
                     state,
@@ -211,7 +212,7 @@ fn modal(app: &App, area: Rect, theme: &Theme) -> Option<Dialog> {
                         vec![("type", "search"), ("⏎", "select"), ("esc", "back")],
                     )
                 }
-                SetupStep::Credential {
+                crate::app::setup::SetupStep::Credential {
                     provider,
                     state,
                     error,
@@ -225,7 +226,7 @@ fn modal(app: &App, area: Rect, theme: &Theme) -> Option<Dialog> {
                         vec![("↑↓", "move"), ("⏎", "select"), ("esc", "back")],
                     )
                 }
-                SetupStep::KeyInput {
+                crate::app::setup::SetupStep::KeyInput {
                     provider,
                     value,
                     busy,
@@ -241,7 +242,7 @@ fn modal(app: &App, area: Rect, theme: &Theme) -> Option<Dialog> {
                         vec![("⏎", "save"), ("esc", "back")],
                     )
                 }
-                SetupStep::LoginWait {
+                crate::app::setup::SetupStep::LoginWait {
                     provider,
                     method,
                     device_code,
@@ -256,7 +257,7 @@ fn modal(app: &App, area: Rect, theme: &Theme) -> Option<Dialog> {
                         vec![("esc", "cancel")],
                     )
                 }
-                SetupStep::CustomForm {
+                crate::app::setup::SetupStep::CustomForm {
                     form, busy, error, ..
                 } => {
                     let (content, rows_h) =
@@ -285,10 +286,10 @@ fn modal(app: &App, area: Rect, theme: &Theme) -> Option<Dialog> {
         } else {
             return None;
         };
-    // Dialog chrome: border rows (2) + actions row.
+    // tuika::components::Dialog chrome: border rows (2) + actions row.
     let height = (content_h + 3).min(area.height.saturating_sub(2));
     Some(
-        Dialog::new(title, content)
+        tuika::components::Dialog::new(title, content)
             .size(width, height)
             .key_hints(hints)
             .dim_backdrop(true),
@@ -297,13 +298,13 @@ fn modal(app: &App, area: Rect, theme: &Theme) -> Option<Dialog> {
 
 /// The provider overview: configured providers plus the two entry actions.
 fn setup_home(
-    rows: &[CatalogProviderRow],
-    state: &SelectState,
-    theme: &Theme,
+    rows: &[crate::CatalogProviderRow],
+    state: &tuika::components::SelectState,
+    theme: &tuika::style::Theme,
     width: u16,
-) -> (Element, u16) {
-    let overview = overview_rows(rows);
-    let total_rows = overview.len() + HOME_ACTIONS.len();
+) -> (tuika::view::Element, u16) {
+    let overview = crate::app::setup::overview_rows(rows);
+    let total_rows = overview.len() + crate::app::setup::HOME_ACTIONS.len();
     let scrollbar_w = u16::from(total_rows > MAX_MODAL_ROWS);
     let usable = width
         .saturating_sub(SELECT_MARKER_W)
@@ -313,130 +314,142 @@ fn setup_home(
         .iter()
         .map(|row| tuika::width::str_cols(&row.display_name))
         .chain(
-            HOME_ACTIONS
+            crate::app::setup::HOME_ACTIONS
                 .iter()
                 .map(|(label, _)| tuika::width::str_cols(label)),
         )
         .max()
         .unwrap_or(0);
     let name_w = max_name_w.min(usable.saturating_sub(max_suffix_w.saturating_add(2)) / 2);
-    let mut lines: Vec<Line<'static>> = overview
+    let mut lines: Vec<ratatui::text::Line<'static>> = overview
         .iter()
         .map(|row| {
             let name = fit_columns(&row.display_name, name_w);
             let name_pad = name_w.saturating_sub(tuika::width::str_cols(&name));
             let suffix_w = if row.active { 8 } else { 0 };
             let status = fit_columns(
-                &overview_status(row),
+                &crate::app::setup::overview_status(row),
                 usable
                     .saturating_sub(name_w)
                     .saturating_sub(2)
                     .saturating_sub(suffix_w),
             );
             let mut spans = vec![
-                Span::styled(
+                ratatui::text::Span::styled(
                     format!("{name}{:width$}  ", "", width = usize::from(name_pad)),
-                    Style::default().fg(theme.text),
+                    ratatui::style::Style::default().fg(theme.text),
                 ),
-                Span::styled(status, Style::default().fg(theme.accent)),
+                ratatui::text::Span::styled(
+                    status,
+                    ratatui::style::Style::default().fg(theme.accent),
+                ),
             ];
             if row.active {
-                spans.push(Span::styled(
+                spans.push(ratatui::text::Span::styled(
                     "  active",
-                    Style::default()
+                    ratatui::style::Style::default()
                         .fg(theme.accent)
-                        .add_modifier(Modifier::BOLD),
+                        .add_modifier(ratatui::style::Modifier::BOLD),
                 ));
             }
-            Line::from(spans)
+            ratatui::text::Line::from(spans)
         })
         .collect();
-    for (label, hint) in HOME_ACTIONS {
+    for (label, hint) in crate::app::setup::HOME_ACTIONS {
         let name = fit_columns(label, name_w);
         let name_pad = name_w.saturating_sub(tuika::width::str_cols(&name));
-        lines.push(Line::from(vec![
-            Span::styled(
+        lines.push(ratatui::text::Line::from(vec![
+            ratatui::text::Span::styled(
                 format!("{name}{:width$}  ", "", width = usize::from(name_pad)),
-                Style::default().fg(theme.accent_alt),
+                ratatui::style::Style::default().fg(theme.accent_alt),
             ),
-            Span::styled(hint.to_string(), theme.muted_style()),
+            ratatui::text::Span::styled(hint.to_string(), theme.muted_style()),
         ]));
     }
     let total = lines.len();
-    let mut column = Flex::column();
+    let mut column = tuika::components::Flex::column();
     if overview.is_empty() {
         column = column.fixed(
             1,
-            element(Text::new(vec![Line::from(Span::styled(
-                "No providers configured yet.",
-                theme.muted_style(),
-            ))])),
+            tuika::view::element(tuika::components::Text::new(vec![
+                ratatui::text::Line::from(ratatui::text::Span::styled(
+                    "No providers configured yet.",
+                    theme.muted_style(),
+                )),
+            ])),
         );
     }
-    let list = SelectList::new(lines, state).viewport(MAX_MODAL_ROWS as u16);
+    let list = tuika::components::SelectList::new(lines, state).viewport(MAX_MODAL_ROWS as u16);
     let empty_h = u16::from(overview.is_empty());
-    column = column.grow(1, element(list));
-    (element(column), total.min(MAX_MODAL_ROWS) as u16 + empty_h)
+    column = column.grow(1, tuika::view::element(list));
+    (
+        tuika::view::element(column),
+        total.min(MAX_MODAL_ROWS) as u16 + empty_h,
+    )
 }
 
 /// The action list for one configured provider.
 fn setup_provider_menu(
-    provider: &CatalogProviderRow,
-    state: &SelectState,
+    provider: &crate::CatalogProviderRow,
+    state: &tuika::components::SelectState,
     busy: bool,
     error: Option<&str>,
-    theme: &Theme,
-) -> (Element, u16) {
-    let options = provider_menu_options(provider);
-    let lines: Vec<Line<'static>> = options
+    theme: &tuika::style::Theme,
+) -> (tuika::view::Element, u16) {
+    let options = crate::app::setup::provider_menu_options(provider);
+    let lines: Vec<ratatui::text::Line<'static>> = options
         .iter()
         .map(|option| {
-            Line::from(vec![
-                Span::styled(
+            ratatui::text::Line::from(vec![
+                ratatui::text::Span::styled(
                     format!("{}  ", option.label),
-                    Style::default().fg(theme.text),
+                    ratatui::style::Style::default().fg(theme.text),
                 ),
-                Span::styled(option.hint.to_string(), theme.muted_style()),
+                ratatui::text::Span::styled(option.hint.to_string(), theme.muted_style()),
             ])
         })
         .collect();
     let count = lines.len() as u16;
-    let list = SelectList::new(lines, state).viewport(MAX_MODAL_ROWS as u16);
-    let mut column = Flex::column()
+    let list = tuika::components::SelectList::new(lines, state).viewport(MAX_MODAL_ROWS as u16);
+    let mut column = tuika::components::Flex::column()
         .fixed(
             1,
-            element(Text::new(vec![Line::from(Span::styled(
-                overview_status(provider),
-                theme.muted_style(),
-            ))])),
+            tuika::view::element(tuika::components::Text::new(vec![
+                ratatui::text::Line::from(ratatui::text::Span::styled(
+                    crate::app::setup::overview_status(provider),
+                    theme.muted_style(),
+                )),
+            ])),
         )
-        .grow(1, element(list));
+        .grow(1, tuika::view::element(list));
     let mut height = count + 1;
     if busy {
         column = column.fixed(
             1,
-            element(Text::new(vec![Line::from(Span::styled(
-                "deleting…",
-                theme.muted_style(),
-            ))])),
+            tuika::view::element(tuika::components::Text::new(vec![
+                ratatui::text::Line::from(ratatui::text::Span::styled(
+                    "deleting…",
+                    theme.muted_style(),
+                )),
+            ])),
         );
         height += 1;
     } else if let Some(message) = error {
         column = column.fixed(1, modal_error(message, theme));
         height += 1;
     }
-    (element(column), height)
+    (tuika::view::element(column), height)
 }
 
 /// The searchable catalog list.
 fn setup_catalog(
-    rows: &[CatalogProviderRow],
+    rows: &[crate::CatalogProviderRow],
     filter: &str,
-    state: &SelectState,
-    theme: &Theme,
+    state: &tuika::components::SelectState,
+    theme: &tuika::style::Theme,
     width: u16,
-) -> (Element, u16) {
-    let filtered = filtered_catalog(rows, filter);
+) -> (tuika::view::Element, u16) {
+    let filtered = crate::app::setup::filtered_catalog(rows, filter);
     let scrollbar_w = u16::from(filtered.len() > MAX_MODAL_ROWS);
     let usable = width
         .saturating_sub(SELECT_MARKER_W)
@@ -447,25 +460,25 @@ fn setup_catalog(
         .max()
         .unwrap_or(0);
     let name_w = max_name_w.min(usable.saturating_sub(2) / 2);
-    let lines: Vec<Line<'static>> = filtered
+    let lines: Vec<ratatui::text::Line<'static>> = filtered
         .iter()
         .map(|row| {
             let name = fit_columns(&row.display_name, name_w);
             let name_pad = name_w.saturating_sub(tuika::width::str_cols(&name));
             let status = fit_columns(
-                &catalog_status(row),
+                &crate::app::setup::catalog_status(row),
                 usable.saturating_sub(name_w).saturating_sub(2),
             );
             let configured = row.configured;
-            Line::from(vec![
-                Span::styled(
+            ratatui::text::Line::from(vec![
+                ratatui::text::Span::styled(
                     format!("{name}{:width$}  ", "", width = usize::from(name_pad)),
-                    Style::default().fg(theme.text),
+                    ratatui::style::Style::default().fg(theme.text),
                 ),
-                Span::styled(
+                ratatui::text::Span::styled(
                     status,
                     if configured {
-                        Style::default().fg(theme.accent)
+                        ratatui::style::Style::default().fg(theme.accent)
                     } else {
                         theme.muted_style()
                     },
@@ -474,73 +487,90 @@ fn setup_catalog(
         })
         .collect();
     let count = lines.len();
-    let search = Line::from(vec![
-        Span::styled("Search: ", theme.muted_style()),
-        Span::styled(filter.to_string(), Style::default().fg(theme.text)),
-        Span::styled("▏", Style::default().fg(theme.accent_alt)),
+    let search = ratatui::text::Line::from(vec![
+        ratatui::text::Span::styled("Search: ", theme.muted_style()),
+        ratatui::text::Span::styled(
+            filter.to_string(),
+            ratatui::style::Style::default().fg(theme.text),
+        ),
+        ratatui::text::Span::styled("▏", ratatui::style::Style::default().fg(theme.accent_alt)),
     ]);
-    let mut column = Flex::column().fixed(1, element(Text::new(vec![search])));
+    let mut column = tuika::components::Flex::column().fixed(
+        1,
+        tuika::view::element(tuika::components::Text::new(vec![search])),
+    );
     let mut height = 1;
     if count == 0 {
         column = column.fixed(
             1,
-            element(Text::new(vec![Line::from(Span::styled(
-                "no providers match",
-                theme.muted_style(),
-            ))])),
+            tuika::view::element(tuika::components::Text::new(vec![
+                ratatui::text::Line::from(ratatui::text::Span::styled(
+                    "no providers match",
+                    theme.muted_style(),
+                )),
+            ])),
         );
         height += 1;
     } else {
-        let list = SelectList::new(lines, state).viewport(MAX_MODAL_ROWS as u16);
-        column = column.grow(1, element(list));
+        let list = tuika::components::SelectList::new(lines, state).viewport(MAX_MODAL_ROWS as u16);
+        column = column.grow(1, tuika::view::element(list));
         height += count.min(MAX_MODAL_ROWS) as u16;
     }
-    (element(column), height)
+    (tuika::view::element(column), height)
 }
 
 /// OAuth sign-in method options.
-fn setup_oauth_options(state: &SelectState, error: Option<&str>, theme: &Theme) -> (Element, u16) {
-    let options = oauth_options();
-    let lines: Vec<Line<'static>> = options
+fn setup_oauth_options(
+    state: &tuika::components::SelectState,
+    error: Option<&str>,
+    theme: &tuika::style::Theme,
+) -> (tuika::view::Element, u16) {
+    let options = crate::app::setup::oauth_options();
+    let lines: Vec<ratatui::text::Line<'static>> = options
         .iter()
         .map(|option| {
-            Line::from(vec![
-                Span::styled(
+            ratatui::text::Line::from(vec![
+                ratatui::text::Span::styled(
                     format!("{}  ", option.label),
-                    Style::default().fg(theme.text),
+                    ratatui::style::Style::default().fg(theme.text),
                 ),
-                Span::styled(option.hint.to_string(), theme.muted_style()),
+                ratatui::text::Span::styled(option.hint.to_string(), theme.muted_style()),
             ])
         })
         .collect();
     let count = lines.len() as u16;
-    let list = SelectList::new(lines, state).viewport(MAX_MODAL_ROWS as u16);
-    let mut column = Flex::column().grow(1, element(list));
+    let list = tuika::components::SelectList::new(lines, state).viewport(MAX_MODAL_ROWS as u16);
+    let mut column = tuika::components::Flex::column().grow(1, tuika::view::element(list));
     let mut height = count;
     if let Some(message) = error {
         column = column.fixed(1, modal_error(message, theme));
         height += 1;
     }
-    (element(column), height)
+    (tuika::view::element(column), height)
 }
 
-fn modal_error(message: &str, theme: &Theme) -> Element {
+fn modal_error(message: &str, theme: &tuika::style::Theme) -> tuika::view::Element {
     // Matches the notice-cell error glyph and color in `cells.rs`.
-    element(Text::new(vec![Line::from(vec![
-        Span::styled("✗ ", Style::default().fg(theme.accent)),
-        Span::styled(message.to_string(), Style::default().fg(theme.text)),
-    ])]))
+    tuika::view::element(tuika::components::Text::new(vec![
+        ratatui::text::Line::from(vec![
+            ratatui::text::Span::styled("✗ ", ratatui::style::Style::default().fg(theme.accent)),
+            ratatui::text::Span::styled(
+                message.to_string(),
+                ratatui::style::Style::default().fg(theme.text),
+            ),
+        ]),
+    ]))
 }
 
 /// Masked API-key entry.
 fn setup_key_input(
-    provider: &CatalogProviderRow,
+    provider: &crate::CatalogProviderRow,
     value: &str,
     busy: bool,
     error: Option<&str>,
-    theme: &Theme,
+    theme: &tuika::style::Theme,
     width: u16,
-) -> (Element, u16) {
+) -> (tuika::view::Element, u16) {
     // The key never renders: a masked run of bullets stands in for it, and
     // overlong keys clip from the left so the caret edge stays visible.
     let masked = "•".repeat(
@@ -549,9 +579,9 @@ fn setup_key_input(
             .count()
             .min(usize::from(width.saturating_sub(4))),
     );
-    let mut lines = vec![Line::from(vec![
-        Span::styled("Paste the API key", theme.muted_style()),
-        Span::styled(
+    let mut lines = vec![ratatui::text::Line::from(vec![
+        ratatui::text::Span::styled("Paste the API key", theme.muted_style()),
+        ratatui::text::Span::styled(
             provider
                 .env_vars
                 .first()
@@ -560,120 +590,154 @@ fn setup_key_input(
             theme.muted_style(),
         ),
     ])];
-    lines.push(Line::from(vec![
-        Span::styled("› ", Style::default().fg(theme.accent_alt)),
-        Span::styled(masked, Style::default().fg(theme.text)),
+    lines.push(ratatui::text::Line::from(vec![
+        ratatui::text::Span::styled("› ", ratatui::style::Style::default().fg(theme.accent_alt)),
+        ratatui::text::Span::styled(masked, ratatui::style::Style::default().fg(theme.text)),
     ]));
     let mut height = 2;
     if let Some(message) = error {
-        lines.push(Line::from(vec![
-            Span::styled("✗ ", Style::default().fg(theme.accent)),
-            Span::styled(message.to_string(), Style::default().fg(theme.text)),
+        lines.push(ratatui::text::Line::from(vec![
+            ratatui::text::Span::styled("✗ ", ratatui::style::Style::default().fg(theme.accent)),
+            ratatui::text::Span::styled(
+                message.to_string(),
+                ratatui::style::Style::default().fg(theme.text),
+            ),
         ]));
         height += 1;
     } else if busy {
-        lines.push(Line::from(Span::styled("saving…", theme.muted_style())));
+        lines.push(ratatui::text::Line::from(ratatui::text::Span::styled(
+            "saving…",
+            theme.muted_style(),
+        )));
         height += 1;
     }
-    (element(Text::new(lines)), height)
+    (
+        tuika::view::element(tuika::components::Text::new(lines)),
+        height,
+    )
 }
 
 /// The login-wait body: device code once it arrives, spinner otherwise.
 fn setup_login_wait(
-    method: LoginMethod,
+    method: crate::LoginMethod,
     device_code: Option<&(String, String)>,
-    app: &App,
-    theme: &Theme,
-) -> (Element, u16) {
+    app: &crate::app::App,
+    theme: &tuika::style::Theme,
+) -> (tuika::view::Element, u16) {
     match (method, device_code) {
-        (LoginMethod::Device, Some((uri, code))) => {
+        (crate::LoginMethod::Device, Some((uri, code))) => {
             let lines = vec![
-                Line::from(vec![
-                    Span::styled("Open ".to_string(), theme.muted_style()),
-                    Span::styled(uri.clone(), Style::default().fg(theme.text)),
+                ratatui::text::Line::from(vec![
+                    ratatui::text::Span::styled("Open ".to_string(), theme.muted_style()),
+                    ratatui::text::Span::styled(
+                        uri.clone(),
+                        ratatui::style::Style::default().fg(theme.text),
+                    ),
                 ]),
-                Line::from(vec![
-                    Span::styled("Enter code ".to_string(), theme.muted_style()),
-                    Span::styled(
+                ratatui::text::Line::from(vec![
+                    ratatui::text::Span::styled("Enter code ".to_string(), theme.muted_style()),
+                    ratatui::text::Span::styled(
                         code.clone(),
-                        Style::default()
+                        ratatui::style::Style::default()
                             .fg(theme.accent)
-                            .add_modifier(Modifier::BOLD),
+                            .add_modifier(ratatui::style::Modifier::BOLD),
                     ),
                 ]),
             ];
-            (element(Text::new(lines)), 2)
+            (tuika::view::element(tuika::components::Text::new(lines)), 2)
         }
         _ => {
             let waiting = match method {
-                LoginMethod::Browser => "waiting for the browser sign-in to finish",
-                LoginMethod::Device => "requesting a device code",
+                crate::LoginMethod::Browser => "waiting for the browser sign-in to finish",
+                crate::LoginMethod::Device => "requesting a device code",
             };
-            let row = view! {
+            let row = tuika::view! {
                 row(gap = 1) {
-                    fixed(1) { node(Spinner::new(app.frame).color(theme.accent)) }
-                    grow(1) { node(Text::new(vec![Line::from(Span::styled(
+                    fixed(1) { node(tuika::components::Spinner::new(app.frame).color(theme.accent)) }
+                    grow(1) { node(tuika::components::Text::new(vec![ratatui::text::Line::from(ratatui::text::Span::styled(
                         waiting.to_string(),
                         theme.muted_style(),
                     ))])) }
                 }
             };
-            (element(Flex::column().fixed(1, row)), 1)
+            (
+                tuika::view::element(tuika::components::Flex::column().fixed(1, row)),
+                1,
+            )
         }
     }
 }
 
 /// The custom-provider form: one row per field, focus marked with `›`.
 fn setup_custom_form(
-    form: &CustomForm,
-    busy: CustomBusy,
+    form: &crate::app::setup::CustomForm,
+    busy: crate::app::setup::CustomBusy,
     error: Option<&str>,
-    theme: &Theme,
+    theme: &tuika::style::Theme,
     width: u16,
-) -> (Element, u16) {
+) -> (tuika::view::Element, u16) {
     let label_w = 10u16;
     let value_w = usize::from(width.saturating_sub(label_w).saturating_sub(4));
     let focused = form.focused();
-    let mut lines: Vec<Line<'static>> = Vec::new();
-    for field in CUSTOM_FIELD_ORDER {
+    let mut lines: Vec<ratatui::text::Line<'static>> = Vec::new();
+    for field in crate::app::setup::CUSTOM_FIELD_ORDER {
         let (label, value, muted_hint): (&str, String, &str) = match field {
-            CustomField::Name => ("name", form.name.clone(), "display name"),
-            CustomField::Id => ("id", form.id.clone(), "slug, a-z 0-9 - _"),
-            CustomField::Api => (
+            crate::app::setup::CustomField::Name => ("name", form.name.clone(), "display name"),
+            crate::app::setup::CustomField::Id => ("id", form.id.clone(), "slug, a-z 0-9 - _"),
+            crate::app::setup::CustomField::Api => (
                 "api",
                 format!(
                     "‹ {} ›",
-                    API_FAMILIES[form.api_index.min(API_FAMILIES.len() - 1)].1
+                    crate::app::setup::API_FAMILIES[form
+                        .api_index
+                        .min(crate::app::setup::API_FAMILIES.len() - 1)]
+                    .1
                 ),
                 "",
             ),
-            CustomField::BaseUrl => ("base URL", form.base_url.clone(), "https://…"),
-            CustomField::ApiKey => (
+            crate::app::setup::CustomField::BaseUrl => {
+                ("base URL", form.base_url.clone(), "https://…")
+            }
+            crate::app::setup::CustomField::ApiKey => (
                 "API key",
                 "•".repeat(form.api_key.chars().count().min(value_w)),
                 "optional for local servers",
             ),
-            CustomField::HeaderName => ("header", form.header_name.clone(), "optional"),
-            CustomField::HeaderValue => ("value", form.header_value.clone(), "optional"),
-            CustomField::Models => ("models", form.models.clone(), "ids, first is default"),
+            crate::app::setup::CustomField::HeaderName => {
+                ("header", form.header_name.clone(), "optional")
+            }
+            crate::app::setup::CustomField::HeaderValue => {
+                ("value", form.header_value.clone(), "optional")
+            }
+            crate::app::setup::CustomField::Models => {
+                ("models", form.models.clone(), "ids, first is default")
+            }
         };
         let is_focused = field == focused;
         let marker = if is_focused { "› " } else { "  " };
         let shown = if value.is_empty() && !is_focused {
-            Span::styled(muted_hint.to_string(), Style::default().fg(theme.dim))
+            ratatui::text::Span::styled(
+                muted_hint.to_string(),
+                ratatui::style::Style::default().fg(theme.dim),
+            )
         } else {
-            Span::styled(
+            ratatui::text::Span::styled(
                 fit_columns_left(&value, value_w as u16),
                 if is_focused {
-                    Style::default().fg(theme.text).add_modifier(Modifier::BOLD)
+                    ratatui::style::Style::default()
+                        .fg(theme.text)
+                        .add_modifier(ratatui::style::Modifier::BOLD)
                 } else {
-                    Style::default().fg(theme.text)
+                    ratatui::style::Style::default().fg(theme.text)
                 },
             )
         };
-        lines.push(Line::from(vec![
-            Span::styled(marker.to_string(), Style::default().fg(theme.accent_alt)),
-            Span::styled(
+        lines.push(ratatui::text::Line::from(vec![
+            ratatui::text::Span::styled(
+                marker.to_string(),
+                ratatui::style::Style::default().fg(theme.accent_alt),
+            ),
+            ratatui::text::Span::styled(
                 format!("{label:<width$}", width = usize::from(label_w)),
                 theme.muted_style(),
             ),
@@ -682,34 +746,50 @@ fn setup_custom_form(
     }
     let mut height = lines.len() as u16;
     match busy {
-        CustomBusy::Upserting => {
-            lines.push(Line::from(Span::styled(
+        crate::app::setup::CustomBusy::Upserting => {
+            lines.push(ratatui::text::Line::from(ratatui::text::Span::styled(
                 "saving provider…",
                 theme.muted_style(),
             )));
             height += 1;
         }
-        CustomBusy::SavingKey => {
-            lines.push(Line::from(Span::styled("saving key…", theme.muted_style())));
+        crate::app::setup::CustomBusy::SavingKey => {
+            lines.push(ratatui::text::Line::from(ratatui::text::Span::styled(
+                "saving key…",
+                theme.muted_style(),
+            )));
             height += 1;
         }
-        CustomBusy::Idle => {
+        crate::app::setup::CustomBusy::Idle => {
             if let Some(message) = error {
-                lines.push(Line::from(vec![
-                    Span::styled("✗ ", Style::default().fg(theme.accent)),
-                    Span::styled(message.to_string(), Style::default().fg(theme.text)),
+                lines.push(ratatui::text::Line::from(vec![
+                    ratatui::text::Span::styled(
+                        "✗ ",
+                        ratatui::style::Style::default().fg(theme.accent),
+                    ),
+                    ratatui::text::Span::styled(
+                        message.to_string(),
+                        ratatui::style::Style::default().fg(theme.text),
+                    ),
                 ]));
                 height += 1;
             }
         }
     }
-    (element(Text::new(lines)), height)
+    (
+        tuika::view::element(tuika::components::Text::new(lines)),
+        height,
+    )
 }
 
 /// The `/models` picker inside the modal frame. Auth problems and the active
 /// selection are annotated per row; the width columns align on the longest
 /// display name.
-fn model_picker(picker: &crate::app::ModelPicker, theme: &Theme, width: u16) -> (Element, u16) {
+fn model_picker(
+    picker: &crate::app::ModelPicker,
+    theme: &tuika::style::Theme,
+    width: u16,
+) -> (tuika::view::Element, u16) {
     let scrollbar_w = u16::from(picker.rows.len() > MAX_MODAL_ROWS);
     let content_w = width
         .saturating_sub(SELECT_MARKER_W)
@@ -727,9 +807,9 @@ fn model_picker(picker: &crate::app::ModelPicker, theme: &Theme, width: u16) -> 
         .max()
         .unwrap_or(0);
     // Keep both existing columns visible on a narrow terminal. Each remains a
-    // single SelectList row; overlong fields are clipped with an ellipsis.
+    // single tuika::components::SelectList row; overlong fields are clipped with an ellipsis.
     let name_w = max_name_w.min(content_w.saturating_sub(max_suffix_w.saturating_add(2)) / 2);
-    let rows: Vec<Line<'static>> = picker
+    let rows: Vec<ratatui::text::Line<'static>> = picker
         .rows
         .iter()
         .map(|row| {
@@ -744,29 +824,33 @@ fn model_picker(picker: &crate::app::ModelPicker, theme: &Theme, width: u16) -> 
             let coordinate =
                 fit_columns(&format!("{}/{}", row.provider_id, row.model), coordinate_w);
             let mut spans = vec![
-                Span::styled(
+                ratatui::text::Span::styled(
                     format!("{name}{:width$}  ", "", width = usize::from(name_pad)),
-                    Style::default().fg(theme.text),
+                    ratatui::style::Style::default().fg(theme.text),
                 ),
-                Span::styled(coordinate, theme.muted_style()),
+                ratatui::text::Span::styled(coordinate, theme.muted_style()),
             ];
             if row.active {
-                spans.push(Span::styled(
+                spans.push(ratatui::text::Span::styled(
                     "  active",
-                    Style::default()
+                    ratatui::style::Style::default()
                         .fg(theme.accent)
-                        .add_modifier(Modifier::BOLD),
+                        .add_modifier(ratatui::style::Modifier::BOLD),
                 ));
             }
             if row.auth_status == "missing" {
-                spans.push(Span::styled("  needs login", theme.muted_style()));
+                spans.push(ratatui::text::Span::styled(
+                    "  needs login",
+                    theme.muted_style(),
+                ));
             }
-            Line::from(spans)
+            ratatui::text::Line::from(spans)
         })
         .collect();
     let count = rows.len();
-    let list = SelectList::new(rows, &picker.state).viewport(MAX_MODAL_ROWS as u16);
-    (element(list), count.min(MAX_MODAL_ROWS) as u16)
+    let list =
+        tuika::components::SelectList::new(rows, &picker.state).viewport(MAX_MODAL_ROWS as u16);
+    (tuika::view::element(list), count.min(MAX_MODAL_ROWS) as u16)
 }
 
 fn model_row_suffix(row: &crate::ModelRow) -> String {
@@ -826,23 +910,26 @@ fn fit_columns_left(text: &str, max_cols: u16) -> String {
 }
 
 /// The rounded input box, with the caret placed by the host through `probe`.
-fn composer(app: &App, theme: &Theme, probe: &RectProbe) -> Element {
-    let input = element(
-        TextInput::new(&app.composer)
-            .style(Style::default().fg(theme.text))
+fn composer(
+    app: &crate::app::App,
+    theme: &tuika::style::Theme,
+    probe: &tuika::probe::RectProbe,
+) -> tuika::view::Element {
+    let input = tuika::view::element(
+        tuika::components::TextInput::new(&app.composer)
+            .style(ratatui::style::Style::default().fg(theme.text))
             .placeholder(
                 "Describe a task, or / for commands",
-                Style::default().fg(theme.dim),
+                ratatui::style::Style::default().fg(theme.dim),
             )
             .highlights(app.composer_highlights(theme)),
     );
-    let prompt = Text::new(vec![Line::from(Span::styled(
-        "› ",
-        Style::default().fg(theme.accent_alt),
-    ))]);
-    view! {
-        boxed(border = BorderStyle::Rounded, border_color = theme.border,
-              padding = Padding::symmetric(1, 0)) {
+    let prompt = tuika::components::Text::new(vec![ratatui::text::Line::from(
+        ratatui::text::Span::styled("› ", ratatui::style::Style::default().fg(theme.accent_alt)),
+    )]);
+    tuika::view! {
+        boxed(border = tuika::style::BorderStyle::Rounded, border_color = theme.border,
+              padding = tuika::geometry::Padding::symmetric(1, 0)) {
             row {
                 fixed(2) { node(prompt) }
                 grow(1) { node(probe.wrap(input)) }
@@ -852,7 +939,7 @@ fn composer(app: &App, theme: &Theme, probe: &RectProbe) -> Element {
 }
 
 /// Key hints on the left; connection, thread, and turn state on the right.
-fn footer(app: &App, theme: &Theme) -> Element {
+fn footer(app: &crate::app::App, theme: &tuika::style::Theme) -> tuika::view::Element {
     let hints = if app.setup_visible() || app.picker.is_some() {
         // The modal window shows its own key hints.
         "".to_string()
@@ -866,16 +953,23 @@ fn footer(app: &App, theme: &Theme) -> Element {
         "  ⏎ send   ⇧⏎ newline   PgUp scroll   ⌃C quit".to_string()
     };
     let hint_style = if app.needs_provider && !app.setup_visible() && app.popup.is_none() {
-        Style::default().fg(theme.accent)
+        ratatui::style::Style::default().fg(theme.accent)
     } else {
         theme.muted_style()
     };
     // Kept short enough to fit beside the hints on an 80-column terminal: a
-    // StatusBar drops an overflowing right group outright. Connection, model,
+    // tuika::components::StatusBar drops an overflowing right group outright. Connection, model,
     // and thread name live in the banner and `/status`.
-    let status = format!("{} · {}  ", short_id(&app.meta.thread_id), app.turn_state);
-    let bar = StatusBar::new()
-        .left(vec![Span::styled(hints, hint_style)])
-        .right(vec![Span::styled(status, Style::default().fg(theme.dim))]);
-    element(bar)
+    let status = format!(
+        "{} · {}  ",
+        crate::cells::short_id(&app.meta.thread_id),
+        app.turn_state
+    );
+    let bar = tuika::components::StatusBar::new()
+        .left(vec![ratatui::text::Span::styled(hints, hint_style)])
+        .right(vec![ratatui::text::Span::styled(
+            status,
+            ratatui::style::Style::default().fg(theme.dim),
+        )]);
+    tuika::view::element(bar)
 }

--- a/crates/verlet-guest-sdk/src/lib.rs
+++ b/crates/verlet-guest-sdk/src/lib.rs
@@ -10,6 +10,15 @@
 mod contract;
 pub mod testkit;
 
+// The re-exports below are a deliberate exception to the workspace's
+// no-`pub use` rule, on the same footing as the engine re-exports in
+// `verlet-sqlite`. This crate is the guest-authoring facade: a guest crate
+// names `verlet_guest_sdk` and nothing else, so the attribute macros must
+// reach it from here rather than through a second direct dependency on
+// `verlet-guest-sdk-macros`. The `prelude` glob is likewise part of the
+// published surface — the scaffold emitted by `verlet coupling init` opens
+// with `use verlet_guest_sdk::prelude::*;` — so both are public API for
+// crates outside this repo, not internal convenience.
 pub use contract::{CouplingContext, Discharge, GuestError, OperationContext};
 pub use verlet_guest_sdk_macros::{coupling, operation};
 

--- a/crates/verlet-kernel/src/adapters/agent_loop/tool_holds.rs
+++ b/crates/verlet-kernel/src/adapters/agent_loop/tool_holds.rs
@@ -16,7 +16,7 @@
 /// `Exclusive` admits nothing else on that key for the call's duration.
 #[derive(Clone, Copy, Debug, serde::Deserialize, Eq, PartialEq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
-pub(super) enum ToolHoldAccess {
+pub(crate) enum ToolHoldAccess {
     Shared,
     Exclusive,
 }
@@ -25,7 +25,7 @@ pub(super) enum ToolHoldAccess {
 /// of the durable tool-call request payload; fields are additive-only.
 #[derive(Clone, Debug, serde::Deserialize, Eq, PartialEq, serde::Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
-pub(super) enum ToolHoldKey {
+pub(crate) enum ToolHoldKey {
     /// The thread's shell/process substrate: one `BashkitExecutionHarness`
     /// and process table per thread, so all writers serialize.
     ShellSession,
@@ -40,9 +40,9 @@ pub(super) enum ToolHoldKey {
 
 /// One witnessed hold: a key and the access taken on it.
 #[derive(Clone, Debug, serde::Deserialize, Eq, PartialEq, serde::Serialize)]
-pub(super) struct ToolHold {
-    pub(super) key: ToolHoldKey,
-    pub(super) access: ToolHoldAccess,
+pub(crate) struct ToolHold {
+    pub(crate) key: ToolHoldKey,
+    pub(crate) access: ToolHoldAccess,
 }
 
 impl ToolHold {
@@ -83,7 +83,7 @@ impl ToolHold {
 /// global key, so the exclusive-global fail-safe is a true barrier: an
 /// invocation with underivable holds overlaps nothing, not merely no other
 /// global holder.
-pub(super) fn derive_tool_holds(tool_name: &str, arguments: &serde_json::Value) -> Vec<ToolHold> {
+pub(crate) fn derive_tool_holds(tool_name: &str, arguments: &serde_json::Value) -> Vec<ToolHold> {
     const SHELL_SESSION_TOOLS: [&str; 6] = [
         "bash",
         "process_exec",
@@ -150,7 +150,7 @@ fn with_global_floor(mut holds: Vec<ToolHold>) -> Vec<ToolHold> {
 /// Whether two hold sets conflict: some key is held exclusively by one side
 /// while held at all by the other. Conflicting calls serialize in call
 /// order; non-conflicting calls may overlap.
-pub(super) fn holds_conflict(a: &[ToolHold], b: &[ToolHold]) -> bool {
+pub(crate) fn holds_conflict(a: &[ToolHold], b: &[ToolHold]) -> bool {
     a.iter().any(|left| {
         b.iter().any(|right| {
             left.key == right.key
@@ -167,7 +167,7 @@ pub(super) fn holds_conflict(a: &[ToolHold], b: &[ToolHold]) -> bool {
 /// order with finish order witnessed, per-call failure isolation (a failed
 /// call never cancels siblings), turn cancellation cancels all in-flight
 /// calls, and one batch counts as one round.
-pub(super) fn batch_wait_edges(holds: &[Vec<ToolHold>]) -> Vec<Vec<usize>> {
+pub(crate) fn batch_wait_edges(holds: &[Vec<ToolHold>]) -> Vec<Vec<usize>> {
     holds
         .iter()
         .enumerate()
@@ -187,7 +187,7 @@ pub(super) fn batch_wait_edges(holds: &[Vec<ToolHold>]) -> Vec<Vec<usize>> {
 /// order witnessed, isolates per-call failures (a failed call never cancels
 /// siblings), propagates turn cancellation to every in-flight call, and
 /// counts the whole batch as one router round.
-pub(super) fn plan_tool_call_batch(
+pub(crate) fn plan_tool_call_batch(
     tool_calls: &[crate::adapters::agent_loop::ProviderToolCall],
 ) -> Vec<Vec<usize>> {
     let holds = tool_calls

--- a/crates/verlet-kernel/src/adapters/app_server.rs
+++ b/crates/verlet-kernel/src/adapters/app_server.rs
@@ -2491,7 +2491,7 @@ fn validate_catalog_codex_responses_url(
     ))
 }
 
-pub(super) fn merged_catalog_headers(
+pub(crate) fn merged_catalog_headers(
     provider: &verlet_metadata::provider_store::LlmProviderRecord,
     model_record: Option<&verlet_metadata::provider_store::LlmProviderModelRecord>,
 ) -> std::collections::BTreeMap<String, verlet_metadata::provider_store::LlmProviderConfigValue> {

--- a/crates/verlet-kernel/src/adapters/app_server/connection.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/connection.rs
@@ -9,27 +9,27 @@ use verlet_metadata::provider_store::LlmProviderCatalogStore as _;
 use verlet_metadata::provider_store::ThreadMetadataStore as _;
 
 #[derive(Clone)]
-pub(super) struct ConnectionState {
-    pub(super) app: crate::adapters::app_server::VerletAppServer,
-    pub(super) resolved_principal: crate::daemon::identity::ResolvedPrincipal,
-    pub(super) witnessed_session_id: String,
-    pub(super) boundary_surface: crate::daemon::identity::BoundarySurface,
-    pub(super) outbound: tokio::sync::mpsc::UnboundedSender<JsonRpcMessage>,
-    pub(super) handshake: std::sync::Arc<tokio::sync::Mutex<HandshakeState>>,
-    pub(super) opt_out_notifications:
+pub(crate) struct ConnectionState {
+    pub(crate) app: crate::adapters::app_server::VerletAppServer,
+    pub(crate) resolved_principal: crate::daemon::identity::ResolvedPrincipal,
+    pub(crate) witnessed_session_id: String,
+    pub(crate) boundary_surface: crate::daemon::identity::BoundarySurface,
+    pub(crate) outbound: tokio::sync::mpsc::UnboundedSender<JsonRpcMessage>,
+    pub(crate) handshake: std::sync::Arc<tokio::sync::Mutex<HandshakeState>>,
+    pub(crate) opt_out_notifications:
         std::sync::Arc<tokio::sync::RwLock<std::collections::HashSet<String>>>,
-    pub(super) subscriptions:
+    pub(crate) subscriptions:
         std::sync::Arc<tokio::sync::Mutex<std::collections::HashMap<String, u64>>>,
-    pub(super) fs_watches:
+    pub(crate) fs_watches:
         std::sync::Arc<tokio::sync::Mutex<std::collections::HashMap<String, std::path::PathBuf>>>,
 }
 
 #[derive(Default)]
-pub(super) struct HandshakeState {
-    pub(super) initialize_seen: bool,
-    pub(super) initialized_seen: bool,
-    pub(super) client_name: Option<String>,
-    pub(super) client_version: Option<String>,
+pub(crate) struct HandshakeState {
+    pub(crate) initialize_seen: bool,
+    pub(crate) initialized_seen: bool,
+    pub(crate) client_name: Option<String>,
+    pub(crate) client_version: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
@@ -96,606 +96,606 @@ pub struct JsonRpcErrorError {
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct InitializeParams {
-    pub(super) client_info: ClientInfo,
+pub(crate) struct InitializeParams {
+    pub(crate) client_info: ClientInfo,
     #[serde(default)]
-    pub(super) capabilities: Option<InitializeCapabilities>,
+    pub(crate) capabilities: Option<InitializeCapabilities>,
 }
 
 #[derive(Debug, serde::Deserialize)]
-pub(super) struct ClientInfo {
-    pub(super) name: String,
+pub(crate) struct ClientInfo {
+    pub(crate) name: String,
     #[serde(default)]
-    pub(super) title: Option<String>,
-    pub(super) version: String,
+    pub(crate) title: Option<String>,
+    pub(crate) version: String,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct InitializeCapabilities {
+pub(crate) struct InitializeCapabilities {
     #[serde(default)]
-    pub(super) experimental_api: bool,
+    pub(crate) experimental_api: bool,
     #[serde(default)]
-    pub(super) request_attestation: bool,
+    pub(crate) request_attestation: bool,
     #[serde(default)]
-    pub(super) opt_out_notification_methods: Option<Vec<String>>,
+    pub(crate) opt_out_notification_methods: Option<Vec<String>>,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ThreadStartParams {
+pub(crate) struct ThreadStartParams {
     #[serde(default)]
-    pub(super) model: Option<String>,
+    pub(crate) model: Option<String>,
     #[serde(default)]
-    pub(super) model_provider: Option<String>,
+    pub(crate) model_provider: Option<String>,
     #[serde(default)]
-    pub(super) service_tier: Option<String>,
+    pub(crate) service_tier: Option<String>,
     #[serde(default)]
-    pub(super) cwd: Option<String>,
+    pub(crate) cwd: Option<String>,
     #[serde(default)]
-    pub(super) ephemeral: Option<bool>,
+    pub(crate) ephemeral: Option<bool>,
     #[serde(default)]
-    pub(super) parent_thread_id: Option<String>,
+    pub(crate) parent_thread_id: Option<String>,
     #[serde(default)]
-    pub(super) topology: Option<verlet_runtime_contracts::ThreadTopology>,
+    pub(crate) topology: Option<verlet_runtime_contracts::ThreadTopology>,
     #[serde(default)]
-    pub(super) capsule_bindings: Option<ThreadCapsuleBindingsParams>,
+    pub(crate) capsule_bindings: Option<ThreadCapsuleBindingsParams>,
     #[serde(default)]
-    pub(super) agent_ref: Option<String>,
+    pub(crate) agent_ref: Option<String>,
     #[serde(default)]
-    pub(super) runtime_overrides: Option<crate::agent::manifest_bind::AgentManifestBindOverrides>,
+    pub(crate) runtime_overrides: Option<crate::agent::manifest_bind::AgentManifestBindOverrides>,
     #[serde(default)]
-    pub(super) placement: Option<crate::agent::manifest_bind::AgentManifestPlacementBinding>,
+    pub(crate) placement: Option<crate::agent::manifest_bind::AgentManifestPlacementBinding>,
     #[serde(default)]
-    pub(super) workspace: Option<crate::agent::manifest_bind::AgentManifestWorkspaceBinding>,
+    pub(crate) workspace: Option<crate::agent::manifest_bind::AgentManifestWorkspaceBinding>,
     #[serde(
         default,
         deserialize_with = "crate::adapters::app_server::threads::deserialize_optional_thinking"
     )]
-    pub(super) thinking: Option<verlet_provider::ThinkingConfig>,
+    pub(crate) thinking: Option<verlet_provider::ThinkingConfig>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ThreadSpawnParams {
-    pub(super) thread_id: String,
-    pub(super) task_name: String,
-    pub(super) message: String,
+pub(crate) struct ThreadSpawnParams {
+    pub(crate) thread_id: String,
+    pub(crate) task_name: String,
+    pub(crate) message: String,
     #[serde(default)]
-    pub(super) agent_ref: Option<String>,
+    pub(crate) agent_ref: Option<String>,
     #[serde(default)]
-    pub(super) placement: Option<crate::agent::manifest_bind::AgentManifestPlacementBinding>,
+    pub(crate) placement: Option<crate::agent::manifest_bind::AgentManifestPlacementBinding>,
     #[serde(default)]
-    pub(super) workspace: Option<crate::agent::manifest_bind::AgentManifestWorkspaceBinding>,
+    pub(crate) workspace: Option<crate::agent::manifest_bind::AgentManifestWorkspaceBinding>,
     #[serde(default)]
-    pub(super) dispatch_id: Option<String>,
+    pub(crate) dispatch_id: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ThreadSubmitParams {
-    pub(super) thread_id: String,
-    pub(super) message: String,
+pub(crate) struct ThreadSubmitParams {
+    pub(crate) thread_id: String,
+    pub(crate) message: String,
     #[serde(default)]
-    pub(super) dispatch_id: Option<String>,
+    pub(crate) dispatch_id: Option<String>,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ThreadCapsuleBindingsParams {
+pub(crate) struct ThreadCapsuleBindingsParams {
     #[serde(default)]
-    pub(super) operation_names: Vec<String>,
+    pub(crate) operation_names: Vec<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct CapsuleBindingSetParams {
-    pub(super) scope: verlet_operations::operation_store::CapsuleBindingScope,
-    pub(super) operation_name: String,
+pub(crate) struct CapsuleBindingSetParams {
+    pub(crate) scope: verlet_operations::operation_store::CapsuleBindingScope,
+    pub(crate) operation_name: String,
     #[serde(default)]
-    pub(super) artifact_hash: Option<String>,
+    pub(crate) artifact_hash: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct CapsuleBindingOperationParams {
-    pub(super) scope: verlet_operations::operation_store::CapsuleBindingScope,
-    pub(super) operation_name: String,
+pub(crate) struct CapsuleBindingOperationParams {
+    pub(crate) scope: verlet_operations::operation_store::CapsuleBindingScope,
+    pub(crate) operation_name: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct CapsuleBindingListParams {
-    pub(super) scope: verlet_operations::operation_store::CapsuleBindingScope,
+pub(crate) struct CapsuleBindingListParams {
+    pub(crate) scope: verlet_operations::operation_store::CapsuleBindingScope,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct CapsuleBindingResolveParams {
+pub(crate) struct CapsuleBindingResolveParams {
     #[serde(default)]
-    pub(super) tenant_id: Option<String>,
+    pub(crate) tenant_id: Option<String>,
     #[serde(default)]
-    pub(super) thread_id: Option<String>,
+    pub(crate) thread_id: Option<String>,
     #[serde(default)]
-    pub(super) operation_names: Vec<String>,
+    pub(crate) operation_names: Vec<String>,
     #[serde(default)]
-    pub(super) load_all_active_when_unbound: Option<bool>,
+    pub(crate) load_all_active_when_unbound: Option<bool>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct AgentReadParams {
+pub(crate) struct AgentReadParams {
     #[serde(rename = "ref")]
-    pub(super) ref_uri: String,
+    pub(crate) ref_uri: String,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct AgentDraftParams {
+pub(crate) struct AgentDraftParams {
     #[serde(default)]
-    pub(super) source: Option<String>,
+    pub(crate) source: Option<String>,
     #[serde(default)]
-    pub(super) manifest: Option<serde_json::Value>,
+    pub(crate) manifest: Option<serde_json::Value>,
     #[serde(default)]
-    pub(super) base_ref: Option<String>,
+    pub(crate) base_ref: Option<String>,
     #[serde(default)]
-    pub(super) base_manifest_hash: Option<String>,
+    pub(crate) base_manifest_hash: Option<String>,
     #[serde(default)]
-    pub(super) expected_latest_version: Option<String>,
+    pub(crate) expected_latest_version: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ModelProviderReadParams {
-    pub(super) provider_id: String,
+pub(crate) struct ModelProviderReadParams {
+    pub(crate) provider_id: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ModelSelectParams {
-    pub(super) provider_id: String,
-    pub(super) model: String,
+pub(crate) struct ModelSelectParams {
+    pub(crate) provider_id: String,
+    pub(crate) model: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ModelProviderUpsertParams {
-    pub(super) provider: ModelProviderUpsertRecord,
+pub(crate) struct ModelProviderUpsertParams {
+    pub(crate) provider: ModelProviderUpsertRecord,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ModelProviderDeleteParams {
-    pub(super) provider_id: String,
+pub(crate) struct ModelProviderDeleteParams {
+    pub(crate) provider_id: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ModelProviderUpsertRecord {
-    pub(super) provider_id: String,
-    pub(super) api: serde_json::Value,
-    pub(super) base_url: String,
+pub(crate) struct ModelProviderUpsertRecord {
+    pub(crate) provider_id: String,
+    pub(crate) api: serde_json::Value,
+    pub(crate) base_url: String,
     #[serde(default)]
-    pub(super) display_name: Option<String>,
+    pub(crate) display_name: Option<String>,
     #[serde(default)]
-    pub(super) auth: verlet_metadata::provider_store::LlmProviderAuthConfig,
+    pub(crate) auth: verlet_metadata::provider_store::LlmProviderAuthConfig,
     #[serde(default)]
-    pub(super) headers:
+    pub(crate) headers:
         std::collections::BTreeMap<String, verlet_metadata::provider_store::LlmProviderConfigValue>,
     #[serde(default)]
-    pub(super) auth_header: bool,
+    pub(crate) auth_header: bool,
     #[serde(default)]
-    pub(super) models: Vec<ModelProviderModelUpsertRecord>,
+    pub(crate) models: Vec<ModelProviderModelUpsertRecord>,
     #[serde(default)]
-    pub(super) metadata: std::collections::BTreeMap<String, String>,
+    pub(crate) metadata: std::collections::BTreeMap<String, String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ModelProviderModelUpsertRecord {
-    pub(super) model_id: String,
+pub(crate) struct ModelProviderModelUpsertRecord {
+    pub(crate) model_id: String,
     #[serde(default)]
-    pub(super) display_name: Option<String>,
+    pub(crate) display_name: Option<String>,
     #[serde(default)]
-    pub(super) api: Option<serde_json::Value>,
+    pub(crate) api: Option<serde_json::Value>,
     #[serde(default)]
-    pub(super) base_url: Option<String>,
+    pub(crate) base_url: Option<String>,
     #[serde(default)]
-    pub(super) context_window_tokens: Option<u64>,
+    pub(crate) context_window_tokens: Option<u64>,
     #[serde(default)]
-    pub(super) max_output_tokens: Option<u32>,
+    pub(crate) max_output_tokens: Option<u32>,
     #[serde(default)]
-    pub(super) input_modalities: Vec<verlet_metadata::provider_store::LlmProviderInputModality>,
+    pub(crate) input_modalities: Vec<verlet_metadata::provider_store::LlmProviderInputModality>,
     #[serde(default)]
-    pub(super) headers:
+    pub(crate) headers:
         std::collections::BTreeMap<String, verlet_metadata::provider_store::LlmProviderConfigValue>,
     #[serde(default)]
-    pub(super) metadata: std::collections::BTreeMap<String, String>,
+    pub(crate) metadata: std::collections::BTreeMap<String, String>,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ModelProviderAuthStatusParams {
+pub(crate) struct ModelProviderAuthStatusParams {
     #[serde(default)]
-    pub(super) provider_id: Option<String>,
+    pub(crate) provider_id: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ModelProviderAuthSetParams {
-    pub(super) provider_id: String,
-    pub(super) api_key: String,
+pub(crate) struct ModelProviderAuthSetParams {
+    pub(crate) provider_id: String,
+    pub(crate) api_key: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ModelProviderAuthSetOAuthParams {
-    pub(super) provider_id: String,
-    pub(super) access: String,
-    pub(super) refresh: String,
-    pub(super) expires_at_ms: i64,
+pub(crate) struct ModelProviderAuthSetOAuthParams {
+    pub(crate) provider_id: String,
+    pub(crate) access: String,
+    pub(crate) refresh: String,
+    pub(crate) expires_at_ms: i64,
     #[serde(default)]
-    pub(super) account_id: Option<String>,
+    pub(crate) account_id: Option<String>,
     #[serde(default)]
-    pub(super) email: Option<String>,
+    pub(crate) email: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ModelProviderAuthDeleteParams {
-    pub(super) provider_id: String,
+pub(crate) struct ModelProviderAuthDeleteParams {
+    pub(crate) provider_id: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct MandateStartParams {
-    pub(super) thread_id: String,
-    pub(super) schedule: crate::kernel::control_decision::MandateSchedulePayload,
+pub(crate) struct MandateStartParams {
+    pub(crate) thread_id: String,
+    pub(crate) schedule: crate::kernel::control_decision::MandateSchedulePayload,
     #[serde(default)]
-    pub(super) max_occurrences: Option<u32>,
+    pub(crate) max_occurrences: Option<u32>,
     #[serde(default)]
-    pub(super) catch_up: Option<crate::kernel::control_decision::MandateCatchUpPolicy>,
+    pub(crate) catch_up: Option<crate::kernel::control_decision::MandateCatchUpPolicy>,
     #[serde(default)]
-    pub(super) input_template: Option<String>,
+    pub(crate) input_template: Option<String>,
     #[serde(default)]
-    pub(super) expires_at: Option<String>,
+    pub(crate) expires_at: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct MandateRevokeParams {
-    pub(super) thread_id: String,
-    pub(super) mandate_event_id: String,
+pub(crate) struct MandateRevokeParams {
+    pub(crate) thread_id: String,
+    pub(crate) mandate_event_id: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct MandateListParams {
-    pub(super) thread_id: String,
+pub(crate) struct MandateListParams {
+    pub(crate) thread_id: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct McpSourceReadParams {
-    pub(super) name: String,
+pub(crate) struct McpSourceReadParams {
+    pub(crate) name: String,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct McpSourceUpsertParams {
-    pub(super) name: String,
+pub(crate) struct McpSourceUpsertParams {
+    pub(crate) name: String,
     #[serde(default)]
-    pub(super) transport: Option<String>,
+    pub(crate) transport: Option<String>,
     #[serde(default)]
-    pub(super) kind: Option<String>,
-    pub(super) url: String,
+    pub(crate) kind: Option<String>,
+    pub(crate) url: String,
     #[serde(default)]
-    pub(super) bearer_secret: Option<String>,
+    pub(crate) bearer_secret: Option<String>,
     #[serde(default)]
-    pub(super) bearer_token: Option<String>,
+    pub(crate) bearer_token: Option<String>,
     #[serde(default)]
-    pub(super) headers: Vec<McpSourceHeaderParam>,
+    pub(crate) headers: Vec<McpSourceHeaderParam>,
     #[serde(default)]
-    pub(super) include_tools: Vec<String>,
+    pub(crate) include_tools: Vec<String>,
     #[serde(default)]
-    pub(super) timeout_ms: Option<u64>,
+    pub(crate) timeout_ms: Option<u64>,
     #[serde(default)]
-    pub(super) max_output_bytes: Option<u64>,
+    pub(crate) max_output_bytes: Option<u64>,
 }
 
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct McpSourceHeaderParam {
-    pub(super) name: String,
-    pub(super) value: String,
+pub(crate) struct McpSourceHeaderParam {
+    pub(crate) name: String,
+    pub(crate) value: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct McpSourceTestToolParams {
-    pub(super) name: String,
-    pub(super) tool: String,
+pub(crate) struct McpSourceTestToolParams {
+    pub(crate) name: String,
+    pub(crate) tool: String,
     #[serde(default)]
-    pub(super) arguments: serde_json::Value,
+    pub(crate) arguments: serde_json::Value,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct McpSourceManifestPatchParams {
-    pub(super) name: String,
+pub(crate) struct McpSourceManifestPatchParams {
+    pub(crate) name: String,
     #[serde(default)]
-    pub(super) import_id: Option<String>,
+    pub(crate) import_id: Option<String>,
     #[serde(default)]
-    pub(super) agent_ref: Option<String>,
+    pub(crate) agent_ref: Option<String>,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ThreadForkParams {
-    pub(super) thread_id: String,
+pub(crate) struct ThreadForkParams {
+    pub(crate) thread_id: String,
     #[serde(default)]
-    pub(super) checkpoint_id: Option<String>,
+    pub(crate) checkpoint_id: Option<String>,
     #[serde(default)]
-    pub(super) model: Option<String>,
+    pub(crate) model: Option<String>,
     #[serde(default)]
-    pub(super) model_provider: Option<String>,
+    pub(crate) model_provider: Option<String>,
     #[serde(default)]
-    pub(super) service_tier: Option<String>,
+    pub(crate) service_tier: Option<String>,
     #[serde(default)]
-    pub(super) cwd: Option<String>,
+    pub(crate) cwd: Option<String>,
     #[serde(default)]
-    pub(super) ephemeral: bool,
+    pub(crate) ephemeral: bool,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ThreadRebindForkParams {
-    pub(super) thread_id: String,
-    pub(super) agent_ref: String,
+pub(crate) struct ThreadRebindForkParams {
+    pub(crate) thread_id: String,
+    pub(crate) agent_ref: String,
     #[serde(default)]
-    pub(super) checkpoint_id: Option<String>,
+    pub(crate) checkpoint_id: Option<String>,
     #[serde(default)]
-    pub(super) model_profile_id: Option<String>,
+    pub(crate) model_profile_id: Option<String>,
     #[serde(default)]
-    pub(super) runtime_overrides: Option<crate::agent::manifest_bind::AgentManifestBindOverrides>,
+    pub(crate) runtime_overrides: Option<crate::agent::manifest_bind::AgentManifestBindOverrides>,
     #[serde(default)]
-    pub(super) placement: Option<crate::agent::manifest_bind::AgentManifestPlacementBinding>,
+    pub(crate) placement: Option<crate::agent::manifest_bind::AgentManifestPlacementBinding>,
     #[serde(default)]
-    pub(super) workspace: Option<crate::agent::manifest_bind::AgentManifestWorkspaceBinding>,
+    pub(crate) workspace: Option<crate::agent::manifest_bind::AgentManifestWorkspaceBinding>,
     #[serde(default)]
-    pub(super) reason: verlet_history::ThreadForkReason,
+    pub(crate) reason: verlet_history::ThreadForkReason,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ThreadResumeParams {
-    pub(super) thread_id: String,
+pub(crate) struct ThreadResumeParams {
+    pub(crate) thread_id: String,
     #[serde(default)]
-    pub(super) model: Option<String>,
+    pub(crate) model: Option<String>,
     #[serde(default)]
-    pub(super) model_provider: Option<String>,
+    pub(crate) model_provider: Option<String>,
     #[serde(default)]
-    pub(super) service_tier: Option<String>,
+    pub(crate) service_tier: Option<String>,
     #[serde(default)]
-    pub(super) cwd: Option<String>,
+    pub(crate) cwd: Option<String>,
     #[serde(default)]
-    pub(super) exclude_turns: bool,
+    pub(crate) exclude_turns: bool,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct TurnStartParams {
-    pub(super) thread_id: String,
-    pub(super) input: Vec<serde_json::Value>,
+pub(crate) struct TurnStartParams {
+    pub(crate) thread_id: String,
+    pub(crate) input: Vec<serde_json::Value>,
     #[serde(default)]
-    pub(super) cwd: Option<String>,
+    pub(crate) cwd: Option<String>,
     #[serde(default)]
-    pub(super) model: Option<String>,
+    pub(crate) model: Option<String>,
     #[serde(
         default,
         deserialize_with = "crate::adapters::app_server::threads::deserialize_optional_thinking"
     )]
-    pub(super) thinking: Option<verlet_provider::ThinkingConfig>,
+    pub(crate) thinking: Option<verlet_provider::ThinkingConfig>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct TurnSteerParams {
-    pub(super) thread_id: String,
-    pub(super) input: Vec<serde_json::Value>,
-    pub(super) expected_turn_id: String,
+pub(crate) struct TurnSteerParams {
+    pub(crate) thread_id: String,
+    pub(crate) input: Vec<serde_json::Value>,
+    pub(crate) expected_turn_id: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct TurnInterruptParams {
-    pub(super) thread_id: String,
-    pub(super) turn_id: String,
+pub(crate) struct TurnInterruptParams {
+    pub(crate) thread_id: String,
+    pub(crate) turn_id: String,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ThreadReadParams {
-    pub(super) thread_id: String,
+pub(crate) struct ThreadReadParams {
+    pub(crate) thread_id: String,
     #[serde(default)]
-    pub(super) include_turns: Option<bool>,
+    pub(crate) include_turns: Option<bool>,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ThreadEventsListParams {
-    pub(super) thread_id: String,
+pub(crate) struct ThreadEventsListParams {
+    pub(crate) thread_id: String,
     #[serde(default)]
-    pub(super) stream: Option<String>,
+    pub(crate) stream: Option<String>,
     #[serde(default)]
-    pub(super) cursor: Option<String>,
+    pub(crate) cursor: Option<String>,
     #[serde(default)]
-    pub(super) stream_cursor: Option<verlet_history::StreamCursorV1>,
+    pub(crate) stream_cursor: Option<verlet_history::StreamCursorV1>,
     #[serde(default)]
-    pub(super) limit: Option<usize>,
+    pub(crate) limit: Option<usize>,
     #[serde(default)]
-    pub(super) kinds: Vec<String>,
+    pub(crate) kinds: Vec<String>,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ThreadControlListParams {
-    pub(super) thread_id: String,
+pub(crate) struct ThreadControlListParams {
+    pub(crate) thread_id: String,
     #[serde(default)]
-    pub(super) limit: Option<usize>,
+    pub(crate) limit: Option<usize>,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ThreadDebugExportParams {
-    pub(super) thread_id: String,
+pub(crate) struct ThreadDebugExportParams {
+    pub(crate) thread_id: String,
     #[serde(default)]
-    pub(super) streams: Vec<String>,
+    pub(crate) streams: Vec<String>,
     #[serde(default)]
-    pub(super) include_thread: Option<bool>,
+    pub(crate) include_thread: Option<bool>,
     #[serde(default)]
-    pub(super) max_events_per_stream: Option<usize>,
+    pub(crate) max_events_per_stream: Option<usize>,
     #[serde(default)]
-    pub(super) redact: Option<bool>,
+    pub(crate) redact: Option<bool>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ThreadUnsubscribeParams {
-    pub(super) thread_id: String,
+pub(crate) struct ThreadUnsubscribeParams {
+    pub(crate) thread_id: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ThreadSetNameParams {
-    pub(super) thread_id: String,
-    pub(super) name: String,
+pub(crate) struct ThreadSetNameParams {
+    pub(crate) thread_id: String,
+    pub(crate) name: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ThreadMetadataUpdateParams {
-    pub(super) thread_id: String,
+pub(crate) struct ThreadMetadataUpdateParams {
+    pub(crate) thread_id: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ThreadCompactStartParams {
-    pub(super) thread_id: String,
+pub(crate) struct ThreadCompactStartParams {
+    pub(crate) thread_id: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ThreadShellCommandParams {
-    pub(super) thread_id: String,
-    pub(super) command: String,
+pub(crate) struct ThreadShellCommandParams {
+    pub(crate) thread_id: String,
+    pub(crate) command: String,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ConfigReadParams {
+pub(crate) struct ConfigReadParams {
     #[serde(default)]
-    pub(super) include_layers: bool,
+    pub(crate) include_layers: bool,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct FsReadFileParams {
-    pub(super) path: std::path::PathBuf,
+pub(crate) struct FsReadFileParams {
+    pub(crate) path: std::path::PathBuf,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct FsWriteFileParams {
-    pub(super) path: std::path::PathBuf,
-    pub(super) data_base64: String,
+pub(crate) struct FsWriteFileParams {
+    pub(crate) path: std::path::PathBuf,
+    pub(crate) data_base64: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct FsCreateDirectoryParams {
-    pub(super) path: std::path::PathBuf,
+pub(crate) struct FsCreateDirectoryParams {
+    pub(crate) path: std::path::PathBuf,
     #[serde(default)]
-    pub(super) recursive: Option<bool>,
+    pub(crate) recursive: Option<bool>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct FsGetMetadataParams {
-    pub(super) path: std::path::PathBuf,
+pub(crate) struct FsGetMetadataParams {
+    pub(crate) path: std::path::PathBuf,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct FsReadDirectoryParams {
-    pub(super) path: std::path::PathBuf,
+pub(crate) struct FsReadDirectoryParams {
+    pub(crate) path: std::path::PathBuf,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct FsRemoveParams {
-    pub(super) path: std::path::PathBuf,
+pub(crate) struct FsRemoveParams {
+    pub(crate) path: std::path::PathBuf,
     #[serde(default)]
-    pub(super) recursive: Option<bool>,
+    pub(crate) recursive: Option<bool>,
     #[serde(default)]
-    pub(super) force: Option<bool>,
+    pub(crate) force: Option<bool>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct FsCopyParams {
-    pub(super) source_path: std::path::PathBuf,
-    pub(super) destination_path: std::path::PathBuf,
+pub(crate) struct FsCopyParams {
+    pub(crate) source_path: std::path::PathBuf,
+    pub(crate) destination_path: std::path::PathBuf,
     #[serde(default)]
-    pub(super) recursive: bool,
+    pub(crate) recursive: bool,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct FsWatchParams {
-    pub(super) watch_id: String,
-    pub(super) path: std::path::PathBuf,
+pub(crate) struct FsWatchParams {
+    pub(crate) watch_id: String,
+    pub(crate) path: std::path::PathBuf,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct FsUnwatchParams {
-    pub(super) watch_id: String,
+pub(crate) struct FsUnwatchParams {
+    pub(crate) watch_id: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct CommandExecParams {
+pub(crate) struct CommandExecParams {
     #[serde(default)]
-    pub(super) command: Vec<String>,
+    pub(crate) command: Vec<String>,
     #[serde(default)]
-    pub(super) process_id: Option<String>,
+    pub(crate) process_id: Option<String>,
     #[serde(default)]
-    pub(super) tty: bool,
+    pub(crate) tty: bool,
     #[serde(default)]
-    pub(super) stream_stdin: bool,
+    pub(crate) stream_stdin: bool,
     #[serde(default)]
-    pub(super) stream_stdout_stderr: bool,
+    pub(crate) stream_stdout_stderr: bool,
     #[serde(default)]
-    pub(super) output_bytes_cap: Option<usize>,
+    pub(crate) output_bytes_cap: Option<usize>,
     #[serde(default)]
-    pub(super) disable_output_cap: bool,
+    pub(crate) disable_output_cap: bool,
     #[serde(default)]
-    pub(super) disable_timeout: bool,
+    pub(crate) disable_timeout: bool,
     #[serde(default)]
-    pub(super) timeout_ms: Option<u64>,
+    pub(crate) timeout_ms: Option<u64>,
     #[serde(default)]
-    pub(super) yield_time_ms: Option<u64>,
+    pub(crate) yield_time_ms: Option<u64>,
     #[serde(default)]
-    pub(super) cwd: Option<String>,
+    pub(crate) cwd: Option<String>,
     #[serde(default)]
-    pub(super) env: Option<std::collections::HashMap<String, Option<String>>>,
+    pub(crate) env: Option<std::collections::HashMap<String, Option<String>>>,
     #[serde(default)]
-    pub(super) dispatch_id: Option<String>,
+    pub(crate) dispatch_id: Option<String>,
     /// Consumer of a handle-returning streaming execution. Buffered
     /// command/exec does not create a handle and does not require this field.
     #[serde(default)]
-    pub(super) thread_id: Option<String>,
+    pub(crate) thread_id: Option<String>,
 }
 
 #[derive(
@@ -703,7 +703,7 @@ pub(super) struct CommandExecParams {
 )]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
-pub(super) enum ApprovalResolveDecision {
+pub(crate) enum ApprovalResolveDecision {
     Approved,
     Denied,
 }
@@ -716,69 +716,69 @@ impl ApprovalResolveDecision {
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ApprovalResolveParams {
-    pub(super) thread_id: String,
-    pub(super) approval_id: String,
-    pub(super) decision: ApprovalResolveDecision,
+pub(crate) struct ApprovalResolveParams {
+    pub(crate) thread_id: String,
+    pub(crate) approval_id: String,
+    pub(crate) decision: ApprovalResolveDecision,
     #[serde(default)]
-    pub(super) reason: Option<String>,
+    pub(crate) reason: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct CommandExecProcessParams {
-    pub(super) process_id: String,
+pub(crate) struct CommandExecProcessParams {
+    pub(crate) process_id: String,
     #[serde(default)]
-    pub(super) yield_time_ms: Option<u64>,
+    pub(crate) yield_time_ms: Option<u64>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct CommandExecWriteParams {
-    pub(super) process_id: String,
-    pub(super) delta_base64: String,
+pub(crate) struct CommandExecWriteParams {
+    pub(crate) process_id: String,
+    pub(crate) delta_base64: String,
     #[serde(default)]
-    pub(super) yield_time_ms: Option<u64>,
+    pub(crate) yield_time_ms: Option<u64>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct CommandExecTerminateParams {
-    pub(super) process_id: String,
+pub(crate) struct CommandExecTerminateParams {
+    pub(crate) process_id: String,
     #[serde(default)]
-    pub(super) reason: Option<String>,
+    pub(crate) reason: Option<String>,
     #[serde(default)]
-    pub(super) yield_time_ms: Option<u64>,
+    pub(crate) yield_time_ms: Option<u64>,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ExperimentalFeatureEnablementSetParams {
+pub(crate) struct ExperimentalFeatureEnablementSetParams {
     #[serde(default)]
-    pub(super) enablement: std::collections::BTreeMap<String, bool>,
+    pub(crate) enablement: std::collections::BTreeMap<String, bool>,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct GetAuthStatusParams {
+pub(crate) struct GetAuthStatusParams {
     #[serde(default)]
-    pub(super) include_token: Option<bool>,
+    pub(crate) include_token: Option<bool>,
     #[serde(default)]
-    pub(super) refresh_token: Option<bool>,
+    pub(crate) refresh_token: Option<bool>,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct GetConversationSummaryParams {
+pub(crate) struct GetConversationSummaryParams {
     #[serde(default)]
-    pub(super) conversation_id: Option<String>,
+    pub(crate) conversation_id: Option<String>,
     #[serde(default)]
-    pub(super) rollout_path: Option<String>,
+    pub(crate) rollout_path: Option<String>,
 }
 
 const METHOD_NOT_AUTHORIZED_CODE: i64 = -32003;
 
-pub(super) const DISPATCH_METHOD_AUTHORITY_CLASSES: &[(
+pub(crate) const DISPATCH_METHOD_AUTHORITY_CLASSES: &[(
     &str,
     crate::daemon::identity::AuthorityClass,
 )] = &[
@@ -1113,7 +1113,7 @@ pub(super) const DISPATCH_METHOD_AUTHORITY_CLASSES: &[(
     ),
 ];
 
-pub(super) const HOST_EFFECT_METHODS: &[&str] = &[
+pub(crate) const HOST_EFFECT_METHODS: &[&str] = &[
     // Local registry mutations.
     "capsule/binding/set",    // lexicon-allow: capsule - existing RPC method.
     "capsule/binding/delete", // lexicon-allow: capsule - existing RPC method.
@@ -1182,7 +1182,7 @@ impl crate::adapters::app_server::VerletAppServer {
         .await
     }
 
-    pub(super) async fn authenticated_json_rpc_request(
+    pub(crate) async fn authenticated_json_rpc_request(
         &self,
         resolved_principal: crate::daemon::identity::ResolvedPrincipal,
         surface: crate::daemon::identity::BoundarySurface,
@@ -1265,7 +1265,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }
     }
 
-    pub(super) async fn handle_websocket<S>(
+    pub(crate) async fn handle_websocket<S>(
         &self,
         websocket: tokio_tungstenite::WebSocketStream<S>,
         resolved_principal: crate::daemon::identity::ResolvedPrincipal,
@@ -1386,7 +1386,7 @@ impl crate::adapters::app_server::VerletAppServer {
         finish_websocket_session(read_result, close_result)
     }
 
-    pub(super) async fn handle_request(
+    pub(crate) async fn handle_request(
         &self,
         connection: &ConnectionState,
         request: JsonRpcRequest,
@@ -1434,7 +1434,7 @@ impl crate::adapters::app_server::VerletAppServer {
         let _ = connection.outbound.send(message);
     }
 
-    pub(super) async fn dispatch_request(
+    pub(crate) async fn dispatch_request(
         &self,
         connection: &ConnectionState,
         method: &str,
@@ -1877,13 +1877,13 @@ impl crate::adapters::app_server::VerletAppServer {
         }
     }
 
-    pub(super) async fn mcp_server_status_list(
+    pub(crate) async fn mcp_server_status_list(
         &self,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
         self.mcp_source_list().await
     }
 
-    pub(super) async fn mcp_source_list(&self) -> Result<serde_json::Value, JsonRpcErrorError> {
+    pub(crate) async fn mcp_source_list(&self) -> Result<serde_json::Value, JsonRpcErrorError> {
         let registry = crate::adapters::mcp_client::SqliteMcpSourceRegistry::open_async(
             &self.inner.metadata_store_path,
         )
@@ -1899,7 +1899,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "data": data, "nextCursor": null }))
     }
 
-    pub(super) async fn mcp_source_read(
+    pub(crate) async fn mcp_source_read(
         &self,
         params: McpSourceReadParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -1912,7 +1912,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "source": record.redacted_json() }))
     }
 
-    pub(super) async fn mcp_source_upsert(
+    pub(crate) async fn mcp_source_upsert(
         &self,
         params: McpSourceUpsertParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -1981,7 +1981,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "source": record.redacted_json() }))
     }
 
-    pub(super) async fn mcp_source_discover(
+    pub(crate) async fn mcp_source_discover(
         &self,
         params: McpSourceReadParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -2005,7 +2005,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "source": record.redacted_json() }))
     }
 
-    pub(super) async fn mcp_source_delete(
+    pub(crate) async fn mcp_source_delete(
         &self,
         params: McpSourceReadParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -2018,7 +2018,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "deleted": deleted }))
     }
 
-    pub(super) async fn mcp_source_test_tool(
+    pub(crate) async fn mcp_source_test_tool(
         &self,
         params: McpSourceTestToolParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -2072,7 +2072,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }
     }
 
-    pub(super) async fn mcp_source_manifest_patch(
+    pub(crate) async fn mcp_source_manifest_patch(
         &self,
         params: McpSourceManifestPatchParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -2176,7 +2176,7 @@ impl crate::adapters::app_server::VerletAppServer {
             .map_err(|err| internal_error(crate::adapters::app_server::secret_store_error(err)))
     }
 
-    pub(super) fn agent_list(&self) -> Result<serde_json::Value, JsonRpcErrorError> {
+    pub(crate) fn agent_list(&self) -> Result<serde_json::Value, JsonRpcErrorError> {
         let registry = self.inner.agent_registry();
         let data = registry
             .list_records()
@@ -2187,7 +2187,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "data": data, "cursor": null }))
     }
 
-    pub(super) fn agent_read(
+    pub(crate) fn agent_read(
         &self,
         params: AgentReadParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -2205,7 +2205,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(value)
     }
 
-    pub(super) fn agent_plan(
+    pub(crate) fn agent_plan(
         &self,
         params: AgentDraftParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -2224,7 +2224,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }))
     }
 
-    pub(super) fn agent_publish(
+    pub(crate) fn agent_publish(
         &self,
         params: AgentDraftParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -2260,7 +2260,7 @@ impl crate::adapters::app_server::VerletAppServer {
             .unwrap_or_else(crate::agent::manifest::default_operations_registry_root)
     }
 
-    pub(super) async fn model_provider_list(&self) -> Result<serde_json::Value, JsonRpcErrorError> {
+    pub(crate) async fn model_provider_list(&self) -> Result<serde_json::Value, JsonRpcErrorError> {
         let mut providers = self
             .inner
             .metadata_store
@@ -2280,7 +2280,7 @@ impl crate::adapters::app_server::VerletAppServer {
     /// `modelProvider/catalog` (EMO-574): read-only merge of the models.dev
     /// provider catalog with provider-store state for the chat setup wizard.
     /// It never writes provider records or credentials.
-    pub(super) async fn model_provider_catalog(
+    pub(crate) async fn model_provider_catalog(
         &self,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
         let catalog_providers = self.inner.model_catalog.providers();
@@ -2435,7 +2435,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "providers": rows }))
     }
 
-    pub(super) async fn model_provider_read(
+    pub(crate) async fn model_provider_read(
         &self,
         params: ModelProviderReadParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -2443,7 +2443,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "provider": self.model_provider_json(&provider).await? }))
     }
 
-    pub(super) async fn model_provider_upsert(
+    pub(crate) async fn model_provider_upsert(
         &self,
         params: ModelProviderUpsertParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -2466,7 +2466,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "provider": self.model_provider_json(&provider).await? }))
     }
 
-    pub(super) async fn model_provider_delete(
+    pub(crate) async fn model_provider_delete(
         &self,
         params: ModelProviderDeleteParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -2522,7 +2522,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "deleted": true, "providerId": provider_id }))
     }
 
-    pub(super) async fn model_provider_auth_status(
+    pub(crate) async fn model_provider_auth_status(
         &self,
         params: ModelProviderAuthStatusParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -2583,7 +2583,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "auth": auth, "data": data, "nextCursor": null }))
     }
 
-    pub(super) async fn model_provider_auth_set(
+    pub(crate) async fn model_provider_auth_set(
         &self,
         params: ModelProviderAuthSetParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -2675,7 +2675,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "auth": self.model_provider_auth_json(&provider).await? }))
     }
 
-    pub(super) async fn model_provider_auth_set_oauth(
+    pub(crate) async fn model_provider_auth_set_oauth(
         &self,
         params: ModelProviderAuthSetOAuthParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -2748,7 +2748,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "auth": self.model_provider_auth_json(&provider).await? }))
     }
 
-    pub(super) async fn model_provider_auth_delete(
+    pub(crate) async fn model_provider_auth_delete(
         &self,
         params: ModelProviderAuthDeleteParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -3037,7 +3037,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }))
     }
 
-    pub(super) fn operation_list(&self) -> Result<serde_json::Value, JsonRpcErrorError> {
+    pub(crate) fn operation_list(&self) -> Result<serde_json::Value, JsonRpcErrorError> {
         let Some(registry_root) = self.inner.capsule_bindings.registry_root.as_deref() else {
             return Ok(serde_json::json!({ "data": [], "cursor": null }));
         };
@@ -3073,7 +3073,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(lifecycle)
     }
 
-    pub(super) async fn thread_events_list(
+    pub(crate) async fn thread_events_list(
         &self,
         params: ThreadEventsListParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -3143,7 +3143,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "data": data, "cursor": cursor, "streamCursor": stream_cursor }))
     }
 
-    pub(super) async fn thread_couplings_list(
+    pub(crate) async fn thread_couplings_list(
         &self,
         params: ThreadControlListParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -3188,7 +3188,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }))
     }
 
-    pub(super) async fn thread_approvals_list(
+    pub(crate) async fn thread_approvals_list(
         &self,
         params: ThreadControlListParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -3217,7 +3217,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "data": data, "nextCursor": null }))
     }
 
-    pub(super) async fn thread_waiting_list(
+    pub(crate) async fn thread_waiting_list(
         &self,
         params: ThreadControlListParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -3325,7 +3325,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "data": data, "nextCursor": null }))
     }
 
-    pub(super) async fn approval_resolve(
+    pub(crate) async fn approval_resolve(
         &self,
         params: ApprovalResolveParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -3422,7 +3422,7 @@ impl crate::adapters::app_server::VerletAppServer {
         ))
     }
 
-    pub(super) async fn mandate_start(
+    pub(crate) async fn mandate_start(
         &self,
         params: MandateStartParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -3460,7 +3460,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }))
     }
 
-    pub(super) async fn mandate_revoke(
+    pub(crate) async fn mandate_revoke(
         &self,
         params: MandateRevokeParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -3493,7 +3493,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }))
     }
 
-    pub(super) async fn mandate_list(
+    pub(crate) async fn mandate_list(
         &self,
         params: MandateListParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -3516,7 +3516,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "data": data, "nextCursor": null }))
     }
 
-    pub(super) async fn thread_debug_export(
+    pub(crate) async fn thread_debug_export(
         &self,
         params: ThreadDebugExportParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -3663,7 +3663,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(bundle)
     }
 
-    pub(super) async fn bind_thread_start_agent(
+    pub(crate) async fn bind_thread_start_agent(
         &self,
         agent_ref: &str,
         params: &ThreadStartParams,
@@ -3689,7 +3689,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(bound)
     }
 
-    pub(super) async fn bind_rebind_fork_agent(
+    pub(crate) async fn bind_rebind_fork_agent(
         &self,
         agent_ref: &str,
         model_profile_id: Option<&str>,
@@ -3719,7 +3719,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(bound)
     }
 
-    pub(super) async fn agent_manifest_provider_surface(
+    pub(crate) async fn agent_manifest_provider_surface(
         &self,
     ) -> crate::kernel::runtime_host::VerletResult<
         crate::agent::manifest_bind::AgentManifestProviderSurface,
@@ -3734,7 +3734,7 @@ impl crate::adapters::app_server::VerletAppServer {
         .await
     }
 
-    pub(super) async fn configured_mcp_server_refs(
+    pub(crate) async fn configured_mcp_server_refs(
         &self,
     ) -> crate::kernel::runtime_host::VerletResult<std::collections::BTreeSet<String>> {
         let registry = crate::adapters::mcp_client::SqliteMcpSourceRegistry::open_async(
@@ -3753,7 +3753,7 @@ impl crate::adapters::app_server::VerletAppServer {
             .collect())
     }
 
-    pub(super) async fn tool_universe_discoverer(
+    pub(crate) async fn tool_universe_discoverer(
         &self,
     ) -> crate::kernel::runtime_host::VerletResult<
         crate::adapters::mcp_client::McpToolUniverseDiscoverer,
@@ -3774,7 +3774,7 @@ impl crate::adapters::app_server::VerletAppServer {
         ))
     }
 
-    pub(super) async fn thread_start(
+    pub(crate) async fn thread_start(
         &self,
         connection: &ConnectionState,
         mut params: ThreadStartParams,
@@ -3903,7 +3903,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }))
     }
 
-    pub(super) async fn thread_start_session_id(
+    pub(crate) async fn thread_start_session_id(
         &self,
         topology: &verlet_runtime_contracts::ThreadTopology,
     ) -> Result<String, JsonRpcErrorError> {
@@ -3939,7 +3939,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(session_id.unwrap_or_else(|| format!("app-server-session-{}", uuid::Uuid::now_v7())))
     }
 
-    pub(super) async fn thread_resume(
+    pub(crate) async fn thread_resume(
         &self,
         connection: &ConnectionState,
         params: ThreadResumeParams,
@@ -4024,7 +4024,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }))
     }
 
-    pub(super) async fn thread_fork(
+    pub(crate) async fn thread_fork(
         &self,
         connection: &ConnectionState,
         params: ThreadForkParams,
@@ -4411,7 +4411,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }))
     }
 
-    pub(super) async fn thread_rebind_fork(
+    pub(crate) async fn thread_rebind_fork(
         &self,
         connection: &ConnectionState,
         params: ThreadRebindForkParams,
@@ -4634,7 +4634,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }))
     }
 
-    pub(super) async fn thread_compact_start(
+    pub(crate) async fn thread_compact_start(
         &self,
         params: ThreadCompactStartParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -4648,7 +4648,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({}))
     }
 
-    pub(super) async fn thread_shell_command(
+    pub(crate) async fn thread_shell_command(
         &self,
         connection: &ConnectionState,
         params: ThreadShellCommandParams,
@@ -4790,7 +4790,7 @@ impl crate::adapters::app_server::VerletAppServer {
             .map_err(internal_error)
     }
 
-    pub(super) async fn thread_spawn(
+    pub(crate) async fn thread_spawn(
         &self,
         connection: &ConnectionState,
         params: ThreadSpawnParams,
@@ -4868,7 +4868,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }))
     }
 
-    pub(super) async fn thread_submit(
+    pub(crate) async fn thread_submit(
         &self,
         params: ThreadSubmitParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -4913,7 +4913,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }))
     }
 
-    pub(super) async fn turn_start(
+    pub(crate) async fn turn_start(
         &self,
         connection: &ConnectionState,
         params: TurnStartParams,
@@ -4992,7 +4992,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "turn": turn }))
     }
 
-    pub(super) async fn turn_steer(
+    pub(crate) async fn turn_steer(
         &self,
         params: TurnSteerParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -5028,7 +5028,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "turnId": params.expected_turn_id }))
     }
 
-    pub(super) async fn turn_interrupt(
+    pub(crate) async fn turn_interrupt(
         &self,
         params: TurnInterruptParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -5051,7 +5051,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({}))
     }
 
-    pub(super) fn capsule_registry_root(&self) -> Result<&std::path::Path, JsonRpcErrorError> {
+    pub(crate) fn capsule_registry_root(&self) -> Result<&std::path::Path, JsonRpcErrorError> {
         self.inner
             .capsule_bindings
             .registry_root
@@ -5059,7 +5059,7 @@ impl crate::adapters::app_server::VerletAppServer {
             .ok_or_else(|| jsonrpc_error(-32602, "capsule bindings require a registry root"))
     }
 
-    pub(super) fn capsule_binding_set(
+    pub(crate) fn capsule_binding_set(
         &self,
         params: CapsuleBindingSetParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -5084,7 +5084,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "binding": binding }))
     }
 
-    pub(super) fn capsule_binding_delete(
+    pub(crate) fn capsule_binding_delete(
         &self,
         params: CapsuleBindingOperationParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -5099,7 +5099,7 @@ impl crate::adapters::app_server::VerletAppServer {
     }
 
     // lexicon-allow: capsule - existing app-server capsule-binding RPC contract
-    pub(super) fn capsule_binding_list(
+    pub(crate) fn capsule_binding_list(
         &self,
         // lexicon-allow: capsule - existing app-server capsule-binding RPC contract
         params: CapsuleBindingListParams,
@@ -5118,7 +5118,7 @@ impl crate::adapters::app_server::VerletAppServer {
     }
 
     // lexicon-allow: capsule - existing app-server capsule-binding surface; line shifted by repo-wide path qualification
-    pub(super) fn capsule_binding_resolve(
+    pub(crate) fn capsule_binding_resolve(
         &self,
         // lexicon-allow: capsule - existing app-server capsule-binding surface; line shifted by repo-wide path qualification
         params: CapsuleBindingResolveParams,
@@ -5184,7 +5184,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(())
     }
 
-    pub(super) async fn command_exec(
+    pub(crate) async fn command_exec(
         &self,
         params: CommandExecParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -5359,7 +5359,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(value)
     }
 
-    pub(super) async fn command_exec_write(
+    pub(crate) async fn command_exec_write(
         &self,
         params: CommandExecWriteParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -5387,7 +5387,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(command_process_snapshot_json(&outcome.snapshot))
     }
 
-    pub(super) async fn command_exec_terminate(
+    pub(crate) async fn command_exec_terminate(
         &self,
         params: CommandExecTerminateParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -5409,7 +5409,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(command_process_snapshot_json(&outcome.snapshot))
     }
 
-    pub(super) fn command_exec_resize(
+    pub(crate) fn command_exec_resize(
         &self,
         params: CommandExecProcessParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -5441,7 +5441,7 @@ impl crate::adapters::app_server::VerletAppServer {
             .map_err(internal_error)
     }
 
-    pub(super) async fn get_conversation_summary(
+    pub(crate) async fn get_conversation_summary(
         &self,
         params: GetConversationSummaryParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -5473,7 +5473,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }))
     }
 
-    pub(super) async fn fs_read_file(
+    pub(crate) async fn fs_read_file(
         &self,
         params: FsReadFileParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -5484,7 +5484,7 @@ impl crate::adapters::app_server::VerletAppServer {
         )
     }
 
-    pub(super) async fn fs_write_file(
+    pub(crate) async fn fs_write_file(
         &self,
         params: FsWriteFileParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -5501,7 +5501,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({}))
     }
 
-    pub(super) async fn fs_create_directory(
+    pub(crate) async fn fs_create_directory(
         &self,
         params: FsCreateDirectoryParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -5515,7 +5515,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({}))
     }
 
-    pub(super) async fn fs_get_metadata(
+    pub(crate) async fn fs_get_metadata(
         &self,
         params: FsGetMetadataParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -5531,7 +5531,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }))
     }
 
-    pub(super) async fn fs_read_directory(
+    pub(crate) async fn fs_read_directory(
         &self,
         params: FsReadDirectoryParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -5554,7 +5554,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({ "entries": values }))
     }
 
-    pub(super) async fn fs_remove(
+    pub(crate) async fn fs_remove(
         &self,
         params: FsRemoveParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -5576,7 +5576,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({}))
     }
 
-    pub(super) async fn fs_copy(
+    pub(crate) async fn fs_copy(
         &self,
         params: FsCopyParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -5603,7 +5603,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(serde_json::json!({}))
     }
 
-    pub(super) async fn coordinates_for_thread(
+    pub(crate) async fn coordinates_for_thread(
         &self,
         thread_id: &str,
     ) -> Result<verlet_runtime_contracts::ThreadCoordinates, JsonRpcErrorError> {
@@ -5616,7 +5616,7 @@ impl crate::adapters::app_server::VerletAppServer {
     }
 
     /// Return a resident runtime handle, loading persisted lifecycle state when needed.
-    pub(super) async fn handle_for_thread(
+    pub(crate) async fn handle_for_thread(
         &self,
         thread_id: &str,
     ) -> Result<crate::kernel::runtime_host::RuntimeThreadHandle, JsonRpcErrorError> {
@@ -5643,7 +5643,7 @@ impl crate::adapters::app_server::VerletAppServer {
     /// providers return invalid-params errors naming the problem and change
     /// nothing. The response echoes the new active selection as
     /// `{ "active": { "providerId": ..., "model": ... } }`.
-    pub(super) async fn model_select(
+    pub(crate) async fn model_select(
         &self,
         params: ModelSelectParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -5772,7 +5772,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }))
     }
 
-    pub(super) async fn model_list_json(
+    pub(crate) async fn model_list_json(
         &self,
     ) -> Result<Vec<serde_json::Value>, JsonRpcErrorError> {
         let mut providers = self
@@ -5994,7 +5994,7 @@ impl crate::adapters::app_server::VerletAppServer {
             .collect())
     }
 
-    pub(super) async fn model_provider_capabilities_json(&self) -> serde_json::Value {
+    pub(crate) async fn model_provider_capabilities_json(&self) -> serde_json::Value {
         let active = self.inner.active_model.read().await.clone();
         let supports_streaming =
             crate::adapters::app_server::agent_manifest_provider_surface_from_parts(
@@ -6014,7 +6014,7 @@ impl crate::adapters::app_server::VerletAppServer {
         })
     }
 
-    pub(super) fn config_json(&self) -> serde_json::Value {
+    pub(crate) fn config_json(&self) -> serde_json::Value {
         serde_json::json!({
             "cwd": cwd_string(&self.inner.cwd),
             "model": self.inner.model,
@@ -6045,7 +6045,7 @@ impl crate::adapters::app_server::VerletAppServer {
     }
 }
 
-pub(super) fn finish_websocket_session(
+pub(crate) fn finish_websocket_session(
     read_result: crate::kernel::runtime_host::VerletResult<()>,
     close_result: crate::kernel::runtime_host::VerletResult<()>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
@@ -6063,7 +6063,7 @@ pub(super) fn finish_websocket_session(
 }
 
 impl ConnectionState {
-    pub(super) async fn handle_initialize(
+    pub(crate) async fn handle_initialize(
         &self,
         params: Option<serde_json::Value>,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -6101,20 +6101,20 @@ impl ConnectionState {
         }))
     }
 
-    pub(super) async fn initialize_seen(&self) -> bool {
+    pub(crate) async fn initialize_seen(&self) -> bool {
         self.handshake.lock().await.initialize_seen
     }
 
-    pub(super) async fn admission_surface(&self) -> &'static str {
+    pub(crate) async fn admission_surface(&self) -> &'static str {
         let handshake = self.handshake.lock().await;
         crate::kernel::admission::app_server_surface(handshake.client_name.as_deref())
     }
 
-    pub(super) async fn mark_initialized(&self) {
+    pub(crate) async fn mark_initialized(&self) {
         self.handshake.lock().await.initialized_seen = true;
     }
 
-    pub(super) async fn notify(&self, method: &str, params: serde_json::Value) {
+    pub(crate) async fn notify(&self, method: &str, params: serde_json::Value) {
         if self.opt_out_notifications.read().await.contains(method) {
             return;
         }
@@ -6126,7 +6126,7 @@ impl ConnectionState {
             }));
     }
 
-    pub(super) async fn subscribe_thread(
+    pub(crate) async fn subscribe_thread(
         &self,
         handle: crate::kernel::runtime_host::RuntimeThreadHandle,
     ) {
@@ -6146,7 +6146,7 @@ impl ConnectionState {
             .insert(thread_id, subscriber_id);
     }
 
-    pub(super) async fn unsubscribe(&self, thread_id: &str) {
+    pub(crate) async fn unsubscribe(&self, thread_id: &str) {
         if let Some(subscriber_id) = self.subscriptions.lock().await.remove(thread_id) {
             self.app
                 .unsubscribe_thread_connection(thread_id, subscriber_id)
@@ -6154,7 +6154,7 @@ impl ConnectionState {
         }
     }
 
-    pub(super) async fn abort_subscriptions(&self) {
+    pub(crate) async fn abort_subscriptions(&self) {
         let subscriptions = std::mem::take(&mut *self.subscriptions.lock().await);
         for (thread_id, subscriber_id) in subscriptions {
             self.app
@@ -6163,7 +6163,7 @@ impl ConnectionState {
         }
     }
 
-    pub(super) async fn fs_watch(
+    pub(crate) async fn fs_watch(
         &self,
         params: FsWatchParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -6178,7 +6178,7 @@ impl ConnectionState {
         Ok(serde_json::json!({ "path": cwd_string(&canonical) }))
     }
 
-    pub(super) async fn fs_unwatch(
+    pub(crate) async fn fs_unwatch(
         &self,
         params: FsUnwatchParams,
     ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -6187,7 +6187,7 @@ impl ConnectionState {
     }
 }
 
-pub(super) async fn handle_inbound_text(
+pub(crate) async fn handle_inbound_text(
     connection: &ConnectionState,
     text: &str,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
@@ -6210,7 +6210,7 @@ pub(super) async fn handle_inbound_text(
     Ok(())
 }
 
-pub(super) fn empty_rate_limits() -> serde_json::Value {
+pub(crate) fn empty_rate_limits() -> serde_json::Value {
     serde_json::json!({
         "limitId": null,
         "limitName": null,
@@ -6226,7 +6226,7 @@ pub(super) fn empty_rate_limits() -> serde_json::Value {
     })
 }
 
-pub(super) fn turn_error(message: String, code: Option<String>) -> serde_json::Value {
+pub(crate) fn turn_error(message: String, code: Option<String>) -> serde_json::Value {
     let _ = code;
     serde_json::json!({
         "message": message,
@@ -6235,7 +6235,7 @@ pub(super) fn turn_error(message: String, code: Option<String>) -> serde_json::V
     })
 }
 
-pub(super) fn parse_params<T>(params: Option<serde_json::Value>) -> Result<T, JsonRpcErrorError>
+pub(crate) fn parse_params<T>(params: Option<serde_json::Value>) -> Result<T, JsonRpcErrorError>
 where
     T: serde::de::DeserializeOwned,
 {
@@ -6247,7 +6247,7 @@ where
         .map_err(|err| jsonrpc_error(-32602, format!("invalid params: {err}")))
 }
 
-pub(super) fn jsonrpc_error(code: i64, message: impl Into<String>) -> JsonRpcErrorError {
+pub(crate) fn jsonrpc_error(code: i64, message: impl Into<String>) -> JsonRpcErrorError {
     JsonRpcErrorError {
         code,
         data: None,
@@ -6255,15 +6255,15 @@ pub(super) fn jsonrpc_error(code: i64, message: impl Into<String>) -> JsonRpcErr
     }
 }
 
-pub(super) fn internal_error(err: crate::kernel::runtime_host::VerletError) -> JsonRpcErrorError {
+pub(crate) fn internal_error(err: crate::kernel::runtime_host::VerletError) -> JsonRpcErrorError {
     jsonrpc_error(-32000, err.to_string())
 }
 
-pub(super) fn json_codec_error(err: serde_json::Error) -> JsonRpcErrorError {
+pub(crate) fn json_codec_error(err: serde_json::Error) -> JsonRpcErrorError {
     jsonrpc_error(-32000, format!("JSON codec failed: {err}"))
 }
 
-pub(super) fn jsonrpc_error_to_runtime_factory(
+pub(crate) fn jsonrpc_error_to_runtime_factory(
     err: JsonRpcErrorError,
 ) -> crate::kernel::runtime_host::VerletError {
     crate::kernel::runtime_host::VerletError::RuntimeFactory(
@@ -6274,7 +6274,7 @@ pub(super) fn jsonrpc_error_to_runtime_factory(
     )
 }
 
-pub(super) fn fs_error(err: std::io::Error) -> JsonRpcErrorError {
+pub(crate) fn fs_error(err: std::io::Error) -> JsonRpcErrorError {
     if err.kind() == std::io::ErrorKind::InvalidInput {
         jsonrpc_error(-32602, err.to_string())
     } else {
@@ -6282,17 +6282,17 @@ pub(super) fn fs_error(err: std::io::Error) -> JsonRpcErrorError {
     }
 }
 
-pub(super) fn command_exec_io_error(err: std::io::Error) -> JsonRpcErrorError {
+pub(crate) fn command_exec_io_error(err: std::io::Error) -> JsonRpcErrorError {
     jsonrpc_error(-32000, format!("command/exec failed: {err}"))
 }
 
-pub(super) fn command_exec_process_error(
+pub(crate) fn command_exec_process_error(
     err: verlet_process::VerletProcessError,
 ) -> JsonRpcErrorError {
     jsonrpc_error(-32000, format!("command/exec failed: {err}"))
 }
 
-pub(super) fn parse_command_process_id(
+pub(crate) fn parse_command_process_id(
     process_id: &str,
 ) -> Result<verlet_process::process::VerletProcessId, JsonRpcErrorError> {
     process_id.parse().map_err(|err| {
@@ -6303,11 +6303,11 @@ pub(super) fn parse_command_process_id(
     })
 }
 
-pub(super) fn command_yield_time(yield_time_ms: Option<u64>) -> std::time::Duration {
+pub(crate) fn command_yield_time(yield_time_ms: Option<u64>) -> std::time::Duration {
     std::time::Duration::from_millis(yield_time_ms.unwrap_or(10_000).min(30_000))
 }
 
-pub(super) fn command_process_output_cap(params: &CommandExecParams) -> usize {
+pub(crate) fn command_process_output_cap(params: &CommandExecParams) -> usize {
     if params.disable_output_cap {
         usize::MAX
     } else {
@@ -6317,11 +6317,11 @@ pub(super) fn command_process_output_cap(params: &CommandExecParams) -> usize {
     }
 }
 
-pub(super) fn command_visible_output_cap(params: &CommandExecParams) -> usize {
+pub(crate) fn command_visible_output_cap(params: &CommandExecParams) -> usize {
     command_process_output_cap(params)
 }
 
-pub(super) fn command_process_snapshot_json(
+pub(crate) fn command_process_snapshot_json(
     snapshot: &verlet_process::live::AsyncProcessSnapshot,
 ) -> serde_json::Value {
     let status: &str = snapshot.status.as_ref();
@@ -6340,33 +6340,33 @@ pub(super) fn command_process_snapshot_json(
     })
 }
 
-pub(super) fn mcp_source_param_error(err: impl std::fmt::Display) -> JsonRpcErrorError {
+pub(crate) fn mcp_source_param_error(err: impl std::fmt::Display) -> JsonRpcErrorError {
     jsonrpc_error(-32602, err.to_string())
 }
 
-pub(super) fn mcp_source_not_found(name: &str) -> JsonRpcErrorError {
+pub(crate) fn mcp_source_not_found(name: &str) -> JsonRpcErrorError {
     jsonrpc_error(-32602, format!("MCP source {name:?} was not found"))
 }
 
-pub(super) fn thread_not_found(thread_id: &str) -> JsonRpcErrorError {
+pub(crate) fn thread_not_found(thread_id: &str) -> JsonRpcErrorError {
     jsonrpc_error(-32001, format!("thread not found: {thread_id}"))
 }
 
-pub(super) fn unknown_agent_ref(
+pub(crate) fn unknown_agent_ref(
     agent_ref: &str,
     err: crate::kernel::runtime_host::VerletError,
 ) -> JsonRpcErrorError {
     jsonrpc_error(-32602, format!("unknown agent ref {agent_ref:?}: {err}"))
 }
 
-pub(super) fn malformed_agent_ref(
+pub(crate) fn malformed_agent_ref(
     agent_ref: &str,
     err: crate::kernel::runtime_host::VerletError,
 ) -> JsonRpcErrorError {
     jsonrpc_error(-32602, format!("malformed agent ref {agent_ref:?}: {err}"))
 }
 
-pub(super) fn thread_start_bind_error(
+pub(crate) fn thread_start_bind_error(
     err: crate::kernel::runtime_host::VerletError,
 ) -> JsonRpcErrorError {
     match &err {
@@ -6379,7 +6379,7 @@ pub(super) fn thread_start_bind_error(
     }
 }
 
-pub(super) fn lower_thread_start_cwd_override(
+pub(crate) fn lower_thread_start_cwd_override(
     params: &mut ThreadStartParams,
     base_cwd: &std::path::Path,
 ) -> Result<(), JsonRpcErrorError> {
@@ -6414,7 +6414,7 @@ pub(super) fn lower_thread_start_cwd_override(
     Ok(())
 }
 
-pub(super) fn thread_start_default_agent_ref(params: &ThreadStartParams) -> Option<&'static str> {
+pub(crate) fn thread_start_default_agent_ref(params: &ThreadStartParams) -> Option<&'static str> {
     if params.agent_ref.is_none() {
         Some(crate::adapters::app_server::default_manifest::DEFAULT_AGENT_REF)
     } else {
@@ -6422,11 +6422,11 @@ pub(super) fn thread_start_default_agent_ref(params: &ThreadStartParams) -> Opti
     }
 }
 
-pub(super) fn malformed_thread_events_cursor() -> JsonRpcErrorError {
+pub(crate) fn malformed_thread_events_cursor() -> JsonRpcErrorError {
     jsonrpc_error(-32602, "malformed thread/events/list cursor")
 }
 
-pub(super) fn thread_events_cursor_history_error(
+pub(crate) fn thread_events_cursor_history_error(
     err: verlet_history::HistoryError,
 ) -> JsonRpcErrorError {
     match err {
@@ -6447,14 +6447,14 @@ pub(super) fn thread_events_cursor_history_error(
     }
 }
 
-pub(super) fn malformed_thread_events_stream(stream: &str) -> JsonRpcErrorError {
+pub(crate) fn malformed_thread_events_stream(stream: &str) -> JsonRpcErrorError {
     jsonrpc_error(
         -32602,
         format!("thread/events/list stream {stream:?} must be thread, control, or derived:<name>"),
     )
 }
 
-pub(super) fn thread_events_stream_id(
+pub(crate) fn thread_events_stream_id(
     coordinates: &verlet_runtime_contracts::ThreadCoordinates,
     stream: &str,
 ) -> Result<verlet_history::EventStreamId, JsonRpcErrorError> {
@@ -6478,7 +6478,7 @@ pub(super) fn thread_events_stream_id(
     )))
 }
 
-pub(super) fn rpc_ingress_received_record(
+pub(crate) fn rpc_ingress_received_record(
     coordinates: verlet_runtime_contracts::ThreadCoordinates,
     payload: verlet_history::IoIngressReceivedPayload,
     principal: &verlet_io_core::IoPrincipal,
@@ -6511,7 +6511,7 @@ pub(super) fn rpc_ingress_received_record(
     ))
 }
 
-pub(super) fn absolute_path(
+pub(crate) fn absolute_path(
     path: std::path::PathBuf,
 ) -> Result<std::path::PathBuf, JsonRpcErrorError> {
     if path.is_absolute() {
@@ -6524,7 +6524,7 @@ pub(super) fn absolute_path(
     }
 }
 
-pub(super) fn cwd_string(path: &std::path::Path) -> String {
+pub(crate) fn cwd_string(path: &std::path::Path) -> String {
     path.to_string_lossy().into_owned()
 }
 
@@ -6543,7 +6543,7 @@ fn thread_source_cut_json(
     })
 }
 
-pub(super) fn thread_fork_reason_string(
+pub(crate) fn thread_fork_reason_string(
     reason: &verlet_history::ThreadForkReason,
 ) -> Result<String, JsonRpcErrorError> {
     let value = serde_json::to_value(reason).map_err(|err| {
@@ -6792,7 +6792,7 @@ fn bump_agent_version(version: &str) -> String {
     format!("{version}.1")
 }
 
-pub(super) fn agent_list_entry(
+pub(crate) fn agent_list_entry(
     registry: &crate::agent::manifest::LocalAgentRegistry,
     record: &crate::agent::manifest::PublishedAgentRecord,
 ) -> Result<serde_json::Value, JsonRpcErrorError> {
@@ -6847,7 +6847,7 @@ pub(super) fn agent_list_entry(
     Ok(entry)
 }
 
-pub(super) fn agent_aliases(
+pub(crate) fn agent_aliases(
     registry: &crate::agent::manifest::LocalAgentRegistry,
     name: &str,
 ) -> Result<Vec<serde_json::Value>, JsonRpcErrorError> {
@@ -6895,7 +6895,7 @@ pub(super) fn agent_aliases(
     Ok(aliases)
 }
 
-pub(super) fn operation_list_entry(
+pub(crate) fn operation_list_entry(
     record: &verlet_operations::operation_store::PublishedOperationRecord,
 ) -> Result<serde_json::Value, JsonRpcErrorError> {
     Ok(serde_json::json!({
@@ -6912,7 +6912,7 @@ pub(super) fn operation_list_entry(
     }))
 }
 
-pub(super) fn operation_summary(
+pub(crate) fn operation_summary(
     record: &verlet_operations::operation_store::PublishedOperationRecord,
 ) -> Option<String> {
     record.interface.as_ref().and_then(|interface| {
@@ -6929,7 +6929,7 @@ pub(super) fn operation_summary(
     })
 }
 
-pub(super) fn configured_model_json(
+pub(crate) fn configured_model_json(
     provider_id: &str,
     model_id: &str,
     display_name: String,
@@ -6959,7 +6959,7 @@ pub(super) fn configured_model_json(
     })
 }
 
-pub(super) fn catalog_provider_display_name(
+pub(crate) fn catalog_provider_display_name(
     provider: &verlet_metadata::provider_store::LlmProviderRecord,
 ) -> String {
     provider
@@ -7066,7 +7066,7 @@ fn missing_model_provider_auth_message(
     }
 }
 
-pub(super) fn model_provider_record_from_rpc(
+pub(crate) fn model_provider_record_from_rpc(
     provider: ModelProviderUpsertRecord,
 ) -> Result<verlet_metadata::provider_store::LlmProviderRecord, JsonRpcErrorError> {
     validate_model_provider_auth_config(&provider.auth)?;
@@ -7353,7 +7353,7 @@ fn model_provider_catalog_models(
     }
 }
 
-pub(super) fn thread_event_record_json(
+pub(crate) fn thread_event_record_json(
     record: &verlet_history::EventRecord,
 ) -> Result<serde_json::Value, JsonRpcErrorError> {
     let envelope = record.to_stream_record_v1();
@@ -7371,7 +7371,7 @@ pub(super) fn thread_event_record_json(
     Ok(value)
 }
 
-pub(super) fn coupling_binding_json(
+pub(crate) fn coupling_binding_json(
     binding: &crate::agent::manifest_bind::AgentManifestCouplingBinding,
 ) -> serde_json::Value {
     let role: &str = binding.role.as_ref();
@@ -7395,7 +7395,7 @@ pub(super) fn coupling_binding_json(
     })
 }
 
-pub(super) fn existing_approval_resolution<'a>(
+pub(crate) fn existing_approval_resolution<'a>(
     events: &'a [verlet_history::EventRecord],
     approval_id: &str,
 ) -> Result<
@@ -7424,11 +7424,11 @@ pub(super) fn existing_approval_resolution<'a>(
     Ok(None)
 }
 
-pub(super) fn approval_decision_from_bool(approved: bool) -> &'static str {
+pub(crate) fn approval_decision_from_bool(approved: bool) -> &'static str {
     if approved { "approved" } else { "denied" }
 }
 
-pub(super) fn approval_resolution_json(
+pub(crate) fn approval_resolution_json(
     status: &str,
     decision: ApprovalResolveDecision,
     record: &verlet_history::EventRecord,
@@ -7449,7 +7449,7 @@ pub(super) fn approval_resolution_json(
     })
 }
 
-pub(super) fn active_mandate_json(
+pub(crate) fn active_mandate_json(
     mandate: &crate::kernel::mandate_lifecycle::ActiveMandate,
 ) -> serde_json::Value {
     serde_json::json!({
@@ -7471,7 +7471,7 @@ pub(super) fn active_mandate_json(
     })
 }
 
-pub(super) fn mandate_jsonrpc_error(
+pub(crate) fn mandate_jsonrpc_error(
     err: crate::kernel::runtime_host::VerletError,
 ) -> JsonRpcErrorError {
     match err {
@@ -7482,7 +7482,7 @@ pub(super) fn mandate_jsonrpc_error(
     }
 }
 
-pub(super) fn pending_tool_approval_json(
+pub(crate) fn pending_tool_approval_json(
     suspension: &crate::kernel::control_decision::PendingToolCallSuspension,
 ) -> serde_json::Value {
     serde_json::json!({
@@ -7499,7 +7499,7 @@ pub(super) fn pending_tool_approval_json(
     })
 }
 
-pub(super) fn pending_tool_waiting_json(
+pub(crate) fn pending_tool_waiting_json(
     suspension: &crate::kernel::control_decision::PendingToolCallSuspension,
 ) -> serde_json::Value {
     serde_json::json!({
@@ -7516,7 +7516,7 @@ pub(super) fn pending_tool_waiting_json(
     })
 }
 
-pub(super) fn turn_waiting_json(record: &verlet_history::EventRecord) -> serde_json::Value {
+pub(crate) fn turn_waiting_json(record: &verlet_history::EventRecord) -> serde_json::Value {
     let subject = record.payload.get("subject");
     let call_id = subject
         .and_then(|subject| subject.get("call_id"))
@@ -7545,11 +7545,11 @@ pub(super) fn turn_waiting_json(record: &verlet_history::EventRecord) -> serde_j
     })
 }
 
-pub(super) fn debug_export_ack_classes() -> Vec<&'static str> {
+pub(crate) fn debug_export_ack_classes() -> Vec<&'static str> {
     vec!["local_committed", "query_projected"]
 }
 
-pub(super) fn debug_export_receipt_json(record: &verlet_history::EventRecord) -> serde_json::Value {
+pub(crate) fn debug_export_receipt_json(record: &verlet_history::EventRecord) -> serde_json::Value {
     let kind: &str = record.kind.as_ref();
     let origin: &str = record.origin.as_ref();
     serde_json::json!({
@@ -7563,7 +7563,7 @@ pub(super) fn debug_export_receipt_json(record: &verlet_history::EventRecord) ->
     })
 }
 
-pub(super) fn redact_debug_export_value_with_evidence(
+pub(crate) fn redact_debug_export_value_with_evidence(
     value: &mut serde_json::Value,
     redacted_keys: &mut std::collections::BTreeSet<String>,
 ) {
@@ -7587,7 +7587,7 @@ pub(super) fn redact_debug_export_value_with_evidence(
     }
 }
 
-pub(super) fn debug_export_redacts_key(key: &str) -> bool {
+pub(crate) fn debug_export_redacts_key(key: &str) -> bool {
     let normalized = key
         .chars()
         .filter(|ch| *ch != '_' && *ch != '-')
@@ -7601,14 +7601,14 @@ pub(super) fn debug_export_redacts_key(key: &str) -> bool {
         || normalized.contains("bearer")
 }
 
-pub(super) fn encode_thread_events_cursor(sequence: i64) -> Result<String, JsonRpcErrorError> {
+pub(crate) fn encode_thread_events_cursor(sequence: i64) -> Result<String, JsonRpcErrorError> {
     if sequence < 1 {
         return Err(malformed_thread_events_cursor());
     }
     Ok(base64::engine::general_purpose::STANDARD.encode(format!("v1:{sequence}")))
 }
 
-pub(super) fn decode_thread_events_cursor(
+pub(crate) fn decode_thread_events_cursor(
     cursor: &str,
 ) -> Result<verlet_history::EventSequence, JsonRpcErrorError> {
     let bytes = base64::engine::general_purpose::STANDARD
@@ -7627,20 +7627,20 @@ pub(super) fn decode_thread_events_cursor(
     Ok(verlet_history::EventSequence::new(sequence))
 }
 
-pub(super) fn metadata_time_ms(time: Option<std::time::SystemTime>) -> u64 {
+pub(crate) fn metadata_time_ms(time: Option<std::time::SystemTime>) -> u64 {
     time.and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
         .unwrap_or(0)
 }
 
-pub(super) fn cap_output(mut output: Vec<u8>, cap: Option<usize>) -> Vec<u8> {
+pub(crate) fn cap_output(mut output: Vec<u8>, cap: Option<usize>) -> Vec<u8> {
     if let Some(cap) = cap {
         output.truncate(cap);
     }
     output
 }
 
-pub(super) fn copy_path(
+pub(crate) fn copy_path(
     source: &std::path::Path,
     destination: &std::path::Path,
     recursive: bool,
@@ -7668,7 +7668,7 @@ pub(super) fn copy_path(
     Ok(())
 }
 
-pub(super) fn now_ms() -> u64 {
+pub(crate) fn now_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()

--- a/crates/verlet-kernel/src/adapters/app_server/default_manifest.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/default_manifest.rs
@@ -7,9 +7,9 @@
 //! plan → publish → bind pipeline with full receipts.
 
 /// Name of the synthesized default agent record (D1).
-pub(super) const DEFAULT_AGENT_NAME: &str = "default";
+pub(crate) const DEFAULT_AGENT_NAME: &str = "default";
 /// Namespace marking kernel-synthesized records (D1).
-pub(super) const DEFAULT_AGENT_NAMESPACE: &str = "verlet";
+pub(crate) const DEFAULT_AGENT_NAMESPACE: &str = "verlet";
 /// The ref a ref-less `thread/start` binds (alias resolution via `@latest`).
 pub(crate) const DEFAULT_AGENT_REF: &str = "agent://verlet/default@latest";
 const DEFAULT_MANIFEST_LOCK_ATTEMPTS: usize = 250;
@@ -21,7 +21,7 @@ const DEFAULT_MANIFEST_LOCK_SLEEP: std::time::Duration = std::time::Duration::fr
 /// publishing; otherwise publish a new version (1.0.0, then patch-bump).
 /// Errors fail daemon startup (fail-closed): an envelope that cannot be
 /// declared does not run.
-pub(super) fn ensure_default_manifest_published(
+pub(crate) fn ensure_default_manifest_published(
     config: &crate::adapters::app_server::VerletAppServerConfig,
     supports_streaming: bool,
 ) -> crate::kernel::runtime_host::VerletResult<crate::agent::manifest::PublishedAgentRecord> {

--- a/crates/verlet-kernel/src/adapters/app_server/instance.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/instance.rs
@@ -58,7 +58,7 @@ pub struct InstanceRootReservation {
 }
 
 impl InstanceRootReservation {
-    pub(super) fn canonical_roots(&self) -> &[std::path::PathBuf] {
+    pub(crate) fn canonical_roots(&self) -> &[std::path::PathBuf] {
         &self.canonical_roots
     }
 }
@@ -243,7 +243,7 @@ impl InstanceEnvironment {
         }
     }
 
-    pub(super) fn validate_hosted(&self) -> crate::kernel::runtime_host::VerletResult<()> {
+    pub(crate) fn validate_hosted(&self) -> crate::kernel::runtime_host::VerletResult<()> {
         if matches!(&self.provider_auth, ProviderAuthSource::ProcessEnvironment) {
             return Err(crate::kernel::runtime_host::VerletError::RuntimeFactory(
                 "hosted instance provider auth must be injected".to_string(),

--- a/crates/verlet-kernel/src/adapters/app_server/lifecycle.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/lifecycle.rs
@@ -152,7 +152,7 @@ fn log_task_result(result: Result<(), tokio::task::JoinError>) {
 mod tests {
     #[tokio::test]
     async fn finished_tasks_are_reaped_before_the_next_spawn() {
-        let tasks = super::InstanceTaskSet::new();
+        let tasks = crate::adapters::app_server::lifecycle::InstanceTaskSet::new();
         let (finished_tx, finished_rx) = tokio::sync::oneshot::channel();
         tasks.spawn(async move {
             let _ = finished_tx.send(());
@@ -171,7 +171,8 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_can_resume_after_the_draining_caller_is_cancelled() {
-        let tasks = std::sync::Arc::new(super::InstanceTaskSet::new());
+        let tasks =
+            std::sync::Arc::new(crate::adapters::app_server::lifecycle::InstanceTaskSet::new());
         let started = std::sync::Arc::new(tokio::sync::Notify::new());
         let release = std::sync::Arc::new(tokio::sync::Notify::new());
         let task_started = std::sync::Arc::clone(&started);
@@ -205,7 +206,8 @@ mod tests {
 
     #[tokio::test]
     async fn concurrent_shutdown_cancels_and_drains_every_owned_task() {
-        let tasks = std::sync::Arc::new(super::InstanceTaskSet::new());
+        let tasks =
+            std::sync::Arc::new(crate::adapters::app_server::lifecycle::InstanceTaskSet::new());
         let started = std::sync::Arc::new(tokio::sync::Notify::new());
         let task_started = std::sync::Arc::clone(&started);
         let cancellation = tasks.cancellation();

--- a/crates/verlet-kernel/src/adapters/app_server/live_models.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/live_models.rs
@@ -100,7 +100,7 @@ impl LiveModelCache {
 
     pub(crate) fn entries_and_refresh(
         self: &std::sync::Arc<Self>,
-        tasks: &std::sync::Arc<super::lifecycle::InstanceTaskSet>,
+        tasks: &std::sync::Arc<crate::adapters::app_server::lifecycle::InstanceTaskSet>,
         provider: &verlet_metadata::provider_store::LlmProviderRecord,
         credential: RefreshCredential,
     ) -> Vec<LiveModel> {
@@ -553,7 +553,10 @@ mod tests {
             .expect("model-list request channel closed")
     }
 
-    async fn wait_until_idle(cache: &super::LiveModelCache, provider_id: &str) {
+    async fn wait_until_idle(
+        cache: &crate::adapters::app_server::live_models::LiveModelCache,
+        provider_id: &str,
+    ) {
         tokio::time::timeout(std::time::Duration::from_secs(30), async {
             while cache.is_refreshing_for_test(provider_id) {
                 tokio::task::yield_now().await;
@@ -576,9 +579,11 @@ mod tests {
         )
         .with_auth_header(true);
 
-        let models = super::fetch_models(
+        let models = crate::adapters::app_server::live_models::fetch_models(
             &provider,
-            &super::RefreshCredential::ApiKey("anthropic-secret".to_string()),
+            &crate::adapters::app_server::live_models::RefreshCredential::ApiKey(
+                "anthropic-secret".to_string(),
+            ),
             std::time::Duration::from_secs(2),
         )
         .await
@@ -610,9 +615,11 @@ mod tests {
         )
         .with_auth_header(true);
 
-        let error = super::fetch_models(
+        let error = crate::adapters::app_server::live_models::fetch_models(
             &provider,
-            &super::RefreshCredential::ApiKey("credential-secret".to_string()),
+            &crate::adapters::app_server::live_models::RefreshCredential::ApiKey(
+                "credential-secret".to_string(),
+            ),
             std::time::Duration::from_secs(2),
         )
         .await
@@ -640,10 +647,13 @@ mod tests {
             format!("{}/v1", server.base_url),
         )
         .with_auth_header(true);
-        let cache = std::sync::Arc::new(super::LiveModelCache::new());
+        let cache =
+            std::sync::Arc::new(crate::adapters::app_server::live_models::LiveModelCache::new());
         let tasks =
             std::sync::Arc::new(crate::adapters::app_server::lifecycle::InstanceTaskSet::new());
-        let credential = super::RefreshCredential::ApiKey("fixture-key".to_string());
+        let credential = crate::adapters::app_server::live_models::RefreshCredential::ApiKey(
+            "fixture-key".to_string(),
+        );
 
         for _ in 0..16 {
             assert!(
@@ -678,20 +688,26 @@ mod tests {
             format!("{}/v1", server.base_url),
         )
         .with_auth_header(true);
-        let cache = std::sync::Arc::new(super::LiveModelCache::new());
+        let cache =
+            std::sync::Arc::new(crate::adapters::app_server::live_models::LiveModelCache::new());
         cache.seed_for_test(
             &provider,
-            &super::RefreshCredential::ApiKey("fixture-key".to_string()),
-            vec![super::LiveModel {
+            &crate::adapters::app_server::live_models::RefreshCredential::ApiKey(
+                "fixture-key".to_string(),
+            ),
+            vec![crate::adapters::app_server::live_models::LiveModel {
                 provider_id: provider.provider_id.clone(),
                 model_id: "stale-model".to_string(),
                 display_name: "Stale Model".to_string(),
             }],
-            super::REFRESH_INTERVAL + std::time::Duration::from_secs(1),
+            crate::adapters::app_server::live_models::REFRESH_INTERVAL
+                + std::time::Duration::from_secs(1),
         );
         let tasks =
             std::sync::Arc::new(crate::adapters::app_server::lifecycle::InstanceTaskSet::new());
-        let credential = super::RefreshCredential::ApiKey("fixture-key".to_string());
+        let credential = crate::adapters::app_server::live_models::RefreshCredential::ApiKey(
+            "fixture-key".to_string(),
+        );
 
         for _ in 0..16 {
             let models = cache.entries_and_refresh(&tasks, &provider, credential.clone());
@@ -725,10 +741,13 @@ mod tests {
             format!("{}/v1", server.base_url),
         )
         .with_auth_header(true);
-        let cache = std::sync::Arc::new(super::LiveModelCache::new());
+        let cache =
+            std::sync::Arc::new(crate::adapters::app_server::live_models::LiveModelCache::new());
         let tasks =
             std::sync::Arc::new(crate::adapters::app_server::lifecycle::InstanceTaskSet::new());
-        let credential = super::RefreshCredential::ApiKey("fixture-key".to_string());
+        let credential = crate::adapters::app_server::live_models::RefreshCredential::ApiKey(
+            "fixture-key".to_string(),
+        );
 
         cache.entries_and_refresh(&tasks, &provider, credential.clone());
         let _request = next_request(&mut server).await;
@@ -759,14 +778,17 @@ mod tests {
             format!("{}/v1", server.base_url),
         )
         .with_auth_header(true);
-        let cache = std::sync::Arc::new(super::LiveModelCache::new());
+        let cache =
+            std::sync::Arc::new(crate::adapters::app_server::live_models::LiveModelCache::new());
         let tasks =
             std::sync::Arc::new(crate::adapters::app_server::lifecycle::InstanceTaskSet::new());
 
         cache.entries_and_refresh(
             &tasks,
             &provider,
-            super::RefreshCredential::ApiKey("fixture-key".to_string()),
+            crate::adapters::app_server::live_models::RefreshCredential::ApiKey(
+                "fixture-key".to_string(),
+            ),
         );
         let _request = next_request(&mut server).await;
         assert!(cache.is_refreshing_for_test("cancelled-refresh-fixture"));
@@ -789,14 +811,17 @@ mod tests {
             format!("{}/v1", server.base_url),
         )
         .with_auth_header(true);
-        let cache = std::sync::Arc::new(super::LiveModelCache::new());
+        let cache =
+            std::sync::Arc::new(crate::adapters::app_server::live_models::LiveModelCache::new());
         let tasks =
             std::sync::Arc::new(crate::adapters::app_server::lifecycle::InstanceTaskSet::new());
 
         cache.entries_and_refresh(
             &tasks,
             &provider,
-            super::RefreshCredential::ApiKey("old-account-key".to_string()),
+            crate::adapters::app_server::live_models::RefreshCredential::ApiKey(
+                "old-account-key".to_string(),
+            ),
         );
         let _request = next_request(&mut server).await;
         wait_until_idle(&cache, "credential-change-fixture").await;
@@ -804,7 +829,9 @@ mod tests {
             cache.entries_and_refresh(
                 &tasks,
                 &provider,
-                super::RefreshCredential::ApiKey("old-account-key".to_string()),
+                crate::adapters::app_server::live_models::RefreshCredential::ApiKey(
+                    "old-account-key".to_string()
+                ),
             )[0]
             .model_id,
             "old-account-model"
@@ -813,7 +840,9 @@ mod tests {
         let after_change = cache.entries_and_refresh(
             &tasks,
             &provider,
-            super::RefreshCredential::ApiKey("new-account-key".to_string()),
+            crate::adapters::app_server::live_models::RefreshCredential::ApiKey(
+                "new-account-key".to_string(),
+            ),
         );
         assert!(
             after_change.is_empty(),
@@ -824,7 +853,9 @@ mod tests {
         let models = cache.entries_and_refresh(
             &tasks,
             &provider,
-            super::RefreshCredential::ApiKey("new-account-key".to_string()),
+            crate::adapters::app_server::live_models::RefreshCredential::ApiKey(
+                "new-account-key".to_string(),
+            ),
         );
         assert_eq!(models[0].model_id, "new-account-model");
         tasks.shutdown().await;

--- a/crates/verlet-kernel/src/adapters/app_server/model_catalog.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/model_catalog.rs
@@ -277,15 +277,18 @@ fn jittered_retry_delays() -> Vec<std::time::Duration> {
     ]
 }
 
+// Mirrors its only call site, which is `#[cfg(not(test))]`: catalog refresh is
+// never started from a test build, where the `_with_env` seam is driven instead.
+#[cfg(not(test))]
 pub(crate) fn spawn_runtime_refresh(
-    tasks: &std::sync::Arc<super::lifecycle::InstanceTaskSet>,
+    tasks: &std::sync::Arc<crate::adapters::app_server::lifecycle::InstanceTaskSet>,
     user_state_home: std::path::PathBuf,
 ) -> bool {
     spawn_runtime_refresh_with_env(tasks, user_state_home, |name| std::env::var(name))
 }
 
 fn spawn_runtime_refresh_with_env(
-    tasks: &std::sync::Arc<super::lifecycle::InstanceTaskSet>,
+    tasks: &std::sync::Arc<crate::adapters::app_server::lifecycle::InstanceTaskSet>,
     user_state_home: std::path::PathBuf,
     read_env: impl FnOnce(&str) -> Result<String, std::env::VarError>,
 ) -> bool {
@@ -297,7 +300,7 @@ fn spawn_runtime_refresh_with_env(
 }
 
 fn spawn_runtime_refresh_with_options(
-    tasks: &std::sync::Arc<super::lifecycle::InstanceTaskSet>,
+    tasks: &std::sync::Arc<crate::adapters::app_server::lifecycle::InstanceTaskSet>,
     options: CatalogRefreshOptions,
 ) -> bool {
     // Abandonment is safe: awaits only cover network/sleep work, while every
@@ -965,7 +968,7 @@ fn replace_file(temporary: &std::path::Path, path: &std::path::Path) -> std::io:
 ///
 /// Auth status and the active flag are not part of the entry: the RPC layer
 /// annotates them per request from the provider store and the live
-/// [`super::ActiveModelSelection`].
+/// [`crate::adapters::app_server::ActiveModelSelection`].
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct ModelCatalogEntry {
     pub(crate) provider_id: String,
@@ -1007,14 +1010,14 @@ impl ModelCatalogSource for StaticModelCatalog {
 
 #[cfg(test)]
 mod tests {
-    use super::ModelCatalogSource as _;
+    use crate::adapters::app_server::model_catalog::ModelCatalogSource as _;
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
     const FIRST_CHECK_SECS: u64 = 1_800_000_000;
 
     #[test]
     fn checked_in_snapshot_parses_and_carries_the_full_schema() {
-        let snapshot = super::built_in_snapshot();
+        let snapshot = crate::adapters::app_server::model_catalog::built_in_snapshot();
 
         assert!(!snapshot.models.is_empty());
         assert!(snapshot.providers.len() > 100);
@@ -1035,8 +1038,14 @@ mod tests {
             .find(|provider| provider.provider_id == "anthropic")
             .unwrap();
         assert_eq!(anthropic.base_url, "https://api.anthropic.com");
-        assert_eq!(anthropic.api, super::CATALOG_API_ANTHROPIC_MESSAGES);
-        assert_eq!(anthropic.auth_kind, super::CATALOG_AUTH_KIND_API_KEY);
+        assert_eq!(
+            anthropic.api,
+            crate::adapters::app_server::model_catalog::CATALOG_API_ANTHROPIC_MESSAGES
+        );
+        assert_eq!(
+            anthropic.auth_kind,
+            crate::adapters::app_server::model_catalog::CATALOG_AUTH_KIND_API_KEY
+        );
         assert!(
             anthropic
                 .env_vars
@@ -1048,7 +1057,10 @@ mod tests {
             .find(|provider| provider.provider_id == "openai")
             .unwrap();
         assert_eq!(openai.base_url, "https://api.openai.com/v1");
-        assert_eq!(openai.api, super::CATALOG_API_OPENAI_CHAT_COMPLETIONS);
+        assert_eq!(
+            openai.api,
+            crate::adapters::app_server::model_catalog::CATALOG_API_OPENAI_CHAT_COMPLETIONS
+        );
         let codex = snapshot
             .providers
             .iter()
@@ -1058,13 +1070,20 @@ mod tests {
             codex.base_url,
             verlet_metadata::provider_store::OPENAI_CODEX_RESPONSES_URL
         );
-        assert_eq!(codex.api, super::CATALOG_API_OPENAI_RESPONSES);
-        assert_eq!(codex.auth_kind, super::CATALOG_AUTH_KIND_OAUTH);
+        assert_eq!(
+            codex.api,
+            crate::adapters::app_server::model_catalog::CATALOG_API_OPENAI_RESPONSES
+        );
+        assert_eq!(
+            codex.auth_kind,
+            crate::adapters::app_server::model_catalog::CATALOG_AUTH_KIND_OAUTH
+        );
         assert!(
-            snapshot
-                .providers
-                .iter()
-                .all(|provider| super::valid_catalog_base_url(&provider.base_url)),
+            snapshot.providers.iter().all(|provider| {
+                crate::adapters::app_server::model_catalog::valid_catalog_base_url(
+                    &provider.base_url,
+                )
+            }),
             "the checked-in snapshot must not carry unusable or cleartext base URLs"
         );
         assert!(snapshot.models.iter().any(|model| {
@@ -1086,7 +1105,9 @@ mod tests {
             "verlet-model-catalog-offline-{}",
             uuid::Uuid::now_v7()
         ));
-        let offline_entries = super::MergedModelCatalog::new(offline_home).entries();
+        let offline_entries =
+            crate::adapters::app_server::model_catalog::MergedModelCatalog::new(offline_home)
+                .entries();
         assert_eq!(
             offline_entries.len(),
             snapshot
@@ -1107,8 +1128,10 @@ mod tests {
 
     #[test]
     fn models_dev_normalization_drops_unknown_fields_and_curates_codex_provider() {
-        let snapshot = super::normalize_models_dev_json(raw_models_dev_fixture().as_bytes())
-            .expect("fixture must normalize");
+        let snapshot = crate::adapters::app_server::model_catalog::normalize_models_dev_json(
+            raw_models_dev_fixture().as_bytes(),
+        )
+        .expect("fixture must normalize");
 
         assert_eq!(snapshot.models.len(), 9);
         assert!(snapshot.models.iter().any(|model| {
@@ -1156,8 +1179,10 @@ mod tests {
 
     #[test]
     fn models_dev_normalization_derives_the_full_provider_set() {
-        let snapshot = super::normalize_models_dev_json(raw_models_dev_fixture().as_bytes())
-            .expect("fixture must normalize");
+        let snapshot = crate::adapters::app_server::model_catalog::normalize_models_dev_json(
+            raw_models_dev_fixture().as_bytes(),
+        )
+        .expect("fixture must normalize");
         let provider = |id: &str| {
             snapshot
                 .providers
@@ -1168,8 +1193,14 @@ mod tests {
         let anthropic = provider("anthropic").expect("override row for anthropic");
         assert_eq!(anthropic.display_name, "Anthropic");
         assert_eq!(anthropic.base_url, "https://api.anthropic.com");
-        assert_eq!(anthropic.api, super::CATALOG_API_ANTHROPIC_MESSAGES);
-        assert_eq!(anthropic.auth_kind, super::CATALOG_AUTH_KIND_API_KEY);
+        assert_eq!(
+            anthropic.api,
+            crate::adapters::app_server::model_catalog::CATALOG_API_ANTHROPIC_MESSAGES
+        );
+        assert_eq!(
+            anthropic.auth_kind,
+            crate::adapters::app_server::model_catalog::CATALOG_AUTH_KIND_API_KEY
+        );
         assert_eq!(anthropic.env_vars, vec!["ANTHROPIC_API_KEY".to_string()]);
         assert_eq!(
             anthropic.doc_url.as_deref(),
@@ -1177,17 +1208,26 @@ mod tests {
         );
         let openai = provider("openai").expect("override row for openai");
         assert_eq!(openai.base_url, "https://api.openai.com/v1");
-        assert_eq!(openai.api, super::CATALOG_API_OPENAI_CHAT_COMPLETIONS);
+        assert_eq!(
+            openai.api,
+            crate::adapters::app_server::model_catalog::CATALOG_API_OPENAI_CHAT_COMPLETIONS
+        );
         let compat = provider("compat-fixture").expect("derived openai-compatible row");
         assert_eq!(compat.base_url, "https://compat.example.invalid/v1");
-        assert_eq!(compat.api, super::CATALOG_API_OPENAI_CHAT_COMPLETIONS);
+        assert_eq!(
+            compat.api,
+            crate::adapters::app_server::model_catalog::CATALOG_API_OPENAI_CHAT_COMPLETIONS
+        );
         let anthropic_compat =
             provider("anthropic-compat-fixture").expect("derived anthropic-sdk row");
         assert_eq!(
             anthropic_compat.base_url,
             "https://anthropic-compat.example.invalid/v1"
         );
-        assert_eq!(anthropic_compat.api, super::CATALOG_API_ANTHROPIC_MESSAGES);
+        assert_eq!(
+            anthropic_compat.api,
+            crate::adapters::app_server::model_catalog::CATALOG_API_ANTHROPIC_MESSAGES
+        );
         assert_eq!(anthropic_compat.display_name, "anthropic-compat-fixture");
         let deepseek = provider("deepseek").expect("override row for deepseek");
         assert_eq!(
@@ -1195,7 +1235,10 @@ mod tests {
             "the curated override must win over the upstream api URL"
         );
         let codex = provider("openai-codex").expect("static openai-codex row");
-        assert_eq!(codex.auth_kind, super::CATALOG_AUTH_KIND_OAUTH);
+        assert_eq!(
+            codex.auth_kind,
+            crate::adapters::app_server::model_catalog::CATALOG_AUTH_KIND_OAUTH
+        );
         assert!(
             provider("google").is_none(),
             "unsupported API families must be skipped"
@@ -1225,28 +1268,64 @@ mod tests {
 
     #[test]
     fn base_url_validation_requires_https_or_loopback_http() {
-        assert!(super::valid_catalog_base_url("https://api.example.com/v1"));
-        assert!(super::valid_catalog_base_url("http://localhost:1234/v1"));
-        assert!(super::valid_catalog_base_url("http://127.0.0.1/v1"));
-        assert!(super::valid_catalog_base_url("http://[::1]:8080/v1"));
-        assert!(!super::valid_catalog_base_url(
-            "http://cleartext.example.invalid/v1"
-        ));
-        assert!(!super::valid_catalog_base_url("${GATEWAY_BASE_URL}/v1"));
-        assert!(!super::valid_catalog_base_url("https://${HOST}/v1"));
-        assert!(!super::valid_catalog_base_url("ftp://example.com"));
-        assert!(!super::valid_catalog_base_url("https://"));
-        assert!(!super::valid_catalog_base_url("api.example.com/v1"));
+        assert!(
+            crate::adapters::app_server::model_catalog::valid_catalog_base_url(
+                "https://api.example.com/v1"
+            )
+        );
+        assert!(
+            crate::adapters::app_server::model_catalog::valid_catalog_base_url(
+                "http://localhost:1234/v1"
+            )
+        );
+        assert!(
+            crate::adapters::app_server::model_catalog::valid_catalog_base_url(
+                "http://127.0.0.1/v1"
+            )
+        );
+        assert!(
+            crate::adapters::app_server::model_catalog::valid_catalog_base_url(
+                "http://[::1]:8080/v1"
+            )
+        );
+        assert!(
+            !crate::adapters::app_server::model_catalog::valid_catalog_base_url(
+                "http://cleartext.example.invalid/v1"
+            )
+        );
+        assert!(
+            !crate::adapters::app_server::model_catalog::valid_catalog_base_url(
+                "${GATEWAY_BASE_URL}/v1"
+            )
+        );
+        assert!(
+            !crate::adapters::app_server::model_catalog::valid_catalog_base_url(
+                "https://${HOST}/v1"
+            )
+        );
+        assert!(
+            !crate::adapters::app_server::model_catalog::valid_catalog_base_url(
+                "ftp://example.com"
+            )
+        );
+        assert!(!crate::adapters::app_server::model_catalog::valid_catalog_base_url("https://"));
+        assert!(
+            !crate::adapters::app_server::model_catalog::valid_catalog_base_url(
+                "api.example.com/v1"
+            )
+        );
     }
 
     #[test]
     fn built_in_snapshot_keeps_every_provider_override_pinned() {
-        let providers = super::built_in_snapshot()
+        let providers = crate::adapters::app_server::model_catalog::built_in_snapshot()
             .providers
             .iter()
             .map(|provider| (provider.provider_id.as_str(), provider))
             .collect::<std::collections::BTreeMap<_, _>>();
-        for (provider_id, base_url, api) in super::PROVIDER_OVERRIDES {
+        for (provider_id, base_url, api) in
+            crate::adapters::app_server::model_catalog::PROVIDER_OVERRIDES
+        {
             let provider = providers
                 .get(provider_id)
                 .unwrap_or_else(|| panic!("built-in snapshot omitted override {provider_id}"));
@@ -1259,18 +1338,28 @@ mod tests {
     fn snapshot_rendering_is_byte_stable() {
         // Regeneration determinism: the same upstream bytes must produce the
         // same snapshot bytes, and re-rendering a parsed snapshot must too.
-        let first = super::render_snapshot_json(
-            &super::normalize_models_dev_json(raw_models_dev_fixture().as_bytes()).unwrap(),
+        let first = crate::adapters::app_server::model_catalog::render_snapshot_json(
+            &crate::adapters::app_server::model_catalog::normalize_models_dev_json(
+                raw_models_dev_fixture().as_bytes(),
+            )
+            .unwrap(),
         )
         .unwrap();
-        let second = super::render_snapshot_json(
-            &super::normalize_models_dev_json(raw_models_dev_fixture().as_bytes()).unwrap(),
+        let second = crate::adapters::app_server::model_catalog::render_snapshot_json(
+            &crate::adapters::app_server::model_catalog::normalize_models_dev_json(
+                raw_models_dev_fixture().as_bytes(),
+            )
+            .unwrap(),
         )
         .unwrap();
         assert_eq!(first, second);
-        let reparsed: super::ModelCatalogSnapshot = serde_json::from_slice(&first).unwrap();
+        let reparsed: crate::adapters::app_server::model_catalog::ModelCatalogSnapshot =
+            serde_json::from_slice(&first).unwrap();
         assert_eq!(
-            super::render_snapshot_json(&super::sanitize_snapshot(reparsed)).unwrap(),
+            crate::adapters::app_server::model_catalog::render_snapshot_json(
+                &crate::adapters::app_server::model_catalog::sanitize_snapshot(reparsed)
+            )
+            .unwrap(),
             first
         );
     }
@@ -1286,45 +1375,51 @@ mod tests {
             .expect("VERLET_MODEL_CATALOG_REGEN_OUTPUT must point at the snapshot to write");
         let bytes = std::fs::read(&input).expect("regeneration input must be readable");
         let mut snapshot =
-            super::normalize_models_dev_json(&bytes).expect("upstream payload must normalize");
+            crate::adapters::app_server::model_catalog::normalize_models_dev_json(&bytes)
+                .expect("upstream payload must normalize");
         snapshot.comment = Some(
             "Generated by scripts/update-model-catalog.sh from models.dev; do not edit by hand."
                 .to_string(),
         );
-        std::fs::write(&output, super::render_snapshot_json(&snapshot).unwrap())
-            .expect("regeneration output must be writable");
+        std::fs::write(
+            &output,
+            crate::adapters::app_server::model_catalog::render_snapshot_json(&snapshot).unwrap(),
+        )
+        .expect("regeneration output must be writable");
     }
 
     #[test]
     fn sanitization_normalizes_strings_limits_and_prices() {
-        let snapshot = super::sanitize_snapshot(super::ModelCatalogSnapshot {
-            comment: None,
-            providers: Vec::new(),
-            models: vec![
-                super::ModelCatalogModel {
-                    provider_id: " openai ".to_string(),
-                    model_id: " gpt-test ".to_string(),
-                    display_name: "   ".to_string(),
-                    context_window: Some(0),
-                    max_output_tokens: Some(42),
-                    input_price: Some(-1.0),
-                    output_price: Some(2.5),
-                    reasoning: false,
-                    deprecated: false,
-                },
-                super::ModelCatalogModel {
-                    provider_id: "openai-codex".to_string(),
-                    model_id: "gpt-uncurated".to_string(),
-                    display_name: "Must be dropped".to_string(),
-                    context_window: None,
-                    max_output_tokens: None,
-                    input_price: None,
-                    output_price: None,
-                    reasoning: false,
-                    deprecated: false,
-                },
-            ],
-        });
+        let snapshot = crate::adapters::app_server::model_catalog::sanitize_snapshot(
+            crate::adapters::app_server::model_catalog::ModelCatalogSnapshot {
+                comment: None,
+                providers: Vec::new(),
+                models: vec![
+                    crate::adapters::app_server::model_catalog::ModelCatalogModel {
+                        provider_id: " openai ".to_string(),
+                        model_id: " gpt-test ".to_string(),
+                        display_name: "   ".to_string(),
+                        context_window: Some(0),
+                        max_output_tokens: Some(42),
+                        input_price: Some(-1.0),
+                        output_price: Some(2.5),
+                        reasoning: false,
+                        deprecated: false,
+                    },
+                    crate::adapters::app_server::model_catalog::ModelCatalogModel {
+                        provider_id: "openai-codex".to_string(),
+                        model_id: "gpt-uncurated".to_string(),
+                        display_name: "Must be dropped".to_string(),
+                        context_window: None,
+                        max_output_tokens: None,
+                        input_price: None,
+                        output_price: None,
+                        reasoning: false,
+                        deprecated: false,
+                    },
+                ],
+            },
+        );
 
         assert_eq!(snapshot.models.len(), 1);
         let model = &snapshot.models[0];
@@ -1340,19 +1435,19 @@ mod tests {
     #[test]
     fn empty_and_garbage_upstream_payloads_are_rejected() {
         assert!(matches!(
-            super::normalize_models_dev_json(b"{}"),
-            Err(super::CatalogRefreshError::EmptyCatalog)
+            crate::adapters::app_server::model_catalog::normalize_models_dev_json(b"{}"),
+            Err(crate::adapters::app_server::model_catalog::CatalogRefreshError::EmptyCatalog)
         ));
         assert!(matches!(
-            super::normalize_models_dev_json(b"not json"),
-            Err(super::CatalogRefreshError::Json(_))
+            crate::adapters::app_server::model_catalog::normalize_models_dev_json(b"not json"),
+            Err(crate::adapters::app_server::model_catalog::CatalogRefreshError::Json(_))
         ));
     }
 
     #[test]
     fn cached_remote_overlays_builtin_by_provider_and_model() {
         let state_home = test_state_home("overlay");
-        let built_in = super::built_in_snapshot();
+        let built_in = crate::adapters::app_server::model_catalog::built_in_snapshot();
         let built_in_provider = built_in
             .providers
             .iter()
@@ -1363,24 +1458,24 @@ mod tests {
             .iter()
             .find(|model| model.provider_id == "anthropic")
             .unwrap();
-        let cached = super::ModelCatalogSnapshot {
+        let cached = crate::adapters::app_server::model_catalog::ModelCatalogSnapshot {
             comment: None,
             providers: vec![
-                super::ModelCatalogProvider {
+                crate::adapters::app_server::model_catalog::ModelCatalogProvider {
                     provider_id: "anthropic".to_string(),
                     display_name: "Remote Anthropic".to_string(),
                     base_url: "https://credential-redirect.example.invalid".to_string(),
-                    api: super::CATALOG_API_OPENAI_RESPONSES.to_string(),
-                    auth_kind: super::CATALOG_AUTH_KIND_OAUTH.to_string(),
+                    api: crate::adapters::app_server::model_catalog::CATALOG_API_OPENAI_RESPONSES.to_string(),
+                    auth_kind: crate::adapters::app_server::model_catalog::CATALOG_AUTH_KIND_OAUTH.to_string(),
                     env_vars: vec!["REMOTE_ANTHROPIC_API_KEY".to_string()],
                     doc_url: Some("https://remote-docs.example.invalid".to_string()),
                 },
-                super::ModelCatalogProvider {
+                crate::adapters::app_server::model_catalog::ModelCatalogProvider {
                     provider_id: "remote-only-provider".to_string(),
                     display_name: "Remote Only Provider".to_string(),
                     base_url: "https://remote-only.example.invalid/v1".to_string(),
-                    api: super::CATALOG_API_OPENAI_CHAT_COMPLETIONS.to_string(),
-                    auth_kind: super::CATALOG_AUTH_KIND_API_KEY.to_string(),
+                    api: crate::adapters::app_server::model_catalog::CATALOG_API_OPENAI_CHAT_COMPLETIONS.to_string(),
+                    auth_kind: crate::adapters::app_server::model_catalog::CATALOG_AUTH_KIND_API_KEY.to_string(),
                     env_vars: vec!["REMOTE_ONLY_API_KEY".to_string()],
                     doc_url: None,
                 },
@@ -1392,7 +1487,7 @@ mod tests {
                     .clone(),
             ],
             models: vec![
-                super::ModelCatalogModel {
+                crate::adapters::app_server::model_catalog::ModelCatalogModel {
                     provider_id: target.provider_id.clone(),
                     model_id: target.model_id.clone(),
                     display_name: "Remote replacement".to_string(),
@@ -1403,7 +1498,7 @@ mod tests {
                     reasoning: true,
                     deprecated: false,
                 },
-                super::ModelCatalogModel {
+                crate::adapters::app_server::model_catalog::ModelCatalogModel {
                     provider_id: "openai".to_string(),
                     model_id: "remote-only".to_string(),
                     display_name: "Remote only".to_string(),
@@ -1416,9 +1511,11 @@ mod tests {
                 },
             ],
         };
-        super::write_catalog_cache(&state_home, &cached).unwrap();
+        crate::adapters::app_server::model_catalog::write_catalog_cache(&state_home, &cached)
+            .unwrap();
 
-        let catalog = super::MergedModelCatalog::new(&state_home);
+        let catalog =
+            crate::adapters::app_server::model_catalog::MergedModelCatalog::new(&state_home);
         let providers = catalog.providers();
         let provider = providers
             .iter()
@@ -1478,15 +1575,22 @@ mod tests {
                 "deprecated": false
             }]
         });
-        std::fs::create_dir_all(state_home.join(super::CATALOG_CACHE_DIR)).unwrap();
+        std::fs::create_dir_all(
+            state_home.join(crate::adapters::app_server::model_catalog::CATALOG_CACHE_DIR),
+        )
+        .unwrap();
         std::fs::write(
-            super::catalog_cache_path(&state_home),
+            crate::adapters::app_server::model_catalog::catalog_cache_path(&state_home),
             old_format.to_string(),
         )
         .unwrap();
 
-        let catalog = super::MergedModelCatalog::new(&state_home);
-        assert_eq!(catalog.providers(), super::built_in_snapshot().providers);
+        let catalog =
+            crate::adapters::app_server::model_catalog::MergedModelCatalog::new(&state_home);
+        assert_eq!(
+            catalog.providers(),
+            crate::adapters::app_server::model_catalog::built_in_snapshot().providers
+        );
         assert!(catalog.entries().iter().any(
             |entry| entry.provider_id == "legacy-provider" && entry.model_id == "legacy-model"
         ));
@@ -1506,8 +1610,8 @@ mod tests {
         .await;
         let expected_url = server.url.clone();
         let mut options =
-            super::CatalogRefreshOptions::for_runtime_with_env(state_home.clone(), move |name| {
-                assert_eq!(name, super::MODEL_CATALOG_URL_ENV);
+            crate::adapters::app_server::model_catalog::CatalogRefreshOptions::for_runtime_with_env(state_home.clone(), move |name| {
+                assert_eq!(name, crate::adapters::app_server::model_catalog::MODEL_CATALOG_URL_ENV);
                 Ok(expected_url)
             })
             .expect("fixture URL enables refresh");
@@ -1516,36 +1620,53 @@ mod tests {
         assert_eq!(options.url, server.url);
 
         assert_eq!(
-            super::refresh_catalog(&options).await.unwrap(),
-            super::CatalogRefreshOutcome::Updated
+            crate::adapters::app_server::model_catalog::refresh_catalog(&options)
+                .await
+                .unwrap(),
+            crate::adapters::app_server::model_catalog::CatalogRefreshOutcome::Updated
         );
-        let original_cache = std::fs::read(super::catalog_cache_path(&state_home)).unwrap();
-        let original_modified = std::fs::metadata(super::catalog_cache_path(&state_home))
-            .unwrap()
-            .modified()
-            .unwrap();
+        let original_cache = std::fs::read(
+            crate::adapters::app_server::model_catalog::catalog_cache_path(&state_home),
+        )
+        .unwrap();
+        let original_modified = std::fs::metadata(
+            crate::adapters::app_server::model_catalog::catalog_cache_path(&state_home),
+        )
+        .unwrap()
+        .modified()
+        .unwrap();
 
         options.now_unix_secs = FIRST_CHECK_SECS + 60;
         assert_eq!(
-            super::refresh_catalog(&options).await.unwrap(),
-            super::CatalogRefreshOutcome::SkippedFresh
+            crate::adapters::app_server::model_catalog::refresh_catalog(&options)
+                .await
+                .unwrap(),
+            crate::adapters::app_server::model_catalog::CatalogRefreshOutcome::SkippedFresh
         );
 
-        options.now_unix_secs = FIRST_CHECK_SECS + super::REFRESH_INTERVAL_SECS;
+        options.now_unix_secs =
+            FIRST_CHECK_SECS + crate::adapters::app_server::model_catalog::REFRESH_INTERVAL_SECS;
         assert_eq!(
-            super::refresh_catalog(&options).await.unwrap(),
-            super::CatalogRefreshOutcome::NotModified
+            crate::adapters::app_server::model_catalog::refresh_catalog(&options)
+                .await
+                .unwrap(),
+            crate::adapters::app_server::model_catalog::CatalogRefreshOutcome::NotModified
         );
         assert_eq!(
-            std::fs::read(super::catalog_cache_path(&state_home)).unwrap(),
+            std::fs::read(
+                crate::adapters::app_server::model_catalog::catalog_cache_path(&state_home)
+            )
+            .unwrap(),
             original_cache,
             "304 must not rewrite the catalog cache"
         );
         assert_eq!(
-            std::fs::metadata(super::catalog_cache_path(&state_home))
-                .unwrap()
-                .modified()
-                .unwrap(),
+            std::fs::metadata(
+                crate::adapters::app_server::model_catalog::catalog_cache_path(&state_home)
+            )
+            .unwrap()
+            .modified()
+            .unwrap(),
             original_modified,
             "304 must leave catalog cache metadata untouched"
         );
@@ -1554,7 +1675,9 @@ mod tests {
         assert_eq!(requests.len(), 2, "fresh refresh state must skip the GET");
         assert!(requests[1].contains("if-none-match: \"catalog-v1\""));
         assert!(requests[1].contains("if-modified-since: sun, 09 aug 2026 20:00:00 gmt"));
-        let state = super::read_refresh_state(&state_home).unwrap().unwrap();
+        let state = crate::adapters::app_server::model_catalog::read_refresh_state(&state_home)
+            .unwrap()
+            .unwrap();
         assert_eq!(state.checked_at_unix_secs, options.now_unix_secs);
 
         remove_test_state_home(&state_home);
@@ -1563,10 +1686,11 @@ mod tests {
     #[tokio::test]
     async fn refresh_does_not_send_validators_without_a_usable_cache() {
         let state_home = test_state_home("validator-without-cache");
-        super::write_refresh_state(
+        crate::adapters::app_server::model_catalog::write_refresh_state(
             &state_home,
-            &super::CatalogRefreshState {
-                checked_at_unix_secs: FIRST_CHECK_SECS - super::REFRESH_INTERVAL_SECS,
+            &crate::adapters::app_server::model_catalog::CatalogRefreshState {
+                checked_at_unix_secs: FIRST_CHECK_SECS
+                    - crate::adapters::app_server::model_catalog::REFRESH_INTERVAL_SECS,
                 etag: Some("\"orphaned-etag\"".to_string()),
                 last_modified: Some("Sun, 09 Aug 2026 20:00:00 GMT".to_string()),
             },
@@ -1574,21 +1698,25 @@ mod tests {
         .unwrap();
         let server =
             FixtureServer::start(vec![FixtureResponse::ok(raw_models_dev_fixture())]).await;
-        let options = super::CatalogRefreshOptions::for_test(
+        let options = crate::adapters::app_server::model_catalog::CatalogRefreshOptions::for_test(
             state_home.clone(),
             server.url.clone(),
             FIRST_CHECK_SECS,
         );
 
         assert_eq!(
-            super::refresh_catalog(&options).await.unwrap(),
-            super::CatalogRefreshOutcome::Updated
+            crate::adapters::app_server::model_catalog::refresh_catalog(&options)
+                .await
+                .unwrap(),
+            crate::adapters::app_server::model_catalog::CatalogRefreshOutcome::Updated
         );
         let requests = server.finish().await;
         assert_eq!(requests.len(), 1);
         assert!(!requests[0].contains("if-none-match:"));
         assert!(!requests[0].contains("if-modified-since:"));
-        assert!(super::catalog_cache_path(&state_home).is_file());
+        assert!(
+            crate::adapters::app_server::model_catalog::catalog_cache_path(&state_home).is_file()
+        );
 
         remove_test_state_home(&state_home);
     }
@@ -1602,19 +1730,24 @@ mod tests {
             FixtureResponse::ok(raw_models_dev_fixture()),
         ])
         .await;
-        let mut options = super::CatalogRefreshOptions::for_test(
-            state_home.clone(),
-            server.url.clone(),
-            FIRST_CHECK_SECS,
-        );
+        let mut options =
+            crate::adapters::app_server::model_catalog::CatalogRefreshOptions::for_test(
+                state_home.clone(),
+                server.url.clone(),
+                FIRST_CHECK_SECS,
+            );
         options.retry_delays = vec![std::time::Duration::ZERO, std::time::Duration::ZERO];
 
         assert_eq!(
-            super::refresh_catalog(&options).await.unwrap(),
-            super::CatalogRefreshOutcome::Updated
+            crate::adapters::app_server::model_catalog::refresh_catalog(&options)
+                .await
+                .unwrap(),
+            crate::adapters::app_server::model_catalog::CatalogRefreshOutcome::Updated
         );
         assert_eq!(server.finish().await.len(), 3);
-        assert!(super::catalog_cache_path(&state_home).is_file());
+        assert!(
+            crate::adapters::app_server::model_catalog::catalog_cache_path(&state_home).is_file()
+        );
 
         remove_test_state_home(&state_home);
     }
@@ -1623,19 +1756,26 @@ mod tests {
     async fn fetch_rejects_oversized_responses_before_reading_the_body() {
         let state_home = test_state_home("oversized");
         let server = FixtureServer::start(vec![
-            FixtureResponse::ok(String::new()).with_declared_length(super::MAX_REMOTE_BYTES + 1),
+            FixtureResponse::ok(String::new()).with_declared_length(
+                crate::adapters::app_server::model_catalog::MAX_REMOTE_BYTES + 1,
+            ),
         ])
         .await;
-        let mut options = super::CatalogRefreshOptions::for_test(
-            state_home.clone(),
-            server.url.clone(),
-            FIRST_CHECK_SECS,
-        );
+        let mut options =
+            crate::adapters::app_server::model_catalog::CatalogRefreshOptions::for_test(
+                state_home.clone(),
+                server.url.clone(),
+                FIRST_CHECK_SECS,
+            );
         options.retry_delays.clear();
 
         assert!(matches!(
-            super::fetch_catalog(&options, &super::CatalogRefreshState::default()).await,
-            Err(super::CatalogRefreshError::ResponseTooLarge)
+            crate::adapters::app_server::model_catalog::fetch_catalog(
+                &options,
+                &crate::adapters::app_server::model_catalog::CatalogRefreshState::default()
+            )
+            .await,
+            Err(crate::adapters::app_server::model_catalog::CatalogRefreshError::ResponseTooLarge)
         ));
         assert_eq!(server.finish().await.len(), 1);
 
@@ -1646,17 +1786,23 @@ mod tests {
     async fn fetch_does_not_retry_non_retryable_http_statuses() {
         let state_home = test_state_home("http-status");
         let server = FixtureServer::start(vec![FixtureResponse::status("400 Bad Request")]).await;
-        let options = super::CatalogRefreshOptions::for_test(
+        let options = crate::adapters::app_server::model_catalog::CatalogRefreshOptions::for_test(
             state_home.clone(),
             server.url.clone(),
             FIRST_CHECK_SECS,
         );
 
         assert!(matches!(
-            super::fetch_catalog(&options, &super::CatalogRefreshState::default()).await,
-            Err(super::CatalogRefreshError::HttpStatus(
-                reqwest::StatusCode::BAD_REQUEST
-            ))
+            crate::adapters::app_server::model_catalog::fetch_catalog(
+                &options,
+                &crate::adapters::app_server::model_catalog::CatalogRefreshState::default()
+            )
+            .await,
+            Err(
+                crate::adapters::app_server::model_catalog::CatalogRefreshError::HttpStatus(
+                    reqwest::StatusCode::BAD_REQUEST
+                )
+            )
         ));
         assert_eq!(server.finish().await.len(), 1);
 
@@ -1673,13 +1819,21 @@ mod tests {
             std::future::pending::<()>().await;
         });
         let mut options =
-            super::CatalogRefreshOptions::for_test(state_home.clone(), url, FIRST_CHECK_SECS);
+            crate::adapters::app_server::model_catalog::CatalogRefreshOptions::for_test(
+                state_home.clone(),
+                url,
+                FIRST_CHECK_SECS,
+            );
         options.request_timeout = std::time::Duration::from_millis(50);
         options.retry_delays.clear();
 
         assert!(matches!(
-            super::fetch_catalog(&options, &super::CatalogRefreshState::default()).await,
-            Err(super::CatalogRefreshError::Request)
+            crate::adapters::app_server::model_catalog::fetch_catalog(
+                &options,
+                &crate::adapters::app_server::model_catalog::CatalogRefreshState::default()
+            )
+            .await,
+            Err(crate::adapters::app_server::model_catalog::CatalogRefreshError::Request)
         ));
 
         server.abort();
@@ -1690,56 +1844,72 @@ mod tests {
     #[tokio::test]
     async fn failed_refresh_keeps_cached_remote_available_and_records_the_attempt() {
         let state_home = test_state_home("fallback");
-        let cached = super::ModelCatalogSnapshot {
+        let cached = crate::adapters::app_server::model_catalog::ModelCatalogSnapshot {
             comment: None,
             providers: Vec::new(),
-            models: vec![super::ModelCatalogModel {
-                provider_id: "openai".to_string(),
-                model_id: "cached-model".to_string(),
-                display_name: "Cached model".to_string(),
-                context_window: Some(1_024),
-                max_output_tokens: Some(128),
-                input_price: Some(1.0),
-                output_price: Some(2.0),
-                reasoning: false,
-                deprecated: false,
-            }],
+            models: vec![
+                crate::adapters::app_server::model_catalog::ModelCatalogModel {
+                    provider_id: "openai".to_string(),
+                    model_id: "cached-model".to_string(),
+                    display_name: "Cached model".to_string(),
+                    context_window: Some(1_024),
+                    max_output_tokens: Some(128),
+                    input_price: Some(1.0),
+                    output_price: Some(2.0),
+                    reasoning: false,
+                    deprecated: false,
+                },
+            ],
         };
-        super::write_catalog_cache(&state_home, &cached).unwrap();
-        let cache_before = std::fs::read(super::catalog_cache_path(&state_home)).unwrap();
+        crate::adapters::app_server::model_catalog::write_catalog_cache(&state_home, &cached)
+            .unwrap();
+        let cache_before = std::fs::read(
+            crate::adapters::app_server::model_catalog::catalog_cache_path(&state_home),
+        )
+        .unwrap();
         let server = FixtureServer::start(vec![
             FixtureResponse::status("500 Internal Server Error"),
             FixtureResponse::status("500 Internal Server Error"),
             FixtureResponse::status("500 Internal Server Error"),
         ])
         .await;
-        let mut options = super::CatalogRefreshOptions::for_test(
-            state_home.clone(),
-            server.url.clone(),
-            FIRST_CHECK_SECS,
-        );
+        let mut options =
+            crate::adapters::app_server::model_catalog::CatalogRefreshOptions::for_test(
+                state_home.clone(),
+                server.url.clone(),
+                FIRST_CHECK_SECS,
+            );
         options.retry_delays = vec![std::time::Duration::ZERO, std::time::Duration::ZERO];
 
-        assert!(super::refresh_catalog(&options).await.is_err());
+        assert!(
+            crate::adapters::app_server::model_catalog::refresh_catalog(&options)
+                .await
+                .is_err()
+        );
         assert_eq!(server.finish().await.len(), 3);
         options.now_unix_secs = FIRST_CHECK_SECS + 60;
         assert_eq!(
-            super::refresh_catalog(&options).await.unwrap(),
-            super::CatalogRefreshOutcome::SkippedFresh,
+            crate::adapters::app_server::model_catalog::refresh_catalog(&options)
+                .await
+                .unwrap(),
+            crate::adapters::app_server::model_catalog::CatalogRefreshOutcome::SkippedFresh,
             "a failed attempt must still enforce the 24-hour cap"
         );
         assert_eq!(
-            std::fs::read(super::catalog_cache_path(&state_home)).unwrap(),
+            std::fs::read(
+                crate::adapters::app_server::model_catalog::catalog_cache_path(&state_home)
+            )
+            .unwrap(),
             cache_before
         );
         assert!(
-            super::MergedModelCatalog::new(&state_home)
+            crate::adapters::app_server::model_catalog::MergedModelCatalog::new(&state_home)
                 .full_entries()
                 .iter()
                 .any(|model| model.model_id == "cached-model")
         );
         assert_eq!(
-            super::read_refresh_state(&state_home)
+            crate::adapters::app_server::model_catalog::read_refresh_state(&state_home)
                 .unwrap()
                 .unwrap()
                 .checked_at_unix_secs,
@@ -1752,29 +1922,46 @@ mod tests {
     #[test]
     fn empty_runtime_url_disables_refresh_scheduling() {
         let state_home = test_state_home("disabled");
-        let tasks = std::sync::Arc::new(super::super::lifecycle::InstanceTaskSet::new());
+        let tasks =
+            std::sync::Arc::new(crate::adapters::app_server::lifecycle::InstanceTaskSet::new());
 
-        let scheduled = super::spawn_runtime_refresh_with_env(&tasks, state_home.clone(), |name| {
-            assert_eq!(name, super::MODEL_CATALOG_URL_ENV);
-            Ok(" \t ".to_string())
-        });
+        let scheduled = crate::adapters::app_server::model_catalog::spawn_runtime_refresh_with_env(
+            &tasks,
+            state_home.clone(),
+            |name| {
+                assert_eq!(
+                    name,
+                    crate::adapters::app_server::model_catalog::MODEL_CATALOG_URL_ENV
+                );
+                Ok(" \t ".to_string())
+            },
+        );
 
         assert!(!scheduled);
         assert_eq!(tasks.task_count(), 0);
-        assert!(!state_home.join(super::CATALOG_CACHE_DIR).exists());
+        assert!(
+            !state_home
+                .join(crate::adapters::app_server::model_catalog::CATALOG_CACHE_DIR)
+                .exists()
+        );
         remove_test_state_home(&state_home);
     }
 
     #[test]
     fn non_unicode_runtime_url_disables_refresh_scheduling() {
         let state_home = test_state_home("non-unicode-url");
-        let tasks = std::sync::Arc::new(super::super::lifecycle::InstanceTaskSet::new());
+        let tasks =
+            std::sync::Arc::new(crate::adapters::app_server::lifecycle::InstanceTaskSet::new());
 
-        let scheduled = super::spawn_runtime_refresh_with_env(&tasks, state_home.clone(), |_| {
-            Err(std::env::VarError::NotUnicode(std::ffi::OsString::from(
-                "configured-but-invalid",
-            )))
-        });
+        let scheduled = crate::adapters::app_server::model_catalog::spawn_runtime_refresh_with_env(
+            &tasks,
+            state_home.clone(),
+            |_| {
+                Err(std::env::VarError::NotUnicode(std::ffi::OsString::from(
+                    "configured-but-invalid",
+                )))
+            },
+        );
 
         assert!(!scheduled);
         assert_eq!(tasks.task_count(), 0);
@@ -1792,12 +1979,21 @@ mod tests {
             let _ = accepted_tx.send(());
             std::future::pending::<()>().await;
         });
-        let tasks = std::sync::Arc::new(super::super::lifecycle::InstanceTaskSet::new());
+        let tasks =
+            std::sync::Arc::new(crate::adapters::app_server::lifecycle::InstanceTaskSet::new());
         let mut options =
-            super::CatalogRefreshOptions::for_test(state_home.clone(), url, FIRST_CHECK_SECS);
+            crate::adapters::app_server::model_catalog::CatalogRefreshOptions::for_test(
+                state_home.clone(),
+                url,
+                FIRST_CHECK_SECS,
+            );
         options.request_timeout = std::time::Duration::from_secs(30);
 
-        assert!(super::spawn_runtime_refresh_with_options(&tasks, options));
+        assert!(
+            crate::adapters::app_server::model_catalog::spawn_runtime_refresh_with_options(
+                &tasks, options
+            )
+        );
         accepted_rx.await.unwrap();
         // tight-timeout: cancellation must not wait for the pending HTTP timeout
         tokio::time::timeout(std::time::Duration::from_secs(1), tasks.shutdown())
@@ -1806,7 +2002,11 @@ mod tests {
 
         server.abort();
         let _ = server.await;
-        assert!(!state_home.join(super::CATALOG_CACHE_DIR).exists());
+        assert!(
+            !state_home
+                .join(crate::adapters::app_server::model_catalog::CATALOG_CACHE_DIR)
+                .exists()
+        );
         remove_test_state_home(&state_home);
     }
 
@@ -1816,12 +2016,18 @@ mod tests {
         let target = state_home.join("target.json");
         std::fs::write(&target, b"old contents").unwrap();
 
-        super::atomic_write(&target, b"new contents").unwrap();
+        crate::adapters::app_server::model_catalog::atomic_write(&target, b"new contents").unwrap();
         assert_eq!(std::fs::read(&target).unwrap(), b"new contents");
 
         let directory_target = state_home.join("directory-target");
         std::fs::create_dir(&directory_target).unwrap();
-        assert!(super::atomic_write(&directory_target, b"cannot replace a directory").is_err());
+        assert!(
+            crate::adapters::app_server::model_catalog::atomic_write(
+                &directory_target,
+                b"cannot replace a directory"
+            )
+            .is_err()
+        );
         let leftovers = std::fs::read_dir(&state_home)
             .unwrap()
             .filter_map(Result::ok)

--- a/crates/verlet-kernel/src/adapters/app_server/orchestrator_boundary.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/orchestrator_boundary.rs
@@ -11,53 +11,53 @@ use verlet_history::EventStore as _;
 /// `client:` followed by one or more `[a-z0-9][a-z0-9-]*` segments joined
 /// by `:`. Recovery and ingress sweeps skip this prefix exactly as they
 /// skip `sync-ingress:`.
-pub(super) const CLIENT_STREAM_PREFIX: &str = "client:";
+pub(crate) const CLIENT_STREAM_PREFIX: &str = "client:";
 
 /// Payload-schema cohort reserved to the kernel; `stream/append` rejects
 /// declared schema ids in it so client cohorts can never collide.
-pub(super) const RESERVED_SCHEMA_COHORT_PREFIX: &str = "cooldis.";
+pub(crate) const RESERVED_SCHEMA_COHORT_PREFIX: &str = "cooldis.";
 
 /// Turn-entry surface name `ingress/submit` registers in
 /// `TURN_ENTRY_SURFACES` (admission coverage ratchet).
-pub(super) const ENVELOPE_INGRESS_SURFACE: &str =
+pub(crate) const ENVELOPE_INGRESS_SURFACE: &str =
     crate::kernel::admission::APP_SERVER_ENVELOPE_INGRESS_SURFACE;
 
-pub(super) const CLIENT_STREAM_THREAD_NAMESPACE: &str = "530827e2-57cf-405e-9ca7-bb08b18c1ab0";
+pub(crate) const CLIENT_STREAM_THREAD_NAMESPACE: &str = "530827e2-57cf-405e-9ca7-bb08b18c1ab0";
 
 // ---------------------------------------------------------------------------
 // ingress/submit
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct IngressSubmitParams {
-    pub(super) thread_id: String,
-    pub(super) input: serde_json::Value,
-    pub(super) delivery: IngressSubmitDelivery,
+pub(crate) struct IngressSubmitParams {
+    pub(crate) thread_id: String,
+    pub(crate) input: serde_json::Value,
+    pub(crate) delivery: IngressSubmitDelivery,
     #[serde(default)]
-    pub(super) dedupe_key: Option<IngressSubmitDedupeKey>,
+    pub(crate) dedupe_key: Option<IngressSubmitDedupeKey>,
     #[serde(default)]
-    pub(super) correlation_id: Option<String>,
+    pub(crate) correlation_id: Option<String>,
     /// `"attested"` (default). `"recorded"` is reserved for the
     /// foreign-harness lane and rejected until that lane exists.
     #[serde(default)]
-    pub(super) tier: Option<String>,
+    pub(crate) tier: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct IngressSubmitDelivery {
-    pub(super) delivery_id: String,
+pub(crate) struct IngressSubmitDelivery {
+    pub(crate) delivery_id: String,
     #[serde(default)]
-    pub(super) attempt: Option<u32>,
+    pub(crate) attempt: Option<u32>,
     #[serde(default)]
-    pub(super) metadata: std::collections::BTreeMap<String, String>,
+    pub(crate) metadata: std::collections::BTreeMap<String, String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct IngressSubmitDedupeKey {
-    pub(super) scope: String,
-    pub(super) key: String,
+pub(crate) struct IngressSubmitDedupeKey {
+    pub(crate) scope: String,
+    pub(crate) key: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -65,27 +65,27 @@ pub(super) struct IngressSubmitDedupeKey {
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct StreamAppendParams {
-    pub(super) stream: String,
-    pub(super) records: Vec<StreamAppendRecord>,
+pub(crate) struct StreamAppendParams {
+    pub(crate) stream: String,
+    pub(crate) records: Vec<StreamAppendRecord>,
     /// Optional fence: the append succeeds only if the stream's next
     /// sequence equals this value (compare-and-set for writers; the
     /// orchestrator's placement lease fence rides on it). Uses the store's
     /// fenced append; a stale expectation fails closed with error data
     /// `{ "expected": …, "actual": … }`.
     #[serde(default)]
-    pub(super) expected_sequence: Option<u64>,
+    pub(crate) expected_sequence: Option<u64>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct StreamAppendRecord {
+pub(crate) struct StreamAppendRecord {
     /// Lowercase dotted lifecycle name, `[a-z]+(\.[a-z_]+)+`.
-    pub(super) kind: String,
+    pub(crate) kind: String,
     /// Declared client cohort id, `[a-z][a-z0-9.-]*/[0-9]+`, not in the
     /// reserved kernel cohort. Recorded, not interpreted.
-    pub(super) payload_schema: String,
-    pub(super) payload: serde_json::Value,
+    pub(crate) payload_schema: String,
+    pub(crate) payload: serde_json::Value,
 }
 
 // ---------------------------------------------------------------------------
@@ -93,22 +93,22 @@ pub(super) struct StreamAppendRecord {
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct StreamReadParams {
-    pub(super) stream: String,
+pub(crate) struct StreamReadParams {
+    pub(crate) stream: String,
     #[serde(default)]
-    pub(super) stream_cursor: Option<verlet_history::StreamCursorV1>,
+    pub(crate) stream_cursor: Option<verlet_history::StreamCursorV1>,
     /// 1..=500, default 100 (same clamp as `thread/events/list`).
     #[serde(default)]
-    pub(super) limit: Option<usize>,
+    pub(crate) limit: Option<usize>,
     #[serde(default)]
-    pub(super) kinds: Vec<String>,
+    pub(crate) kinds: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
 // Validation (normative rules from ADR 0009; pure, unit-testable)
 
 /// Accepts `client:<name>` per the ADR grammar, rejects everything else.
-pub(super) fn validate_client_stream_id(
+pub(crate) fn validate_client_stream_id(
     stream: &str,
 ) -> Result<(), crate::adapters::app_server::connection::JsonRpcErrorError> {
     let Some(name) = stream.strip_prefix(CLIENT_STREAM_PREFIX) else {
@@ -136,7 +136,7 @@ pub(super) fn validate_client_stream_id(
 }
 
 /// Kind grammar + declared-schema grammar + reserved-cohort rejection.
-pub(super) fn validate_append_record(
+pub(crate) fn validate_append_record(
     record: &StreamAppendRecord,
 ) -> Result<(), crate::adapters::app_server::connection::JsonRpcErrorError> {
     let kind_segments = record.kind.split('.').collect::<Vec<_>>();
@@ -197,7 +197,7 @@ pub(super) fn validate_append_record(
 
 /// `"attested"` or absent passes; `"recorded"` and anything else rejects
 /// with a validation error naming the reserved lane.
-pub(super) fn validate_tier(
+pub(crate) fn validate_tier(
     tier: Option<&str>,
 ) -> Result<(), crate::adapters::app_server::connection::JsonRpcErrorError> {
     match tier {
@@ -223,7 +223,7 @@ impl crate::adapters::app_server::VerletAppServer {
     /// scheduling, dedupe on the effective key (duplicates return the
     /// original ingress event id with `deduped: true` and schedule
     /// nothing). Result per ADR 0009.
-    pub(super) async fn ingress_submit(
+    pub(crate) async fn ingress_submit(
         &self,
         connection: &crate::adapters::app_server::connection::ConnectionState,
         params: IngressSubmitParams,
@@ -408,7 +408,7 @@ impl crate::adapters::app_server::VerletAppServer {
     /// witnessed records (coordinates: thread_id = UUIDv5 of the full stream
     /// id, tenant from session identity; principal stamped). Fenced when
     /// `expected_sequence` is present. Host-effect witnessed.
-    pub(super) async fn stream_append(
+    pub(crate) async fn stream_append(
         &self,
         connection: &crate::adapters::app_server::connection::ConnectionState,
         params: StreamAppendParams,
@@ -505,7 +505,7 @@ impl crate::adapters::app_server::VerletAppServer {
 
     /// `stream/read`: client streams only; paging/cursor/kinds semantics
     /// mirror `thread/events/list`.
-    pub(super) async fn stream_read(
+    pub(crate) async fn stream_read(
         &self,
         _connection: &crate::adapters::app_server::connection::ConnectionState,
         params: StreamReadParams,

--- a/crates/verlet-kernel/src/adapters/app_server/subscriptions.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/subscriptions.rs
@@ -2,25 +2,25 @@ const INITIAL_THREAD_STATUS_WAIT_TIMEOUT: std::time::Duration = std::time::Durat
 const FAILED_THREAD_EVENT_GRACE: std::time::Duration = std::time::Duration::from_millis(20);
 
 #[derive(Default)]
-pub(super) struct AppServerSubscriptions {
-    pub(super) next_subscriber_id: u64,
-    pub(super) next_watcher_id: u64,
-    pub(super) subscribers:
+pub(crate) struct AppServerSubscriptions {
+    pub(crate) next_subscriber_id: u64,
+    pub(crate) next_watcher_id: u64,
+    pub(crate) subscribers:
         std::collections::HashMap<String, std::collections::BTreeMap<u64, AppServerSubscriber>>,
-    pub(super) watchers: std::collections::HashMap<String, AppServerThreadWatcher>,
+    pub(crate) watchers: std::collections::HashMap<String, AppServerThreadWatcher>,
 }
 
 #[derive(Clone)]
-pub(super) struct AppServerSubscriber {
-    pub(super) outbound:
+pub(crate) struct AppServerSubscriber {
+    pub(crate) outbound:
         tokio::sync::mpsc::UnboundedSender<crate::adapters::app_server::connection::JsonRpcMessage>,
-    pub(super) opt_out_notifications:
+    pub(crate) opt_out_notifications:
         std::sync::Arc<tokio::sync::RwLock<std::collections::HashSet<String>>>,
 }
 
-pub(super) struct AppServerThreadWatcher {
-    pub(super) id: u64,
-    pub(super) cancellation: tokio_util::sync::CancellationToken,
+pub(crate) struct AppServerThreadWatcher {
+    pub(crate) id: u64,
+    pub(crate) cancellation: tokio_util::sync::CancellationToken,
 }
 
 enum ResyncedTurnItem {
@@ -46,24 +46,24 @@ struct ResyncedTurnFacts {
 
 #[cfg(test)]
 #[derive(Clone)]
-pub(super) struct ThreadResyncTestGate {
+pub(crate) struct ThreadResyncTestGate {
     entered: std::sync::Arc<tokio::sync::Notify>,
     release: std::sync::Arc<tokio::sync::Notify>,
 }
 
 #[cfg(test)]
 impl ThreadResyncTestGate {
-    pub(super) async fn wait_until_entered(&self) {
+    pub(crate) async fn wait_until_entered(&self) {
         self.entered.notified().await;
     }
 
-    pub(super) fn release(&self) {
+    pub(crate) fn release(&self) {
         self.release.notify_one();
     }
 }
 
 #[cfg(test)]
-pub(super) fn install_thread_resync_test_gate(thread_id: &str) -> ThreadResyncTestGate {
+pub(crate) fn install_thread_resync_test_gate(thread_id: &str) -> ThreadResyncTestGate {
     let gate = ThreadResyncTestGate {
         entered: std::sync::Arc::new(tokio::sync::Notify::new()),
         release: std::sync::Arc::new(tokio::sync::Notify::new()),
@@ -103,7 +103,7 @@ async fn pause_thread_resync_for_test(thread_id: &str) {
 }
 
 impl crate::adapters::app_server::VerletAppServer {
-    pub(super) async fn subscribe_thread_connection(
+    pub(crate) async fn subscribe_thread_connection(
         &self,
         handle: crate::kernel::runtime_host::RuntimeThreadHandle,
         subscriber: AppServerSubscriber,
@@ -147,7 +147,7 @@ impl crate::adapters::app_server::VerletAppServer {
         subscriber_id
     }
 
-    pub(super) async fn unsubscribe_thread_connection(&self, thread_id: &str, subscriber_id: u64) {
+    pub(crate) async fn unsubscribe_thread_connection(&self, thread_id: &str, subscriber_id: u64) {
         let thread_has_active_turn = self.thread_has_active_turn(thread_id).await;
         let watcher = {
             let mut subscriptions = self.inner.subscriptions.lock().await;
@@ -175,7 +175,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }
     }
 
-    pub(super) async fn finish_thread_watcher(&self, thread_id: &str, watcher_id: u64) {
+    pub(crate) async fn finish_thread_watcher(&self, thread_id: &str, watcher_id: u64) {
         let mut subscriptions = self.inner.subscriptions.lock().await;
         if subscriptions
             .watchers
@@ -186,7 +186,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }
     }
 
-    pub(super) async fn thread_has_active_turn(&self, thread_id: &str) -> bool {
+    pub(crate) async fn thread_has_active_turn(&self, thread_id: &str) -> bool {
         let state = self.inner.state.read().await;
         state
             .threads
@@ -194,7 +194,7 @@ impl crate::adapters::app_server::VerletAppServer {
             .is_some_and(|thread| thread.active_turn_id.is_some())
     }
 
-    pub(super) async fn abort_thread_watcher_if_idle_and_unsubscribed(&self, thread_id: &str) {
+    pub(crate) async fn abort_thread_watcher_if_idle_and_unsubscribed(&self, thread_id: &str) {
         if self.thread_has_active_turn(thread_id).await {
             return;
         }
@@ -215,7 +215,7 @@ impl crate::adapters::app_server::VerletAppServer {
         }
     }
 
-    pub(super) async fn notify_thread_subscribers(
+    pub(crate) async fn notify_thread_subscribers(
         &self,
         thread_id: &str,
         method: &str,
@@ -236,7 +236,7 @@ impl crate::adapters::app_server::VerletAppServer {
 }
 
 impl AppServerSubscriber {
-    pub(super) async fn notify(&self, method: &str, params: serde_json::Value) {
+    pub(crate) async fn notify(&self, method: &str, params: serde_json::Value) {
         if self.opt_out_notifications.read().await.contains(method) {
             return;
         }
@@ -251,7 +251,7 @@ impl AppServerSubscriber {
     }
 }
 
-pub(super) async fn watch_thread(
+pub(crate) async fn watch_thread(
     app: crate::adapters::app_server::VerletAppServer,
     handle: crate::kernel::runtime_host::RuntimeThreadHandle,
     cancellation: tokio_util::sync::CancellationToken,
@@ -408,7 +408,7 @@ pub(super) async fn watch_thread(
     }
 }
 
-pub(super) async fn resynchronize_thread_after_lag(
+pub(crate) async fn resynchronize_thread_after_lag(
     app: &crate::adapters::app_server::VerletAppServer,
     handle: &crate::kernel::runtime_host::RuntimeThreadHandle,
     thread_id: &str,
@@ -823,7 +823,7 @@ fn apply_resynced_turn_projection(
     turn.thinking_completed = false;
 }
 
-pub(super) async fn wait_for_initial_thread_status(
+pub(crate) async fn wait_for_initial_thread_status(
     handle: &crate::kernel::runtime_host::RuntimeThreadHandle,
 ) {
     if handle.status() != verlet_runtime_contracts::ThreadStatus::Starting {
@@ -843,7 +843,7 @@ pub(super) async fn wait_for_initial_thread_status(
     .await;
 }
 
-pub(super) async fn handle_thread_status(
+pub(crate) async fn handle_thread_status(
     app: &crate::adapters::app_server::VerletAppServer,
     thread_id: &str,
     status: verlet_runtime_contracts::ThreadStatus,
@@ -910,7 +910,7 @@ pub(super) async fn handle_thread_status(
 
 /// Lets queued runtime failure events provide their code and message before a
 /// failed thread status falls back to a generic failed-turn projection.
-pub(super) async fn handle_failed_thread_status(
+pub(crate) async fn handle_failed_thread_status(
     app: &crate::adapters::app_server::VerletAppServer,
     thread_id: &str,
     events: &mut tokio::sync::broadcast::Receiver<
@@ -935,7 +935,7 @@ pub(super) async fn handle_failed_thread_status(
     .await;
 }
 
-pub(super) async fn complete_turn_after_settle(
+pub(crate) async fn complete_turn_after_settle(
     app: crate::adapters::app_server::VerletAppServer,
     thread_id: String,
     turn_id: String,
@@ -1057,9 +1057,9 @@ pub(super) async fn complete_turn_after_settle(
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub(super) struct AssistantContentProjection {
-    pub(super) text: String,
-    pub(super) thinking: String,
+pub(crate) struct AssistantContentProjection {
+    pub(crate) text: String,
+    pub(crate) thinking: String,
 }
 
 impl AssistantContentProjection {
@@ -1068,7 +1068,7 @@ impl AssistantContentProjection {
     }
 }
 
-pub(super) async fn wait_for_current_turn_assistant_content(
+pub(crate) async fn wait_for_current_turn_assistant_content(
     app: &crate::adapters::app_server::VerletAppServer,
     thread_id: &str,
     turn_id: &str,
@@ -1085,7 +1085,7 @@ pub(super) async fn wait_for_current_turn_assistant_content(
     None
 }
 
-pub(super) async fn turn_is_active(
+pub(crate) async fn turn_is_active(
     app: &crate::adapters::app_server::VerletAppServer,
     thread_id: &str,
     turn_id: &str,
@@ -1099,7 +1099,7 @@ pub(super) async fn turn_is_active(
 
 /// Reconciles completion payloads from saved session text after fast runtime
 /// turns, because status notifications can outrun queued text notifications.
-pub(super) fn reconcile_turn_assistant_text(
+pub(crate) fn reconcile_turn_assistant_text(
     turn: &mut crate::adapters::app_server::threads::AppServerTurnState,
     text: &str,
 ) -> Option<(Option<serde_json::Value>, String, String)> {
@@ -1147,7 +1147,7 @@ pub(super) fn reconcile_turn_assistant_text(
     Some((None, delta.to_string(), item_id))
 }
 
-pub(super) fn reconcile_turn_thinking_text(
+pub(crate) fn reconcile_turn_thinking_text(
     turn: &mut crate::adapters::app_server::threads::AppServerTurnState,
     text: &str,
 ) -> Option<(Option<serde_json::Value>, String, String)> {
@@ -1195,7 +1195,7 @@ pub(super) fn reconcile_turn_thinking_text(
     Some((None, delta.to_string(), item_id))
 }
 
-pub(super) fn upsert_agent_message_item(
+pub(crate) fn upsert_agent_message_item(
     turn: &mut crate::adapters::app_server::threads::AppServerTurnState,
 ) {
     let item_id = turn.assistant_item_id.clone();
@@ -1211,7 +1211,7 @@ pub(super) fn upsert_agent_message_item(
     }
 }
 
-pub(super) fn upsert_agent_thinking_item(
+pub(crate) fn upsert_agent_thinking_item(
     turn: &mut crate::adapters::app_server::threads::AppServerTurnState,
 ) {
     let item_id = turn.thinking_item_id.clone();
@@ -1227,7 +1227,7 @@ pub(super) fn upsert_agent_thinking_item(
     }
 }
 
-pub(super) async fn current_turn_assistant_content(
+pub(crate) async fn current_turn_assistant_content(
     app: &crate::adapters::app_server::VerletAppServer,
     thread_id: &str,
     turn_id: &str,
@@ -1251,7 +1251,7 @@ pub(super) async fn current_turn_assistant_content(
     assistant_content_after_latest_user(&context.messages, &user_text)
 }
 
-pub(super) fn turn_user_text(
+pub(crate) fn turn_user_text(
     turn: &crate::adapters::app_server::threads::AppServerTurnState,
 ) -> Option<String> {
     turn.items
@@ -1262,7 +1262,7 @@ pub(super) fn turn_user_text(
         .filter(|text| !text.is_empty())
 }
 
-pub(super) fn assistant_content_after_latest_user(
+pub(crate) fn assistant_content_after_latest_user(
     messages: &[verlet_history::CanonicalMessage],
     user_text: &str,
 ) -> Option<AssistantContentProjection> {
@@ -1296,7 +1296,7 @@ pub(super) fn assistant_content_after_latest_user(
 }
 
 #[cfg(test)]
-pub(super) async fn latest_assistant_text(
+pub(crate) async fn latest_assistant_text(
     app: &crate::adapters::app_server::VerletAppServer,
     thread_id: &str,
 ) -> Option<String> {
@@ -1322,7 +1322,7 @@ pub(super) async fn latest_assistant_text(
         })
 }
 
-pub(super) async fn complete_shell_command(
+pub(crate) async fn complete_shell_command(
     connection: crate::adapters::app_server::connection::ConnectionState,
     thread_id: String,
     turn_id: String,
@@ -1398,7 +1398,7 @@ pub(super) async fn complete_shell_command(
         .await;
 }
 
-pub(super) async fn run_shell_command(
+pub(crate) async fn run_shell_command(
     cwd: std::path::PathBuf,
     command: String,
 ) -> (i32, String, String) {
@@ -1419,7 +1419,7 @@ pub(super) async fn run_shell_command(
     }
 }
 
-pub(super) async fn handle_thread_event(
+pub(crate) async fn handle_thread_event(
     app: &crate::adapters::app_server::VerletAppServer,
     thread_id: &str,
     event: crate::kernel::runtime_host::runtime_api::ThreadEvent,
@@ -1442,7 +1442,7 @@ pub(super) async fn handle_thread_event(
     }
 }
 
-pub(super) async fn handle_runtime_event(
+pub(crate) async fn handle_runtime_event(
     app: &crate::adapters::app_server::VerletAppServer,
     thread_id: &str,
     event: crate::kernel::runtime_host::runtime_events::RuntimeEventKind,
@@ -1579,7 +1579,7 @@ pub(super) async fn handle_runtime_event(
     }
 }
 
-pub(super) async fn append_agent_delta(
+pub(crate) async fn append_agent_delta(
     app: &crate::adapters::app_server::VerletAppServer,
     thread_id: &str,
     delta: &str,
@@ -1639,7 +1639,7 @@ pub(super) async fn append_agent_delta(
     .await;
 }
 
-pub(super) async fn append_agent_thinking_delta(
+pub(crate) async fn append_agent_thinking_delta(
     app: &crate::adapters::app_server::VerletAppServer,
     thread_id: &str,
     delta: &str,
@@ -1699,7 +1699,7 @@ pub(super) async fn append_agent_thinking_delta(
     .await;
 }
 
-pub(super) async fn complete_dynamic_tool(
+pub(crate) async fn complete_dynamic_tool(
     app: &crate::adapters::app_server::VerletAppServer,
     thread_id: &str,
     call_id: &str,
@@ -1726,7 +1726,7 @@ pub(super) async fn complete_dynamic_tool(
     None
 }
 
-pub(super) async fn interrupt_active_turn(
+pub(crate) async fn interrupt_active_turn(
     app: &crate::adapters::app_server::VerletAppServer,
     thread_id: &str,
     reason: String,
@@ -1773,7 +1773,7 @@ pub(super) async fn interrupt_active_turn(
     }
 }
 
-pub(super) async fn fail_active_turn(
+pub(crate) async fn fail_active_turn(
     app: &crate::adapters::app_server::VerletAppServer,
     thread_id: &str,
     code: impl Into<String>,

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -361,10 +361,10 @@ fn dispatcher_method_authority_classes_are_exhaustive_and_explicit() {
     ];
 
     let dispatch_source = include_str!("connection.rs")
-        .split_once("pub(super) async fn dispatch_request")
+        .split_once("pub(crate) async fn dispatch_request")
         .expect("dispatch_request source")
         .1
-        .split_once("pub(super) async fn mcp_server_status_list")
+        .split_once("pub(crate) async fn mcp_server_status_list")
         .expect("method following dispatch_request")
         .0;
     let dispatch_methods = dispatch_source
@@ -10367,9 +10367,10 @@ async fn stale_daemon_stream_append_returns_distinct_rehome_error_before_sequenc
     let (connection, _outbound_rx) = test_connection(app.clone()).await;
     initialize_for_test(&connection).await;
     let stream_id = verlet_history::EventStreamId::new("client:orch:stale-lease");
-    let namespace =
-        uuid::Uuid::parse_str(super::orchestrator_boundary::CLIENT_STREAM_THREAD_NAMESPACE)
-            .unwrap();
+    let namespace = uuid::Uuid::parse_str(
+        crate::adapters::app_server::orchestrator_boundary::CLIENT_STREAM_THREAD_NAMESPACE,
+    )
+    .unwrap();
     let coordinates = verlet_runtime_contracts::ThreadCoordinates {
         tenant_id: app.tenant_id().to_string(),
         user_id: connection.resolved_principal.principal_id.to_string(),

--- a/crates/verlet-kernel/src/adapters/app_server/threads.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/threads.rs
@@ -4,52 +4,52 @@ use verlet_metadata::provider_store::ThreadMetadataStore as _;
 const THREAD_REMOTE_PLACEMENT_PROJECTION_METADATA: &str = "cooldis.remote_placement_projection";
 
 #[derive(Default)]
-pub(super) struct AppServerState {
-    pub(super) threads: std::collections::HashMap<String, AppServerThreadState>,
+pub(crate) struct AppServerState {
+    pub(crate) threads: std::collections::HashMap<String, AppServerThreadState>,
 }
 
 #[derive(Clone)]
-pub(super) struct AppServerThreadState {
-    pub(super) thread_id: String,
-    pub(super) session_id: String,
-    pub(super) parent_thread_id: Option<String>,
-    pub(super) topology: verlet_runtime_contracts::ThreadTopology,
-    pub(super) cwd: std::path::PathBuf,
-    pub(super) model_provider: String,
-    pub(super) created_at_ms: u64,
-    pub(super) updated_at_ms: u64,
-    pub(super) status: verlet_runtime_contracts::ThreadStatus,
-    pub(super) preview: String,
-    pub(super) ephemeral: bool,
-    pub(super) name: Option<String>,
-    pub(super) thinking: Option<verlet_provider::ThinkingConfig>,
-    pub(super) turns: std::collections::BTreeMap<String, AppServerTurnState>,
-    pub(super) active_turn_id: Option<String>,
+pub(crate) struct AppServerThreadState {
+    pub(crate) thread_id: String,
+    pub(crate) session_id: String,
+    pub(crate) parent_thread_id: Option<String>,
+    pub(crate) topology: verlet_runtime_contracts::ThreadTopology,
+    pub(crate) cwd: std::path::PathBuf,
+    pub(crate) model_provider: String,
+    pub(crate) created_at_ms: u64,
+    pub(crate) updated_at_ms: u64,
+    pub(crate) status: verlet_runtime_contracts::ThreadStatus,
+    pub(crate) preview: String,
+    pub(crate) ephemeral: bool,
+    pub(crate) name: Option<String>,
+    pub(crate) thinking: Option<verlet_provider::ThinkingConfig>,
+    pub(crate) turns: std::collections::BTreeMap<String, AppServerTurnState>,
+    pub(crate) active_turn_id: Option<String>,
 }
 
 #[derive(Clone)]
-pub(super) struct AppServerTurnState {
-    pub(super) id: String,
-    pub(super) items: Vec<serde_json::Value>,
-    pub(super) status: AppServerTurnStatus,
-    pub(super) started_at_ms: u64,
-    pub(super) completed_at_ms: Option<u64>,
-    pub(super) error: Option<serde_json::Value>,
-    pub(super) assistant_item_id: String,
-    pub(super) assistant_text: String,
-    pub(super) assistant_started: bool,
-    pub(super) assistant_completed: bool,
-    pub(super) thinking_item_id: String,
-    pub(super) thinking_text: String,
-    pub(super) thinking_started: bool,
-    pub(super) thinking_completed: bool,
-    pub(super) observed_running: bool,
-    pub(super) completion_scheduled: bool,
+pub(crate) struct AppServerTurnState {
+    pub(crate) id: String,
+    pub(crate) items: Vec<serde_json::Value>,
+    pub(crate) status: AppServerTurnStatus,
+    pub(crate) started_at_ms: u64,
+    pub(crate) completed_at_ms: Option<u64>,
+    pub(crate) error: Option<serde_json::Value>,
+    pub(crate) assistant_item_id: String,
+    pub(crate) assistant_text: String,
+    pub(crate) assistant_started: bool,
+    pub(crate) assistant_completed: bool,
+    pub(crate) thinking_item_id: String,
+    pub(crate) thinking_text: String,
+    pub(crate) thinking_started: bool,
+    pub(crate) thinking_completed: bool,
+    pub(crate) observed_running: bool,
+    pub(crate) completion_scheduled: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, strum::AsRefStr, strum::Display)]
 #[strum(serialize_all = "camelCase")]
-pub(super) enum AppServerTurnStatus {
+pub(crate) enum AppServerTurnStatus {
     InProgress,
     Completed,
     Interrupted,
@@ -57,12 +57,12 @@ pub(super) enum AppServerTurnStatus {
 }
 
 #[derive(Clone)]
-pub(super) struct AppServerThreadLifecycleSink {
+pub(crate) struct AppServerThreadLifecycleSink {
     inner: std::sync::Weak<crate::adapters::app_server::VerletAppServerInner>,
 }
 
 impl AppServerThreadLifecycleSink {
-    pub(super) fn new(app: &crate::adapters::app_server::VerletAppServer) -> Self {
+    pub(crate) fn new(app: &crate::adapters::app_server::VerletAppServer) -> Self {
         Self {
             inner: std::sync::Arc::downgrade(&app.inner),
         }
@@ -502,7 +502,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(())
     }
 
-    pub(super) async fn load_threads_from_metadata(
+    pub(crate) async fn load_threads_from_metadata(
         &self,
     ) -> crate::kernel::runtime_host::VerletResult<()> {
         let records = self
@@ -557,7 +557,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(())
     }
 
-    pub(super) async fn load_thread_from_metadata(
+    pub(crate) async fn load_thread_from_metadata(
         &self,
         thread_id: &str,
         parsed: verlet_runtime_contracts::ThreadId,
@@ -681,7 +681,7 @@ impl crate::adapters::app_server::VerletAppServer {
         )
     }
 
-    pub(super) async fn bind_app_server_agent_ref(
+    pub(crate) async fn bind_app_server_agent_ref(
         &self,
         agent_ref: &str,
         model_selection: &crate::agent::manifest_bind::AgentManifestModelProfileSelection,
@@ -716,7 +716,7 @@ impl crate::adapters::app_server::VerletAppServer {
         .await
     }
 
-    pub(super) async fn thread_state_from_lifecycle(
+    pub(crate) async fn thread_state_from_lifecycle(
         &self,
         record: &verlet_runtime_contracts::ThreadLifecycleRecord,
         status: verlet_runtime_contracts::ThreadStatus,
@@ -753,7 +753,7 @@ impl crate::adapters::app_server::VerletAppServer {
     }
 
     /// Rebuild the app-server thread projection from durable session history.
-    pub(super) async fn thread_history_from_lifecycle(
+    pub(crate) async fn thread_history_from_lifecycle(
         &self,
         record: &verlet_runtime_contracts::ThreadLifecycleRecord,
     ) -> crate::kernel::runtime_host::VerletResult<(
@@ -771,7 +771,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(app_server_turns_from_session_entries(&context.entries))
     }
 
-    pub(super) async fn persist_thread_lifecycle(
+    pub(crate) async fn persist_thread_lifecycle(
         &self,
         handle: &crate::kernel::runtime_host::RuntimeThreadHandle,
     ) -> Result<(), crate::adapters::app_server::connection::JsonRpcErrorError> {
@@ -779,7 +779,7 @@ impl crate::adapters::app_server::VerletAppServer {
             .await
     }
 
-    pub(super) async fn persist_thread_lifecycle_with_metadata(
+    pub(crate) async fn persist_thread_lifecycle_with_metadata(
         &self,
         handle: &crate::kernel::runtime_host::RuntimeThreadHandle,
         metadata: std::collections::BTreeMap<String, String>,
@@ -790,7 +790,7 @@ impl crate::adapters::app_server::VerletAppServer {
             .map_err(crate::adapters::app_server::connection::internal_error)
     }
 
-    pub(super) async fn persist_thread_lifecycle_record_with_metadata(
+    pub(crate) async fn persist_thread_lifecycle_record_with_metadata(
         &self,
         handle: &crate::kernel::runtime_host::RuntimeThreadHandle,
         metadata: std::collections::BTreeMap<String, String>,
@@ -817,7 +817,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(record)
     }
 
-    pub(super) async fn register_runtime_thread(
+    pub(crate) async fn register_runtime_thread(
         &self,
         handle: crate::kernel::runtime_host::RuntimeThreadHandle,
     ) -> crate::kernel::runtime_host::VerletResult<()> {
@@ -843,7 +843,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(())
     }
 
-    pub(super) fn spawn_lifecycle_persistence_watcher(
+    pub(crate) fn spawn_lifecycle_persistence_watcher(
         &self,
         thread_id: String,
         handle: crate::kernel::runtime_host::RuntimeThreadHandle,
@@ -889,7 +889,7 @@ impl crate::adapters::app_server::VerletAppServer {
         });
     }
 
-    pub(super) async fn thread_json_by_id(
+    pub(crate) async fn thread_json_by_id(
         &self,
         thread_id: &str,
         include_turns: bool,
@@ -902,7 +902,7 @@ impl crate::adapters::app_server::VerletAppServer {
         Ok(thread_json(thread, include_turns))
     }
 
-    pub(super) async fn register_remote_thread_projection(
+    pub(crate) async fn register_remote_thread_projection(
         &self,
         parent: &crate::kernel::runtime_host::RuntimeThreadHandle,
         receipt: &crate::kernel::runtime_host::kernel_control::AgentProcessSpawnReceipt,
@@ -965,7 +965,7 @@ impl crate::adapters::app_server::VerletAppServer {
     }
 }
 
-pub(super) fn require_local_binding_surface(
+pub(crate) fn require_local_binding_surface(
     surface: &str,
     bound: &crate::agent::manifest_bind::AgentManifestBoundThread,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
@@ -988,7 +988,7 @@ pub(super) fn require_local_binding_surface(
 }
 
 impl AppServerTurnState {
-    pub(super) fn new(id: String, input: Vec<serde_json::Value>) -> Self {
+    pub(crate) fn new(id: String, input: Vec<serde_json::Value>) -> Self {
         let assistant_item_id = format!("{id}:agent-message");
         let thinking_item_id = format!("{id}:agent-thinking");
         Self {
@@ -1015,7 +1015,7 @@ impl AppServerTurnState {
         }
     }
 
-    pub(super) fn restored(id: String, started_at_ms: u64, items: Vec<serde_json::Value>) -> Self {
+    pub(crate) fn restored(id: String, started_at_ms: u64, items: Vec<serde_json::Value>) -> Self {
         let assistant_item_id = format!("{id}:agent-message");
         let thinking_item_id = format!("{id}:agent-thinking");
         Self {
@@ -1039,7 +1039,7 @@ impl AppServerTurnState {
     }
 }
 
-pub(super) fn finalize_turn_payload(
+pub(crate) fn finalize_turn_payload(
     turn: &mut AppServerTurnState,
 ) -> (serde_json::Value, Vec<serde_json::Value>) {
     let should_complete_message = turn.assistant_started && !turn.assistant_completed;
@@ -1066,7 +1066,7 @@ pub(super) fn finalize_turn_payload(
     (turn_json(turn), items)
 }
 
-pub(super) fn finalize_agent_message_item(turn: &mut AppServerTurnState) {
+pub(crate) fn finalize_agent_message_item(turn: &mut AppServerTurnState) {
     if !turn.assistant_started || turn.assistant_completed {
         return;
     }
@@ -1081,7 +1081,7 @@ pub(super) fn finalize_agent_message_item(turn: &mut AppServerTurnState) {
     turn.assistant_completed = true;
 }
 
-pub(super) fn finalize_agent_thinking_item(turn: &mut AppServerTurnState) {
+pub(crate) fn finalize_agent_thinking_item(turn: &mut AppServerTurnState) {
     if !turn.thinking_started || turn.thinking_completed {
         return;
     }
@@ -1096,11 +1096,11 @@ pub(super) fn finalize_agent_thinking_item(turn: &mut AppServerTurnState) {
     turn.thinking_completed = true;
 }
 
-pub(super) fn agent_message_item(turn: &AppServerTurnState) -> serde_json::Value {
+pub(crate) fn agent_message_item(turn: &AppServerTurnState) -> serde_json::Value {
     agent_message_item_from_text(&turn.assistant_item_id, &turn.assistant_text)
 }
 
-pub(super) fn agent_message_item_from_text(id: &str, text: &str) -> serde_json::Value {
+pub(crate) fn agent_message_item_from_text(id: &str, text: &str) -> serde_json::Value {
     serde_json::json!({
         "type": "agentMessage",
         "id": id,
@@ -1111,11 +1111,11 @@ pub(super) fn agent_message_item_from_text(id: &str, text: &str) -> serde_json::
     })
 }
 
-pub(super) fn agent_thinking_item(turn: &AppServerTurnState) -> serde_json::Value {
+pub(crate) fn agent_thinking_item(turn: &AppServerTurnState) -> serde_json::Value {
     agent_thinking_item_from_text(&turn.thinking_item_id, &turn.thinking_text)
 }
 
-pub(super) fn agent_thinking_item_from_text(id: &str, text: &str) -> serde_json::Value {
+pub(crate) fn agent_thinking_item_from_text(id: &str, text: &str) -> serde_json::Value {
     serde_json::json!({
         "type": "agentThinking",
         "id": id,
@@ -1126,7 +1126,7 @@ pub(super) fn agent_thinking_item_from_text(id: &str, text: &str) -> serde_json:
     })
 }
 
-pub(super) fn command_execution_item(
+pub(crate) fn command_execution_item(
     id: &str,
     command: &str,
     cwd: &std::path::Path,
@@ -1150,7 +1150,7 @@ pub(super) fn command_execution_item(
     })
 }
 
-pub(super) fn thread_json(thread: &AppServerThreadState, include_turns: bool) -> serde_json::Value {
+pub(crate) fn thread_json(thread: &AppServerThreadState, include_turns: bool) -> serde_json::Value {
     let turns = if include_turns {
         thread.turns.values().map(turn_json).collect::<Vec<_>>()
     } else {
@@ -1182,7 +1182,7 @@ pub(super) fn thread_json(thread: &AppServerThreadState, include_turns: bool) ->
     })
 }
 
-pub(super) fn turn_json(turn: &AppServerTurnState) -> serde_json::Value {
+pub(crate) fn turn_json(turn: &AppServerTurnState) -> serde_json::Value {
     let completed_at = turn.completed_at_ms.map(|ms| ms / 1000);
     let duration_ms = turn
         .completed_at_ms
@@ -1200,7 +1200,7 @@ pub(super) fn turn_json(turn: &AppServerTurnState) -> serde_json::Value {
     })
 }
 
-pub(super) fn thread_status_json(
+pub(crate) fn thread_status_json(
     status: verlet_runtime_contracts::ThreadStatus,
 ) -> serde_json::Value {
     match status {
@@ -1219,7 +1219,7 @@ pub(super) fn thread_status_json(
     }
 }
 
-pub(super) fn turn_input_from_values(
+pub(crate) fn turn_input_from_values(
     input: &[serde_json::Value],
 ) -> crate::kernel::runtime_host::turn::TurnInput {
     let mut content = Vec::new();
@@ -1256,7 +1256,7 @@ pub(super) fn turn_input_from_values(
     crate::kernel::runtime_host::turn::TurnInput::new(content)
 }
 
-pub(super) fn deserialize_optional_thinking<'de, D>(
+pub(crate) fn deserialize_optional_thinking<'de, D>(
     deserializer: D,
 ) -> Result<Option<verlet_provider::ThinkingConfig>, D::Error>
 where
@@ -1268,7 +1268,7 @@ where
         .transpose()
 }
 
-pub(super) fn thinking_from_app_server_value(
+pub(crate) fn thinking_from_app_server_value(
     value: &serde_json::Value,
 ) -> Result<verlet_provider::ThinkingConfig, String> {
     let object = value
@@ -1308,7 +1308,7 @@ pub(super) fn thinking_from_app_server_value(
     }
 }
 
-pub(super) fn app_server_thinking_json(
+pub(crate) fn app_server_thinking_json(
     thinking: &Option<verlet_provider::ThinkingConfig>,
 ) -> serde_json::Value {
     thinking
@@ -1317,7 +1317,7 @@ pub(super) fn app_server_thinking_json(
         .unwrap_or(serde_json::Value::Null)
 }
 
-pub(super) fn app_server_thinking_value(
+pub(crate) fn app_server_thinking_value(
     thinking: &verlet_provider::ThinkingConfig,
 ) -> serde_json::Value {
     match thinking {
@@ -1336,7 +1336,7 @@ pub(super) fn app_server_thinking_value(
     }
 }
 
-pub(super) fn encode_app_server_thinking(
+pub(crate) fn encode_app_server_thinking(
     thinking: &verlet_provider::ThinkingConfig,
 ) -> Result<String, crate::adapters::app_server::connection::JsonRpcErrorError> {
     serde_json::to_string(&app_server_thinking_value(thinking)).map_err(|err| {
@@ -1347,7 +1347,7 @@ pub(super) fn encode_app_server_thinking(
     })
 }
 
-pub(super) fn user_input_preview(input: &[serde_json::Value]) -> String {
+pub(crate) fn user_input_preview(input: &[serde_json::Value]) -> String {
     input
         .iter()
         .filter_map(|item| item.get("text").and_then(serde_json::Value::as_str))
@@ -1355,7 +1355,7 @@ pub(super) fn user_input_preview(input: &[serde_json::Value]) -> String {
         .join("\n")
 }
 
-pub(super) fn app_server_turns_from_session_entries(
+pub(crate) fn app_server_turns_from_session_entries(
     entries: &[verlet_history::SessionEntry],
 ) -> (
     String,
@@ -1491,7 +1491,7 @@ fn restored_assistant_items_from_canonical_content(
     }
 }
 
-pub(super) fn canonical_text_content_items(
+pub(crate) fn canonical_text_content_items(
     content: &[verlet_history::CanonicalContent],
 ) -> Vec<serde_json::Value> {
     content
@@ -1507,7 +1507,7 @@ pub(super) fn canonical_text_content_items(
         .collect()
 }
 
-pub(super) fn text_content_preview(content: &[serde_json::Value]) -> String {
+pub(crate) fn text_content_preview(content: &[serde_json::Value]) -> String {
     content
         .iter()
         .filter_map(|item| item.get("text").and_then(serde_json::Value::as_str))
@@ -1515,11 +1515,11 @@ pub(super) fn text_content_preview(content: &[serde_json::Value]) -> String {
         .join("\n")
 }
 
-pub(super) fn entry_created_at_ms(entry: &verlet_history::SessionEntry) -> u64 {
+pub(crate) fn entry_created_at_ms(entry: &verlet_history::SessionEntry) -> u64 {
     entry.created_at_ms.max(0) as u64
 }
 
-pub(super) fn resolve_cwd(default_cwd: &std::path::Path, cwd: Option<&str>) -> std::path::PathBuf {
+pub(crate) fn resolve_cwd(default_cwd: &std::path::Path, cwd: Option<&str>) -> std::path::PathBuf {
     match cwd {
         Some(cwd) if !cwd.trim().is_empty() => {
             let path = std::path::PathBuf::from(cwd);
@@ -1533,7 +1533,7 @@ pub(super) fn resolve_cwd(default_cwd: &std::path::Path, cwd: Option<&str>) -> s
     }
 }
 
-pub(super) fn normalize_registry_roots(
+pub(crate) fn normalize_registry_roots(
     config: &mut crate::adapters::app_server::VerletAppServerConfig,
 ) {
     let blob_registry_root_was_default = config.blob_registry_root
@@ -1553,7 +1553,7 @@ pub(super) fn normalize_registry_roots(
     }
 }
 
-pub(super) fn resolve_path_against_cwd(
+pub(crate) fn resolve_path_against_cwd(
     cwd: &std::path::Path,
     path: &std::path::Path,
 ) -> std::path::PathBuf {
@@ -1564,7 +1564,7 @@ pub(super) fn resolve_path_against_cwd(
     }
 }
 
-pub(super) fn thread_start_topology(
+pub(crate) fn thread_start_topology(
     params: &crate::adapters::app_server::connection::ThreadStartParams,
 ) -> Result<
     verlet_runtime_contracts::ThreadTopology,
@@ -1592,7 +1592,7 @@ pub(super) fn thread_start_topology(
     }
 }
 
-pub(super) fn thread_start_metadata(
+pub(crate) fn thread_start_metadata(
     params: &crate::adapters::app_server::connection::ThreadStartParams,
     cwd: &std::path::Path,
     model_provider: &str,
@@ -1608,7 +1608,7 @@ pub(super) fn thread_start_metadata(
     Ok(metadata)
 }
 
-pub(super) fn insert_app_server_thinking_metadata(
+pub(crate) fn insert_app_server_thinking_metadata(
     metadata: &mut std::collections::BTreeMap<String, String>,
     thinking: Option<&verlet_provider::ThinkingConfig>,
 ) -> Result<(), crate::adapters::app_server::connection::JsonRpcErrorError> {
@@ -1621,7 +1621,7 @@ pub(super) fn insert_app_server_thinking_metadata(
     Ok(())
 }
 
-pub(super) fn append_bound_agent_metadata(
+pub(crate) fn append_bound_agent_metadata(
     metadata: &mut std::collections::BTreeMap<String, String>,
     bound: &crate::agent::manifest_bind::AgentManifestBoundThread,
     overrides: Option<&crate::agent::manifest_bind::AgentManifestBindOverrides>,
@@ -1846,7 +1846,7 @@ is present in the conversation.",
     )
 }
 
-pub(super) async fn record_bound_agent_receipts(
+pub(crate) async fn record_bound_agent_receipts(
     handle: &crate::kernel::runtime_host::RuntimeThreadHandle,
     bound: &crate::agent::manifest_bind::AgentManifestBoundThread,
     principal_id: &str,
@@ -1924,7 +1924,7 @@ pub(crate) async fn active_manifest_receipt_payloads(
 }
 
 impl crate::adapters::app_server::VerletAppServer {
-    pub(super) async fn witness_bound_agent_and_persist_lifecycle(
+    pub(crate) async fn witness_bound_agent_and_persist_lifecycle(
         &self,
         handle: crate::kernel::runtime_host::RuntimeThreadHandle,
         bound: crate::agent::manifest_bind::AgentManifestBoundThread,
@@ -1943,7 +1943,7 @@ impl crate::adapters::app_server::VerletAppServer {
         .await
     }
 
-    pub(super) async fn witness_manifest_payloads_and_persist_lifecycle(
+    pub(crate) async fn witness_manifest_payloads_and_persist_lifecycle(
         &self,
         handle: crate::kernel::runtime_host::RuntimeThreadHandle,
         compile_payload: serde_json::Value,
@@ -1969,7 +1969,7 @@ impl crate::adapters::app_server::VerletAppServer {
         .await
     }
 
-    pub(super) async fn witness_and_persist_lifecycle<F, Fut>(
+    pub(crate) async fn witness_and_persist_lifecycle<F, Fut>(
         &self,
         handle: crate::kernel::runtime_host::RuntimeThreadHandle,
         operation: F,
@@ -2043,7 +2043,7 @@ fn kernel_thread_spawn_agent_binding(
     })
 }
 
-pub(super) fn app_server_thread_metadata(
+pub(crate) fn app_server_thread_metadata(
     cwd: &std::path::Path,
     model_provider: &str,
     ephemeral: bool,
@@ -2051,7 +2051,7 @@ pub(super) fn app_server_thread_metadata(
     app_server_thread_metadata_with_name(cwd, model_provider, ephemeral, None)
 }
 
-pub(super) fn app_server_thread_metadata_with_name(
+pub(crate) fn app_server_thread_metadata_with_name(
     cwd: &std::path::Path,
     model_provider: &str,
     ephemeral: bool,
@@ -2079,7 +2079,7 @@ pub(super) fn app_server_thread_metadata_with_name(
     metadata
 }
 
-pub(super) fn thread_lifecycle_cwd(
+pub(crate) fn thread_lifecycle_cwd(
     record: &verlet_runtime_contracts::ThreadLifecycleRecord,
 ) -> Option<std::path::PathBuf> {
     record
@@ -2089,13 +2089,13 @@ pub(super) fn thread_lifecycle_cwd(
         .map(std::path::PathBuf::from)
 }
 
-pub(super) fn thread_lifecycle_thinking(
+pub(crate) fn thread_lifecycle_thinking(
     record: &verlet_runtime_contracts::ThreadLifecycleRecord,
 ) -> crate::kernel::runtime_host::VerletResult<Option<verlet_provider::ThinkingConfig>> {
     thread_metadata_thinking(&record.metadata)
 }
 
-pub(super) fn thread_metadata_thinking(
+pub(crate) fn thread_metadata_thinking(
     metadata: &std::collections::BTreeMap<String, String>,
 ) -> crate::kernel::runtime_host::VerletResult<Option<verlet_provider::ThinkingConfig>> {
     metadata
@@ -2115,7 +2115,7 @@ pub(super) fn thread_metadata_thinking(
         .transpose()
 }
 
-pub(super) fn is_loadable_lifecycle_status(
+pub(crate) fn is_loadable_lifecycle_status(
     status: verlet_runtime_contracts::ThreadLifecycleStatus,
 ) -> bool {
     !matches!(
@@ -2125,7 +2125,7 @@ pub(super) fn is_loadable_lifecycle_status(
     )
 }
 
-pub(super) fn thread_manifest_operation_bindings(
+pub(crate) fn thread_manifest_operation_bindings(
     context: &verlet_runtime_contracts::ThreadContext,
 ) -> crate::kernel::runtime_host::VerletResult<
     Vec<crate::agent::manifest_bind::AgentManifestOperationBinding>,
@@ -2171,7 +2171,7 @@ pub(crate) fn validate_manifest_binding_event_contract(
     Ok(())
 }
 
-pub(super) fn thread_operation_bindings_from_events(
+pub(crate) fn thread_operation_bindings_from_events(
     events: &[verlet_history::EventRecord],
 ) -> crate::kernel::runtime_host::VerletResult<Vec<ThreadOperationBinding>> {
     validate_manifest_binding_event_contract(events)?;
@@ -2207,7 +2207,7 @@ pub(super) fn thread_operation_bindings_from_events(
     Ok(Vec::new())
 }
 
-pub(super) fn thread_manifest_workspace_mount(
+pub(crate) fn thread_manifest_workspace_mount(
     context: &verlet_runtime_contracts::ThreadContext,
 ) -> crate::kernel::runtime_host::VerletResult<
     Option<crate::agent::manifest_bind::AgentManifestResolvedWorkspaceMount>,
@@ -2225,7 +2225,7 @@ pub(super) fn thread_manifest_workspace_mount(
         .transpose()
 }
 
-pub(super) fn thread_manifest_tool_universes(
+pub(crate) fn thread_manifest_tool_universes(
     context: &verlet_runtime_contracts::ThreadContext,
 ) -> crate::kernel::runtime_host::VerletResult<Vec<crate::agent::tool_universe::ToolUniverseBinding>>
 {
@@ -2248,7 +2248,7 @@ pub(super) fn thread_manifest_tool_universes(
     Ok(bindings)
 }
 
-pub(super) fn thread_manifest_skill_packages(
+pub(crate) fn thread_manifest_skill_packages(
     context: &verlet_runtime_contracts::ThreadContext,
 ) -> crate::kernel::runtime_host::VerletResult<
     Vec<crate::agent::manifest_bind::AgentManifestSkillPackageBinding>,
@@ -2270,7 +2270,7 @@ pub(super) fn thread_manifest_skill_packages(
     Ok(bindings)
 }
 
-pub(super) fn thread_manifest_skill_discovery(
+pub(crate) fn thread_manifest_skill_discovery(
     context: &verlet_runtime_contracts::ThreadContext,
 ) -> crate::kernel::runtime_host::VerletResult<
     Option<crate::agent::manifest_bind::AgentManifestSkillDiscovery>,
@@ -2288,7 +2288,7 @@ pub(super) fn thread_manifest_skill_discovery(
         .transpose()
 }
 
-pub(super) fn thread_manifest_skill_context_segments(
+pub(crate) fn thread_manifest_skill_context_segments(
     context: &verlet_runtime_contracts::ThreadContext,
 ) -> crate::kernel::runtime_host::VerletResult<
     Vec<crate::agent::manifest_bind::AgentManifestStaticContextSegment>,
@@ -2306,27 +2306,27 @@ pub(super) fn thread_manifest_skill_context_segments(
     })
 }
 
-pub(super) struct CapsuleBindingRuntimeFactory {
-    pub(super) config: crate::adapters::agent_loop::AgentLoopConfig,
-    pub(super) client: std::sync::Arc<dyn verlet_provider::ProviderClient>,
-    pub(super) capsule_bindings: crate::adapters::app_server::CapsuleBindingsConfig,
-    pub(super) secret_resolver:
+pub(crate) struct CapsuleBindingRuntimeFactory {
+    pub(crate) config: crate::adapters::agent_loop::AgentLoopConfig,
+    pub(crate) client: std::sync::Arc<dyn verlet_provider::ProviderClient>,
+    pub(crate) capsule_bindings: crate::adapters::app_server::CapsuleBindingsConfig,
+    pub(crate) secret_resolver:
         Option<std::sync::Arc<dyn verlet_metadata::secret_store::SecretResolver>>,
-    pub(super) metadata_store_path: Option<std::path::PathBuf>,
-    pub(super) secret_store_path: Option<std::path::PathBuf>,
-    pub(super) session_store_path: Option<std::path::PathBuf>,
-    pub(super) lease_epoch: u64,
-    pub(super) agent_registry_root: Option<std::path::PathBuf>,
-    pub(super) blob_registry_root: Option<std::path::PathBuf>,
-    pub(super) skill_registry_root: Option<std::path::PathBuf>,
-    pub(super) cwd: Option<std::path::PathBuf>,
-    pub(super) hook_shell: Option<String>,
-    pub(super) turn_endpoint_router:
+    pub(crate) metadata_store_path: Option<std::path::PathBuf>,
+    pub(crate) secret_store_path: Option<std::path::PathBuf>,
+    pub(crate) session_store_path: Option<std::path::PathBuf>,
+    pub(crate) lease_epoch: u64,
+    pub(crate) agent_registry_root: Option<std::path::PathBuf>,
+    pub(crate) blob_registry_root: Option<std::path::PathBuf>,
+    pub(crate) skill_registry_root: Option<std::path::PathBuf>,
+    pub(crate) cwd: Option<std::path::PathBuf>,
+    pub(crate) hook_shell: Option<String>,
+    pub(crate) turn_endpoint_router:
         Option<std::sync::Arc<dyn crate::adapters::agent_loop::TurnEndpointRouter>>,
-    pub(super) default_placement: crate::agent::manifest_bind::AgentManifestPlacementBinding,
-    pub(super) default_workspace:
+    pub(crate) default_placement: crate::agent::manifest_bind::AgentManifestPlacementBinding,
+    pub(crate) default_workspace:
         Option<crate::agent::manifest_bind::AgentManifestWorkspaceBinding>,
-    pub(super) remote_event_store_served: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    pub(crate) remote_event_store_served: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 struct ThreadOperationCatalog {
@@ -2338,9 +2338,9 @@ struct ThreadOperationCatalog {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(super) struct ThreadOperationBinding {
-    pub(super) binding: crate::agent::manifest_bind::AgentManifestOperationBinding,
-    pub(super) attach_event_id: Option<verlet_history::EventRecordId>,
+pub(crate) struct ThreadOperationBinding {
+    pub(crate) binding: crate::agent::manifest_bind::AgentManifestOperationBinding,
+    pub(crate) attach_event_id: Option<verlet_history::EventRecordId>,
 }
 
 fn context_operation_binding_plan(
@@ -2355,7 +2355,7 @@ fn context_operation_binding_plan(
         .collect())
 }
 
-pub(super) async fn runtime_operation_bindings_for_thread(
+pub(crate) async fn runtime_operation_bindings_for_thread(
     context: &verlet_runtime_contracts::ThreadContext,
     session_store_path: Option<&std::path::Path>,
     metadata_store_path: Option<&std::path::Path>,
@@ -2477,7 +2477,7 @@ impl crate::kernel::runtime_host::runtime_api::AgentRuntimeFactory
 }
 
 #[derive(Clone)]
-pub(super) struct AppServerThreadSpawnAgentResolver {
+pub(crate) struct AppServerThreadSpawnAgentResolver {
     agent_registry_root: std::path::PathBuf,
     operation_registry_root: Option<std::path::PathBuf>,
     blob_registry_root: Option<std::path::PathBuf>,
@@ -2609,7 +2609,7 @@ impl AppServerThreadSpawnAgentResolver {
 }
 
 impl crate::adapters::app_server::VerletAppServer {
-    pub(super) async fn app_server_thread_spawn_agent_resolver(
+    pub(crate) async fn app_server_thread_spawn_agent_resolver(
         &self,
         placement_override: Option<crate::agent::manifest_bind::AgentManifestPlacementBinding>,
         workspace_override: Option<crate::agent::manifest_bind::AgentManifestWorkspaceBinding>,
@@ -2934,7 +2934,7 @@ fn provider_surface_for_runtime_config(
     .with_supports_streaming(supports_streaming)
 }
 
-pub(super) fn apply_manifest_runtime_metadata(
+pub(crate) fn apply_manifest_runtime_metadata(
     context: &verlet_runtime_contracts::ThreadContext,
     config: &mut crate::adapters::agent_loop::AgentLoopConfig,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
@@ -2978,7 +2978,7 @@ pub(super) fn apply_manifest_runtime_metadata(
     Ok(())
 }
 
-pub(super) fn manifest_compaction_policy(
+pub(crate) fn manifest_compaction_policy(
     context: &verlet_runtime_contracts::ThreadContext,
 ) -> crate::kernel::runtime_host::VerletResult<Option<crate::kernel::compaction::CompactionPolicy>>
 {
@@ -2996,7 +2996,7 @@ pub(super) fn manifest_compaction_policy(
         .transpose()
 }
 
-pub(super) async fn operation_registry_capability_grants(
+pub(crate) async fn operation_registry_capability_grants(
     registry: &verlet_operations::operation_registry::OperationRegistry,
 ) -> std::collections::BTreeSet<String> {
     registry

--- a/crates/verlet-kernel/src/adapters/host.rs
+++ b/crates/verlet-kernel/src/adapters/host.rs
@@ -34,11 +34,6 @@
 //!    never `Websocket`/`Console` — the surface names how the connection
 //!    reached the instance.
 
-use crate::adapters::app_server::VerletAppServer;
-use crate::adapters::app_server::VerletAppServerConfig;
-use crate::adapters::app_server::lifecycle::InstanceTaskSet;
-use crate::kernel::runtime_host::VerletResult;
-
 /// Host-scoped name of one hosted instance. Distinct from tenant id (an
 /// instance HAS a tenant; the host does not interpret it) and never taken
 /// from an RPC body — the routed connection is the only source.
@@ -48,7 +43,7 @@ pub struct InstanceId(String);
 impl InstanceId {
     /// Non-empty, no whitespace or control characters; used in logs and error
     /// messages, so keep it printable. Never secret material.
-    pub fn new(id: impl Into<String>) -> VerletResult<Self> {
+    pub fn new(id: impl Into<String>) -> crate::kernel::runtime_host::VerletResult<Self> {
         let id = id.into();
         if id.is_empty()
             || id
@@ -97,13 +92,15 @@ struct VerletHostInner {
     /// OUTSIDE this lock (both are slow: store opens, task drains) — the
     /// lock guards the map, not the lifecycle transitions; a per-id claim
     /// keeps concurrent start/shutdown of the same id single-file.
-    instances: tokio::sync::RwLock<std::collections::HashMap<InstanceId, VerletAppServer>>,
+    instances: tokio::sync::RwLock<
+        std::collections::HashMap<InstanceId, crate::adapters::app_server::VerletAppServer>,
+    >,
     /// Credential-digest → instance selection table (decision 1). Values
     /// are digests from `identity_token_digest`; raw tokens are never
     /// stored, logged, or printed.
     credential_routes: std::sync::Mutex<std::collections::HashMap<String, InstanceId>>,
     /// Listener + per-connection tasks (decision 2).
-    tasks: InstanceTaskSet,
+    tasks: crate::adapters::app_server::lifecycle::InstanceTaskSet,
     /// The v0 host owns exactly one listener installation for its lifetime.
     listener_installed: std::sync::atomic::AtomicBool,
     /// Per-id lifecycle serialization. Claims live for the host lifetime so
@@ -132,7 +129,7 @@ impl VerletHost {
             inner: std::sync::Arc::new(VerletHostInner {
                 instances: tokio::sync::RwLock::new(std::collections::HashMap::new()),
                 credential_routes: std::sync::Mutex::new(std::collections::HashMap::new()),
-                tasks: InstanceTaskSet::new(),
+                tasks: crate::adapters::app_server::lifecycle::InstanceTaskSet::new(),
                 listener_installed: std::sync::atomic::AtomicBool::new(false),
                 lifecycle_claims: std::sync::Mutex::new(std::collections::HashMap::new()),
                 shutdown: tokio::sync::RwLock::new(false),
@@ -141,7 +138,7 @@ impl VerletHost {
     }
 
     /// Construct and register one instance under `id`. The config must be
-    /// a hosted config ([`VerletAppServerConfig::hosted`]); root
+    /// a hosted config ([`crate::adapters::app_server::VerletAppServerConfig::hosted`]); root
     /// reservation (EMO-552) already guarantees two live instances cannot
     /// share storage, whichever host they belong to. Fails on duplicate
     /// `id`, after host shutdown, and on any constructor failure (the
@@ -149,8 +146,8 @@ impl VerletHost {
     pub async fn start_instance(
         &self,
         id: InstanceId,
-        config: VerletAppServerConfig,
-    ) -> VerletResult<()> {
+        config: crate::adapters::app_server::VerletAppServerConfig,
+    ) -> crate::kernel::runtime_host::VerletResult<()> {
         if *self.inner.shutdown.read().await {
             return Err(host_error("Verlet host is shut down"));
         }
@@ -167,11 +164,11 @@ impl VerletHost {
         }
         if !config.is_hosted() {
             return Err(host_error(format!(
-                "Verlet host instance {id} requires VerletAppServerConfig::hosted"
+                "Verlet host instance {id} requires crate::adapters::app_server::VerletAppServerConfig::hosted"
             )));
         }
 
-        let instance = VerletAppServer::new(config).await?;
+        let instance = crate::adapters::app_server::VerletAppServer::new(config).await?;
         self.inner.instances.write().await.insert(id, instance);
         drop(shutdown);
         Ok(())
@@ -179,12 +176,15 @@ impl VerletHost {
 
     /// Shut down and deregister one instance: drop its credential routes
     /// first (new connections stop routing to it), then
-    /// [`VerletAppServer::shutdown`] (which drains instance tasks and
+    /// [`crate::adapters::app_server::VerletAppServer::shutdown`] (which drains instance tasks and
     /// closes its dispatch gate under any live host connection), then
     /// remove it from the map, releasing its root reservation with the
     /// last handle. Replace = `shutdown_instance` + `start_instance` over
     /// the same roots. Idempotent per id; unknown ids are an error.
-    pub async fn shutdown_instance(&self, id: &InstanceId) -> VerletResult<()> {
+    pub async fn shutdown_instance(
+        &self,
+        id: &InstanceId,
+    ) -> crate::kernel::runtime_host::VerletResult<()> {
         if *self.inner.shutdown.read().await {
             return Err(host_error("Verlet host is shut down"));
         }
@@ -237,8 +237,11 @@ impl VerletHost {
     /// Observe/dispatch: a handle to one hosted instance (cheap clone of
     /// its shared inner). In-process callers (the embedding orchestrator)
     /// dispatch through
-    /// [`VerletAppServer::dispatch_authenticated_json_rpc`] on it.
-    pub async fn instance(&self, id: &InstanceId) -> Option<VerletAppServer> {
+    /// [`crate::adapters::app_server::VerletAppServer::dispatch_authenticated_json_rpc`] on it.
+    pub async fn instance(
+        &self,
+        id: &InstanceId,
+    ) -> Option<crate::adapters::app_server::VerletAppServer> {
         self.inner.instances.read().await.get(id).cloned()
     }
 
@@ -302,14 +305,14 @@ impl VerletHost {
     /// Per connection: peek the HTTP request, extract the bearer token
     /// (`request_bearer_token`), digest it, select the routed instance,
     /// and hand the un-consumed stream to
-    /// [`VerletAppServer::serve_host_routed_tcp_stream`] — which
+    /// [`crate::adapters::app_server::VerletAppServer::serve_host_routed_tcp_stream`] — which
     /// authenticates against that instance's own authority and witnesses
     /// the session on `BoundarySurface::Host`. No route: refuse per
     /// decision 3 without touching any instance.
     pub async fn serve_websocket_listener(
         &self,
         listener: tokio::net::TcpListener,
-    ) -> VerletResult<()> {
+    ) -> crate::kernel::runtime_host::VerletResult<()> {
         self.serve_websocket_listener_with_options(listener, HostListenerOptions::default())
             .await
     }
@@ -324,7 +327,7 @@ impl VerletHost {
         &self,
         listener: tokio::net::TcpListener,
         options: HostListenerOptions,
-    ) -> VerletResult<()> {
+    ) -> crate::kernel::runtime_host::VerletResult<()> {
         let shutdown = self.inner.shutdown.read().await;
         if *shutdown {
             return Err(host_error("Verlet host is shut down"));
@@ -390,10 +393,10 @@ impl VerletHost {
 
     /// Host shutdown: cancel + drain the listener and every connection
     /// task, then shut down every remaining instance (each per
-    /// [`VerletAppServer::shutdown`]), then clear the route table.
+    /// [`crate::adapters::app_server::VerletAppServer::shutdown`]), then clear the route table.
     /// Idempotent. Explicit shutdown is mandatory (EMO-551 policy: drop
     /// never tears down).
-    pub async fn shutdown(&self) -> VerletResult<()> {
+    pub async fn shutdown(&self) -> crate::kernel::runtime_host::VerletResult<()> {
         let mut shutdown = self.inner.shutdown.write().await;
         *shutdown = true;
 
@@ -444,7 +447,10 @@ impl VerletHost {
         )
     }
 
-    async fn route_tcp_stream(&self, stream: tokio::net::TcpStream) -> VerletResult<()> {
+    async fn route_tcp_stream(
+        &self,
+        stream: tokio::net::TcpStream,
+    ) -> crate::kernel::runtime_host::VerletResult<()> {
         let request = crate::adapters::app_server::peek_http_request(&stream).await?;
         if request.as_ref().is_some_and(is_health_check_request) {
             return respond_health_ok(stream).await;
@@ -505,7 +511,9 @@ fn is_health_check_request(request: &crate::adapters::app_server::HttpRequestHea
 /// Answer a health probe with a minimal `200 OK` (no body detail — the
 /// health endpoint discloses liveness only, never instance names or
 /// counts) and close the stream.
-async fn respond_health_ok(mut stream: tokio::net::TcpStream) -> VerletResult<()> {
+async fn respond_health_ok(
+    mut stream: tokio::net::TcpStream,
+) -> crate::kernel::runtime_host::VerletResult<()> {
     use tokio::io::AsyncWriteExt as _;
 
     crate::adapters::app_server::consume_http_request_headers(&mut stream).await?;
@@ -568,10 +576,12 @@ mod tests {
     #[test]
     fn instance_ids_reject_log_control_characters() {
         for invalid in ["", "two words", "line\nfeed", "escape\u{1b}", "nul\0byte"] {
-            assert!(super::InstanceId::new(invalid).is_err());
+            assert!(crate::adapters::host::InstanceId::new(invalid).is_err());
         }
         assert_eq!(
-            super::InstanceId::new("tenant-01").unwrap().as_str(),
+            crate::adapters::host::InstanceId::new("tenant-01")
+                .unwrap()
+                .as_str(),
             "tenant-01"
         );
     }
@@ -579,8 +589,8 @@ mod tests {
     #[tokio::test]
     async fn concurrent_starts_for_one_id_admit_exactly_one_instance() {
         let root = test_root("same-id-start");
-        let host = super::VerletHost::new();
-        let id = super::InstanceId::new("same").unwrap();
+        let host = crate::adapters::host::VerletHost::new();
+        let id = crate::adapters::host::InstanceId::new("same").unwrap();
         let first = {
             let host = host.clone();
             let id = id.clone();
@@ -605,13 +615,16 @@ mod tests {
     #[tokio::test]
     async fn shutdown_and_concurrent_start_cannot_leave_a_late_instance() {
         let root = test_root("shutdown-start-race");
-        let host = super::VerletHost::new();
+        let host = crate::adapters::host::VerletHost::new();
         let start = {
             let host = host.clone();
             let config = test_config(&root.join("instance"), "tenant", "operator");
             tokio::spawn(async move {
-                host.start_instance(super::InstanceId::new("instance").unwrap(), config)
-                    .await
+                host.start_instance(
+                    crate::adapters::host::InstanceId::new("instance").unwrap(),
+                    config,
+                )
+                .await
             })
         };
         tokio::task::yield_now().await;
@@ -623,7 +636,7 @@ mod tests {
         assert!(host.instance_ids().await.is_empty());
         assert!(
             host.start_instance(
-                super::InstanceId::new("late").unwrap(),
+                crate::adapters::host::InstanceId::new("late").unwrap(),
                 test_config(&root.join("late"), "late-tenant", "late-operator"),
             )
             .await
@@ -636,7 +649,7 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_resumes_after_the_draining_caller_is_cancelled() {
-        let host = super::VerletHost::new();
+        let host = crate::adapters::host::VerletHost::new();
         let started = std::sync::Arc::new(tokio::sync::Notify::new());
         let release = std::sync::Arc::new(tokio::sync::Notify::new());
         let task_started = std::sync::Arc::clone(&started);
@@ -663,8 +676,8 @@ mod tests {
     #[tokio::test]
     async fn instance_shutdown_retires_every_route_to_that_instance() {
         let root = test_root("route-retirement");
-        let host = super::VerletHost::new();
-        let id = super::InstanceId::new("instance").unwrap();
+        let host = crate::adapters::host::VerletHost::new();
+        let id = crate::adapters::host::InstanceId::new("instance").unwrap();
         host.start_instance(
             id.clone(),
             test_config(&root.join("instance"), "tenant", "operator"),
@@ -696,7 +709,7 @@ mod tests {
 
     #[tokio::test]
     async fn listener_requires_explicit_non_loopback_opt_in() {
-        let host = super::VerletHost::new();
+        let host = crate::adapters::host::VerletHost::new();
         let guarded = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
         let error = host.serve_websocket_listener(guarded).await.unwrap_err();
         assert!(error.to_string().contains("is not loopback"), "{error}");
@@ -704,7 +717,7 @@ mod tests {
         let allowed = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
         host.serve_websocket_listener_with_options(
             allowed,
-            super::HostListenerOptions {
+            crate::adapters::host::HostListenerOptions {
                 allow_non_loopback: true,
             },
         )
@@ -718,7 +731,7 @@ mod tests {
         use tokio::io::AsyncReadExt as _;
         use tokio::io::AsyncWriteExt as _;
 
-        let host = super::VerletHost::new();
+        let host = crate::adapters::host::VerletHost::new();
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         host.serve_websocket_listener(listener).await.unwrap();

--- a/crates/verlet-kernel/src/cli/agent.rs
+++ b/crates/verlet-kernel/src/cli/agent.rs
@@ -3,7 +3,7 @@
 use chrono::TimeZone as _;
 use std::io::Write as _;
 
-pub(super) async fn run_agent(
+pub(crate) async fn run_agent(
     mut args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args.is_empty()
@@ -30,7 +30,7 @@ pub(super) async fn run_agent(
     }
 }
 
-pub(super) async fn agent_init(
+pub(crate) async fn agent_init(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_agent_init_args(args)?;
@@ -54,7 +54,7 @@ pub(super) async fn agent_init(
     Ok(())
 }
 
-pub(super) async fn agent_plan(
+pub(crate) async fn agent_plan(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_agent_manifest_args(args, "agent plan")?;
@@ -125,7 +125,7 @@ pub(super) async fn agent_plan(
     Ok(())
 }
 
-pub(super) async fn agent_publish(
+pub(crate) async fn agent_publish(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_agent_manifest_args(args, "agent publish")?;
@@ -183,24 +183,24 @@ pub(super) async fn agent_publish(
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) struct ManifestOperationRef {
+pub(crate) struct ManifestOperationRef {
     tool_id: String,
     reference: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) struct OperationRefResolution {
+pub(crate) struct OperationRefResolution {
     declared: String,
     resolved: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) struct UnpinnedOperationRef {
+pub(crate) struct UnpinnedOperationRef {
     record_name: String,
     operation_name: Option<String>,
 }
 
-pub(super) fn resolve_manifest_operation_refs(
+pub(crate) fn resolve_manifest_operation_refs(
     manifest_path: &std::path::Path,
     operation_registry_root: &std::path::Path,
 ) -> crate::kernel::runtime_host::VerletResult<Vec<OperationRefResolution>> {
@@ -273,7 +273,7 @@ pub(super) fn resolve_manifest_operation_refs(
     Ok(resolutions)
 }
 
-pub(super) fn manifest_operation_refs_from_source(
+pub(crate) fn manifest_operation_refs_from_source(
     source: &str,
 ) -> crate::kernel::runtime_host::VerletResult<Vec<ManifestOperationRef>> {
     let value: toml::Value = toml::from_str(source).map_err(|err| {
@@ -305,7 +305,7 @@ pub(super) fn manifest_operation_refs_from_source(
     Ok(refs)
 }
 
-pub(super) fn parse_resolvable_operation_ref(
+pub(crate) fn parse_resolvable_operation_ref(
     reference: &str,
 ) -> crate::kernel::runtime_host::VerletResult<Option<UnpinnedOperationRef>> {
     let Some(body) = reference.strip_prefix("op://") else {
@@ -342,7 +342,7 @@ pub(super) fn parse_resolvable_operation_ref(
     }
 }
 
-pub(super) fn rewrite_operation_ref_values(
+pub(crate) fn rewrite_operation_ref_values(
     source: &str,
     replacements: &std::collections::BTreeMap<String, String>,
     manifest_path: &std::path::Path,
@@ -373,7 +373,7 @@ pub(super) fn rewrite_operation_ref_values(
     Ok(rewritten)
 }
 
-pub(super) fn rewrite_operation_ref_line(
+pub(crate) fn rewrite_operation_ref_line(
     line: &str,
     replacements: &std::collections::BTreeMap<String, String>,
     touched: &mut std::collections::BTreeSet<String>,
@@ -435,7 +435,7 @@ pub(super) fn rewrite_operation_ref_line(
     rewritten
 }
 
-pub(super) fn is_escaped_basic_string_quote(bytes: &[u8], quote_index: usize) -> bool {
+pub(crate) fn is_escaped_basic_string_quote(bytes: &[u8], quote_index: usize) -> bool {
     let mut backslashes = 0;
     let mut index = quote_index;
     while index > 0 {
@@ -449,7 +449,7 @@ pub(super) fn is_escaped_basic_string_quote(bytes: &[u8], quote_index: usize) ->
     backslashes % 2 == 1
 }
 
-pub(super) fn write_text_atomically(
+pub(crate) fn write_text_atomically(
     path: &std::path::Path,
     label: String,
     body: &str,
@@ -493,7 +493,7 @@ pub(super) fn write_text_atomically(
     })
 }
 
-pub(super) async fn agent_list(
+pub(crate) async fn agent_list(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_agent_registry_args(args, "agent list")?;
@@ -518,7 +518,7 @@ pub(super) async fn agent_list(
     Ok(())
 }
 
-pub(super) async fn agent_versions(
+pub(crate) async fn agent_versions(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_agent_versions_args(args)?;
@@ -570,7 +570,7 @@ pub(super) async fn agent_versions(
     Ok(())
 }
 
-pub(super) async fn agent_diff(
+pub(crate) async fn agent_diff(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_agent_diff_args(args)?;
@@ -628,7 +628,7 @@ pub(super) async fn agent_diff(
     Ok(())
 }
 
-pub(super) fn manifest_diff_snapshot(
+pub(crate) fn manifest_diff_snapshot(
     record: &crate::agent::manifest::PublishedAgentRecord,
     form: AgentManifestForm,
 ) -> crate::kernel::runtime_host::VerletResult<serde_json::Value> {
@@ -640,7 +640,7 @@ pub(super) fn manifest_diff_snapshot(
     }
 }
 
-pub(super) fn render_manifest_diff_value(value: &serde_json::Value) -> String {
+pub(crate) fn render_manifest_diff_value(value: &serde_json::Value) -> String {
     let rendered = serde_json::to_string(value).unwrap_or_else(|_| "null".to_string());
     if rendered.chars().count() <= 120 {
         return rendered;
@@ -648,7 +648,7 @@ pub(super) fn render_manifest_diff_value(value: &serde_json::Value) -> String {
     rendered.chars().take(117).collect::<String>() + "..."
 }
 
-pub(super) async fn agent_show(
+pub(crate) async fn agent_show(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_agent_show_args(args)?;
@@ -665,7 +665,7 @@ pub(super) async fn agent_show(
     print_agent_record_json(&record)
 }
 
-pub(super) async fn agent_run(
+pub(crate) async fn agent_run(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_agent_run_args(args)?;
@@ -725,7 +725,7 @@ pub(super) async fn agent_run(
 }
 
 #[derive(Debug)]
-pub(super) struct AgentInitArgs {
+pub(crate) struct AgentInitArgs {
     name: Option<String>,
     out_path: Option<std::path::PathBuf>,
     force: bool,
@@ -733,7 +733,7 @@ pub(super) struct AgentInitArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct AgentManifestArgs {
+pub(crate) struct AgentManifestArgs {
     manifest_path: Option<std::path::PathBuf>,
     registry_root: Option<std::path::PathBuf>,
     operations_registry_root: Option<std::path::PathBuf>,
@@ -742,13 +742,13 @@ pub(super) struct AgentManifestArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct AgentRegistryArgs {
+pub(crate) struct AgentRegistryArgs {
     registry_root: Option<std::path::PathBuf>,
     help: bool,
 }
 
 #[derive(Debug)]
-pub(super) struct AgentVersionsArgs {
+pub(crate) struct AgentVersionsArgs {
     name: Option<String>,
     registry_root: Option<std::path::PathBuf>,
     json: bool,
@@ -757,19 +757,19 @@ pub(super) struct AgentVersionsArgs {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, strum::AsRefStr, strum::Display)]
 #[strum(serialize_all = "snake_case")]
-pub(super) enum AgentManifestForm {
+pub(crate) enum AgentManifestForm {
     Authored,
     Resolved,
 }
 
 #[derive(Debug)]
-pub(super) struct AgentDiffEndpoint {
+pub(crate) struct AgentDiffEndpoint {
     version: String,
     form: AgentManifestForm,
 }
 
 #[derive(Debug)]
-pub(super) struct AgentDiffArgs {
+pub(crate) struct AgentDiffArgs {
     name: Option<String>,
     from: Option<AgentDiffEndpoint>,
     to: Option<AgentDiffEndpoint>,
@@ -779,21 +779,21 @@ pub(super) struct AgentDiffArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct AgentShowArgs {
+pub(crate) struct AgentShowArgs {
     reference: Option<String>,
     registry_root: Option<std::path::PathBuf>,
     help: bool,
 }
 
 #[derive(Debug)]
-pub(super) struct AgentRunArgs {
+pub(crate) struct AgentRunArgs {
     reference: Option<String>,
     input: Option<String>,
     registry_root: Option<std::path::PathBuf>,
     help: bool,
 }
 
-pub(super) fn parse_agent_init_args(
+pub(crate) fn parse_agent_init_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<AgentInitArgs> {
     let mut name = None;
@@ -829,7 +829,7 @@ pub(super) fn parse_agent_init_args(
     })
 }
 
-pub(super) fn parse_agent_manifest_args(
+pub(crate) fn parse_agent_manifest_args(
     args: Vec<std::ffi::OsString>,
     command: &str,
 ) -> crate::kernel::runtime_host::VerletResult<AgentManifestArgs> {
@@ -879,7 +879,7 @@ pub(super) fn parse_agent_manifest_args(
     })
 }
 
-pub(super) fn parse_agent_registry_args(
+pub(crate) fn parse_agent_registry_args(
     args: Vec<std::ffi::OsString>,
     command: &str,
 ) -> crate::kernel::runtime_host::VerletResult<AgentRegistryArgs> {
@@ -908,7 +908,7 @@ pub(super) fn parse_agent_registry_args(
     })
 }
 
-pub(super) fn parse_agent_versions_args(
+pub(crate) fn parse_agent_versions_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<AgentVersionsArgs> {
     let mut name = None;
@@ -949,7 +949,7 @@ pub(super) fn parse_agent_versions_args(
     })
 }
 
-pub(super) fn parse_agent_diff_args(
+pub(crate) fn parse_agent_diff_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<AgentDiffArgs> {
     let mut name = None;
@@ -1004,7 +1004,7 @@ pub(super) fn parse_agent_diff_args(
     })
 }
 
-pub(super) fn parse_agent_diff_endpoint(
+pub(crate) fn parse_agent_diff_endpoint(
     value: &str,
 ) -> crate::kernel::runtime_host::VerletResult<AgentDiffEndpoint> {
     let (version, form) = match value.rsplit_once(':') {
@@ -1032,7 +1032,7 @@ fn required_agent_history_value(
     Ok(value)
 }
 
-pub(super) fn parse_agent_show_args(
+pub(crate) fn parse_agent_show_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<AgentShowArgs> {
     let mut reference = None;
@@ -1070,7 +1070,7 @@ pub(super) fn parse_agent_show_args(
     })
 }
 
-pub(super) fn parse_agent_run_args(
+pub(crate) fn parse_agent_run_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<AgentRunArgs> {
     let mut reference = None;
@@ -1115,17 +1115,17 @@ pub(super) fn parse_agent_run_args(
     })
 }
 
-pub(super) fn agent_registry_root(registry_root: Option<std::path::PathBuf>) -> std::path::PathBuf {
+pub(crate) fn agent_registry_root(registry_root: Option<std::path::PathBuf>) -> std::path::PathBuf {
     registry_root.unwrap_or_else(|| std::path::PathBuf::from(".verlet/agents"))
 }
 
-pub(super) fn agent_operations_registry_root(
+pub(crate) fn agent_operations_registry_root(
     registry_root: Option<std::path::PathBuf>,
 ) -> std::path::PathBuf {
     registry_root.unwrap_or_else(crate::agent::manifest::default_operations_registry_root)
 }
 
-pub(super) fn write_agent_project(
+pub(crate) fn write_agent_project(
     name: &str,
     root: &std::path::Path,
     force: bool,
@@ -1179,7 +1179,7 @@ pub(super) fn write_agent_project(
     .map_err(crate::cli::io_error)
 }
 
-pub(super) fn render_agent_manifest_template(
+pub(crate) fn render_agent_manifest_template(
     name: &str,
 ) -> crate::kernel::runtime_host::VerletResult<String> {
     verlet_operations::operation_store::validate_record_name(name)?;
@@ -1207,7 +1207,7 @@ streaming = false\n\
     ))
 }
 
-pub(super) fn render_agent_system_prompt_template(
+pub(crate) fn render_agent_system_prompt_template(
     name: &str,
 ) -> crate::kernel::runtime_host::VerletResult<String> {
     verlet_operations::operation_store::validate_record_name(name)?;
@@ -1219,7 +1219,7 @@ receipt or event evidence needed to resume or debug the run.\n"
     ))
 }
 
-pub(super) fn render_agent_operation_refs_template(
+pub(crate) fn render_agent_operation_refs_template(
     name: &str,
 ) -> crate::kernel::runtime_host::VerletResult<String> {
     verlet_operations::operation_store::validate_record_name(name)?;
@@ -1235,7 +1235,7 @@ operation_ref = \"op://example-tool@sha256:0000000000000000000000000000000000000
     ))
 }
 
-pub(super) fn render_agent_coupling_templates_template(
+pub(crate) fn render_agent_coupling_templates_template(
     name: &str,
 ) -> crate::kernel::runtime_host::VerletResult<String> {
     verlet_operations::operation_store::validate_record_name(name)?;
@@ -1269,7 +1269,7 @@ summary = {:?}\n",
     Ok(out)
 }
 
-pub(super) fn render_agent_operation_slot_template(
+pub(crate) fn render_agent_operation_slot_template(
     name: &str,
 ) -> crate::kernel::runtime_host::VerletResult<String> {
     verlet_operations::operation_store::validate_record_name(name)?;
@@ -1282,11 +1282,11 @@ before publishing verlet.agent.toml.\n"
     ))
 }
 
-pub(super) fn toml_string(value: &str) -> String {
+pub(crate) fn toml_string(value: &str) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
 }
 
-pub(super) fn print_agent_record_json(
+pub(crate) fn print_agent_record_json(
     record: &crate::agent::manifest::PublishedAgentRecord,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let json = serde_json::to_string_pretty(record)
@@ -1295,7 +1295,7 @@ pub(super) fn print_agent_record_json(
     Ok(())
 }
 
-pub(super) fn agent_context_source_lines(manifest: &serde_json::Value) -> Vec<String> {
+pub(crate) fn agent_context_source_lines(manifest: &serde_json::Value) -> Vec<String> {
     let resources = manifest
         .get("resources")
         .and_then(serde_json::Value::as_array)
@@ -1332,7 +1332,7 @@ pub(super) fn agent_context_source_lines(manifest: &serde_json::Value) -> Vec<St
         .collect()
 }
 
-pub(super) fn content_hash_label_from_ref(ref_uri: &str) -> Option<String> {
+pub(crate) fn content_hash_label_from_ref(ref_uri: &str) -> Option<String> {
     if let Some(hash) = ref_uri.strip_prefix("resource://artifact/sha256:")
         && hash.len() == 64
     {
@@ -1342,7 +1342,7 @@ pub(super) fn content_hash_label_from_ref(ref_uri: &str) -> Option<String> {
     (hash.len() == 64).then(|| format!("sha256:{hash}"))
 }
 
-pub(super) fn print_agent_help() {
+pub(crate) fn print_agent_help() {
     println!(
         "verlet agent\n\
 \n\
@@ -1361,7 +1361,7 @@ writes nothing; `publish` reruns the plan and writes an immutable local record.\
     );
 }
 
-pub(super) fn print_agent_init_help() {
+pub(crate) fn print_agent_init_help() {
     println!(
         "verlet agent init\n\
 \n\
@@ -1373,7 +1373,7 @@ Writes a folder-first Verlet agent project. --out selects the project directory.
     );
 }
 
-pub(super) fn print_agent_plan_help() {
+pub(crate) fn print_agent_plan_help() {
     println!(
         "verlet agent plan\n\
 \n\
@@ -1388,7 +1388,7 @@ reported unverified-offline.\n"
     );
 }
 
-pub(super) fn print_agent_publish_help() {
+pub(crate) fn print_agent_publish_help() {
     println!(
         "verlet agent publish\n\
 \n\
@@ -1403,7 +1403,7 @@ op://name@sha256:<hash> refs before publish verification runs.\n"
     );
 }
 
-pub(super) fn print_agent_list_help() {
+pub(crate) fn print_agent_list_help() {
     println!(
         "verlet agent list\n\
 \n\
@@ -1414,7 +1414,7 @@ Lists published agent records in the local registry.\n"
     );
 }
 
-pub(super) fn print_agent_versions_help() {
+pub(crate) fn print_agent_versions_help() {
     println!(
         "verlet agent versions\n\
 \n\
@@ -1425,7 +1425,7 @@ Lists immutable agent versions in publication order.\n"
     );
 }
 
-pub(super) fn print_agent_diff_help() {
+pub(crate) fn print_agent_diff_help() {
     println!(
         "verlet agent diff\n\
 \n\
@@ -1436,7 +1436,7 @@ Prints a structural diff between immutable authored or resolved manifest snapsho
     );
 }
 
-pub(super) fn print_agent_show_help() {
+pub(crate) fn print_agent_show_help() {
     println!(
         "verlet agent show\n\
 \n\
@@ -1447,7 +1447,7 @@ Prints the published agent record as JSON.\n"
     );
 }
 
-pub(super) fn print_agent_run_help() {
+pub(crate) fn print_agent_run_help() {
     println!(
         "verlet agent run\n\
 \n\

--- a/crates/verlet-kernel/src/cli/auth.rs
+++ b/crates/verlet-kernel/src/cli/auth.rs
@@ -4,7 +4,7 @@ use std::io::Read as _;
 use verlet_metadata::provider_store::LlmProviderAuthStore as _;
 use verlet_metadata::provider_store::LlmProviderCatalogStore as _;
 
-pub(super) async fn run_auth(
+pub(crate) async fn run_auth(
     mut args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args.is_empty()
@@ -27,7 +27,7 @@ pub(super) async fn run_auth(
     }
 }
 
-pub(super) async fn auth_login(
+pub(crate) async fn auth_login(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_auth_login_args(args)?;
@@ -128,7 +128,7 @@ fn oauth_identity(
     }
 }
 
-pub(super) async fn auth_status(
+pub(crate) async fn auth_status(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_auth_name_args(args, "auth status")?;
@@ -197,7 +197,7 @@ fn auth_status_value(
     })
 }
 
-pub(super) async fn auth_set(
+pub(crate) async fn auth_set(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_auth_set_args(args)?;
@@ -248,7 +248,7 @@ pub(super) async fn auth_set(
     Ok(())
 }
 
-pub(super) async fn auth_delete(
+pub(crate) async fn auth_delete(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_auth_name_args(args, "auth delete")?;
@@ -269,7 +269,7 @@ pub(super) async fn auth_delete(
 }
 
 #[derive(Debug)]
-pub(super) struct AuthSetArgs {
+pub(crate) struct AuthSetArgs {
     provider_id: Option<String>,
     api_key_stdin: bool,
     state_home: Option<std::path::PathBuf>,
@@ -277,7 +277,7 @@ pub(super) struct AuthSetArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct AuthLoginArgs {
+pub(crate) struct AuthLoginArgs {
     provider_id: Option<String>,
     device: bool,
     state_home: Option<std::path::PathBuf>,
@@ -285,13 +285,13 @@ pub(super) struct AuthLoginArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct AuthNameArgs {
+pub(crate) struct AuthNameArgs {
     provider_id: Option<String>,
     state_home: Option<std::path::PathBuf>,
     help: bool,
 }
 
-pub(super) fn parse_auth_set_args(
+pub(crate) fn parse_auth_set_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<AuthSetArgs> {
     let mut provider_id = None;
@@ -332,7 +332,7 @@ pub(super) fn parse_auth_set_args(
     })
 }
 
-pub(super) fn parse_auth_login_args(
+pub(crate) fn parse_auth_login_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<AuthLoginArgs> {
     let mut provider_id = None;
@@ -373,7 +373,7 @@ pub(super) fn parse_auth_login_args(
     })
 }
 
-pub(super) fn parse_auth_name_args(
+pub(crate) fn parse_auth_name_args(
     args: Vec<std::ffi::OsString>,
     command: &str,
 ) -> crate::kernel::runtime_host::VerletResult<AuthNameArgs> {
@@ -412,7 +412,7 @@ pub(super) fn parse_auth_name_args(
     })
 }
 
-pub(super) fn print_auth_help() {
+pub(crate) fn print_auth_help() {
     println!(
         "verlet auth\n\
 \n\
@@ -427,7 +427,7 @@ secret values are never printed.\n"
     );
 }
 
-pub(super) fn print_auth_login_help() {
+pub(crate) fn print_auth_login_help() {
     println!(
         "verlet auth login\n\
 \n\
@@ -440,7 +440,7 @@ stored only in the local provider store and are never printed.\n"
     );
 }
 
-pub(super) fn print_auth_status_help() {
+pub(crate) fn print_auth_status_help() {
     println!(
         "verlet auth status\n\
 \n\
@@ -451,7 +451,7 @@ Prints redacted model-provider credential status.\n"
     );
 }
 
-pub(super) fn print_auth_set_help() {
+pub(crate) fn print_auth_set_help() {
     println!(
         "verlet auth set\n\
 \n\
@@ -462,7 +462,7 @@ Stores a model-provider API key read from stdin. The stored value is never print
     );
 }
 
-pub(super) fn print_auth_delete_help() {
+pub(crate) fn print_auth_delete_help() {
     println!(
         "verlet auth delete\n\
 \n\
@@ -477,7 +477,7 @@ Deletes a stored model-provider credential.\n"
 mod tests {
     #[tokio::test]
     async fn api_key_set_rejects_openai_codex_before_reading_stdin() {
-        let error = super::auth_set(
+        let error = crate::cli::auth::auth_set(
             ["openai-codex", "--api-key-stdin"]
                 .into_iter()
                 .map(std::ffi::OsString::from)
@@ -491,7 +491,7 @@ mod tests {
 
     #[test]
     fn login_args_accept_device_and_state_home() {
-        let parsed = super::parse_auth_login_args(
+        let parsed = crate::cli::auth::parse_auth_login_args(
             [
                 "openai-codex",
                 "--device",
@@ -527,7 +527,7 @@ mod tests {
             email: Some("user@example.com".to_string()),
         };
 
-        let value = super::auth_status_value(&provider, &status, Some(&credential));
+        let value = crate::cli::auth::auth_status_value(&provider, &status, Some(&credential));
         assert_eq!(value["signed_in"], true);
         assert_eq!(value["credential_type"], "oauth");
         assert_eq!(value["account_id"], "acct-123");

--- a/crates/verlet-kernel/src/cli/blob.rs
+++ b/crates/verlet-kernel/src/cli/blob.rs
@@ -1,6 +1,6 @@
 //! The `blob` subcommand family.
 
-pub(super) async fn run_blob(
+pub(crate) async fn run_blob(
     mut args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args.is_empty()
@@ -34,7 +34,7 @@ pub(super) async fn run_blob(
     }
 }
 
-pub(super) async fn blob_publish(
+pub(crate) async fn blob_publish(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_blob_publish_args(args)?;
@@ -64,14 +64,14 @@ pub(super) async fn blob_publish(
 }
 
 #[derive(Debug)]
-pub(super) struct BlobPublishArgs {
+pub(crate) struct BlobPublishArgs {
     file: Option<std::path::PathBuf>,
     name: Option<String>,
     registry_root: Option<std::path::PathBuf>,
     help: bool,
 }
 
-pub(super) fn parse_blob_publish_args(
+pub(crate) fn parse_blob_publish_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<BlobPublishArgs> {
     let mut file = None;
@@ -116,7 +116,7 @@ pub(super) fn parse_blob_publish_args(
     })
 }
 
-pub(super) fn print_blob_help() {
+pub(crate) fn print_blob_help() {
     println!(
         "verlet blob\n\
 \n\
@@ -129,7 +129,7 @@ folder-first prompts and other static context inputs.\n"
     );
 }
 
-pub(super) fn print_blob_publish_help() {
+pub(crate) fn print_blob_publish_help() {
     println!(
         "verlet blob publish\n\
 \n\

--- a/crates/verlet-kernel/src/cli/chat.rs
+++ b/crates/verlet-kernel/src/cli/chat.rs
@@ -8,7 +8,7 @@
 //! and the UI is a pure function of what this driver feeds it.
 
 #[derive(Clone, Copy, Debug)]
-pub(super) enum ChatInvocation {
+pub(crate) enum ChatInvocation {
     Chat,
 }
 
@@ -33,12 +33,12 @@ impl ChatInvocation {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) enum ChatAttachTarget {
+pub(crate) enum ChatAttachTarget {
     Unix(std::path::PathBuf),
     WebSocket(String),
 }
 
-pub(super) async fn run(
+pub(crate) async fn run(
     args: Vec<std::ffi::OsString>,
     invocation: ChatInvocation,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
@@ -135,7 +135,7 @@ fn chat_connect_config(
     }
 }
 
-pub(super) fn parse_attach_target(
+pub(crate) fn parse_attach_target(
     raw: &str,
 ) -> crate::kernel::runtime_host::VerletResult<ChatAttachTarget> {
     if let Some(path) = raw.strip_prefix("unix://") {
@@ -181,7 +181,7 @@ where
         thread_name: thread_name(&thread.raw),
         version: env!("CARGO_PKG_VERSION").to_string(),
     };
-    let mut app = verlet_chat::App::new(meta);
+    let mut app = verlet_chat::app::App::new(meta);
     if let Some(prompt) = initial_prompt {
         app.submit(&prompt);
     }
@@ -197,7 +197,7 @@ where
     let mut driver = ChatDriver::new(thread.id)?;
 
     let run_result = {
-        let ui = verlet_chat::run_ui(&mut app, no_color, action_tx, event_rx);
+        let ui = verlet_chat::runner::run_ui(&mut app, no_color, action_tx, event_rx);
         let driven = driver.drive(&mut client, action_rx, event_tx);
         tokio::pin!(ui);
         tokio::pin!(driven);

--- a/crates/verlet-kernel/src/cli/chat/tests.rs
+++ b/crates/verlet-kernel/src/cli/chat/tests.rs
@@ -1,7 +1,5 @@
 use base64::Engine as _;
 use futures_util::{SinkExt as _, StreamExt as _};
-use std::collections::VecDeque;
-use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
 #[derive(Clone)]
@@ -28,7 +26,7 @@ async fn mock_operator_client(
     replies: Vec<MockRpcReply>,
 ) -> (
     crate::adapters::operator_client::OperatorClient<tokio::io::DuplexStream>,
-    Arc<Mutex<Vec<crate::adapters::app_server::connection::JsonRpcRequest>>>,
+    std::sync::Arc<std::sync::Mutex<Vec<crate::adapters::app_server::connection::JsonRpcRequest>>>,
     tokio::task::JoinHandle<()>,
 ) {
     let (client_io, server_io) = tokio::io::duplex(64 * 1024);
@@ -44,10 +42,10 @@ async fn mock_operator_client(
         None,
     )
     .await;
-    let requests = Arc::new(Mutex::new(Vec::new()));
-    let captured = Arc::clone(&requests);
+    let requests = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let captured = std::sync::Arc::clone(&requests);
     let task = tokio::spawn(async move {
-        let mut replies = VecDeque::from(replies);
+        let mut replies = std::collections::VecDeque::from(replies);
         while let Some(message) = server_websocket.next().await {
             let message = message.expect("mock app-server websocket read");
             let tokio_tungstenite::tungstenite::Message::Text(text) = message else {
@@ -128,7 +126,7 @@ async fn drive_actions(
         action_tx.send(action).unwrap();
     }
     drop(action_tx);
-    let mut driver = super::ChatDriver::new("thread-1".to_string()).unwrap();
+    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string()).unwrap();
     driver
         .drive(&mut client, action_rx, event_tx)
         .await
@@ -145,15 +143,15 @@ async fn drive_actions(
 
 struct FakeOAuthServer {
     base_url: String,
-    requests: Arc<Mutex<Vec<String>>>,
+    requests: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
     task: tokio::task::JoinHandle<()>,
 }
 
 async fn fake_oauth_server(responses: Vec<(u16, serde_json::Value)>) -> FakeOAuthServer {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
-    let requests = Arc::new(Mutex::new(Vec::new()));
-    let captured = Arc::clone(&requests);
+    let requests = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let captured = std::sync::Arc::clone(&requests);
     let task = tokio::spawn(async move {
         for (status, body) in responses {
             let (mut socket, _) = listener.accept().await.unwrap();
@@ -177,16 +175,16 @@ async fn fake_oauth_server(responses: Vec<(u16, serde_json::Value)>) -> FakeOAut
 
 async fn pending_oauth_server() -> (
     String,
-    Arc<Mutex<Vec<String>>>,
-    Arc<tokio::sync::Notify>,
+    std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    std::sync::Arc<tokio::sync::Notify>,
     tokio::task::JoinHandle<()>,
 ) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
-    let requests = Arc::new(Mutex::new(Vec::new()));
-    let captured = Arc::clone(&requests);
-    let shutdown = Arc::new(tokio::sync::Notify::new());
-    let stop = Arc::clone(&shutdown);
+    let requests = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let captured = std::sync::Arc::clone(&requests);
+    let shutdown = std::sync::Arc::new(tokio::sync::Notify::new());
+    let stop = std::sync::Arc::clone(&shutdown);
     let task = tokio::spawn(async move {
         let (mut socket, _) = listener.accept().await.unwrap();
         let request = read_http_request(&mut socket).await;
@@ -269,20 +267,20 @@ async fn recv_event(
 #[test]
 fn parse_attach_target_accepts_unix_and_websocket() {
     assert_eq!(
-        super::parse_attach_target("unix:///tmp/sock").expect("unix target"),
-        super::ChatAttachTarget::Unix(std::path::PathBuf::from("/tmp/sock"))
+        crate::cli::chat::parse_attach_target("unix:///tmp/sock").expect("unix target"),
+        crate::cli::chat::ChatAttachTarget::Unix(std::path::PathBuf::from("/tmp/sock"))
     );
     assert_eq!(
-        super::parse_attach_target("ws://127.0.0.1:7000/rpc").expect("ws target"),
-        super::ChatAttachTarget::WebSocket("ws://127.0.0.1:7000/rpc".to_string())
+        crate::cli::chat::parse_attach_target("ws://127.0.0.1:7000/rpc").expect("ws target"),
+        crate::cli::chat::ChatAttachTarget::WebSocket("ws://127.0.0.1:7000/rpc".to_string())
     );
 }
 
 #[test]
 fn parse_attach_target_rejects_empty_and_unknown_schemes() {
-    assert!(super::parse_attach_target("unix://").is_err());
-    assert!(super::parse_attach_target("wss://host/rpc").is_err());
-    assert!(super::parse_attach_target("http://host").is_err());
+    assert!(crate::cli::chat::parse_attach_target("unix://").is_err());
+    assert!(crate::cli::chat::parse_attach_target("wss://host/rpc").is_err());
+    assert!(crate::cli::chat::parse_attach_target("http://host").is_err());
 }
 
 fn notification(
@@ -295,8 +293,8 @@ fn notification(
     }
 }
 
-fn driver() -> super::ChatDriver {
-    let mut driver = super::ChatDriver::new("thread-1".to_string()).unwrap();
+fn driver() -> crate::cli::chat::ChatDriver {
+    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string()).unwrap();
     driver.active_turn_id = Some("turn-1".to_string());
     driver
 }
@@ -587,7 +585,7 @@ fn turn_completed_clears_the_active_turn_and_reports_errors() {
 
 #[test]
 fn session_rows_mark_the_current_thread() {
-    let rows = super::session_rows(
+    let rows = crate::cli::chat::session_rows(
         &serde_json::json!({
             "data": [
                 {"id": "thread-1", "name": "alpha", "status": {"type": "idle"}, "preview": "  hello   world  "},
@@ -605,7 +603,7 @@ fn session_rows_mark_the_current_thread() {
 
 #[test]
 fn model_rows_preserve_coordinates_auth_and_active_selection() {
-    let rows = super::model_rows(&crate::adapters::operator_client::OperatorModelList {
+    let rows = crate::cli::chat::model_rows(&crate::adapters::operator_client::OperatorModelList {
         data: vec![crate::adapters::operator_client::OperatorModel {
             provider_id: "provider-id".to_string(),
             model: "server-model".to_string(),
@@ -668,7 +666,7 @@ fn catalog_provider_rows_map_the_typed_rpc_response() {
     >(catalog)
     .expect("catalog response must deserialize into the typed client struct");
     assert_eq!(
-        super::catalog_provider_rows(&catalog),
+        crate::cli::chat::catalog_provider_rows(&catalog),
         vec![
             verlet_chat::CatalogProviderRow {
                 provider_id: "anthropic".to_string(),
@@ -704,15 +702,16 @@ fn catalog_provider_rows_map_the_typed_rpc_response() {
 
 #[test]
 fn custom_provider_upsert_params_carry_no_key_and_mark_the_default_model() {
-    let params = super::custom_provider_upsert_params(&verlet_chat::CustomProviderSpec {
-        provider_id: "my-llm".to_string(),
-        display_name: "My LLM".to_string(),
-        api: "anthropic_messages".to_string(),
-        base_url: "https://llm.example".to_string(),
-        header: Some(("X-Team".to_string(), "research".to_string())),
-        models: vec!["model-one".to_string(), "model-two".to_string()],
-        keyless: false,
-    });
+    let params =
+        crate::cli::chat::custom_provider_upsert_params(&verlet_chat::CustomProviderSpec {
+            provider_id: "my-llm".to_string(),
+            display_name: "My LLM".to_string(),
+            api: "anthropic_messages".to_string(),
+            base_url: "https://llm.example".to_string(),
+            header: Some(("X-Team".to_string(), "research".to_string())),
+            models: vec!["model-one".to_string(), "model-two".to_string()],
+            keyless: false,
+        });
     assert_eq!(
         serde_json::to_value(&params).unwrap(),
         serde_json::json!({
@@ -736,15 +735,16 @@ fn custom_provider_upsert_params_carry_no_key_and_mark_the_default_model() {
 
 #[test]
 fn keyless_custom_provider_upsert_params_declare_auth_none_without_auth_header() {
-    let params = super::custom_provider_upsert_params(&verlet_chat::CustomProviderSpec {
-        provider_id: "local-llm".to_string(),
-        display_name: "Local LLM".to_string(),
-        api: "openai_chat_completions".to_string(),
-        base_url: "http://127.0.0.1:11434/v1".to_string(),
-        header: None,
-        models: vec!["llama-local".to_string()],
-        keyless: true,
-    });
+    let params =
+        crate::cli::chat::custom_provider_upsert_params(&verlet_chat::CustomProviderSpec {
+            provider_id: "local-llm".to_string(),
+            display_name: "Local LLM".to_string(),
+            api: "openai_chat_completions".to_string(),
+            base_url: "http://127.0.0.1:11434/v1".to_string(),
+            header: None,
+            models: vec!["llama-local".to_string()],
+            keyless: true,
+        });
     assert_eq!(
         serde_json::to_value(&params).unwrap(),
         serde_json::json!({
@@ -831,7 +831,7 @@ async fn upsert_custom_provider_sends_one_upsert_and_reports_success() {
         keyless: true,
     };
     let expected_params =
-        serde_json::to_value(super::custom_provider_upsert_params(&spec)).unwrap();
+        serde_json::to_value(crate::cli::chat::custom_provider_upsert_params(&spec)).unwrap();
     let (events, requests) = drive_actions(
         vec![rpc_ok(
             "modelProvider/upsert",
@@ -1040,7 +1040,7 @@ async fn set_provider_key_maps_rpc_error_without_echoing_the_key() {
 #[test]
 fn oauth_rpc_error_redaction_removes_access_and_refresh_values() {
     assert_eq!(
-        super::redact_secret_values(
+        crate::cli::chat::redact_secret_values(
             "server echoed access-secret and refresh-secret".to_string(),
             [&"access-secret".to_string(), &"refresh-secret".to_string()],
         ),
@@ -1067,7 +1067,7 @@ async fn pending_login_aborts_its_task_when_dropped() {
         std::future::pending::<()>().await;
     });
     started_rx.await.unwrap();
-    drop(super::PendingLogin { id: 1, task });
+    drop(crate::cli::chat::PendingLogin { id: 1, task });
     tokio::time::timeout(std::time::Duration::from_secs(30), dropped_rx)
         .await
         .expect("aborted login task did not drop")
@@ -1153,7 +1153,7 @@ async fn device_login_emits_code_then_sends_oauth_credential_over_rpc() {
     .await;
     let (action_tx, action_rx) = tokio::sync::mpsc::unbounded_channel();
     let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
-    let mut driver = super::ChatDriver::new("thread-1".to_string()).unwrap();
+    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string()).unwrap();
     driver.oauth_client =
         crate::openai_codex::OpenAICodexOAuthClient::with_test_endpoints(&oauth.base_url).unwrap();
 
@@ -1208,7 +1208,7 @@ async fn second_start_login_while_pending_reports_error_without_spawning() {
     let (mut client, _, server) = mock_operator_client(Vec::new()).await;
     let (action_tx, action_rx) = tokio::sync::mpsc::unbounded_channel();
     let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
-    let mut driver = super::ChatDriver::new("thread-1".to_string()).unwrap();
+    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string()).unwrap();
     driver.oauth_client =
         crate::openai_codex::OpenAICodexOAuthClient::with_test_endpoints(&base_url).unwrap();
 
@@ -1259,8 +1259,8 @@ async fn stale_login_completion_after_cancel_is_ignored() {
     let (mut client, requests, server) = mock_operator_client(Vec::new()).await;
     let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
     let (login_tx, _) = tokio::sync::mpsc::unbounded_channel();
-    let mut driver = super::ChatDriver::new("thread-1".to_string()).unwrap();
-    driver.pending_login = Some(super::PendingLogin {
+    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string()).unwrap();
+    driver.pending_login = Some(crate::cli::chat::PendingLogin {
         id: 7,
         task: tokio::spawn(std::future::pending()),
     });
@@ -1277,7 +1277,7 @@ async fn stale_login_completion_after_cancel_is_ignored() {
         .apply_login_event(
             &mut client,
             &event_tx,
-            super::LoginTaskEvent::Finished {
+            crate::cli::chat::LoginTaskEvent::Finished {
                 id: 7,
                 provider_id: "openai-codex".to_string(),
                 result: Ok(
@@ -1304,8 +1304,8 @@ async fn set_provider_key_while_login_pending_is_rejected_without_rpc() {
     let (mut client, requests, server) = mock_operator_client(Vec::new()).await;
     let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
     let (login_tx, _) = tokio::sync::mpsc::unbounded_channel();
-    let mut driver = super::ChatDriver::new("thread-1".to_string()).unwrap();
-    driver.pending_login = Some(super::PendingLogin {
+    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string()).unwrap();
+    driver.pending_login = Some(crate::cli::chat::PendingLogin {
         id: 11,
         task: tokio::spawn(std::future::pending()),
     });
@@ -1389,9 +1389,10 @@ async fn bootstrap_without_configured_providers_emits_the_first_run_gate() {
     ])
     .await;
 
-    let session = super::bootstrap_chat_client(&mut client, "attach ws://test".to_string())
-        .await
-        .unwrap();
+    let session =
+        crate::cli::chat::bootstrap_chat_client(&mut client, "attach ws://test".to_string())
+            .await
+            .unwrap();
     assert_eq!(
         session.initial_events,
         vec![verlet_chat::ChatEvent::NoConfiguredProviders]
@@ -1427,9 +1428,10 @@ async fn bootstrap_with_a_configured_provider_skips_the_first_run_gate() {
     ])
     .await;
 
-    let session = super::bootstrap_chat_client(&mut client, "attach ws://test".to_string())
-        .await
-        .unwrap();
+    let session =
+        crate::cli::chat::bootstrap_chat_client(&mut client, "attach ws://test".to_string())
+            .await
+            .unwrap();
     assert_eq!(session.initial_events, Vec::new());
     assert_eq!(session.model_label, "anthropic/claude");
     assert_eq!(requests.lock().unwrap().len(), 3);

--- a/crates/verlet-kernel/src/cli/console.rs
+++ b/crates/verlet-kernel/src/cli/console.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 mod tests;
 
-pub(super) async fn run_console(
+pub(crate) async fn run_console(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args
@@ -64,20 +64,20 @@ pub(super) async fn run_console(
 }
 
 #[cfg(test)]
-pub(super) fn console_app_server_config(
+pub(crate) fn console_app_server_config(
     options: &ConsoleArgs,
     listen: crate::adapters::app_server::AppServerListenAddr,
 ) -> crate::kernel::runtime_host::VerletResult<crate::adapters::app_server::VerletAppServerConfig> {
     resolve_console_app_server_config(options, listen).map(|resolved| resolved.config)
 }
 
-pub(super) struct ResolvedConsoleAppServerConfig {
+pub(crate) struct ResolvedConsoleAppServerConfig {
     config: crate::adapters::app_server::VerletAppServerConfig,
     project_root: std::path::PathBuf,
     config_path: Option<std::path::PathBuf>,
 }
 
-pub(super) struct ConsoleEnvironment {
+pub(crate) struct ConsoleEnvironment {
     selected_cwd: std::path::PathBuf,
     project_root: std::path::PathBuf,
     project_storage_root: std::path::PathBuf,
@@ -85,7 +85,7 @@ pub(super) struct ConsoleEnvironment {
     config_paths: Vec<std::path::PathBuf>,
 }
 
-pub(super) fn resolve_console_app_server_config(
+pub(crate) fn resolve_console_app_server_config(
     options: &ConsoleArgs,
     listen: crate::adapters::app_server::AppServerListenAddr,
 ) -> crate::kernel::runtime_host::VerletResult<ResolvedConsoleAppServerConfig> {
@@ -144,7 +144,7 @@ pub(super) fn resolve_console_app_server_config(
     })
 }
 
-pub(super) fn resolve_console_environment(
+pub(crate) fn resolve_console_environment(
     options: &ConsoleArgs,
 ) -> crate::kernel::runtime_host::VerletResult<ConsoleEnvironment> {
     let selected_cwd = absolute_path(&options.cwd)?;
@@ -172,7 +172,7 @@ pub(super) fn resolve_console_environment(
     })
 }
 
-pub(super) fn console_project_storage_root(
+pub(crate) fn console_project_storage_root(
     project_root: &std::path::Path,
     user_home: &std::path::Path,
 ) -> std::path::PathBuf {
@@ -183,7 +183,7 @@ pub(super) fn console_project_storage_root(
     storage_root
 }
 
-pub(super) fn prepare_console_project_storage(
+pub(crate) fn prepare_console_project_storage(
     config: &crate::adapters::app_server::VerletAppServerConfig,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let mut roots = vec![
@@ -206,7 +206,7 @@ pub(super) fn prepare_console_project_storage(
     Ok(())
 }
 
-pub(super) fn default_user_verlet_home()
+pub(crate) fn default_user_verlet_home()
 -> crate::kernel::runtime_host::VerletResult<std::path::PathBuf> {
     if let Some(home) = std::env::var_os("VERLET_HOME").map(std::path::PathBuf::from) {
         return Ok(home);
@@ -219,7 +219,7 @@ pub(super) fn default_user_verlet_home()
     Ok(home.join(".verlet"))
 }
 
-pub(super) fn absolute_path(
+pub(crate) fn absolute_path(
     path: &std::path::Path,
 ) -> crate::kernel::runtime_host::VerletResult<std::path::PathBuf> {
     if path.is_absolute() {
@@ -232,13 +232,13 @@ pub(super) fn absolute_path(
         .join(path))
 }
 
-pub(super) fn push_unique_path(paths: &mut Vec<std::path::PathBuf>, path: std::path::PathBuf) {
+pub(crate) fn push_unique_path(paths: &mut Vec<std::path::PathBuf>, path: std::path::PathBuf) {
     if !paths.iter().any(|existing| existing == &path) {
         paths.push(path);
     }
 }
 
-pub(super) fn resolve_console_asset_root()
+pub(crate) fn resolve_console_asset_root()
 -> crate::kernel::runtime_host::VerletResult<std::path::PathBuf> {
     if let Some(path) = std::env::var_os("VERLET_CONSOLE_ASSET_DIR").map(std::path::PathBuf::from) {
         return console_asset_root_if_valid(path).ok_or_else(|| {
@@ -278,24 +278,24 @@ pub(super) fn resolve_console_asset_root()
         })
 }
 
-pub(super) fn exe_asset_candidate(exe: &std::path::Path) -> std::path::PathBuf {
+pub(crate) fn exe_asset_candidate(exe: &std::path::Path) -> std::path::PathBuf {
     exe.parent()
         .unwrap_or(std::path::Path::new("."))
         .join("share/verlet/console")
 }
 
-pub(super) fn console_asset_root_if_valid(path: std::path::PathBuf) -> Option<std::path::PathBuf> {
+pub(crate) fn console_asset_root_if_valid(path: std::path::PathBuf) -> Option<std::path::PathBuf> {
     path.join("index.html").is_file().then_some(path)
 }
 
-pub(super) fn open_browser_url(url: &str) -> crate::kernel::runtime_host::VerletResult<()> {
+pub(crate) fn open_browser_url(url: &str) -> crate::kernel::runtime_host::VerletResult<()> {
     browser_open_command(url)?
         .spawn()
         .map(|_| ())
         .map_err(|err| crate::cli::usage_error(format!("failed to open browser: {err}")))
 }
 
-pub(super) async fn open_browser_url_checked(
+pub(crate) async fn open_browser_url_checked(
     url: &str,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let command = browser_open_command(url)?;
@@ -325,7 +325,7 @@ async fn wait_for_browser_open_command(
 }
 
 #[cfg(target_os = "macos")]
-pub(super) fn browser_open_command(
+pub(crate) fn browser_open_command(
     url: &str,
 ) -> crate::kernel::runtime_host::VerletResult<std::process::Command> {
     let mut command = std::process::Command::new("open");
@@ -334,7 +334,7 @@ pub(super) fn browser_open_command(
 }
 
 #[cfg(target_os = "linux")]
-pub(super) fn browser_open_command(
+pub(crate) fn browser_open_command(
     url: &str,
 ) -> crate::kernel::runtime_host::VerletResult<std::process::Command> {
     let mut command = std::process::Command::new("xdg-open");
@@ -343,7 +343,7 @@ pub(super) fn browser_open_command(
 }
 
 #[cfg(target_os = "windows")]
-pub(super) fn browser_open_command(
+pub(crate) fn browser_open_command(
     url: &str,
 ) -> crate::kernel::runtime_host::VerletResult<std::process::Command> {
     let mut command = std::process::Command::new("cmd");
@@ -352,7 +352,7 @@ pub(super) fn browser_open_command(
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-pub(super) fn browser_open_command(
+pub(crate) fn browser_open_command(
     _url: &str,
 ) -> crate::kernel::runtime_host::VerletResult<std::process::Command> {
     Err(crate::cli::usage_error(
@@ -361,7 +361,7 @@ pub(super) fn browser_open_command(
 }
 
 #[derive(Debug)]
-pub(super) struct ConsoleArgs {
+pub(crate) struct ConsoleArgs {
     listen: std::net::SocketAddr,
     cwd: std::path::PathBuf,
     cwd_explicit: bool,
@@ -371,8 +371,8 @@ pub(super) struct ConsoleArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct ChatArgs {
-    pub(super) cwd: std::path::PathBuf,
+pub(crate) struct ChatArgs {
+    pub(crate) cwd: std::path::PathBuf,
     config_path: Option<std::path::PathBuf>,
     env_file: Option<std::path::PathBuf>,
     runtime_home: Option<std::path::PathBuf>,
@@ -384,13 +384,13 @@ pub(super) struct ChatArgs {
     model: Option<String>,
     max_tokens: Option<u32>,
     stream: Option<bool>,
-    pub(super) attach: Option<String>,
-    pub(super) prompt: Option<String>,
-    pub(super) help: bool,
+    pub(crate) attach: Option<String>,
+    pub(crate) prompt: Option<String>,
+    pub(crate) help: bool,
 }
 
 #[derive(Clone, Debug, Default, serde::Deserialize)]
-pub(super) struct ChatConfigFile {
+pub(crate) struct ChatConfigFile {
     chat: Option<ChatConfigSection>,
     provider: Option<String>,
     base_url: Option<String>,
@@ -409,7 +409,7 @@ pub(super) struct ChatConfigFile {
 }
 
 #[derive(Clone, Debug, Default, serde::Deserialize)]
-pub(super) struct ChatConfigSection {
+pub(crate) struct ChatConfigSection {
     provider: Option<String>,
     base_url: Option<String>,
     api_key: Option<String>,
@@ -427,7 +427,7 @@ pub(super) struct ChatConfigSection {
 }
 
 #[derive(Clone, Debug)]
-pub(super) enum ChatProviderConfig {
+pub(crate) enum ChatProviderConfig {
     Local,
     OpenAICodex {
         model: String,
@@ -475,7 +475,7 @@ pub(super) enum ChatProviderConfig {
     },
 }
 
-pub(super) fn apply_chat_provider_config(
+pub(crate) fn apply_chat_provider_config(
     config: &mut crate::adapters::app_server::VerletAppServerConfig,
     provider: ChatProviderConfig,
 ) {
@@ -606,7 +606,7 @@ pub(super) fn apply_chat_provider_config(
     }
 }
 
-pub(super) fn parse_console_args(
+pub(crate) fn parse_console_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<ConsoleArgs> {
     let mut listen = "127.0.0.1:0"
@@ -665,7 +665,7 @@ pub(super) fn parse_console_args(
     })
 }
 
-pub(super) fn parse_chat_args(
+pub(crate) fn parse_chat_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<ChatArgs> {
     let mut cwd = std::env::current_dir().map_err(|err| {
@@ -789,7 +789,7 @@ pub(super) fn parse_chat_args(
     })
 }
 
-pub(super) fn load_chat_provider_config(
+pub(crate) fn load_chat_provider_config(
     args: &ChatArgs,
 ) -> crate::kernel::runtime_host::VerletResult<ChatProviderConfig> {
     let (mut config, config_base) = load_chat_config_file(args.config_path.as_deref())?;
@@ -1200,7 +1200,7 @@ pub(super) fn load_chat_provider_config(
     }
 }
 
-pub(super) fn load_chat_capsule_bindings_config(
+pub(crate) fn load_chat_capsule_bindings_config(
     args: &ChatArgs,
 ) -> crate::kernel::runtime_host::VerletResult<crate::adapters::app_server::CapsuleBindingsConfig> {
     let (config, config_base) = load_chat_config_file(args.config_path.as_deref())?;
@@ -1214,7 +1214,7 @@ pub(super) fn load_chat_capsule_bindings_config(
     Ok(capsule_bindings)
 }
 
-pub(super) fn load_chat_config_file(
+pub(crate) fn load_chat_config_file(
     path: Option<&std::path::Path>,
 ) -> crate::kernel::runtime_host::VerletResult<(ChatConfigSection, Option<std::path::PathBuf>)> {
     let discovered;
@@ -1258,7 +1258,7 @@ pub(super) fn load_chat_config_file(
     Ok((config, path.parent().map(|base| base.to_path_buf())))
 }
 
-pub(super) fn read_env_file_if_exists(
+pub(crate) fn read_env_file_if_exists(
     path: &std::path::Path,
 ) -> crate::kernel::runtime_host::VerletResult<std::collections::BTreeMap<String, String>> {
     if !path.exists() {
@@ -1273,7 +1273,7 @@ pub(super) fn read_env_file_if_exists(
     Ok(parse_env_lines(&text))
 }
 
-pub(super) fn parse_env_lines(text: &str) -> std::collections::BTreeMap<String, String> {
+pub(crate) fn parse_env_lines(text: &str) -> std::collections::BTreeMap<String, String> {
     text.lines()
         .filter_map(|line| {
             let line = line.trim();
@@ -1286,7 +1286,7 @@ pub(super) fn parse_env_lines(text: &str) -> std::collections::BTreeMap<String, 
         .collect()
 }
 
-pub(super) fn unquote_env_value(value: &str) -> String {
+pub(crate) fn unquote_env_value(value: &str) -> String {
     if value.len() >= 2 {
         let bytes = value.as_bytes();
         if (bytes[0] == b'"' && bytes[value.len() - 1] == b'"')
@@ -1298,7 +1298,7 @@ pub(super) fn unquote_env_value(value: &str) -> String {
     value.to_string()
 }
 
-pub(super) fn env_or_file(
+pub(crate) fn env_or_file(
     name: &str,
     file_env: &std::collections::BTreeMap<String, String>,
 ) -> Option<String> {
@@ -1308,14 +1308,14 @@ pub(super) fn env_or_file(
         .or_else(|| file_env.get(name).cloned())
 }
 
-pub(super) struct PrivateAppServer {
+pub(crate) struct PrivateAppServer {
     listen: crate::adapters::app_server::AppServerListenAddr,
     root: std::path::PathBuf,
     task: tokio::task::JoinHandle<crate::kernel::runtime_host::VerletResult<()>>,
 }
 
 impl PrivateAppServer {
-    pub(super) async fn start(
+    pub(crate) async fn start(
         options: &ChatArgs,
     ) -> crate::kernel::runtime_host::VerletResult<Self> {
         let root = std::path::PathBuf::from("/tmp")
@@ -1349,11 +1349,11 @@ impl PrivateAppServer {
         Ok(Self { listen, root, task })
     }
 
-    pub(super) fn socket_path(&self) -> &std::path::Path {
+    pub(crate) fn socket_path(&self) -> &std::path::Path {
         socket_path(&self.listen)
     }
 
-    pub(super) fn shutdown(self) {}
+    pub(crate) fn shutdown(self) {}
 }
 
 impl Drop for PrivateAppServer {
@@ -1363,7 +1363,7 @@ impl Drop for PrivateAppServer {
     }
 }
 
-pub(super) fn socket_path(
+pub(crate) fn socket_path(
     listen: &crate::adapters::app_server::AppServerListenAddr,
 ) -> &std::path::Path {
     match listen {
@@ -1374,7 +1374,7 @@ pub(super) fn socket_path(
     }
 }
 
-pub(super) async fn wait_for_private_socket(
+pub(crate) async fn wait_for_private_socket(
     path: &std::path::Path,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     for _ in 0..100 {
@@ -1389,7 +1389,7 @@ pub(super) async fn wait_for_private_socket(
     )))
 }
 
-pub(super) async fn manifest_receipt_event_ids(
+pub(crate) async fn manifest_receipt_event_ids(
     app: &crate::adapters::app_server::VerletAppServer,
     thread_id: &str,
 ) -> crate::kernel::runtime_host::VerletResult<(String, String)> {
@@ -1431,7 +1431,7 @@ pub(super) async fn manifest_receipt_event_ids(
     Ok((compile_id.to_string(), bind_id.to_string()))
 }
 
-pub(super) async fn run_local_app_turn(
+pub(crate) async fn run_local_app_turn(
     app: &crate::adapters::app_server::VerletAppServer,
     thread_id: &str,
     input: &str,
@@ -1498,7 +1498,7 @@ pub(super) async fn run_local_app_turn(
     }
 }
 
-pub(super) fn notification_matches_thread_turn(
+pub(crate) fn notification_matches_thread_turn(
     notification: &crate::adapters::app_server::connection::JsonRpcNotification,
     thread_id: &str,
     turn_id: &str,
@@ -1517,7 +1517,7 @@ pub(super) fn notification_matches_thread_turn(
             == Some(turn_id)
 }
 
-pub(super) fn notification_turn_id(
+pub(crate) fn notification_turn_id(
     notification: &crate::adapters::app_server::connection::JsonRpcNotification,
 ) -> Option<&str> {
     notification
@@ -1528,7 +1528,7 @@ pub(super) fn notification_turn_id(
         .and_then(serde_json::Value::as_str)
 }
 
-pub(super) fn notification_error_message(
+pub(crate) fn notification_error_message(
     notification: &crate::adapters::app_server::connection::JsonRpcNotification,
 ) -> String {
     notification
@@ -1541,7 +1541,7 @@ pub(super) fn notification_error_message(
         .to_string()
 }
 
-pub(super) fn print_console_help() {
+pub(crate) fn print_console_help() {
     println!(
         "verlet console\n\
 \n\
@@ -1554,7 +1554,7 @@ the UI and RPC URLs, and opens the browser unless --no-open is set.\n"
     );
 }
 
-pub(super) fn print_chat_help() {
+pub(crate) fn print_chat_help() {
     println!(
         "verlet chat\n\
 \n\

--- a/crates/verlet-kernel/src/cli/console/tests.rs
+++ b/crates/verlet-kernel/src/cli/console/tests.rs
@@ -4,7 +4,7 @@ async fn checked_browser_open_reports_a_launcher_failure() {
     let mut command = std::process::Command::new("sh");
     command.args(["-c", "exit 7"]);
 
-    let error = super::wait_for_browser_open_command(command)
+    let error = crate::cli::console::wait_for_browser_open_command(command)
         .await
         .unwrap_err();
 

--- a/crates/verlet-kernel/src/cli/coupling.rs
+++ b/crates/verlet-kernel/src/cli/coupling.rs
@@ -1,6 +1,6 @@
 //! The `coupling` subcommand family.
 
-pub(super) async fn run_coupling(
+pub(crate) async fn run_coupling(
     mut args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args.is_empty()
@@ -36,7 +36,7 @@ pub(super) async fn run_coupling(
     }
 }
 
-pub(super) async fn coupling_init(
+pub(crate) async fn coupling_init(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_coupling_init_args(args)?;
@@ -55,7 +55,7 @@ pub(super) async fn coupling_init(
     Ok(())
 }
 
-pub(super) async fn coupling_run(
+pub(crate) async fn coupling_run(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_coupling_run_args(args)?;
@@ -92,7 +92,7 @@ pub(super) async fn coupling_run(
     Ok(())
 }
 
-pub(super) fn load_replay_coupling_set(
+pub(crate) fn load_replay_coupling_set(
     options: &CouplingRunArgs,
 ) -> crate::kernel::runtime_host::VerletResult<crate::agent::manifest_bind::BoundCouplingSet> {
     if let Some(path) = &options.coupling_file {
@@ -109,7 +109,7 @@ pub(super) fn load_replay_coupling_set(
     ))
 }
 
-pub(super) fn load_replay_coupling_set_file(
+pub(crate) fn load_replay_coupling_set_file(
     path: &std::path::Path,
 ) -> crate::kernel::runtime_host::VerletResult<crate::agent::manifest_bind::BoundCouplingSet> {
     let raw = std::fs::read_to_string(path).map_err(|err| {
@@ -139,7 +139,7 @@ pub(super) fn load_replay_coupling_set_file(
     )))
 }
 
-pub(super) fn coupling_set_from_export_bundle(
+pub(crate) fn coupling_set_from_export_bundle(
     value: &serde_json::Value,
 ) -> crate::kernel::runtime_host::VerletResult<Option<crate::agent::manifest_bind::BoundCouplingSet>>
 {
@@ -171,7 +171,7 @@ pub(super) fn coupling_set_from_export_bundle(
     Ok(None)
 }
 
-pub(super) fn select_replay_coupling(
+pub(crate) fn select_replay_coupling(
     coupling_set: &crate::agent::manifest_bind::BoundCouplingSet,
     coupling_id: &str,
 ) -> crate::kernel::runtime_host::VerletResult<crate::agent::manifest_bind::BoundCouplingSet> {
@@ -238,7 +238,7 @@ mod selection_tests {
     }
 }
 
-pub(super) async fn resolve_replay_artifact(
+pub(crate) async fn resolve_replay_artifact(
     artifact: &str,
     registry_root: Option<std::path::PathBuf>,
     coupling_set: &mut crate::agent::manifest_bind::BoundCouplingSet,
@@ -285,7 +285,7 @@ pub(super) async fn resolve_replay_artifact(
     Ok(root)
 }
 
-pub(super) fn apply_replay_operation_record(
+pub(crate) fn apply_replay_operation_record(
     coupling_set: &mut crate::agent::manifest_bind::BoundCouplingSet,
     record: &verlet_operations::operation_store::PublishedOperationRecord,
     selected_operation: Option<&str>,
@@ -308,7 +308,7 @@ pub(super) fn apply_replay_operation_record(
     Ok(())
 }
 
-pub(super) fn select_replay_operation_name(
+pub(crate) fn select_replay_operation_name(
     coupling_id: &str,
     selected_operation: Option<&str>,
     manifest: &verlet_abi::WasmOperationManifest,
@@ -329,7 +329,7 @@ pub(super) fn select_replay_operation_name(
     )))
 }
 
-pub(super) fn validate_replay_coupling_operation(
+pub(crate) fn validate_replay_coupling_operation(
     coupling_id: &str,
     operation_name: &str,
     manifest: &verlet_abi::WasmOperationManifest,
@@ -359,7 +359,7 @@ pub(super) fn validate_replay_coupling_operation(
     Ok(())
 }
 
-pub(super) async fn load_replay_recorded_events(
+pub(crate) async fn load_replay_recorded_events(
     options: &CouplingRunArgs,
 ) -> crate::kernel::runtime_host::VerletResult<Vec<verlet_history::EventRecord>> {
     match (&options.journal, &options.thread_id, &options.export_bundle) {
@@ -402,7 +402,7 @@ pub(super) async fn load_replay_recorded_events(
     }
 }
 
-pub(super) fn load_replay_events_from_export(
+pub(crate) fn load_replay_events_from_export(
     path: &std::path::Path,
 ) -> crate::kernel::runtime_host::VerletResult<Vec<verlet_history::EventRecord>> {
     let value = read_json_file(path)?;
@@ -442,7 +442,7 @@ pub(super) fn load_replay_events_from_export(
     Ok(events)
 }
 
-pub(super) fn event_record_from_export_value(
+pub(crate) fn event_record_from_export_value(
     value: serde_json::Value,
 ) -> crate::kernel::runtime_host::VerletResult<verlet_history::EventRecord> {
     let envelope = serde_json::from_value::<verlet_history::StreamRecordEnvelopeV1>(value)
@@ -465,7 +465,7 @@ pub(super) fn event_record_from_export_value(
     })
 }
 
-pub(super) async fn replay_coupling_events(
+pub(crate) async fn replay_coupling_events(
     coupling_set: &crate::agent::manifest_bind::BoundCouplingSet,
     recorded_events: Vec<verlet_history::EventRecord>,
     operation_registry_root: std::path::PathBuf,
@@ -497,7 +497,7 @@ pub(super) async fn replay_coupling_events(
     Ok(aggregate)
 }
 
-pub(super) fn read_json_file(
+pub(crate) fn read_json_file(
     path: &std::path::Path,
 ) -> crate::kernel::runtime_host::VerletResult<serde_json::Value> {
     let raw = std::fs::read_to_string(path).map_err(|err| {
@@ -508,7 +508,7 @@ pub(super) fn read_json_file(
     })
 }
 
-pub(super) fn parse_pinned_operation_ref(
+pub(crate) fn parse_pinned_operation_ref(
     reference: &str,
 ) -> crate::kernel::runtime_host::VerletResult<ParsedOperationRef> {
     let body = reference
@@ -543,7 +543,7 @@ pub(super) fn parse_pinned_operation_ref(
     })
 }
 
-pub(super) fn print_coupling_replay_report(report: &CouplingReplayReport) {
+pub(crate) fn print_coupling_replay_report(report: &CouplingReplayReport) {
     println!("DRY RUN ONLY: proposed coupling discharges; no stream was appended.");
     println!("mode {}", report.mode);
     println!("snapshot {}", report.snapshot_id);
@@ -581,7 +581,7 @@ pub(super) fn print_coupling_replay_report(report: &CouplingReplayReport) {
 }
 
 #[derive(Debug)]
-pub(super) struct CouplingInitArgs {
+pub(crate) struct CouplingInitArgs {
     name: Option<String>,
     out_path: Option<std::path::PathBuf>,
     force: bool,
@@ -589,7 +589,7 @@ pub(super) struct CouplingInitArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct CouplingRunArgs {
+pub(crate) struct CouplingRunArgs {
     replay: bool,
     artifact: Option<String>,
     coupling_file: Option<std::path::PathBuf>,
@@ -603,14 +603,14 @@ pub(super) struct CouplingRunArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct ParsedOperationRef {
+pub(crate) struct ParsedOperationRef {
     name: String,
     operation: Option<String>,
     artifact_hash: String,
 }
 
 #[derive(Default)]
-pub(super) struct CouplingReplayEventStore {
+pub(crate) struct CouplingReplayEventStore {
     streams: std::sync::Mutex<std::collections::BTreeMap<String, Vec<verlet_history::EventRecord>>>,
 }
 
@@ -696,7 +696,7 @@ impl verlet_history::EventStore for CouplingReplayEventStore {
 
 #[derive(Debug, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct CouplingReplayReport {
+pub(crate) struct CouplingReplayReport {
     schema: &'static str,
     mode: &'static str,
     dry_run: bool,
@@ -765,7 +765,7 @@ impl CouplingReplayReport {
 
 #[derive(Debug, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct CouplingReplayRunReport {
+pub(crate) struct CouplingReplayRunReport {
     coupling_id: String,
     status: String,
     scheduler_status: crate::kernel::coupling_scheduler::CouplingRunStatus,
@@ -811,7 +811,7 @@ impl CouplingReplayRunReport {
 
 #[derive(Debug, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct CouplingReplayProposalEvent {
+pub(crate) struct CouplingReplayProposalEvent {
     stream: String,
     stream_id: String,
     kind: String,
@@ -819,7 +819,7 @@ pub(super) struct CouplingReplayProposalEvent {
     provenance: verlet_history::EventProvenance,
 }
 
-pub(super) fn replay_run_is_blocked(
+pub(crate) fn replay_run_is_blocked(
     run: &crate::kernel::coupling_scheduler::CouplingRunReceipt,
 ) -> bool {
     run.reason.as_deref() == Some("quota_exhausted")
@@ -829,7 +829,7 @@ pub(super) fn replay_run_is_blocked(
             .is_some_and(|reason| reason.starts_with("budget:"))
 }
 
-pub(super) fn parse_coupling_init_args(
+pub(crate) fn parse_coupling_init_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<CouplingInitArgs> {
     let mut name = None;
@@ -865,7 +865,7 @@ pub(super) fn parse_coupling_init_args(
     })
 }
 
-pub(super) fn parse_coupling_run_args(
+pub(crate) fn parse_coupling_run_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<CouplingRunArgs> {
     let mut replay = false;
@@ -953,7 +953,7 @@ pub(super) fn parse_coupling_run_args(
     })
 }
 
-pub(super) fn write_coupling_project(
+pub(crate) fn write_coupling_project(
     name: &str,
     root: &std::path::Path,
     force: bool,
@@ -1012,7 +1012,7 @@ pub(super) fn write_coupling_project(
     .map_err(crate::cli::io_error)
 }
 
-pub(super) fn render_coupling_cargo_toml(
+pub(crate) fn render_coupling_cargo_toml(
     name: &str,
 ) -> crate::kernel::runtime_host::VerletResult<String> {
     let crate_name = coupling_crate_name(name)?;
@@ -1041,11 +1041,11 @@ panic = \"abort\"\n",
     ))
 }
 
-pub(super) fn render_coupling_lib_rs(operation_name: &str) -> String {
+pub(crate) fn render_coupling_lib_rs(operation_name: &str) -> String {
     COUPLING_LIB_RS_TEMPLATE.replace("__OPERATION_NAME__", operation_name)
 }
 
-pub(super) fn render_coupling_tool_manifest(name: &str, operation_name: &str) -> String {
+pub(crate) fn render_coupling_tool_manifest(name: &str, operation_name: &str) -> String {
     format!(
         "kind = \"cooldis.tool\"\n\
 schema_version = 0\n\
@@ -1091,7 +1091,7 @@ expect = \"fixtures/expect.discharge.json\"\n",
     )
 }
 
-pub(super) fn render_coupling_fixture_input(name: &str) -> String {
+pub(crate) fn render_coupling_fixture_input(name: &str) -> String {
     format!(
         "{{\n\
   \"abi\": \"cooldis.coupling.invocation/0.1\",\n\
@@ -1123,7 +1123,7 @@ pub(super) fn render_coupling_fixture_input(name: &str) -> String {
     )
 }
 
-pub(super) fn render_coupling_fixture_expect(name: &str) -> String {
+pub(crate) fn render_coupling_fixture_expect(name: &str) -> String {
     format!(
         "{{\n\
   \"abi\": \"cooldis.coupling.discharge/0.1\",\n\
@@ -1144,7 +1144,7 @@ pub(super) fn render_coupling_fixture_expect(name: &str) -> String {
     )
 }
 
-pub(super) fn coupling_operation_name(
+pub(crate) fn coupling_operation_name(
     name: &str,
 ) -> crate::kernel::runtime_host::VerletResult<String> {
     let mut operation = String::new();
@@ -1167,7 +1167,7 @@ pub(super) fn coupling_operation_name(
     Ok(operation)
 }
 
-pub(super) fn coupling_crate_name(name: &str) -> crate::kernel::runtime_host::VerletResult<String> {
+pub(crate) fn coupling_crate_name(name: &str) -> crate::kernel::runtime_host::VerletResult<String> {
     let mut suffix = String::new();
     for byte in name.bytes() {
         match byte {
@@ -1186,12 +1186,12 @@ pub(super) fn coupling_crate_name(name: &str) -> crate::kernel::runtime_host::Ve
     Ok(format!("verlet-coupling-{suffix}"))
 }
 
-pub(super) fn guest_sdk_dependency_path() -> std::path::PathBuf {
+pub(crate) fn guest_sdk_dependency_path() -> std::path::PathBuf {
     let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../verlet-guest-sdk");
     path.canonicalize().unwrap_or(path)
 }
 
-pub(super) const COUPLING_LIB_RS_TEMPLATE: &str = r#"use verlet_guest_sdk::prelude::*;
+pub(crate) const COUPLING_LIB_RS_TEMPLATE: &str = r#"use verlet_guest_sdk::prelude::*;
 use serde_json::json;
 
 #[derive(Deserialize)]
@@ -1254,7 +1254,7 @@ mod tests {
 }
 "#;
 
-pub(super) const COUPLING_INVOCATION_SCHEMA: &str = r#"{
+pub(crate) const COUPLING_INVOCATION_SCHEMA: &str = r#"{
   "type": "object",
   "required": ["abi", "trigger_event", "invocation_meta"],
   "properties": {
@@ -1271,7 +1271,7 @@ pub(super) const COUPLING_INVOCATION_SCHEMA: &str = r#"{
 }
 "#;
 
-pub(super) const COUPLING_DISCHARGE_SCHEMA: &str = r#"{
+pub(crate) const COUPLING_DISCHARGE_SCHEMA: &str = r#"{
   "type": "object",
   "required": ["abi", "events"],
   "properties": {
@@ -1285,7 +1285,7 @@ pub(super) const COUPLING_DISCHARGE_SCHEMA: &str = r#"{
 }
 "#;
 
-pub(super) fn print_coupling_help() {
+pub(crate) fn print_coupling_help() {
     println!(
         "verlet coupling\n\
 \n\
@@ -1301,7 +1301,7 @@ the source journal.\n"
     );
 }
 
-pub(super) fn print_coupling_init_help() {
+pub(crate) fn print_coupling_init_help() {
     println!(
         "verlet coupling init\n\
 \n\
@@ -1313,7 +1313,7 @@ fixtures, and one native testkit test.\n"
     );
 }
 
-pub(super) fn print_coupling_run_help() {
+pub(crate) fn print_coupling_run_help() {
     println!(
         "verlet coupling run\n\
 \n\

--- a/crates/verlet-kernel/src/cli/daemon.rs
+++ b/crates/verlet-kernel/src/cli/daemon.rs
@@ -4,7 +4,7 @@ use std::io::Read as _;
 #[cfg(test)]
 mod tests;
 
-pub(super) async fn run_daemon(
+pub(crate) async fn run_daemon(
     mut args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args.is_empty()
@@ -27,7 +27,7 @@ pub(super) async fn run_daemon(
     }
 }
 
-pub(super) async fn daemon_run(
+pub(crate) async fn daemon_run(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_daemon_run_args(args)?;
@@ -56,7 +56,7 @@ pub(super) async fn daemon_run(
     server.serve(listen).await
 }
 
-pub(super) fn daemon_app_server_config_from_loaded(
+pub(crate) fn daemon_app_server_config_from_loaded(
     loaded: &crate::daemon::daemon_config::LoadedVerletDaemonConfig,
 ) -> crate::kernel::runtime_host::VerletResult<crate::adapters::app_server::VerletAppServerConfig> {
     loaded.config.validate()?;
@@ -102,7 +102,7 @@ pub(super) fn daemon_app_server_config_from_loaded(
     Ok(config)
 }
 
-pub(super) fn daemon_app_server_registry_root(
+pub(crate) fn daemon_app_server_registry_root(
     path: std::path::PathBuf,
 ) -> crate::kernel::runtime_host::VerletResult<std::path::PathBuf> {
     if path.is_absolute() {
@@ -116,7 +116,7 @@ pub(super) fn daemon_app_server_registry_root(
         .join(path))
 }
 
-pub(super) async fn start_daemon_io(
+pub(crate) async fn start_daemon_io(
     io: &crate::daemon::daemon_config::VerletIoConfig,
     sync: &crate::daemon::remote_store::endpoint::VerletDaemonSyncConfig,
     daemon_config_path: Option<std::path::PathBuf>,
@@ -169,7 +169,7 @@ pub(super) async fn start_daemon_io(
     Ok(tasks)
 }
 
-pub(super) async fn start_daemon_sync(
+pub(crate) async fn start_daemon_sync(
     config: &crate::daemon::remote_store::endpoint::VerletDaemonSyncConfig,
     daemon_config_path: Option<std::path::PathBuf>,
     app_server: &crate::adapters::app_server::VerletAppServer,
@@ -238,7 +238,7 @@ pub(super) async fn start_daemon_sync(
     Ok(())
 }
 
-pub(super) async fn remote_child_run() -> crate::kernel::runtime_host::VerletResult<()> {
+pub(crate) async fn remote_child_run() -> crate::kernel::runtime_host::VerletResult<()> {
     let mut encoded = Vec::new();
     std::io::stdin()
         .read_to_end(&mut encoded)
@@ -265,7 +265,7 @@ pub(super) async fn remote_child_run() -> crate::kernel::runtime_host::VerletRes
 /// Starts the push-first settlement lane independently of external route
 /// policy. Handle outcomes always require the durable queue even when an
 /// operator has explicitly made a protocol route best-effort direct.
-pub(super) async fn start_thread_handle_ingress(
+pub(crate) async fn start_thread_handle_ingress(
     ingress: &crate::daemon::daemon_config::VerletIngressConfig,
     server: &crate::adapters::app_server::VerletAppServer,
     bridge: &crate::daemon::daemon_io::VerletDaemonIoBridge,
@@ -307,7 +307,7 @@ pub(super) async fn start_thread_handle_ingress(
     Ok(())
 }
 
-pub(super) async fn route_sink_for_ingress(
+pub(crate) async fn route_sink_for_ingress(
     route: &crate::daemon::daemon_config::VerletIoRouteConfig,
     ingress: &crate::daemon::daemon_config::VerletIngressConfig,
     bridge: &crate::daemon::daemon_io::VerletDaemonIoBridge,
@@ -350,7 +350,7 @@ pub(super) async fn route_sink_for_ingress(
     ))
 }
 
-pub(super) async fn start_clock_route(
+pub(crate) async fn start_clock_route(
     route: &crate::daemon::daemon_config::VerletIoRouteConfig,
     sink: std::sync::Arc<dyn verlet_io_core::IngressSink>,
     server: &crate::adapters::app_server::VerletAppServer,
@@ -374,7 +374,7 @@ pub(super) async fn start_clock_route(
     Ok(())
 }
 
-pub(super) async fn start_telegram_route(
+pub(crate) async fn start_telegram_route(
     route: &crate::daemon::daemon_config::VerletIoRouteConfig,
     sink: std::sync::Arc<dyn verlet_io_core::IngressSink>,
     bridge: &crate::daemon::daemon_io::VerletDaemonIoBridge,
@@ -448,7 +448,7 @@ pub(super) async fn start_telegram_route(
     Ok(())
 }
 
-pub(super) async fn daemon_config(
+pub(crate) async fn daemon_config(
     mut args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args.is_empty() {
@@ -484,7 +484,7 @@ pub(super) async fn daemon_config(
     }
 }
 
-pub(super) async fn daemon_service(
+pub(crate) async fn daemon_service(
     mut args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args.is_empty() {
@@ -537,7 +537,7 @@ pub(super) async fn daemon_service(
     }
 }
 
-pub(super) fn daemon_service_spec_from_args(
+pub(crate) fn daemon_service_spec_from_args(
     options: &DaemonServicePrintArgs,
 ) -> crate::kernel::runtime_host::VerletResult<crate::daemon::daemon_config::VerletDaemonServiceSpec>
 {
@@ -554,17 +554,17 @@ pub(super) fn daemon_service_spec_from_args(
 }
 
 #[derive(Debug)]
-pub(super) struct DaemonRunArgs {
+pub(crate) struct DaemonRunArgs {
     config_path: Option<std::path::PathBuf>,
 }
 
 #[derive(Debug)]
-pub(super) struct DaemonConfigValidateArgs {
+pub(crate) struct DaemonConfigValidateArgs {
     config_path: Option<std::path::PathBuf>,
 }
 
 #[derive(Debug)]
-pub(super) struct DaemonServicePrintArgs {
+pub(crate) struct DaemonServicePrintArgs {
     target: crate::daemon::daemon_config::VerletDaemonServiceTarget,
     config_path: std::path::PathBuf,
     executable: std::path::PathBuf,
@@ -573,12 +573,12 @@ pub(super) struct DaemonServicePrintArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct DaemonServiceUninstallArgs {
+pub(crate) struct DaemonServiceUninstallArgs {
     target: crate::daemon::daemon_config::VerletDaemonServiceTarget,
     label: String,
 }
 
-pub(super) fn parse_daemon_run_args(
+pub(crate) fn parse_daemon_run_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<DaemonRunArgs> {
     let mut config_path = None;
@@ -600,7 +600,7 @@ pub(super) fn parse_daemon_run_args(
     Ok(DaemonRunArgs { config_path })
 }
 
-pub(super) fn parse_daemon_config_validate_args(
+pub(crate) fn parse_daemon_config_validate_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<DaemonConfigValidateArgs> {
     let mut config_path = None;
@@ -622,7 +622,7 @@ pub(super) fn parse_daemon_config_validate_args(
     Ok(DaemonConfigValidateArgs { config_path })
 }
 
-pub(super) fn parse_daemon_service_print_args(
+pub(crate) fn parse_daemon_service_print_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<DaemonServicePrintArgs> {
     let mut target = default_daemon_service_target();
@@ -686,7 +686,7 @@ pub(super) fn parse_daemon_service_print_args(
     })
 }
 
-pub(super) fn parse_daemon_service_uninstall_args(
+pub(crate) fn parse_daemon_service_uninstall_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<DaemonServiceUninstallArgs> {
     let mut target = default_daemon_service_target();
@@ -722,7 +722,7 @@ fn parse_daemon_service_target(
     })
 }
 
-pub(super) fn default_daemon_service_target()
+pub(crate) fn default_daemon_service_target()
 -> crate::daemon::daemon_config::VerletDaemonServiceTarget {
     if cfg!(target_os = "macos") {
         crate::daemon::daemon_config::VerletDaemonServiceTarget::Launchd
@@ -731,7 +731,7 @@ pub(super) fn default_daemon_service_target()
     }
 }
 
-pub(super) fn load_daemon_provider_config(
+pub(crate) fn load_daemon_provider_config(
     config: &crate::daemon::daemon_config::VerletProviderConfig,
 ) -> crate::kernel::runtime_host::VerletResult<crate::cli::console::ChatProviderConfig> {
     match config.provider_name() {
@@ -1119,7 +1119,7 @@ pub(super) fn load_daemon_provider_config(
     }
 }
 
-pub(super) fn provider_is_openai_compatible(provider: &str) -> bool {
+pub(crate) fn provider_is_openai_compatible(provider: &str) -> bool {
     matches!(
         provider,
         "openai_compatible"
@@ -1129,7 +1129,7 @@ pub(super) fn provider_is_openai_compatible(provider: &str) -> bool {
     )
 }
 
-pub(super) fn chat_completions_provider_name(provider: &str) -> String {
+pub(crate) fn chat_completions_provider_name(provider: &str) -> String {
     if provider_is_openai_compatible(provider) {
         crate::adapters::app_server::APP_SERVER_OPENAI_COMPATIBLE_PROVIDER.to_string()
     } else {
@@ -1137,7 +1137,7 @@ pub(super) fn chat_completions_provider_name(provider: &str) -> String {
     }
 }
 
-pub(super) fn provider_default_headers(provider: &str) -> Vec<(String, String)> {
+pub(crate) fn provider_default_headers(provider: &str) -> Vec<(String, String)> {
     if provider_is_openai_compatible(provider) {
         vec![("X-Example-Provider".to_string(), "required".to_string())]
     } else {
@@ -1145,7 +1145,7 @@ pub(super) fn provider_default_headers(provider: &str) -> Vec<(String, String)> 
     }
 }
 
-pub(super) fn print_daemon_help() {
+pub(crate) fn print_daemon_help() {
     println!(
         "verlet daemon\n\
 \n\

--- a/crates/verlet-kernel/src/cli/debug_bind.rs
+++ b/crates/verlet-kernel/src/cli/debug_bind.rs
@@ -5,7 +5,7 @@ use chrono::TimeZone as _;
 mod tests;
 
 #[derive(Debug)]
-pub(super) struct DebugBindArgs {
+pub(crate) struct DebugBindArgs {
     thread_id: String,
     json: bool,
     journal: Option<std::path::PathBuf>,
@@ -127,7 +127,7 @@ struct RecordedReceiptEvent {
     payload: serde_json::Value,
 }
 
-pub(super) async fn run_debug_bind(
+pub(crate) async fn run_debug_bind(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args
@@ -175,7 +175,7 @@ pub(super) async fn run_debug_bind(
     Ok(())
 }
 
-pub(super) fn parse_debug_bind_args(
+pub(crate) fn parse_debug_bind_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<DebugBindArgs> {
     let mut endpoint = crate::cli::debug_rpc::DebugRpcEndpointArgs {
@@ -781,7 +781,7 @@ fn binding_origin_text(
     }
 }
 
-pub(super) fn print_debug_bind_help() {
+pub(crate) fn print_debug_bind_help() {
     println!(
         "verlet debug bind\n\
 \n\

--- a/crates/verlet-kernel/src/cli/debug_rpc.rs
+++ b/crates/verlet-kernel/src/cli/debug_rpc.rs
@@ -4,7 +4,7 @@ use std::io::Write as _;
 #[cfg(test)]
 mod tests;
 
-pub(super) async fn run_debug(
+pub(crate) async fn run_debug(
     mut args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args.is_empty()
@@ -28,7 +28,7 @@ pub(super) async fn run_debug(
 /// `verlet debug rpc` — protocol-level debug client for a RUNNING daemon's
 /// app-server websocket. Connects with `OperatorClient::connect_websocket`,
 /// performs the initialize handshake, then dispatches a subcommand.
-pub(super) async fn run_debug_rpc(
+pub(crate) async fn run_debug_rpc(
     mut args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args.is_empty()
@@ -55,26 +55,26 @@ pub(super) async fn run_debug_rpc(
 /// `daemon.app_server.listen`; else default `ws://127.0.0.1:49200/rpc`.
 /// `--url` and `--config` together is a usage error.
 #[derive(Debug)]
-pub(super) struct DebugRpcEndpointArgs {
-    pub(super) url: Option<String>,
-    pub(super) config: Option<std::path::PathBuf>,
+pub(crate) struct DebugRpcEndpointArgs {
+    pub(crate) url: Option<String>,
+    pub(crate) config: Option<std::path::PathBuf>,
 }
 
 #[derive(Debug)]
-pub(super) struct DebugRpcCallArgs {
+pub(crate) struct DebugRpcCallArgs {
     method: String,
     params: serde_json::Value,
     endpoint: DebugRpcEndpointArgs,
 }
 
 #[derive(Debug)]
-pub(super) enum DebugRpcThreadTarget {
+pub(crate) enum DebugRpcThreadTarget {
     New,
     Existing(String),
 }
 
 #[derive(Debug)]
-pub(super) struct DebugRpcTurnArgs {
+pub(crate) struct DebugRpcTurnArgs {
     target: DebugRpcThreadTarget,
     json: bool,
     text: String,
@@ -82,24 +82,24 @@ pub(super) struct DebugRpcTurnArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct DebugRpcTailArgs {
+pub(crate) struct DebugRpcTailArgs {
     thread_id: String,
     endpoint: DebugRpcEndpointArgs,
 }
 
-pub(super) enum DebugRpcTurnStreamResult {
+pub(crate) enum DebugRpcTurnStreamResult {
     Completed,
     TurnError(String),
 }
 
-pub(super) const DEBUG_RPC_DEFAULT_URL: &str = "ws://127.0.0.1:49200/rpc";
-pub(super) const DEBUG_RPC_TURN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+pub(crate) const DEBUG_RPC_DEFAULT_URL: &str = "ws://127.0.0.1:49200/rpc";
+pub(crate) const DEBUG_RPC_TURN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
 /// One-shot JSON-RPC request: `verlet debug rpc call <method> [PARAMS_JSON]`.
 /// PARAMS_JSON is an inline JSON object (omitted = no params). Prints the
 /// result pretty-printed to stdout. A JSON-RPC error response prints the error
 /// to stderr and exits 1 (transport failures likewise).
-pub(super) async fn run_debug_rpc_call(
+pub(crate) async fn run_debug_rpc_call(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_debug_rpc_call_args(args)?;
@@ -121,7 +121,7 @@ pub(super) async fn run_debug_rpc_call(
 /// delta), terminated by a newline at turn completion. `--json` instead emits
 /// every notification scoped to the thread as one JSON object per line.
 /// Exit codes: 0 turn completed, 2 turn error, 1 transport/protocol failure.
-pub(super) async fn run_debug_rpc_turn(
+pub(crate) async fn run_debug_rpc_turn(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_debug_rpc_turn_args(args)?;
@@ -162,7 +162,7 @@ pub(super) async fn run_debug_rpc_turn(
 /// Subscribe and watch: `verlet debug rpc tail --thread <id>`.
 /// Resumes the thread for the subscription, then prints every received
 /// notification as one JSON object per line until Ctrl-C/EOF.
-pub(super) async fn run_debug_rpc_tail(
+pub(crate) async fn run_debug_rpc_tail(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_debug_rpc_tail_args(args)?;
@@ -207,7 +207,7 @@ fn rpc_connection_was_closed(err: &crate::kernel::runtime_host::VerletError) -> 
     )
 }
 
-pub(super) fn print_debug_rpc_help() {
+pub(crate) fn print_debug_rpc_help() {
     println!(
         "verlet debug rpc\n\
 \n\
@@ -223,7 +223,7 @@ notifications as JSONL with --json); tail prints notifications until Ctrl-C.\n"
     );
 }
 
-pub(super) fn parse_debug_rpc_call_args(
+pub(crate) fn parse_debug_rpc_call_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<DebugRpcCallArgs> {
     let mut endpoint = DebugRpcEndpointArgs {
@@ -278,7 +278,7 @@ pub(super) fn parse_debug_rpc_call_args(
     })
 }
 
-pub(super) fn parse_debug_rpc_turn_args(
+pub(crate) fn parse_debug_rpc_turn_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<DebugRpcTurnArgs> {
     let mut endpoint = DebugRpcEndpointArgs {
@@ -343,7 +343,7 @@ pub(super) fn parse_debug_rpc_turn_args(
     })
 }
 
-pub(super) fn parse_debug_rpc_tail_args(
+pub(crate) fn parse_debug_rpc_tail_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<DebugRpcTailArgs> {
     let mut endpoint = DebugRpcEndpointArgs {
@@ -382,7 +382,7 @@ pub(super) fn parse_debug_rpc_tail_args(
     })
 }
 
-pub(super) fn validate_debug_rpc_endpoint_args(
+pub(crate) fn validate_debug_rpc_endpoint_args(
     endpoint: &DebugRpcEndpointArgs,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if endpoint.url.is_some() && endpoint.config.is_some() {
@@ -393,7 +393,7 @@ pub(super) fn validate_debug_rpc_endpoint_args(
     Ok(())
 }
 
-pub(super) fn resolve_debug_rpc_endpoint(
+pub(crate) fn resolve_debug_rpc_endpoint(
     endpoint: &DebugRpcEndpointArgs,
 ) -> crate::kernel::runtime_host::VerletResult<String> {
     validate_debug_rpc_endpoint_args(endpoint)?;
@@ -416,7 +416,7 @@ pub(super) fn resolve_debug_rpc_endpoint(
     Ok(DEBUG_RPC_DEFAULT_URL.to_string())
 }
 
-pub(super) async fn connect_debug_rpc_client(
+pub(crate) async fn connect_debug_rpc_client(
     url: &str,
 ) -> crate::kernel::runtime_host::VerletResult<
     crate::adapters::operator_client::OperatorClient<tokio::net::TcpStream>,
@@ -431,7 +431,7 @@ pub(super) async fn connect_debug_rpc_client(
     .await
 }
 
-pub(super) async fn stream_debug_rpc_turn(
+pub(crate) async fn stream_debug_rpc_turn(
     client: &mut crate::adapters::operator_client::OperatorClient<tokio::net::TcpStream>,
     thread_id: &str,
     turn_id: &str,
@@ -497,7 +497,7 @@ pub(super) async fn stream_debug_rpc_turn(
     }
 }
 
-pub(super) fn print_jsonl_notification(
+pub(crate) fn print_jsonl_notification(
     notification: &crate::adapters::app_server::connection::JsonRpcNotification,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     serde_json::to_writer(std::io::stdout(), notification).map_err(|err| {
@@ -507,7 +507,7 @@ pub(super) fn print_jsonl_notification(
     flush_stdout()
 }
 
-pub(super) fn notification_thread_id(
+pub(crate) fn notification_thread_id(
     notification: &crate::adapters::app_server::connection::JsonRpcNotification,
 ) -> Option<&str> {
     notification
@@ -517,7 +517,7 @@ pub(super) fn notification_thread_id(
         .and_then(serde_json::Value::as_str)
 }
 
-pub(super) fn notification_delta(
+pub(crate) fn notification_delta(
     notification: &crate::adapters::app_server::connection::JsonRpcNotification,
 ) -> Option<&str> {
     notification
@@ -527,7 +527,7 @@ pub(super) fn notification_delta(
         .and_then(serde_json::Value::as_str)
 }
 
-pub(super) fn notification_is_turn_error(
+pub(crate) fn notification_is_turn_error(
     notification: &crate::adapters::app_server::connection::JsonRpcNotification,
     thread_id: &str,
     turn_id: &str,
@@ -550,7 +550,7 @@ pub(super) fn notification_is_turn_error(
             .is_some_and(|status| status == "failed" || status == "interrupted")
 }
 
-pub(super) fn notification_turn_error_message(
+pub(crate) fn notification_turn_error_message(
     notification: &crate::adapters::app_server::connection::JsonRpcNotification,
 ) -> String {
     notification
@@ -564,7 +564,7 @@ pub(super) fn notification_turn_error_message(
         .unwrap_or_else(|| crate::cli::console::notification_error_message(notification))
 }
 
-pub(super) fn debug_rpc_usage_error(
+pub(crate) fn debug_rpc_usage_error(
     message: impl Into<String>,
 ) -> crate::kernel::runtime_host::VerletError {
     crate::cli::usage_error(format!(
@@ -573,13 +573,13 @@ pub(super) fn debug_rpc_usage_error(
     ))
 }
 
-pub(super) fn flush_stdout() -> crate::kernel::runtime_host::VerletResult<()> {
+pub(crate) fn flush_stdout() -> crate::kernel::runtime_host::VerletResult<()> {
     std::io::stdout()
         .flush()
         .map_err(|err| crate::cli::usage_error(format!("failed to flush stdout: {err}")))
 }
 
-pub(super) fn print_debug_help() {
+pub(crate) fn print_debug_help() {
     println!(
         "verlet debug\n\
 \n\

--- a/crates/verlet-kernel/src/cli/host.rs
+++ b/crates/verlet-kernel/src/cli/host.rs
@@ -140,7 +140,7 @@ impl std::fmt::Debug for ResolvedProviderApiKey {
 }
 
 /// Route `verlet host <subcommand>`.
-pub(super) async fn run_host(
+pub(crate) async fn run_host(
     mut args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args.is_empty()
@@ -167,7 +167,7 @@ pub(super) async fn run_host(
 /// ids), then wait for SIGTERM/SIGINT and run
 /// [`crate::adapters::host::VerletHost::shutdown`]. Exit is non-zero on
 /// any boot or shutdown error.
-pub(super) async fn host_run(
+pub(crate) async fn host_run(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args
@@ -731,7 +731,7 @@ async fn shutdown_io_tasks(tasks: &mut Vec<tokio::task::JoinHandle<()>>) {
 }
 
 /// Print help for `verlet host`.
-pub(super) fn print_host_help() {
+pub(crate) fn print_host_help() {
     println!(
         "verlet host\n\
          \n\
@@ -750,7 +750,7 @@ pub(super) fn print_host_help() {
 }
 
 /// Print help for `verlet host run`.
-pub(super) fn print_host_run_help() {
+pub(crate) fn print_host_run_help() {
     println!(
         "verlet host run\n\
          \n\

--- a/crates/verlet-kernel/src/cli/host/tests.rs
+++ b/crates/verlet-kernel/src/cli/host/tests.rs
@@ -82,7 +82,7 @@ provider = "local_offline"
 
 fn load_error(label: &str, contents: &str) -> String {
     let file = TestConfigFile::write(label, contents);
-    super::load_host_run_config(&file.path)
+    crate::cli::host::load_host_run_config(&file.path)
         .unwrap_err()
         .to_string()
 }
@@ -91,8 +91,8 @@ fn direct_local_instance(
     id: &str,
     root: std::path::PathBuf,
     cwd: &std::path::Path,
-) -> super::HostInstanceConfig {
-    super::HostInstanceConfig {
+) -> crate::cli::host::HostInstanceConfig {
+    crate::cli::host::HostInstanceConfig {
         id: id.to_string(),
         root,
         cwd: cwd.to_path_buf(),
@@ -101,7 +101,7 @@ fn direct_local_instance(
         hook_shell: "/bin/sh".to_string(),
         clock: None,
         route_digests: Vec::new(),
-        provider: super::HostInstanceProviderConfig {
+        provider: crate::cli::host::HostInstanceProviderConfig {
             provider: "local_offline".to_string(),
             base_url: None,
             api_key_env: None,
@@ -120,7 +120,7 @@ fn parse_minimal_config_with_defaults() {
     );
     let file = TestConfigFile::write("minimal", &config);
 
-    let loaded = super::load_host_run_config(&file.path).unwrap();
+    let loaded = crate::cli::host::load_host_run_config(&file.path).unwrap();
 
     assert_eq!(loaded.listen.addr, "127.0.0.1:0");
     assert!(!loaded.listen.allow_non_loopback);
@@ -139,7 +139,7 @@ fn clock_can_be_disabled_but_must_be_a_boolean() {
     );
     let config = format!("[listen]\naddr = \"127.0.0.1:0\"\n{disabled}");
     let file = TestConfigFile::write("clock-disabled", &config);
-    let loaded = super::load_host_run_config(&file.path).unwrap();
+    let loaded = crate::cli::host::load_host_run_config(&file.path).unwrap();
     assert!(!loaded.instance[0].clock_enabled());
     assert_eq!(loaded.instance[0].clock, Some(false));
 
@@ -161,8 +161,9 @@ fn hosted_clock_queue_paths_are_isolated_under_instance_roots() {
         std::env::temp_dir().join(format!("verlet-host-clock-paths-{}", uuid::Uuid::now_v7()));
     let first_id = crate::adapters::host::InstanceId::new("first").unwrap();
     let second_id = crate::adapters::host::InstanceId::new("second").unwrap();
-    let (first_io, first_route) = super::hosted_clock_io(&first_id, &root.join("first"));
-    let (second_io, second_route) = super::hosted_clock_io(&second_id, &root.join("second"));
+    let (first_io, first_route) = crate::cli::host::hosted_clock_io(&first_id, &root.join("first"));
+    let (second_io, second_route) =
+        crate::cli::host::hosted_clock_io(&second_id, &root.join("second"));
 
     assert_eq!(first_route.id, "clock-first");
     assert_eq!(second_route.id, "clock-second");
@@ -186,15 +187,16 @@ fn hosted_clock_queue_paths_are_isolated_under_instance_roots() {
 #[test]
 fn host_run_args_require_only_a_config_path() {
     let path =
-        super::parse_host_run_args(vec!["--config".into(), "/tmp/host.toml".into()]).unwrap();
+        crate::cli::host::parse_host_run_args(vec!["--config".into(), "/tmp/host.toml".into()])
+            .unwrap();
     assert_eq!(path, std::path::PathBuf::from("/tmp/host.toml"));
     assert!(
-        super::parse_host_run_args(Vec::new())
+        crate::cli::host::parse_host_run_args(Vec::new())
             .unwrap_err()
             .to_string()
             .contains("requires --config")
     );
-    let error = super::parse_host_run_args(vec![
+    let error = crate::cli::host::parse_host_run_args(vec![
         "--token".into(),
         "argument-secret-that-must-not-be-echoed".into(),
     ])
@@ -501,12 +503,12 @@ model = "openai/test"
         root.join("workspace").display(),
     );
     let file = TestConfigFile::write("key-once", &config);
-    let loaded = super::load_host_run_config(&file.path).unwrap();
+    let loaded = crate::cli::host::load_host_run_config(&file.path).unwrap();
     assert!(!format!("{loaded:?}").contains("original-key"));
     // SAFETY: the module lock serializes this mutation and `_env` restores it.
     unsafe { std::env::set_var(&env_name, "changed-after-load") };
 
-    let (_, hosted) = super::hosted_instance_config(&loaded.instance[0]).unwrap();
+    let (_, hosted) = crate::cli::host::hosted_instance_config(&loaded.instance[0]).unwrap();
     assert!(!format!("{hosted:?}").contains("original-key"));
     let auth = hosted.instance_environment.provider_auth.resolve();
     assert!(!format!("{auth:?}").contains("original-key"));
@@ -636,7 +638,10 @@ fn listener_accepts_literal_ipv4_and_ipv6_binds_but_rejects_hostnames() {
         );
         let file = TestConfigFile::write(label, &config);
         assert_eq!(
-            super::load_host_run_config(&file.path).unwrap().listen.addr,
+            crate::cli::host::load_host_run_config(&file.path)
+                .unwrap()
+                .listen
+                .addr,
             addr
         );
     }
@@ -671,21 +676,21 @@ async fn mid_boot_failure_shuts_down_started_instances_and_releases_roots() {
     std::fs::create_dir_all(&workspace).unwrap();
     let first = direct_local_instance("duplicate", root.join("first"), &workspace);
     let second = direct_local_instance("duplicate", root.join("second"), &workspace);
-    let config = super::VerletHostRunConfig {
-        listen: super::HostListenConfig {
+    let config = crate::cli::host::VerletHostRunConfig {
+        listen: crate::cli::host::HostListenConfig {
             addr: "127.0.0.1:0".to_string(),
             allow_non_loopback: false,
         },
         instance: vec![first.clone(), second.clone()],
     };
 
-    let error = super::serve_until_shutdown(config, async { Ok(()) })
+    let error = crate::cli::host::serve_until_shutdown(config, async { Ok(()) })
         .await
         .unwrap_err();
     assert!(error.to_string().contains("already exists"), "{error}");
 
-    let (_, first_successor) = super::hosted_instance_config(&first).unwrap();
-    let (_, second_successor) = super::hosted_instance_config(&second).unwrap();
+    let (_, first_successor) = crate::cli::host::hosted_instance_config(&first).unwrap();
+    let (_, second_successor) = crate::cli::host::hosted_instance_config(&second).unwrap();
     drop(first_successor);
     drop(second_successor);
     std::fs::remove_dir_all(root).unwrap();
@@ -708,15 +713,15 @@ async fn pending_config_failure_releases_reservations_before_listener_bind() {
     let port = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = port.local_addr().unwrap();
     drop(port);
-    let config = super::VerletHostRunConfig {
-        listen: super::HostListenConfig {
+    let config = crate::cli::host::VerletHostRunConfig {
+        listen: crate::cli::host::HostListenConfig {
             addr: addr.to_string(),
             allow_non_loopback: false,
         },
         instance: vec![first.clone(), second],
     };
 
-    let error = super::serve_until_shutdown(config, async { Ok(()) })
+    let error = crate::cli::host::serve_until_shutdown(config, async { Ok(()) })
         .await
         .unwrap_err();
     assert!(
@@ -726,7 +731,7 @@ async fn pending_config_failure_releases_reservations_before_listener_bind() {
 
     let rebound = tokio::net::TcpListener::bind(addr).await.unwrap();
     drop(rebound);
-    let (_, successor) = super::hosted_instance_config(&first).unwrap();
+    let (_, successor) = crate::cli::host::hosted_instance_config(&first).unwrap();
     drop(successor);
     std::fs::remove_dir_all(root).unwrap();
 }

--- a/crates/verlet-kernel/src/cli/identity.rs
+++ b/crates/verlet-kernel/src/cli/identity.rs
@@ -3,7 +3,7 @@
 use crate::daemon::identity::IdentityAuthority as _;
 
 /// Dispatch an offline identity-store command.
-pub(super) async fn run_identity(
+pub(crate) async fn run_identity(
     mut args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args.is_empty()
@@ -48,7 +48,7 @@ pub(super) async fn run_identity(
 }
 
 /// Declare the first operator and print its credential once.
-pub(super) async fn identity_bootstrap(
+pub(crate) async fn identity_bootstrap(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_identity_bootstrap_args(args)?;
@@ -78,7 +78,7 @@ pub(super) async fn identity_bootstrap(
 }
 
 /// Declare an adapter principal in the offline identity store.
-pub(super) async fn identity_declare(
+pub(crate) async fn identity_declare(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_identity_declare_args(args)?;
@@ -113,7 +113,7 @@ pub(super) async fn identity_declare(
 }
 
 /// Mint and print one credential for an active principal.
-pub(super) async fn identity_mint(
+pub(crate) async fn identity_mint(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_identity_mint_args(args)?;
@@ -147,7 +147,7 @@ pub(super) async fn identity_mint(
 }
 
 /// Revoke one credential in the offline identity store.
-pub(super) async fn identity_revoke_credential(
+pub(crate) async fn identity_revoke_credential(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_identity_revoke_args(args, "identity revoke-credential")?;
@@ -174,7 +174,7 @@ pub(super) async fn identity_revoke_credential(
 }
 
 /// Revoke one principal in the offline identity store.
-pub(super) async fn identity_revoke_principal(
+pub(crate) async fn identity_revoke_principal(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_identity_revoke_args(args, "identity revoke-principal")?;
@@ -201,7 +201,7 @@ pub(super) async fn identity_revoke_principal(
 }
 
 /// Print redacted principal and credential records from the identity store.
-pub(super) async fn identity_list(
+pub(crate) async fn identity_list(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_identity_list_args(args)?;
@@ -551,7 +551,7 @@ fn identity_cli_error(error: impl std::fmt::Display) -> crate::kernel::runtime_h
 }
 
 /// Print help for the identity subcommand family.
-pub(super) fn print_identity_help() {
+pub(crate) fn print_identity_help() {
     println!(
         "verlet identity\n\
 \n\
@@ -569,7 +569,7 @@ daemon before running these commands. Credential tokens are printed only when mi
 }
 
 /// Print help for `identity bootstrap`.
-pub(super) fn print_identity_bootstrap_help() {
+pub(crate) fn print_identity_bootstrap_help() {
     println!(
         "verlet identity bootstrap\n\
 \n\
@@ -582,7 +582,7 @@ token is shown once. Bootstrap refuses a store with an active operator.\n"
 }
 
 /// Print help for `identity declare`.
-pub(super) fn print_identity_declare_help() {
+pub(crate) fn print_identity_declare_help() {
     println!(
         "verlet identity declare\n\
 \n\
@@ -594,7 +594,7 @@ Declares an adapter principal. Member principals are reserved in v0.\n"
 }
 
 /// Print help for `identity mint`.
-pub(super) fn print_identity_mint_help() {
+pub(crate) fn print_identity_mint_help() {
     println!(
         "verlet identity mint\n\
 \n\
@@ -606,7 +606,7 @@ Mints a credential for an active principal. The credential token is shown once.\
 }
 
 /// Print help for `identity revoke-credential`.
-pub(super) fn print_identity_revoke_credential_help() {
+pub(crate) fn print_identity_revoke_credential_help() {
     println!(
         "verlet identity revoke-credential\n\
 \n\
@@ -616,7 +616,7 @@ Usage:\n\
 }
 
 /// Print help for `identity revoke-principal`.
-pub(super) fn print_identity_revoke_principal_help() {
+pub(crate) fn print_identity_revoke_principal_help() {
     println!(
         "verlet identity revoke-principal\n\
 \n\
@@ -626,7 +626,7 @@ Usage:\n\
 }
 
 /// Print help for `identity list`.
-pub(super) fn print_identity_list_help() {
+pub(crate) fn print_identity_list_help() {
     println!(
         "verlet identity list\n\
 \n\

--- a/crates/verlet-kernel/src/cli/import.rs
+++ b/crates/verlet-kernel/src/cli/import.rs
@@ -6,7 +6,7 @@ use std::os::unix::fs::DirBuilderExt as _;
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt as _;
 
-pub(super) async fn run_import(
+pub(crate) async fn run_import(
     mut args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args.is_empty()
@@ -42,7 +42,7 @@ pub(super) async fn run_import(
     }
 }
 
-pub(super) async fn import_build(
+pub(crate) async fn import_build(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_import_args(args, "import build")?;
@@ -63,7 +63,7 @@ pub(super) async fn import_build(
     Ok(())
 }
 
-pub(super) async fn import_publish(
+pub(crate) async fn import_publish(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_import_args(args, "import publish")?;
@@ -106,7 +106,7 @@ pub(super) async fn import_publish(
 }
 
 #[derive(Debug)]
-pub(super) struct BuiltImportPackage {
+pub(crate) struct BuiltImportPackage {
     package: verlet_operations::import_package::ImportPackageSource,
     plan: verlet_operations::openapi_plan::OperationImportPlan,
     artifact_path: std::path::PathBuf,
@@ -115,7 +115,7 @@ pub(super) struct BuiltImportPackage {
     receipt: verlet_operations::import_package::ImportBuildReceipt,
 }
 
-pub(super) async fn build_import_package(
+pub(crate) async fn build_import_package(
     package_path: &std::path::Path,
 ) -> crate::kernel::runtime_host::VerletResult<BuiltImportPackage> {
     let package = verlet_operations::import_package::ImportPackageSource::load(package_path)
@@ -270,7 +270,7 @@ pub(super) async fn build_import_package(
     })
 }
 
-pub(super) fn print_import_package_build(build: &BuiltImportPackage) {
+pub(crate) fn print_import_package_build(build: &BuiltImportPackage) {
     println!("import package {}", build.plan.name);
     println!("receipt import_build_v0");
     println!("source_hash {}", build.receipt.source_hash);
@@ -290,20 +290,20 @@ pub(super) fn print_import_package_build(build: &BuiltImportPackage) {
     }
 }
 
-pub(super) fn import_error(
+pub(crate) fn import_error(
     error: verlet_operations::openapi_plan::OpenApiImportError,
 ) -> crate::kernel::runtime_host::VerletError {
     crate::kernel::runtime_host::VerletError::RuntimeFactory(error.to_string())
 }
 
 #[derive(Debug)]
-pub(super) struct ImportArgs {
+pub(crate) struct ImportArgs {
     package_path: Option<std::path::PathBuf>,
     registry_root: Option<std::path::PathBuf>,
     help: bool,
 }
 
-pub(super) fn parse_import_args(
+pub(crate) fn parse_import_args(
     args: Vec<std::ffi::OsString>,
     command: &str,
 ) -> crate::kernel::runtime_host::VerletResult<ImportArgs> {
@@ -340,7 +340,7 @@ pub(super) fn parse_import_args(
     })
 }
 
-pub(super) fn print_import_help() {
+pub(crate) fn print_import_help() {
     println!(
         "verlet import\n\
 \n\
@@ -354,7 +354,7 @@ registry gate. OpenAPI remains an authoring input, not a runtime contract.\n"
     );
 }
 
-pub(super) fn print_import_build_help() {
+pub(crate) fn print_import_build_help() {
     println!(
         "verlet import build\n\
 \n\
@@ -367,7 +367,7 @@ receipt without writing an operation record.\n"
     );
 }
 
-pub(super) fn print_import_publish_help() {
+pub(crate) fn print_import_publish_help() {
     println!(
         "verlet import publish\n\
 \n\

--- a/crates/verlet-kernel/src/cli/rpc.rs
+++ b/crates/verlet-kernel/src/cli/rpc.rs
@@ -1,6 +1,6 @@
 //! The `rpc` subcommand family.
 
-pub(super) async fn run_rpc(
+pub(crate) async fn run_rpc(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args.is_empty()
@@ -42,14 +42,14 @@ pub(super) async fn run_rpc(
 }
 
 #[derive(Debug)]
-pub(super) struct RpcArgs {
+pub(crate) struct RpcArgs {
     listen: crate::adapters::app_server::AppServerListenAddr,
     runtime_home: Option<std::path::PathBuf>,
     state_home: Option<std::path::PathBuf>,
     cwd: Option<std::path::PathBuf>,
 }
 
-pub(super) fn parse_rpc_args(
+pub(crate) fn parse_rpc_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<RpcArgs> {
     let mut listen = None;
@@ -98,7 +98,7 @@ pub(super) fn parse_rpc_args(
     })
 }
 
-pub(super) fn print_rpc_help() {
+pub(crate) fn print_rpc_help() {
     println!(
         "verlet rpc\n\
 \n\

--- a/crates/verlet-kernel/src/cli/secret.rs
+++ b/crates/verlet-kernel/src/cli/secret.rs
@@ -4,7 +4,7 @@ use std::io::Read as _;
 #[cfg(test)]
 mod tests;
 
-pub(super) async fn run_secret(
+pub(crate) async fn run_secret(
     mut args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args.is_empty()
@@ -46,7 +46,7 @@ pub(super) async fn run_secret(
     }
 }
 
-pub(super) async fn secret_import(
+pub(crate) async fn secret_import(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_secret_import_args(args)?;
@@ -70,7 +70,7 @@ pub(super) async fn secret_import(
     Ok(())
 }
 
-pub(super) async fn secret_set(
+pub(crate) async fn secret_set(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_secret_set_args(args)?;
@@ -104,7 +104,7 @@ pub(super) async fn secret_set(
     Ok(())
 }
 
-pub(super) async fn secret_list(
+pub(crate) async fn secret_list(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_secret_list_args(args, "secret list")?;
@@ -129,7 +129,7 @@ pub(super) async fn secret_list(
     Ok(())
 }
 
-pub(super) async fn secret_status(
+pub(crate) async fn secret_status(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_secret_name_args(args, "secret status")?;
@@ -157,7 +157,7 @@ pub(super) async fn secret_status(
     Ok(())
 }
 
-pub(super) async fn secret_delete(
+pub(crate) async fn secret_delete(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_secret_name_args(args, "secret delete")?;
@@ -178,7 +178,7 @@ pub(super) async fn secret_delete(
 }
 
 #[derive(Debug)]
-pub(super) struct SecretImportArgs {
+pub(crate) struct SecretImportArgs {
     name: Option<String>,
     from_env: Option<String>,
     state_home: Option<std::path::PathBuf>,
@@ -186,7 +186,7 @@ pub(super) struct SecretImportArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct SecretSetArgs {
+pub(crate) struct SecretSetArgs {
     name: Option<String>,
     value_stdin: bool,
     state_home: Option<std::path::PathBuf>,
@@ -194,19 +194,19 @@ pub(super) struct SecretSetArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct SecretNameArgs {
+pub(crate) struct SecretNameArgs {
     name: Option<String>,
     state_home: Option<std::path::PathBuf>,
     help: bool,
 }
 
 #[derive(Debug)]
-pub(super) struct SecretListArgs {
+pub(crate) struct SecretListArgs {
     state_home: Option<std::path::PathBuf>,
     help: bool,
 }
 
-pub(super) fn parse_secret_import_args(
+pub(crate) fn parse_secret_import_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<SecretImportArgs> {
     let mut name = None;
@@ -252,7 +252,7 @@ pub(super) fn parse_secret_import_args(
     })
 }
 
-pub(super) fn parse_secret_set_args(
+pub(crate) fn parse_secret_set_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<SecretSetArgs> {
     let mut name = None;
@@ -293,7 +293,7 @@ pub(super) fn parse_secret_set_args(
     })
 }
 
-pub(super) fn parse_secret_name_args(
+pub(crate) fn parse_secret_name_args(
     args: Vec<std::ffi::OsString>,
     command: &str,
 ) -> crate::kernel::runtime_host::VerletResult<SecretNameArgs> {
@@ -332,7 +332,7 @@ pub(super) fn parse_secret_name_args(
     })
 }
 
-pub(super) fn parse_secret_list_args(
+pub(crate) fn parse_secret_list_args(
     args: Vec<std::ffi::OsString>,
     command: &str,
 ) -> crate::kernel::runtime_host::VerletResult<SecretListArgs> {
@@ -358,16 +358,16 @@ pub(super) fn parse_secret_list_args(
     Ok(SecretListArgs { state_home, help })
 }
 
-pub(super) fn default_project_state_home() -> std::path::PathBuf {
+pub(crate) fn default_project_state_home() -> std::path::PathBuf {
     std::path::PathBuf::from(".verlet/state")
 }
 
-pub(super) fn default_user_state_home()
+pub(crate) fn default_user_state_home()
 -> crate::kernel::runtime_host::VerletResult<std::path::PathBuf> {
     Ok(crate::cli::console::default_user_verlet_home()?.join("state"))
 }
 
-pub(super) fn metadata_store_path_for_state_home(
+pub(crate) fn metadata_store_path_for_state_home(
     state_home: Option<std::path::PathBuf>,
     default_state_home: std::path::PathBuf,
 ) -> std::path::PathBuf {
@@ -376,7 +376,7 @@ pub(super) fn metadata_store_path_for_state_home(
         .join("metadata.sqlite3")
 }
 
-pub(super) async fn open_secret_store(
+pub(crate) async fn open_secret_store(
     state_home: Option<std::path::PathBuf>,
 ) -> crate::kernel::runtime_host::VerletResult<verlet_metadata::secret_store::SqliteSecretStore> {
     verlet_metadata::secret_store::SqliteSecretStore::open(metadata_store_path_for_state_home(
@@ -393,7 +393,7 @@ pub(super) async fn open_secret_store(
     })
 }
 
-pub(super) async fn open_provider_store(
+pub(crate) async fn open_provider_store(
     state_home: Option<std::path::PathBuf>,
 ) -> crate::kernel::runtime_host::VerletResult<verlet_metadata::provider_store::SqliteMetadataStore>
 {
@@ -416,7 +416,7 @@ pub(super) async fn open_provider_store(
     Ok(store)
 }
 
-pub(super) fn cross_process_database_guidance(
+pub(crate) fn cross_process_database_guidance(
     alternative: &str,
 ) -> crate::kernel::runtime_host::VerletError {
     crate::cli::usage_error(format!(
@@ -424,7 +424,7 @@ pub(super) fn cross_process_database_guidance(
     ))
 }
 
-pub(super) fn turso_cross_process_lock_error(message: &str) -> bool {
+pub(crate) fn turso_cross_process_lock_error(message: &str) -> bool {
     // turso 0.7.0-pre.18 erases LimboError::LockingError through turso::Error.
     let Some((_, engine_error)) = message.split_once("sqlite engine error: ") else {
         return false;
@@ -434,13 +434,13 @@ pub(super) fn turso_cross_process_lock_error(message: &str) -> bool {
             && engine_error.ends_with("'. File is locked by another process"))
 }
 
-pub(super) fn secret_cli_error(
+pub(crate) fn secret_cli_error(
     err: impl std::fmt::Display,
 ) -> crate::kernel::runtime_host::VerletError {
     crate::kernel::runtime_host::VerletError::RuntimeFactory(format!("secret store failed: {err}"))
 }
 
-pub(super) fn provider_cli_error(
+pub(crate) fn provider_cli_error(
     err: impl std::fmt::Display,
 ) -> crate::kernel::runtime_host::VerletError {
     crate::kernel::runtime_host::VerletError::RuntimeFactory(format!(
@@ -448,7 +448,7 @@ pub(super) fn provider_cli_error(
     ))
 }
 
-pub(super) fn secret_source_display(
+pub(crate) fn secret_source_display(
     status: &verlet_metadata::secret_store::SecretStatus,
 ) -> String {
     match (&status.source_kind, status.source_label.as_deref()) {
@@ -464,7 +464,7 @@ pub(super) fn secret_source_display(
     }
 }
 
-pub(super) fn trim_stdin_secret_value(mut value: String) -> String {
+pub(crate) fn trim_stdin_secret_value(mut value: String) -> String {
     if value.ends_with('\n') {
         value.pop();
         if value.ends_with('\r') {
@@ -474,7 +474,7 @@ pub(super) fn trim_stdin_secret_value(mut value: String) -> String {
     value
 }
 
-pub(super) fn print_secret_help() {
+pub(crate) fn print_secret_help() {
     println!(
         "verlet secret\n\
 \n\
@@ -490,7 +490,7 @@ redact values; tool runtimes receive only manifest-declared secret names.\n"
     );
 }
 
-pub(super) fn print_secret_import_help() {
+pub(crate) fn print_secret_import_help() {
     println!(
         "verlet secret import\n\
 \n\
@@ -502,7 +502,7 @@ stable secret name such as EXAMPLE_API_KEY.\n"
     );
 }
 
-pub(super) fn print_secret_set_help() {
+pub(crate) fn print_secret_set_help() {
     println!(
         "verlet secret set\n\
 \n\
@@ -513,7 +513,7 @@ Stores a secret value read from stdin. The stored value is never printed.\n"
     );
 }
 
-pub(super) fn print_secret_list_help() {
+pub(crate) fn print_secret_list_help() {
     println!(
         "verlet secret list\n\
 \n\
@@ -524,7 +524,7 @@ Lists configured secret refs without printing secret values.\n"
     );
 }
 
-pub(super) fn print_secret_status_help() {
+pub(crate) fn print_secret_status_help() {
     println!(
         "verlet secret status\n\
 \n\
@@ -535,7 +535,7 @@ Prints redacted metadata for one secret ref.\n"
     );
 }
 
-pub(super) fn print_secret_delete_help() {
+pub(crate) fn print_secret_delete_help() {
     println!(
         "verlet secret delete\n\
 \n\

--- a/crates/verlet-kernel/src/cli/skill.rs
+++ b/crates/verlet-kernel/src/cli/skill.rs
@@ -1,6 +1,6 @@
 //! The `skill` subcommand family.
 
-pub(super) async fn run_skill(
+pub(crate) async fn run_skill(
     mut args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args.is_empty()
@@ -36,7 +36,7 @@ pub(super) async fn run_skill(
     }
 }
 
-pub(super) async fn skill_publish(
+pub(crate) async fn skill_publish(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_skill_publish_args(args)?;
@@ -66,7 +66,7 @@ pub(super) async fn skill_publish(
     Ok(())
 }
 
-pub(super) async fn skill_import(
+pub(crate) async fn skill_import(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_skill_import_args(args)?;
@@ -129,7 +129,7 @@ pub(super) async fn skill_import(
 }
 
 #[derive(Debug)]
-pub(super) struct SkillPublishArgs {
+pub(crate) struct SkillPublishArgs {
     package_dir: Option<std::path::PathBuf>,
     name: Option<String>,
     registry_root: Option<std::path::PathBuf>,
@@ -137,7 +137,7 @@ pub(super) struct SkillPublishArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct SkillImportArgs {
+pub(crate) struct SkillImportArgs {
     skill_dir: Option<std::path::PathBuf>,
     name: Option<String>,
     registry_root: Option<std::path::PathBuf>,
@@ -146,7 +146,7 @@ pub(super) struct SkillImportArgs {
     help: bool,
 }
 
-pub(super) fn parse_skill_publish_args(
+pub(crate) fn parse_skill_publish_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<SkillPublishArgs> {
     let mut package_dir = None;
@@ -191,7 +191,7 @@ pub(super) fn parse_skill_publish_args(
     })
 }
 
-pub(super) fn parse_skill_import_args(
+pub(crate) fn parse_skill_import_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<SkillImportArgs> {
     let mut skill_dir = None;
@@ -247,11 +247,11 @@ pub(super) fn parse_skill_import_args(
     })
 }
 
-pub(super) fn skill_registry_root(registry_root: Option<std::path::PathBuf>) -> std::path::PathBuf {
+pub(crate) fn skill_registry_root(registry_root: Option<std::path::PathBuf>) -> std::path::PathBuf {
     registry_root.unwrap_or_else(|| std::path::PathBuf::from(".verlet/skills"))
 }
 
-pub(super) fn print_skill_help() {
+pub(crate) fn print_skill_help() {
     println!(
         "verlet skill\n\
 \n\
@@ -266,7 +266,7 @@ the same package and blob registries.\n"
     );
 }
 
-pub(super) fn print_skill_publish_help() {
+pub(crate) fn print_skill_publish_help() {
     println!(
         "verlet skill publish\n\
 \n\
@@ -281,7 +281,7 @@ and the floating package-name ref.\n"
     );
 }
 
-pub(super) fn print_skill_import_help() {
+pub(crate) fn print_skill_import_help() {
     println!(
         "verlet skill import\n\
 \n\

--- a/crates/verlet-kernel/src/cli/tool.rs
+++ b/crates/verlet-kernel/src/cli/tool.rs
@@ -5,7 +5,7 @@ use std::io::Write as _;
 #[cfg(test)]
 mod tests;
 
-pub(super) async fn tool_manual(
+pub(crate) async fn tool_manual(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_tool_manual_args(args)?;
@@ -31,7 +31,7 @@ pub(super) async fn tool_manual(
     Ok(())
 }
 
-pub(super) async fn run_tool(
+pub(crate) async fn run_tool(
     mut args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args.is_empty()
@@ -75,7 +75,7 @@ pub(super) async fn run_tool(
     }
 }
 
-pub(super) async fn tool_build(
+pub(crate) async fn tool_build(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_build_args(args)?;
@@ -138,7 +138,7 @@ pub(super) async fn tool_build(
     Ok(())
 }
 
-pub(super) async fn tool_list(
+pub(crate) async fn tool_list(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_tool_registry_args(args, "tool list")?;
@@ -175,7 +175,7 @@ pub(super) async fn tool_list(
     Ok(())
 }
 
-pub(super) async fn tool_publish(
+pub(crate) async fn tool_publish(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_publish_args(args)?;
@@ -212,7 +212,7 @@ pub(super) async fn tool_publish(
     ))
 }
 
-pub(super) fn manuals_for_record(
+pub(crate) fn manuals_for_record(
     record: &verlet_operations::operation_store::PublishedOperationRecord,
     operation: Option<&str>,
 ) -> crate::kernel::runtime_host::VerletResult<
@@ -295,7 +295,7 @@ pub(super) fn manuals_for_record(
     Ok(manuals)
 }
 
-pub(super) fn cli_manual_exit_status() -> Vec<verlet_operations::tool_package::ToolManualExitStatus>
+pub(crate) fn cli_manual_exit_status() -> Vec<verlet_operations::tool_package::ToolManualExitStatus>
 {
     vec![
         verlet_operations::tool_package::ToolManualExitStatus {
@@ -321,7 +321,7 @@ pub(super) fn cli_manual_exit_status() -> Vec<verlet_operations::tool_package::T
     ]
 }
 
-pub(super) fn print_manuals(manuals: &[verlet_operations::tool_package::ToolOperationManual]) {
+pub(crate) fn print_manuals(manuals: &[verlet_operations::tool_package::ToolOperationManual]) {
     for (index, manual) in manuals.iter().enumerate() {
         if index > 0 {
             println!();
@@ -370,12 +370,12 @@ pub(super) fn print_manuals(manuals: &[verlet_operations::tool_package::ToolOper
     }
 }
 
-pub(super) fn compact_json(value: &serde_json::Value) -> String {
+pub(crate) fn compact_json(value: &serde_json::Value) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| "null".to_string())
 }
 
 #[derive(Debug)]
-pub(super) struct BuiltToolPackage {
+pub(crate) struct BuiltToolPackage {
     package: verlet_operations::tool_package::ToolPackageSource,
     artifact_path: std::path::PathBuf,
     source: verlet_operations::operation_store::PublishedOperationSource,
@@ -384,7 +384,7 @@ pub(super) struct BuiltToolPackage {
     receipt: verlet_operations::tool_package::ToolBuildReceipt,
 }
 
-pub(super) async fn build_tool_package(
+pub(crate) async fn build_tool_package(
     package_path: &std::path::Path,
 ) -> crate::kernel::runtime_host::VerletResult<BuiltToolPackage> {
     let package = verlet_operations::tool_package::ToolPackageSource::load(package_path)?;
@@ -423,7 +423,7 @@ pub(super) async fn build_tool_package(
     })
 }
 
-pub(super) fn reject_user_kernel_tool_package(
+pub(crate) fn reject_user_kernel_tool_package(
     package: &verlet_operations::tool_package::ToolPackageSource,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if package.manifest.runtime.kind == "kernel" {
@@ -434,7 +434,7 @@ pub(super) fn reject_user_kernel_tool_package(
     Ok(())
 }
 
-pub(super) fn build_tool_package_artifact(
+pub(crate) fn build_tool_package_artifact(
     package: &verlet_operations::tool_package::ToolPackageSource,
 ) -> crate::kernel::runtime_host::VerletResult<(
     std::path::PathBuf,
@@ -473,7 +473,7 @@ pub(super) fn build_tool_package_artifact(
     }
 }
 
-pub(super) fn package_capability_requests(
+pub(crate) fn package_capability_requests(
     package: &verlet_operations::tool_package::ToolPackageSource,
 ) -> std::collections::BTreeSet<String> {
     package
@@ -484,7 +484,7 @@ pub(super) fn package_capability_requests(
         .collect()
 }
 
-pub(super) async fn run_tool_package_fixtures(
+pub(crate) async fn run_tool_package_fixtures(
     package: &verlet_operations::tool_package::ToolPackageSource,
     artifact_path: &std::path::Path,
     interface: &verlet_operations::tool_package::ToolInterfaceContract,
@@ -547,7 +547,7 @@ pub(super) async fn run_tool_package_fixtures(
 }
 
 /// Builds the read-only VFS mount available while package fixtures run.
-pub(super) fn package_fixture_vfs(
+pub(crate) fn package_fixture_vfs(
     package: &verlet_operations::tool_package::ToolPackageSource,
 ) -> crate::kernel::runtime_host::VerletResult<std::sync::Arc<verlet_vfs::VerletVfs>> {
     let vfs = std::sync::Arc::new(verlet_vfs::VerletVfs::new(std::sync::Arc::new(
@@ -574,7 +574,7 @@ pub(super) fn package_fixture_vfs(
     Ok(vfs)
 }
 
-pub(super) fn fixture_output_matches(expected: &[u8], actual: &[u8]) -> bool {
+pub(crate) fn fixture_output_matches(expected: &[u8], actual: &[u8]) -> bool {
     match (
         serde_json::from_slice::<serde_json::Value>(expected),
         serde_json::from_slice::<serde_json::Value>(actual),
@@ -584,7 +584,7 @@ pub(super) fn fixture_output_matches(expected: &[u8], actual: &[u8]) -> bool {
     }
 }
 
-pub(super) fn size_limit(
+pub(crate) fn size_limit(
     label: &str,
     value: u64,
 ) -> crate::kernel::runtime_host::VerletResult<usize> {
@@ -595,7 +595,7 @@ pub(super) fn size_limit(
     })
 }
 
-pub(super) fn print_tool_package_build(build: &BuiltToolPackage) {
+pub(crate) fn print_tool_package_build(build: &BuiltToolPackage) {
     println!("tool package {}", build.package.manifest.identity.name);
     println!("receipt tool_build_v0");
     println!("runtime {}", build.package.manifest.runtime.kind);
@@ -629,7 +629,7 @@ pub(super) fn print_tool_package_build(build: &BuiltToolPackage) {
     }
 }
 
-pub(super) fn reject_package_build_overrides(
+pub(crate) fn reject_package_build_overrides(
     options: &BuildArgs,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if options.name.is_some()
@@ -645,7 +645,7 @@ pub(super) fn reject_package_build_overrides(
     Ok(())
 }
 
-pub(super) fn reject_package_publish_overrides(
+pub(crate) fn reject_package_publish_overrides(
     options: &PublishArgs,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if options.name.is_some()
@@ -665,7 +665,7 @@ pub(super) fn reject_package_publish_overrides(
     Ok(())
 }
 
-pub(super) async fn tool_run(
+pub(crate) async fn tool_run(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_run_args(args)?;
@@ -798,7 +798,7 @@ pub(super) async fn tool_run(
     Ok(())
 }
 
-pub(super) async fn tool_source(
+pub(crate) async fn tool_source(
     mut args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     if args.is_empty()
@@ -840,7 +840,7 @@ pub(super) async fn tool_source(
     }
 }
 
-pub(super) async fn tool_source_add(
+pub(crate) async fn tool_source_add(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_tool_source_add_args(args)?;
@@ -885,7 +885,7 @@ pub(super) async fn tool_source_add(
     Ok(())
 }
 
-pub(super) async fn tool_source_discover(
+pub(crate) async fn tool_source_discover(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_tool_source_name_args(args, "tool source discover")?;
@@ -916,7 +916,7 @@ pub(super) async fn tool_source_discover(
     Ok(())
 }
 
-pub(super) async fn tool_source_list(
+pub(crate) async fn tool_source_list(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_tool_source_list_args(args, "tool source list")?;
@@ -959,7 +959,7 @@ pub(super) async fn tool_source_list(
     Ok(())
 }
 
-pub(super) async fn tool_source_show(
+pub(crate) async fn tool_source_show(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_tool_source_show_args(args)?;
@@ -1000,7 +1000,7 @@ pub(super) async fn tool_source_show(
     Ok(())
 }
 
-pub(super) async fn tool_source_remove(
+pub(crate) async fn tool_source_remove(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_tool_source_name_args(args, "tool source remove")?;
@@ -1021,7 +1021,7 @@ pub(super) async fn tool_source_remove(
 }
 
 #[derive(Debug)]
-pub(super) struct BuildArgs {
+pub(crate) struct BuildArgs {
     name: Option<String>,
     module_path: Option<std::path::PathBuf>,
     package_path: Option<std::path::PathBuf>,
@@ -1031,7 +1031,7 @@ pub(super) struct BuildArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct PublishArgs {
+pub(crate) struct PublishArgs {
     name: Option<String>,
     module_path: Option<std::path::PathBuf>,
     bin_path: Option<std::path::PathBuf>,
@@ -1046,13 +1046,13 @@ pub(super) struct PublishArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct ToolRegistryArgs {
+pub(crate) struct ToolRegistryArgs {
     registry_root: Option<std::path::PathBuf>,
     help: bool,
 }
 
 #[derive(Debug)]
-pub(super) struct RunArgs {
+pub(crate) struct RunArgs {
     registered_name: Option<String>,
     module_path: Option<std::path::PathBuf>,
     bin_path: Option<std::path::PathBuf>,
@@ -1067,7 +1067,7 @@ pub(super) struct RunArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct ToolManualArgs {
+pub(crate) struct ToolManualArgs {
     tool_name: Option<String>,
     operation: Option<String>,
     registry_root: Option<std::path::PathBuf>,
@@ -1076,7 +1076,7 @@ pub(super) struct ToolManualArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct ToolSourceAddArgs {
+pub(crate) struct ToolSourceAddArgs {
     name: Option<String>,
     kind: Option<crate::adapters::mcp_client::McpRemoteTransport>,
     url: Option<String>,
@@ -1090,21 +1090,21 @@ pub(super) struct ToolSourceAddArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct ToolSourceNameArgs {
+pub(crate) struct ToolSourceNameArgs {
     name: Option<String>,
     state_home: Option<std::path::PathBuf>,
     help: bool,
 }
 
 #[derive(Debug)]
-pub(super) struct ToolSourceListArgs {
+pub(crate) struct ToolSourceListArgs {
     state_home: Option<std::path::PathBuf>,
     json: bool,
     help: bool,
 }
 
 #[derive(Debug)]
-pub(super) struct ToolSourceShowArgs {
+pub(crate) struct ToolSourceShowArgs {
     name: Option<String>,
     state_home: Option<std::path::PathBuf>,
     json: bool,
@@ -1112,13 +1112,13 @@ pub(super) struct ToolSourceShowArgs {
 }
 
 #[derive(Debug)]
-pub(super) struct MountArg {
+pub(crate) struct MountArg {
     guest_path: std::path::PathBuf,
     host_path: std::path::PathBuf,
 }
 
 #[derive(Clone, Debug, Default, serde::Deserialize)]
-pub(super) struct ToolConfigFile {
+pub(crate) struct ToolConfigFile {
     name: Option<String>,
     module_path: Option<std::path::PathBuf>,
     bin_path: Option<std::path::PathBuf>,
@@ -1129,13 +1129,13 @@ pub(super) struct ToolConfigFile {
 }
 
 #[derive(Clone, Debug, Default, serde::Deserialize)]
-pub(super) struct ToolConversionConfig {
+pub(crate) struct ToolConversionConfig {
     upstream_url: Option<String>,
     upstream_rev: Option<String>,
     upstream_crate: Option<String>,
 }
 
-pub(super) fn parse_build_args(
+pub(crate) fn parse_build_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<BuildArgs> {
     let mut name = None;
@@ -1184,7 +1184,7 @@ pub(super) fn parse_build_args(
     })
 }
 
-pub(super) fn parse_publish_args(
+pub(crate) fn parse_publish_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<PublishArgs> {
     let mut name = None;
@@ -1259,7 +1259,7 @@ pub(super) fn parse_publish_args(
     })
 }
 
-pub(super) fn parse_tool_registry_args(
+pub(crate) fn parse_tool_registry_args(
     args: Vec<std::ffi::OsString>,
     command: &str,
 ) -> crate::kernel::runtime_host::VerletResult<ToolRegistryArgs> {
@@ -1285,7 +1285,7 @@ pub(super) fn parse_tool_registry_args(
     })
 }
 
-pub(super) fn parse_run_args(
+pub(crate) fn parse_run_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<RunArgs> {
     let mut module_path = None;
@@ -1364,7 +1364,7 @@ pub(super) fn parse_run_args(
     })
 }
 
-pub(super) fn parse_tool_manual_args(
+pub(crate) fn parse_tool_manual_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<ToolManualArgs> {
     let mut registry_root = None;
@@ -1401,7 +1401,7 @@ pub(super) fn parse_tool_manual_args(
     })
 }
 
-pub(super) fn parse_tool_source_add_args(
+pub(crate) fn parse_tool_source_add_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<ToolSourceAddArgs> {
     let mut name = None;
@@ -1482,7 +1482,7 @@ pub(super) fn parse_tool_source_add_args(
     })
 }
 
-pub(super) fn parse_tool_source_name_args(
+pub(crate) fn parse_tool_source_name_args(
     args: Vec<std::ffi::OsString>,
     command: &str,
 ) -> crate::kernel::runtime_host::VerletResult<ToolSourceNameArgs> {
@@ -1516,7 +1516,7 @@ pub(super) fn parse_tool_source_name_args(
     })
 }
 
-pub(super) fn parse_tool_source_list_args(
+pub(crate) fn parse_tool_source_list_args(
     args: Vec<std::ffi::OsString>,
     command: &str,
 ) -> crate::kernel::runtime_host::VerletResult<ToolSourceListArgs> {
@@ -1543,7 +1543,7 @@ pub(super) fn parse_tool_source_list_args(
     })
 }
 
-pub(super) fn parse_tool_source_show_args(
+pub(crate) fn parse_tool_source_show_args(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<ToolSourceShowArgs> {
     let mut name = None;
@@ -1579,7 +1579,7 @@ pub(super) fn parse_tool_source_show_args(
     })
 }
 
-pub(super) fn required_path_value(
+pub(crate) fn required_path_value(
     iter: &mut impl Iterator<Item = std::ffi::OsString>,
     flag: &'static str,
 ) -> crate::kernel::runtime_host::VerletResult<std::path::PathBuf> {
@@ -1588,7 +1588,7 @@ pub(super) fn required_path_value(
         .ok_or_else(|| crate::cli::usage_error(format!("{flag} requires a value")))
 }
 
-pub(super) fn required_string_value(
+pub(crate) fn required_string_value(
     iter: &mut impl Iterator<Item = std::ffi::OsString>,
     flag: &'static str,
 ) -> crate::kernel::runtime_host::VerletResult<String> {
@@ -1597,7 +1597,7 @@ pub(super) fn required_string_value(
         .ok_or_else(|| crate::cli::usage_error(format!("{flag} requires a value")))
 }
 
-pub(super) fn parse_mount_arg(value: &str) -> crate::kernel::runtime_host::VerletResult<MountArg> {
+pub(crate) fn parse_mount_arg(value: &str) -> crate::kernel::runtime_host::VerletResult<MountArg> {
     let Some((guest_path, host_path)) = value.split_once('=') else {
         return Err(crate::cli::usage_error(
             "--mount must use /guest/path=/host/path",
@@ -1615,7 +1615,7 @@ pub(super) fn parse_mount_arg(value: &str) -> crate::kernel::runtime_host::Verle
     })
 }
 
-pub(super) fn parse_header_arg(
+pub(crate) fn parse_header_arg(
     value: &str,
 ) -> crate::kernel::runtime_host::VerletResult<(String, String)> {
     let Some((name, header_value)) = value.split_once('=') else {
@@ -1627,7 +1627,7 @@ pub(super) fn parse_header_arg(
     Ok((name.trim().to_string(), header_value.to_string()))
 }
 
-pub(super) fn parse_u64_arg(
+pub(crate) fn parse_u64_arg(
     flag: &str,
     value: &str,
 ) -> crate::kernel::runtime_host::VerletResult<u64> {
@@ -1636,7 +1636,7 @@ pub(super) fn parse_u64_arg(
         .map_err(|_| crate::cli::usage_error(format!("{flag} must be a positive integer")))
 }
 
-pub(super) fn parse_metadata_arg(
+pub(crate) fn parse_metadata_arg(
     value: &str,
 ) -> crate::kernel::runtime_host::VerletResult<(String, serde_json::Value)> {
     let Some((key, raw_value)) = value.split_once('=') else {
@@ -1650,11 +1650,11 @@ pub(super) fn parse_metadata_arg(
     Ok((key.to_string(), value))
 }
 
-pub(super) fn default_registry_root() -> std::path::PathBuf {
+pub(crate) fn default_registry_root() -> std::path::PathBuf {
     crate::agent::manifest::default_operations_registry_root()
 }
 
-pub(super) async fn open_mcp_source_registry(
+pub(crate) async fn open_mcp_source_registry(
     state_home: Option<std::path::PathBuf>,
 ) -> crate::kernel::runtime_host::VerletResult<crate::adapters::mcp_client::SqliteMcpSourceRegistry>
 {
@@ -1676,7 +1676,7 @@ pub(super) async fn open_mcp_source_registry(
     })
 }
 
-pub(super) fn load_tool_config(
+pub(crate) fn load_tool_config(
     path: Option<&std::path::Path>,
 ) -> crate::kernel::runtime_host::VerletResult<ToolConfigFile> {
     let discovered;
@@ -1707,7 +1707,7 @@ pub(super) fn load_tool_config(
 }
 
 #[derive(Debug)]
-pub(super) struct ToolConversionAudit {
+pub(crate) struct ToolConversionAudit {
     manifest_path: std::path::PathBuf,
     crate_name: String,
     issues: Vec<String>,
@@ -1740,7 +1740,7 @@ impl ToolConversionAudit {
     }
 }
 
-pub(super) fn audit_strict_stateless_conversion(
+pub(crate) fn audit_strict_stateless_conversion(
     module_path: &std::path::Path,
     conversion: Option<&ToolConversionConfig>,
 ) -> crate::kernel::runtime_host::VerletResult<ToolConversionAudit> {
@@ -1790,7 +1790,7 @@ pub(super) fn audit_strict_stateless_conversion(
     })
 }
 
-pub(super) fn resolve_cargo_manifest_path(
+pub(crate) fn resolve_cargo_manifest_path(
     module_path: &std::path::Path,
 ) -> crate::kernel::runtime_host::VerletResult<std::path::PathBuf> {
     let path = if module_path.file_name() == Some(std::ffi::OsStr::new("Cargo.toml")) {
@@ -1806,7 +1806,7 @@ pub(super) fn resolve_cargo_manifest_path(
     Ok(path)
 }
 
-pub(super) fn collect_cargo_dependency_names(
+pub(crate) fn collect_cargo_dependency_names(
     manifest: &toml::Value,
 ) -> std::collections::BTreeSet<String> {
     let mut dependencies = std::collections::BTreeSet::new();
@@ -1823,7 +1823,7 @@ pub(super) fn collect_cargo_dependency_names(
     dependencies
 }
 
-pub(super) fn collect_dependency_table(
+pub(crate) fn collect_dependency_table(
     value: Option<&toml::Value>,
     dependencies: &mut std::collections::BTreeSet<String>,
 ) {
@@ -1833,20 +1833,20 @@ pub(super) fn collect_dependency_table(
     dependencies.extend(table.keys().cloned());
 }
 
-pub(super) fn strict_conversion_denied_dependencies() -> std::collections::BTreeSet<&'static str> {
+pub(crate) fn strict_conversion_denied_dependencies() -> std::collections::BTreeSet<&'static str> {
     ["git2", "heed", "libc", "memmap2", "notify", "rayon"]
         .into_iter()
         .collect()
 }
 
-pub(super) fn json_label(value: &impl serde::Serialize) -> String {
+pub(crate) fn json_label(value: &impl serde::Serialize) -> String {
     serde_json::to_value(value)
         .ok()
         .and_then(|value| value.as_str().map(str::to_string))
         .unwrap_or_else(|| "unknown".to_string())
 }
 
-pub(super) fn relativize_config_paths(config: &mut ToolConfigFile, base: &std::path::Path) {
+pub(crate) fn relativize_config_paths(config: &mut ToolConfigFile, base: &std::path::Path) {
     if let Some(path) = config.module_path.take() {
         config.module_path = Some(resolve_config_path(base, path));
     }
@@ -1858,7 +1858,7 @@ pub(super) fn relativize_config_paths(config: &mut ToolConfigFile, base: &std::p
     }
 }
 
-pub(super) fn resolve_config_path(
+pub(crate) fn resolve_config_path(
     base: &std::path::Path,
     path: std::path::PathBuf,
 ) -> std::path::PathBuf {
@@ -1869,7 +1869,7 @@ pub(super) fn resolve_config_path(
     }
 }
 
-pub(super) async fn validate_wasm_artifact(
+pub(crate) async fn validate_wasm_artifact(
     artifact_path: std::path::PathBuf,
     capability_grants: std::collections::BTreeSet<String>,
 ) -> crate::kernel::runtime_host::VerletResult<verlet_abi::WasmOperationManifest> {
@@ -1880,7 +1880,7 @@ pub(super) async fn validate_wasm_artifact(
     factory.validate_operation_artifact().await
 }
 
-pub(super) async fn load_vfs(
+pub(crate) async fn load_vfs(
     mounts: Vec<MountArg>,
 ) -> crate::kernel::runtime_host::VerletResult<std::sync::Arc<verlet_vfs::VerletVfs>> {
     let vfs = std::sync::Arc::new(verlet_vfs::VerletVfs::new(std::sync::Arc::new(
@@ -1914,7 +1914,7 @@ pub(super) async fn load_vfs(
     Ok(vfs)
 }
 
-pub(super) fn print_tool_help() {
+pub(crate) fn print_tool_help() {
     println!(
         "verlet tool\n\
 \n\
@@ -1939,7 +1939,7 @@ virtual-bash commands, HTTP routes, MCP exports, or other runtime surfaces.\n"
     );
 }
 
-pub(super) fn print_tool_source_help() {
+pub(crate) fn print_tool_source_help() {
     println!(
         "verlet tool source\n\
 \n\
@@ -1959,7 +1959,7 @@ external MCP client use Verlet, run the local Verlet MCP stdio adapter.\n"
     );
 }
 
-pub(super) fn print_tool_source_add_help() {
+pub(crate) fn print_tool_source_add_help() {
     println!(
         "verlet tool source add\n\
 \n\
@@ -1970,7 +1970,7 @@ Adds or updates a remote MCP tool source without discovering tools yet.\n"
     );
 }
 
-pub(super) fn print_tool_source_discover_help() {
+pub(crate) fn print_tool_source_discover_help() {
     println!(
         "verlet tool source discover\n\
 \n\
@@ -1982,7 +1982,7 @@ tool definitions in the local metadata DB.\n"
     );
 }
 
-pub(super) fn print_tool_source_list_help() {
+pub(crate) fn print_tool_source_list_help() {
     println!(
         "verlet tool source list\n\
 \n\
@@ -1993,7 +1993,7 @@ Lists registered remote MCP tool sources with redacted auth metadata.\n"
     );
 }
 
-pub(super) fn print_tool_source_show_help() {
+pub(crate) fn print_tool_source_show_help() {
     println!(
         "verlet tool source show\n\
 \n\
@@ -2004,7 +2004,7 @@ Shows one remote MCP source and its latest discovered tool snapshot.\n"
     );
 }
 
-pub(super) fn print_tool_source_remove_help() {
+pub(crate) fn print_tool_source_remove_help() {
     println!(
         "verlet tool source remove\n\
 \n\
@@ -2015,7 +2015,7 @@ Removes a remote MCP source record from the local metadata DB.\n"
     );
 }
 
-pub(super) fn print_tool_build_help() {
+pub(crate) fn print_tool_build_help() {
     println!(
         "verlet tool build\n\
 \n\
@@ -2030,7 +2030,7 @@ fixtures when present, print a build receipt, and write nothing to the registry.
     );
 }
 
-pub(super) fn print_tool_list_help() {
+pub(crate) fn print_tool_list_help() {
     println!(
         "verlet tool list\n\
 \n\
@@ -2041,7 +2041,7 @@ Lists published operation records and their active artifact hashes.\n"
     );
 }
 
-pub(super) fn print_tool_publish_help() {
+pub(crate) fn print_tool_publish_help() {
     println!(
         "verlet tool publish\n\
 \n\
@@ -2054,7 +2054,7 @@ before the published tool can become visible through agent attachments.\n"
     );
 }
 
-pub(super) fn print_tool_run_help() {
+pub(crate) fn print_tool_run_help() {
     println!(
         "verlet tool run\n\
 \n\
@@ -2067,7 +2067,7 @@ Runs an operation from source, a Wasm artifact, or a published tool record.\n"
     );
 }
 
-pub(super) fn print_tool_manual_help() {
+pub(crate) fn print_tool_manual_help() {
     println!(
         "verlet tool manual\n\
 \n\

--- a/crates/verlet-kernel/src/kernel/binding_projector.rs
+++ b/crates/verlet-kernel/src/kernel/binding_projector.rs
@@ -252,8 +252,8 @@ mod tests {
     #[test]
     fn empty_and_unrelated_streams_fold_to_empty() {
         assert_eq!(
-            super::fold_thread_bindings(&[]),
-            super::ThreadBindingsFold::default()
+            crate::kernel::binding_projector::fold_thread_bindings(&[]),
+            crate::kernel::binding_projector::ThreadBindingsFold::default()
         );
         let unrelated = event(
             1,
@@ -263,8 +263,8 @@ mod tests {
         );
 
         assert_eq!(
-            super::fold_thread_bindings(&[unrelated]),
-            super::ThreadBindingsFold::default()
+            crate::kernel::binding_projector::fold_thread_bindings(&[unrelated]),
+            crate::kernel::binding_projector::ThreadBindingsFold::default()
         );
     }
 
@@ -288,9 +288,12 @@ mod tests {
             reattached.clone(),
         ];
 
-        let folded = super::fold_thread_bindings(&events);
+        let folded = crate::kernel::binding_projector::fold_thread_bindings(&events);
 
-        assert_eq!(folded, super::fold_thread_bindings(&events));
+        assert_eq!(
+            folded,
+            crate::kernel::binding_projector::fold_thread_bindings(&events)
+        );
         assert_eq!(folded.anomalies, Vec::new());
         assert_eq!(
             folded
@@ -328,7 +331,7 @@ mod tests {
         rebound_search.payload["artifact_hash"] = serde_json::json!("sha256:search-tools-v2");
         let rebound_files = attach_event_for_bind(6, 100, "file-tools", 901);
 
-        let folded = super::fold_thread_bindings(&[
+        let folded = crate::kernel::binding_projector::fold_thread_bindings(&[
             first_bind,
             first_search,
             first_files,
@@ -379,7 +382,7 @@ mod tests {
         rebound_search.payload["artifact_hash"] = serde_json::json!("sha256:search-tools-v2");
         let rebound_files = attach_event_for_bind(6, 100, "file-tools", 901);
 
-        let folded = super::fold_thread_bindings(&[
+        let folded = crate::kernel::binding_projector::fold_thread_bindings(&[
             first_bind,
             first_search,
             first_files,
@@ -427,7 +430,7 @@ mod tests {
         );
         let added_clock = attach_event_for_bind(5, 200, "clock-tools", 901);
 
-        let folded = super::fold_thread_bindings(&[
+        let folded = crate::kernel::binding_projector::fold_thread_bindings(&[
             first_bind,
             first_search.clone(),
             first_files.clone(),
@@ -470,7 +473,7 @@ mod tests {
         second_search.payload["artifact_hash"] = serde_json::json!("sha256:search-tools-v2");
         let detach_first_search = detach_event_for_bind(6, 100, first_search.id, 901);
 
-        let folded = super::fold_thread_bindings(&[
+        let folded = crate::kernel::binding_projector::fold_thread_bindings(&[
             first_bind,
             first_search,
             first_files.clone(),
@@ -524,7 +527,7 @@ mod tests {
             events.extend([search, files]);
         }
 
-        let folded = super::fold_thread_bindings(&events);
+        let folded = crate::kernel::binding_projector::fold_thread_bindings(&events);
 
         assert!(folded.anomalies.is_empty());
         assert_eq!(
@@ -550,7 +553,11 @@ mod tests {
         let empty_bind = bind_event(3, 901, serde_json::json!([]));
 
         let first_search_id = first_search.id;
-        let folded = super::fold_thread_bindings(&[first_bind, first_search, empty_bind]);
+        let folded = crate::kernel::binding_projector::fold_thread_bindings(&[
+            first_bind,
+            first_search,
+            empty_bind,
+        ]);
 
         assert!(folded.anomalies.is_empty());
         assert_eq!(folded.active[0].attach_event_id, first_search_id);
@@ -561,7 +568,10 @@ mod tests {
         let first = attach_event(1, 1, "search-tools");
         let second = attach_event(2, 2, "search-tools");
 
-        let folded = super::fold_thread_bindings(&[first.clone(), second.clone()]);
+        let folded = crate::kernel::binding_projector::fold_thread_bindings(&[
+            first.clone(),
+            second.clone(),
+        ]);
 
         assert!(folded.anomalies.is_empty());
         assert_eq!(
@@ -587,7 +597,10 @@ mod tests {
         );
         second.provenance.source_event_ids = first.provenance.source_event_ids.clone();
 
-        let folded = super::fold_thread_bindings(&[first.clone(), second.clone()]);
+        let folded = crate::kernel::binding_projector::fold_thread_bindings(&[
+            first.clone(),
+            second.clone(),
+        ]);
 
         assert!(folded.anomalies.is_empty());
         assert_eq!(
@@ -608,20 +621,24 @@ mod tests {
         let unknown_id = verlet_history::EventRecordId::from_uuid(uuid::Uuid::from_u128(99));
         let unknown = detach_event(4, 4, unknown_id);
 
-        let folded =
-            super::fold_thread_bindings(&[attached, detached, repeated.clone(), unknown.clone()]);
+        let folded = crate::kernel::binding_projector::fold_thread_bindings(&[
+            attached,
+            detached,
+            repeated.clone(),
+            unknown.clone(),
+        ]);
 
         assert!(folded.active.is_empty());
         assert_eq!(
             folded.anomalies,
             vec![
-                super::ThreadBindingAnomaly::AlreadyDetached {
+                crate::kernel::binding_projector::ThreadBindingAnomaly::AlreadyDetached {
                     detach_event_id: repeated.id,
                     attach_event_id: verlet_history::EventRecordId::from_uuid(
                         uuid::Uuid::from_u128(1)
                     ),
                 },
-                super::ThreadBindingAnomaly::UnknownDetach {
+                crate::kernel::binding_projector::ThreadBindingAnomaly::UnknownDetach {
                     detach_event_id: unknown.id,
                     attach_event_id: unknown_id,
                 },
@@ -644,18 +661,21 @@ mod tests {
             serde_json::json!({"attach_event_id": 42}),
         );
 
-        let folded = super::fold_thread_bindings(&[bad_attach.clone(), bad_detach.clone()]);
+        let folded = crate::kernel::binding_projector::fold_thread_bindings(&[
+            bad_attach.clone(),
+            bad_detach.clone(),
+        ]);
 
         assert!(folded.active.is_empty());
         assert_eq!(folded.anomalies.len(), 2);
         assert!(matches!(
             &folded.anomalies[0],
-            super::ThreadBindingAnomaly::UndecodableAttached { event_id, message }
+            crate::kernel::binding_projector::ThreadBindingAnomaly::UndecodableAttached { event_id, message }
                 if *event_id == bad_attach.id && !message.is_empty()
         ));
         assert!(matches!(
             &folded.anomalies[1],
-            super::ThreadBindingAnomaly::UndecodableDetached { event_id, message }
+            crate::kernel::binding_projector::ThreadBindingAnomaly::UndecodableDetached { event_id, message }
                 if *event_id == bad_detach.id && !message.is_empty()
         ));
     }
@@ -687,7 +707,12 @@ mod tests {
             uuid::Uuid::from_u128(901),
         )];
 
-        let folded = super::fold_thread_bindings(&[old_bind, old, new_bind, bad_attach.clone()]);
+        let folded = crate::kernel::binding_projector::fold_thread_bindings(&[
+            old_bind,
+            old,
+            new_bind,
+            bad_attach.clone(),
+        ]);
 
         assert_eq!(
             folded
@@ -701,7 +726,7 @@ mod tests {
         );
         assert!(matches!(
             folded.anomalies.as_slice(),
-            [super::ThreadBindingAnomaly::UndecodableAttached { event_id, .. }]
+            [crate::kernel::binding_projector::ThreadBindingAnomaly::UndecodableAttached { event_id, .. }]
                 if *event_id == bad_attach.id
         ));
     }
@@ -733,7 +758,7 @@ mod tests {
             ));
         }
 
-        let folded = super::fold_thread_bindings(&events);
+        let folded = crate::kernel::binding_projector::fold_thread_bindings(&events);
 
         assert!(folded.active.is_empty());
         assert_eq!(folded.anomalies.len(), events.len());
@@ -743,7 +768,7 @@ mod tests {
                 .iter()
                 .filter(|anomaly| matches!(
                     anomaly,
-                    super::ThreadBindingAnomaly::UndecodableAttached { .. }
+                    crate::kernel::binding_projector::ThreadBindingAnomaly::UndecodableAttached { .. }
                 ))
                 .count(),
             events.len() / 2
@@ -754,7 +779,7 @@ mod tests {
                 .iter()
                 .filter(|anomaly| matches!(
                     anomaly,
-                    super::ThreadBindingAnomaly::UndecodableDetached { .. }
+                    crate::kernel::binding_projector::ThreadBindingAnomaly::UndecodableDetached { .. }
                 ))
                 .count(),
             events.len() / 2

--- a/crates/verlet-kernel/src/kernel/runtime_host.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host.rs
@@ -183,7 +183,7 @@ fn fork_child_context_is_compatible(
         && context.metadata.get("forked_from_thread_id") == Some(&parent_thread_id.to_string())
 }
 
-struct RuntimeHostInner {
+pub(crate) struct RuntimeHostInner {
     factory: std::sync::Arc<dyn crate::kernel::runtime_host::runtime_api::AgentRuntimeFactory>,
     runtime_store: std::sync::Arc<dyn verlet_history::RuntimeStore>,
     execution_policy: crate::kernel::runtime_host::runtime_services::RuntimeExecutionPolicy,
@@ -342,7 +342,7 @@ impl Drop for PublishedThreadStartGuard {
 
 impl ReservedTurnSubmission {
     /// Publishes a submission after all fallible admission work has completed.
-    pub(super) async fn submit_unchecked(self) -> bool {
+    pub(crate) async fn submit_unchecked(self) -> bool {
         let Self {
             host,
             thread,
@@ -1112,7 +1112,7 @@ impl RuntimeHost {
         .await
     }
 
-    pub(super) async fn reserve_turn_submission_at_choke_point(
+    pub(crate) async fn reserve_turn_submission_at_choke_point(
         &self,
         thread_id: verlet_runtime_contracts::ThreadId,
         turn_id: impl Into<String>,

--- a/crates/verlet-kernel/src/kernel/runtime_host/context_read_plan.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/context_read_plan.rs
@@ -1,4 +1,4 @@
-pub(super) fn context_compile_payload_v1(
+pub(crate) fn context_compile_payload_v1(
     payload: serde_json::Value,
     stream_id: &verlet_history::EventStreamId,
     source_ranges: &[verlet_history::ObservationSourceRange],
@@ -22,7 +22,7 @@ pub(super) fn context_compile_payload_v1(
     serde_json::Value::Object(object)
 }
 
-pub(super) fn is_recall_context_read_plan_event(event: &verlet_history::EventRecord) -> bool {
+pub(crate) fn is_recall_context_read_plan_event(event: &verlet_history::EventRecord) -> bool {
     event.kind == verlet_history::EventKind::ContextReadPlanSet
         && event.payload.get("scope").and_then(|value| value.as_str()) == Some("thread")
         && event
@@ -32,7 +32,7 @@ pub(super) fn is_recall_context_read_plan_event(event: &verlet_history::EventRec
             == Some("context.memory")
 }
 
-pub(super) fn is_instruction_context_read_plan_event(event: &verlet_history::EventRecord) -> bool {
+pub(crate) fn is_instruction_context_read_plan_event(event: &verlet_history::EventRecord) -> bool {
     event.kind == verlet_history::EventKind::ContextReadPlanSet
         && event.payload.get("scope").and_then(|value| value.as_str()) == Some("thread")
         && event
@@ -42,7 +42,7 @@ pub(super) fn is_instruction_context_read_plan_event(event: &verlet_history::Eve
             == Some("context.instructions")
 }
 
-pub(super) fn render_recall_context(texts: &[String]) -> String {
+pub(crate) fn render_recall_context(texts: &[String]) -> String {
     let body = texts
         .iter()
         .map(|text| format!("- {}", text.trim()))
@@ -51,7 +51,7 @@ pub(super) fn render_recall_context(texts: &[String]) -> String {
     format!("<memory_context>\n{body}\n</memory_context>")
 }
 
-pub(super) fn render_instruction_context(instruction_texts: &[String]) -> String {
+pub(crate) fn render_instruction_context(instruction_texts: &[String]) -> String {
     let body = instruction_texts
         .iter()
         .map(|text| format!("- {}", text.trim()))
@@ -114,7 +114,7 @@ fn read_plan_from_cursor(sequence: verlet_history::EventSequence) -> serde_json:
     }
 }
 
-pub(super) fn context_summary_completed_payload_v1(
+pub(crate) fn context_summary_completed_payload_v1(
     summary: &str,
     source_ranges: &[verlet_history::ObservationSourceRange],
 ) -> serde_json::Value {
@@ -129,7 +129,7 @@ pub(super) fn context_summary_completed_payload_v1(
     })
 }
 
-pub(super) fn context_read_plan_set_payload_v1(
+pub(crate) fn context_read_plan_set_payload_v1(
     name: &str,
     stream_id: &verlet_history::EventStreamId,
     summary_event_id: verlet_history::EventRecordId,
@@ -197,7 +197,7 @@ fn source_ranges_json(
         .collect()
 }
 
-pub(super) async fn context_source_ranges(
+pub(crate) async fn context_source_ranges(
     store: &dyn verlet_history::RuntimeStore,
     source_cuts: &[verlet_history::SessionContextSourceCut],
 ) -> crate::kernel::runtime_host::VerletResult<Vec<verlet_history::ObservationSourceRange>> {
@@ -248,7 +248,7 @@ fn context_source_range(
     })
 }
 
-pub(super) fn session_context_source_cut_for_entries(
+pub(crate) fn session_context_source_cut_for_entries(
     coordinates: &verlet_runtime_contracts::ThreadCoordinates,
     session_entries: &[verlet_history::SessionEntry],
 ) -> Vec<verlet_history::SessionContextSourceCut> {
@@ -268,7 +268,7 @@ pub(super) fn session_context_source_cut_for_entries(
     }]
 }
 
-pub(super) fn context_source_streams(
+pub(crate) fn context_source_streams(
     source_cuts: &[verlet_history::SessionContextSourceCut],
     fallback_stream_id: &verlet_history::EventStreamId,
 ) -> Vec<verlet_history::EventStreamId> {
@@ -284,7 +284,7 @@ pub(super) fn context_source_streams(
     streams
 }
 
-pub(super) fn primary_context_source_range(
+pub(crate) fn primary_context_source_range(
     stream_id: &verlet_history::EventStreamId,
     source_ranges: &[verlet_history::ObservationSourceRange],
 ) -> Option<verlet_history::ObservationSourceRange> {

--- a/crates/verlet-kernel/src/kernel/runtime_host/kernel_control.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/kernel_control.rs
@@ -4,7 +4,7 @@ pub struct RuntimeKernelControl {
 }
 
 impl RuntimeKernelControl {
-    pub(super) fn new(
+    pub(crate) fn new(
         inner: std::sync::Weak<crate::kernel::runtime_host::RuntimeHostInner>,
     ) -> Self {
         Self { inner }

--- a/crates/verlet-kernel/src/kernel/runtime_host/loop_continuation.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/loop_continuation.rs
@@ -15,7 +15,7 @@ pub enum LoopContinuationReceipt {
     },
 }
 
-pub(super) async fn latest_turn_continue_request(
+pub(crate) async fn latest_turn_continue_request(
     store: &dyn verlet_history::RuntimeStore,
     coordinates: &verlet_runtime_contracts::ThreadCoordinates,
     loop_id: &str,
@@ -60,7 +60,7 @@ pub(super) async fn latest_turn_continue_request(
     Ok(latest.map(|(_, event, payload)| (event, payload)))
 }
 
-pub(super) async fn existing_continuation_receipt(
+pub(crate) async fn existing_continuation_receipt(
     store: &dyn verlet_history::RuntimeStore,
     coordinates: &verlet_runtime_contracts::ThreadCoordinates,
     subject: &crate::kernel::control_decision::TurnContinuationSubject,
@@ -128,7 +128,7 @@ pub(super) async fn existing_continuation_receipt(
     Ok(latest.map(|(_, receipt)| receipt))
 }
 
-pub(super) async fn append_continuation_accepted_event(
+pub(crate) async fn append_continuation_accepted_event(
     store: &dyn verlet_history::RuntimeStore,
     coordinates: &verlet_runtime_contracts::ThreadCoordinates,
     subject: &crate::kernel::control_decision::TurnContinuationSubject,
@@ -157,7 +157,7 @@ pub(super) async fn append_continuation_accepted_event(
     .await
 }
 
-pub(super) async fn append_continuation_rejected_event(
+pub(crate) async fn append_continuation_rejected_event(
     store: &dyn verlet_history::RuntimeStore,
     coordinates: &verlet_runtime_contracts::ThreadCoordinates,
     subject: &crate::kernel::control_decision::TurnContinuationSubject,
@@ -221,7 +221,7 @@ async fn append_control_discharge(
         })
 }
 
-pub(super) async fn append_loop_turn_submitted_event(
+pub(crate) async fn append_loop_turn_submitted_event(
     store: &dyn verlet_history::RuntimeStore,
     coordinates: &verlet_runtime_contracts::ThreadCoordinates,
     next_turn_id: &str,
@@ -263,7 +263,7 @@ pub(super) async fn append_loop_turn_submitted_event(
         })
 }
 
-pub(super) async fn turn_submitted_event(
+pub(crate) async fn turn_submitted_event(
     store: &dyn verlet_history::RuntimeStore,
     coordinates: &verlet_runtime_contracts::ThreadCoordinates,
     turn_id: &str,
@@ -288,7 +288,7 @@ pub(super) async fn turn_submitted_event(
         .max_by_key(|event| event.sequence.get()))
 }
 
-pub(super) async fn decide_continuation(
+pub(crate) async fn decide_continuation(
     store: &dyn verlet_history::RuntimeStore,
     request: crate::kernel::control_decision::TurnContinuationDecisionRequest,
 ) -> crate::kernel::runtime_host::VerletResult<

--- a/crates/verlet-kernel/src/kernel/runtime_host/runtime_services.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/runtime_services.rs
@@ -138,7 +138,7 @@ impl RuntimeServices {
         self.kernel_control.clone()
     }
 
-    pub(super) fn register_turn_watchdog(
+    pub(crate) fn register_turn_watchdog(
         &self,
         input: &mut crate::kernel::runtime_host::turn::TurnInput,
     ) -> crate::kernel::runtime_host::turn::TurnWatchdogHandle {

--- a/crates/verlet-kernel/src/kernel/runtime_host/runtime_utils.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/runtime_utils.rs
@@ -1,11 +1,11 @@
-pub(super) fn unix_timestamp_ms() -> u64 {
+pub(crate) fn unix_timestamp_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
 }
 
-pub(super) async fn wait_until_thread_settled(
+pub(crate) async fn wait_until_thread_settled(
     thread: &crate::kernel::runtime_host::RuntimeThreadHandle,
 ) {
     let mut status = thread.subscribe_status();
@@ -25,7 +25,7 @@ pub(super) async fn wait_until_thread_settled(
     }
 }
 
-pub(super) fn latest_message_text(messages: &[verlet_history::CanonicalMessage]) -> Option<String> {
+pub(crate) fn latest_message_text(messages: &[verlet_history::CanonicalMessage]) -> Option<String> {
     messages.iter().rev().find_map(|message| {
         let text = match message {
             verlet_history::CanonicalMessage::Assistant { content, .. }
@@ -45,7 +45,7 @@ pub(super) fn latest_message_text(messages: &[verlet_history::CanonicalMessage])
 
 const THREAD_INTERACTION_RESULT_PREVIEW_MAX_CHARS: usize = 512;
 
-pub(super) fn thread_interaction_preview(output: &str) -> String {
+pub(crate) fn thread_interaction_preview(output: &str) -> String {
     let mut chars = output.chars();
     let preview: String = chars
         .by_ref()
@@ -58,7 +58,7 @@ pub(super) fn thread_interaction_preview(output: &str) -> String {
     }
 }
 
-pub(super) fn emit_thread_interaction(
+pub(crate) fn emit_thread_interaction(
     thread: &crate::kernel::runtime_host::RuntimeThreadHandle,
     interaction_id: verlet_runtime_contracts::RuntimeEventId,
     kind: verlet_runtime_contracts::ThreadInteractionKind,

--- a/crates/verlet-kernel/src/kernel/runtime_host/thread_handle.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/thread_handle.rs
@@ -433,7 +433,7 @@ impl crate::kernel::runtime_host::RuntimeThreadHandle {
     /// publishes lifecycle side effects. Only the append is retried: an
     /// unrelated history-shaped factory or lifecycle error must not re-enter
     /// the whole child start.
-    pub(super) async fn record_thread_start_identity_with_reconciliation(
+    pub(crate) async fn record_thread_start_identity_with_reconciliation(
         &self,
     ) -> crate::kernel::runtime_host::VerletResult<()> {
         let mut first_error = None;
@@ -605,7 +605,7 @@ impl crate::kernel::runtime_host::RuntimeThreadHandle {
             .map_err(|_| crate::kernel::runtime_host::VerletError::ThreadClosed(thread_id))
     }
 
-    pub(super) fn try_reserve_command(
+    pub(crate) fn try_reserve_command(
         &self,
     ) -> Result<
         tokio::sync::mpsc::Permit<'_, crate::kernel::runtime_host::runtime_api::ThreadCommand>,

--- a/crates/verlet-kernel/src/kernel/runtime_host/turn.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/turn.rs
@@ -154,7 +154,7 @@ enum TurnWatchdogPhase {
 /// Enqueueing another turn cannot start, replace, or retire this token. The
 /// token becomes active at the canonical runtime turn-entry boundary and
 /// finishes when the corresponding input leaves the runtime.
-pub(super) struct TurnWatchdogToken {
+pub(crate) struct TurnWatchdogToken {
     id: u64,
     lease: std::sync::Arc<TurnWatchdogLease>,
 }
@@ -169,7 +169,7 @@ struct TurnWatchdogState {
 }
 
 impl TurnWatchdogToken {
-    pub(super) fn new(id: u64) -> (Self, TurnWatchdogHandle) {
+    pub(crate) fn new(id: u64) -> (Self, TurnWatchdogHandle) {
         let (phase, phase_rx) = tokio::sync::watch::channel(TurnWatchdogPhase::Pending);
         let state = std::sync::Arc::new(TurnWatchdogState {
             phase: std::sync::atomic::AtomicU8::new(TurnWatchdogPhase::Pending as u8),
@@ -247,18 +247,18 @@ impl Drop for TurnWatchdogLease {
     }
 }
 
-pub(super) struct TurnWatchdogHandle {
+pub(crate) struct TurnWatchdogHandle {
     id: u64,
     state: std::sync::Arc<TurnWatchdogState>,
     phase: tokio::sync::watch::Receiver<TurnWatchdogPhase>,
 }
 
 impl TurnWatchdogHandle {
-    pub(super) fn id(&self) -> u64 {
+    pub(crate) fn id(&self) -> u64 {
         self.id
     }
 
-    pub(super) async fn wait_until_started(&mut self) -> bool {
+    pub(crate) async fn wait_until_started(&mut self) -> bool {
         loop {
             match *self.phase.borrow() {
                 TurnWatchdogPhase::Pending => {}
@@ -271,7 +271,7 @@ impl TurnWatchdogHandle {
         }
     }
 
-    pub(super) fn try_timeout(&self) -> bool {
+    pub(crate) fn try_timeout(&self) -> bool {
         if self
             .state
             .phase
@@ -290,7 +290,7 @@ impl TurnWatchdogHandle {
         }
     }
 
-    pub(super) fn is_timed_out(&self) -> bool {
+    pub(crate) fn is_timed_out(&self) -> bool {
         self.state.phase.load(std::sync::atomic::Ordering::SeqCst)
             == TurnWatchdogPhase::TimedOut as u8
     }
@@ -399,13 +399,13 @@ impl TurnInput {
         }
     }
 
-    pub(super) fn set_turn_watchdog(&mut self, turn_watchdog: TurnWatchdogToken) {
+    pub(crate) fn set_turn_watchdog(&mut self, turn_watchdog: TurnWatchdogToken) {
         self.runtime_state
             .get_or_insert_with(Default::default)
             .turn_watchdog = Some(turn_watchdog);
     }
 
-    pub(super) fn set_pending_input_permit(&mut self, permit: tokio::sync::OwnedSemaphorePermit) {
+    pub(crate) fn set_pending_input_permit(&mut self, permit: tokio::sync::OwnedSemaphorePermit) {
         self.runtime_state
             .get_or_insert_with(Default::default)
             .pending_input_permit = Some(PendingInputPermitToken::new(permit));
@@ -418,7 +418,7 @@ impl TurnInput {
             .map(|watchdog| watchdog.id)
     }
 
-    pub(super) fn start_turn_watchdog(&self) {
+    pub(crate) fn start_turn_watchdog(&self) {
         let Some(runtime_state) = &self.runtime_state else {
             return;
         };

--- a/crates/verlet-kernel/src/openai_codex.rs
+++ b/crates/verlet-kernel/src/openai_codex.rs
@@ -818,9 +818,8 @@ impl verlet_provider::ProviderClient for OpenAICodexProviderClient {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::collections::VecDeque;
-    use std::sync::{Arc, Mutex};
+    // The parent module's trait imports; `as _` is the one import form kept.
+    use base64::Engine as _;
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
     use verlet_metadata::provider_store::LlmProviderAuthStore as _;
     use verlet_provider::{ProviderClient as _, ProviderWireAdapter as _};
@@ -836,25 +835,25 @@ mod tests {
 
     struct FakeHttpServer {
         base_url: String,
-        requests: Arc<Mutex<Vec<String>>>,
+        requests: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
         task: tokio::task::JoinHandle<()>,
     }
 
     struct GatedFakeHttpServer {
         base_url: String,
-        requests: Arc<Mutex<Vec<String>>>,
-        request_seen: Arc<tokio::sync::Notify>,
-        release_response: Arc<tokio::sync::Notify>,
+        requests: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+        request_seen: std::sync::Arc<tokio::sync::Notify>,
+        release_response: std::sync::Arc<tokio::sync::Notify>,
         task: tokio::task::JoinHandle<()>,
     }
 
     async fn fake_http_server(responses: Vec<(u16, serde_json::Value)>) -> FakeHttpServer {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
-        let requests = Arc::new(Mutex::new(Vec::new()));
-        let captured = Arc::clone(&requests);
+        let requests = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured = std::sync::Arc::clone(&requests);
         let task = tokio::spawn(async move {
-            let mut responses = VecDeque::from(responses);
+            let mut responses = std::collections::VecDeque::from(responses);
             while let Some((status, body)) = responses.pop_front() {
                 let (mut socket, _) = listener.accept().await.unwrap();
                 let request = read_http_request(&mut socket).await;
@@ -878,12 +877,12 @@ mod tests {
     async fn gated_fake_http_server(status: u16, body: serde_json::Value) -> GatedFakeHttpServer {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
-        let requests = Arc::new(Mutex::new(Vec::new()));
-        let captured = Arc::clone(&requests);
-        let request_seen = Arc::new(tokio::sync::Notify::new());
-        let seen = Arc::clone(&request_seen);
-        let release_response = Arc::new(tokio::sync::Notify::new());
-        let release = Arc::clone(&release_response);
+        let requests = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured = std::sync::Arc::clone(&requests);
+        let request_seen = std::sync::Arc::new(tokio::sync::Notify::new());
+        let seen = std::sync::Arc::clone(&request_seen);
+        let release_response = std::sync::Arc::new(tokio::sync::Notify::new());
+        let release = std::sync::Arc::clone(&release_response);
         let task = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
             let request = read_http_request(&mut socket).await;
@@ -964,7 +963,7 @@ mod tests {
 
     #[test]
     fn pkce_uses_s256_base64url_without_padding() {
-        let (verifier, challenge) = pkce_pair_from_bytes(&[7; 32]);
+        let (verifier, challenge) = crate::openai_codex::pkce_pair_from_bytes(&[7; 32]);
         assert_eq!(verifier.len(), 43);
         assert_eq!(challenge.len(), 43);
         assert!(!verifier.contains('='));
@@ -978,7 +977,7 @@ mod tests {
             "https://api.openai.com/auth": { "chatgpt_account_id": "acct-123" },
             "https://api.openai.com/profile": { "email": "user@example.com" }
         }));
-        let credential = credential_from_token_value(
+        let credential = crate::openai_codex::credential_from_token_value(
             &serde_json::json!({
                 "access_token": access,
                 "refresh_token": "refresh-secret",
@@ -1005,10 +1004,11 @@ mod tests {
         let _callback_guard = CALLBACK_TEST_GATE.lock().await;
         let token = token_response("acct-browser", "", "refresh-browser");
         let server = fake_http_server(vec![(200, token)]).await;
-        let mut endpoints = OAuthEndpoints::default();
+        let mut endpoints = crate::openai_codex::OAuthEndpoints::default();
         endpoints.authorize = format!("{}/authorize", server.base_url);
         endpoints.token = format!("{}/token", server.base_url);
-        let client = OpenAICodexOAuthClient::with_endpoints(endpoints).unwrap();
+        let client =
+            crate::openai_codex::OpenAICodexOAuthClient::with_endpoints(endpoints).unwrap();
         let login = client.begin_browser_login().await.unwrap();
         let authorization = reqwest::Url::parse(login.authorization_url()).unwrap();
         let query = authorization
@@ -1020,7 +1020,10 @@ mod tests {
             Some("S256")
         );
         assert_eq!(query.get("originator").map(String::as_str), Some("verlet"));
-        assert_eq!(query.get("scope").map(String::as_str), Some(SCOPE));
+        assert_eq!(
+            query.get("scope").map(String::as_str),
+            Some(crate::openai_codex::SCOPE)
+        );
         let state = query["state"].clone();
 
         let callback = tokio::spawn(async move {
@@ -1030,19 +1033,27 @@ mod tests {
                     "404 Not Found",
                 ),
                 (
-                    format!("{CALLBACK_PATH}?code=browser-code&state=wrong-state"),
+                    format!(
+                        "{}?code=browser-code&state=wrong-state",
+                        crate::openai_codex::CALLBACK_PATH
+                    ),
                     "400 Bad Request",
                 ),
                 (
-                    format!("{CALLBACK_PATH}?code=&state={state}"),
+                    format!("{}?code=&state={state}", crate::openai_codex::CALLBACK_PATH),
                     "400 Bad Request",
                 ),
                 (
-                    format!("{CALLBACK_PATH}?code=browser-code&state={state}"),
+                    format!(
+                        "{}?code=browser-code&state={state}",
+                        crate::openai_codex::CALLBACK_PATH
+                    ),
                     "200 OK",
                 ),
             ] {
-                let mut socket = tokio::net::TcpStream::connect(CALLBACK_ADDR).await.unwrap();
+                let mut socket = tokio::net::TcpStream::connect(crate::openai_codex::CALLBACK_ADDR)
+                    .await
+                    .unwrap();
                 let request = format!("GET {path} HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 socket.write_all(request.as_bytes()).await.unwrap();
                 let mut response = Vec::new();
@@ -1072,14 +1083,20 @@ mod tests {
                     .contains("redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback")
             );
         }
-        assert!(tokio::net::TcpStream::connect(CALLBACK_ADDR).await.is_err());
+        assert!(
+            tokio::net::TcpStream::connect(crate::openai_codex::CALLBACK_ADDR)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
     async fn browser_login_bind_failure_recommends_the_device_flow() {
         let _callback_guard = CALLBACK_TEST_GATE.lock().await;
-        let _occupied = tokio::net::TcpListener::bind(CALLBACK_ADDR).await.unwrap();
-        let client = OpenAICodexOAuthClient::new().unwrap();
+        let _occupied = tokio::net::TcpListener::bind(crate::openai_codex::CALLBACK_ADDR)
+            .await
+            .unwrap();
+        let client = crate::openai_codex::OpenAICodexOAuthClient::new().unwrap();
 
         let error = match client.begin_browser_login().await {
             Ok(_) => panic!("browser login unexpectedly bound an occupied callback port"),
@@ -1087,7 +1104,7 @@ mod tests {
         };
 
         let message = error.to_string();
-        assert!(message.contains(CALLBACK_ADDR));
+        assert!(message.contains(crate::openai_codex::CALLBACK_ADDR));
         assert!(message.contains("verlet auth login openai-codex --device"));
     }
 
@@ -1112,15 +1129,19 @@ mod tests {
             (200, token_response("acct-device", "", "refresh-device")),
         ])
         .await;
-        let mut endpoints = OAuthEndpoints::default();
+        let mut endpoints = crate::openai_codex::OAuthEndpoints::default();
         endpoints.device_user_code = format!("{}/device/usercode", server.base_url);
         endpoints.device_token = format!("{}/device/token", server.base_url);
         endpoints.token = format!("{}/oauth/token", server.base_url);
-        let mut client = OpenAICodexOAuthClient::with_endpoints(endpoints).unwrap();
+        let mut client =
+            crate::openai_codex::OpenAICodexOAuthClient::with_endpoints(endpoints).unwrap();
         client.device_poll_floor = std::time::Duration::ZERO;
         let login = client.start_device_login().await.unwrap();
         assert_eq!(login.user_code, "ABCD-EFGH");
-        assert_eq!(login.verification_uri, DEVICE_VERIFICATION_URI);
+        assert_eq!(
+            login.verification_uri,
+            crate::openai_codex::DEVICE_VERIFICATION_URI
+        );
         let credential = client.complete_device_login(login).await.unwrap();
         server.task.await.unwrap();
 
@@ -1134,7 +1155,7 @@ mod tests {
         let requests = server.requests.lock().unwrap();
         assert_eq!(requests.len(), 3);
         assert!(requests[0].starts_with("POST /device/usercode "));
-        assert!(requests[0].contains(CLIENT_ID));
+        assert!(requests[0].contains(crate::openai_codex::CLIENT_ID));
         assert!(requests[1].starts_with("POST /device/token "));
         assert!(requests[1].contains("device-123"));
         assert!(requests[2].starts_with("POST /oauth/token "));
@@ -1163,7 +1184,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let client = OpenAICodexProviderClient::with_urls(
+        let client = crate::openai_codex::OpenAICodexProviderClient::with_urls(
             store.clone(),
             format!("{}/oauth/token", server.base_url),
             "http://unused.invalid/responses",
@@ -1194,10 +1215,22 @@ mod tests {
     #[test]
     fn refresh_window_includes_expired_and_exactly_sixty_seconds_remaining() {
         let now_ms = 1_700_000_000_000;
-        assert!(credential_needs_refresh(now_ms - 1, now_ms));
-        assert!(credential_needs_refresh(now_ms + 60_000, now_ms));
-        assert!(!credential_needs_refresh(now_ms + 60_001, now_ms));
-        assert!(credential_needs_refresh(i64::MIN, i64::MAX));
+        assert!(crate::openai_codex::credential_needs_refresh(
+            now_ms - 1,
+            now_ms
+        ));
+        assert!(crate::openai_codex::credential_needs_refresh(
+            now_ms + 60_000,
+            now_ms
+        ));
+        assert!(!crate::openai_codex::credential_needs_refresh(
+            now_ms + 60_001,
+            now_ms
+        ));
+        assert!(crate::openai_codex::credential_needs_refresh(
+            i64::MIN,
+            i64::MAX
+        ));
     }
 
     #[tokio::test]
@@ -1214,7 +1247,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let client = OpenAICodexProviderClient::with_urls(
+        let client = crate::openai_codex::OpenAICodexProviderClient::with_urls(
             store.clone(),
             format!("{}/oauth/token", server.base_url),
             "http://unused.invalid/responses",
@@ -1264,7 +1297,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let client = OpenAICodexProviderClient::with_urls(
+        let client = crate::openai_codex::OpenAICodexProviderClient::with_urls(
             store.clone(),
             format!("{}/oauth/token", server.base_url),
             "http://unused.invalid/responses",
@@ -1320,7 +1353,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let client = OpenAICodexProviderClient::with_urls(
+        let client = crate::openai_codex::OpenAICodexProviderClient::with_urls(
             store.clone(),
             format!("{}/oauth/token", server.base_url),
             "http://unused.invalid/responses",
@@ -1359,7 +1392,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let client = OpenAICodexProviderClient::with_urls(
+        let client = crate::openai_codex::OpenAICodexProviderClient::with_urls(
             store.clone(),
             format!("{}/oauth/token", server.base_url),
             "http://unused.invalid/responses",
@@ -1395,7 +1428,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let client = OpenAICodexProviderClient::with_urls(
+        let client = crate::openai_codex::OpenAICodexProviderClient::with_urls(
             store.clone(),
             format!("{}/oauth/token", server.base_url),
             "http://unused.invalid/responses",
@@ -1420,7 +1453,7 @@ mod tests {
             include_encrypted_reasoning: false,
             reasoning_summary: verlet_provider::OpenAIReasoningSummary::Auto,
         };
-        let adapter = OpenAICodexResponsesAdapter {
+        let adapter = crate::openai_codex::OpenAICodexResponsesAdapter {
             inner: inner.clone(),
         };
         let request = verlet_provider::ProviderRequest::new(
@@ -1472,7 +1505,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let client = OpenAICodexProviderClient::with_urls(
+        let client = crate::openai_codex::OpenAICodexProviderClient::with_urls(
             store,
             "http://unused.invalid/token",
             format!("{}/backend-api/codex/responses", server.base_url),

--- a/crates/verlet-kernel/tests/fixtures/wasm-csv-profile/Cargo.lock
+++ b/crates/verlet-kernel/tests/fixtures/wasm-csv-profile/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/verlet-kernel/tests/fixtures/wasm-employee-lookup/Cargo.lock
+++ b/crates/verlet-kernel/tests/fixtures/wasm-employee-lookup/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/verlet-kernel/tests/fixtures/wasm-vfs-tools/Cargo.lock
+++ b/crates/verlet-kernel/tests/fixtures/wasm-vfs-tools/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/verlet-operations/src/operation_registry.rs
+++ b/crates/verlet-operations/src/operation_registry.rs
@@ -616,7 +616,7 @@ mod tests {
     }
 
     #[async_trait::async_trait]
-    impl super::KernelOperationDispatcher for ThreadDispatcher {
+    impl crate::operation_registry::KernelOperationDispatcher for ThreadDispatcher {
         async fn invoke_kernel_operation(
             &self,
             _operation_name: &str,
@@ -629,19 +629,19 @@ mod tests {
 
     #[test]
     fn scoped_registries_isolate_concurrent_kernel_dispatch() {
-        let registry = std::sync::Arc::new(super::OperationRegistry::new());
-        block_on(
-            registry.register_kernel(super::KernelOperationRegistration::new(
+        let registry = std::sync::Arc::new(crate::operation_registry::OperationRegistry::new());
+        block_on(registry.register_kernel(
+            crate::operation_registry::KernelOperationRegistration::new(
                 "kernel-package",
                 kernel_manifest(),
-            )),
-        )
+            ),
+        ))
         .unwrap();
 
         let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
-        let thread_a = super::ScopedOperationRegistry::new(
+        let thread_a = crate::operation_registry::ScopedOperationRegistry::new(
             std::sync::Arc::clone(&registry),
-            super::KernelDispatchOverlay::new().with_dispatcher(
+            crate::operation_registry::KernelDispatchOverlay::new().with_dispatcher(
                 "kernel-package",
                 std::sync::Arc::new(ThreadDispatcher {
                     thread_id: "thread-a",
@@ -649,9 +649,9 @@ mod tests {
                 }),
             ),
         );
-        let thread_b = super::ScopedOperationRegistry::new(
+        let thread_b = crate::operation_registry::ScopedOperationRegistry::new(
             registry,
-            super::KernelDispatchOverlay::new().with_dispatcher(
+            crate::operation_registry::KernelDispatchOverlay::new().with_dispatcher(
                 "kernel-package",
                 std::sync::Arc::new(ThreadDispatcher {
                     thread_id: "thread-b",
@@ -677,20 +677,23 @@ mod tests {
 
     #[test]
     fn scoped_registry_prefers_overlay_then_falls_back_to_registration_dispatcher() {
-        let registry = std::sync::Arc::new(super::OperationRegistry::new());
+        let registry = std::sync::Arc::new(crate::operation_registry::OperationRegistry::new());
         block_on(
             registry.register_kernel(
-                super::KernelOperationRegistration::new("kernel-package", kernel_manifest())
-                    .with_dispatcher(std::sync::Arc::new(ThreadDispatcher {
-                        thread_id: "registration",
-                        barrier: std::sync::Arc::new(std::sync::Barrier::new(1)),
-                    })),
+                crate::operation_registry::KernelOperationRegistration::new(
+                    "kernel-package",
+                    kernel_manifest(),
+                )
+                .with_dispatcher(std::sync::Arc::new(ThreadDispatcher {
+                    thread_id: "registration",
+                    barrier: std::sync::Arc::new(std::sync::Barrier::new(1)),
+                })),
             ),
         )
         .unwrap();
-        let scoped = super::ScopedOperationRegistry::new(
+        let scoped = crate::operation_registry::ScopedOperationRegistry::new(
             std::sync::Arc::clone(&registry),
-            super::KernelDispatchOverlay::new().with_dispatcher(
+            crate::operation_registry::KernelDispatchOverlay::new().with_dispatcher(
                 "kernel-package",
                 std::sync::Arc::new(ThreadDispatcher {
                     thread_id: "overlay",

--- a/examples/wasm-counter-coupling/Cargo.lock
+++ b/examples/wasm-counter-coupling/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Applies the four Rust rules added in #121 to `verlet-chat` and every other crate that did not already follow them.

## Rules applied

- No `use` imports; full paths, with `use some::Trait as _;` as the only exception. No globs, no `super::`.
- No `pub use` re-exports, except when a module's primary export shares the module name.
- Visibility limited to `pub` / `pub(crate)` / private.
- No `mod.rs` — already true repo-wide, nothing to change.

## What changed

**verlet-chat** carried the bulk of it: 44 `use` imports and 5 `tuika::prelude::*` globs expanded to full paths, `use super::App` removed, and the four crate-root `pub use` re-exports replaced by `pub mod app/cells/runner/theme` — the two consumers in `cli/chat.rs` updated to `verlet_chat::app::App` and `verlet_chat::runner::run_ui`.

**Elsewhere:** 254 `super::` paths rewritten to absolute `crate::` paths across verlet-kernel and verlet-operations, and 1107 `pub(super)` widened to `pub(crate)` — the only in-rule option, and never a compilation change.

## Deliberate exceptions, now documented

Two facade crates keep their re-exports. `verlet-sqlite` already carried an ADR-0005 comment naming itself the exception to this exact rule; `verlet-guest-sdk` gains the equivalent, because a guest crate names `verlet_guest_sdk` and nothing else — so the attribute macros must reach it from there rather than through a second direct dependency on `verlet-guest-sdk-macros` — and the scaffold emitted by `verlet coupling init` opens with `use verlet_guest_sdk::prelude::*;`. Both are public API for crates outside this repo, not internal convenience.

## Untouched on purpose

The `use super::*`, prelude glob and `pub(super)` inside the `COUPLING_LIB_RS_TEMPLATE` raw string in `cli/coupling.rs`, and the fixture string in `kernel/admission.rs` that the raw-submit lint scans. Those are string literals — generated guest code and scanner test input — not workspace code. Worth knowing that a naive repo-wide regex will corrupt the scaffold template.

## Two latent warnings fixed

Widening visibility surfaced both, and neither is new behaviour:

- `RuntimeHostInner` was private while `RuntimeKernelControl::new` became `pub(crate)` → `RuntimeHostInner` is now `pub(crate)`.
- `spawn_runtime_refresh`'s only caller is `#[cfg(not(test))]`, so the definition now carries the same gate.

## Verification

`cargo fmt --check` clean, `cargo check --workspace --all-targets` clean with zero warnings, and the test suite is unchanged against `main`: **2338 passing**, with the same **29** failures — all `wasm32-unknown-unknown` target-missing on this machine, byte-identical to the pre-change failure set.