### PR TITLE
Read release version from workspace package (EMO-596)

### DIFF
--- a/scripts/check-release-tag.sh
+++ b/scripts/check-release-tag.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TAG="${1:-${GITHUB_REF_NAME:-}}"
 
+source "$ROOT/scripts/release-version.sh"
+
 usage() {
   cat <<'USAGE'
 check-release-tag.sh - validate a Verlet release tag against the kernel version.
@@ -29,7 +31,7 @@ if [[ -z "$TAG" ]]; then
 fi
 
 VERSION="$(
-  sed -n 's/^version = "\(.*\)"/\1/p' "$ROOT/crates/verlet-kernel/Cargo.toml" | head -n 1
+  read_verlet_workspace_version "$ROOT/Cargo.toml"
 )"
 if [[ -z "$VERSION" ]]; then
   echo "could not read verlet version from crates/verlet-kernel/Cargo.toml" >&2

--- a/scripts/package-release-binary.sh
+++ b/scripts/package-release-binary.sh
@@ -78,8 +78,10 @@ sha256_file() {
 
 cd "$ROOT"
 
+source scripts/release-version.sh
+
 VERSION="$(
-  sed -n 's/^version = "\(.*\)"/\1/p' crates/verlet-kernel/Cargo.toml | head -n 1
+  read_verlet_workspace_version Cargo.toml
 )"
 if [[ -z "$VERSION" ]]; then
   echo "could not read verlet version from crates/verlet-kernel/Cargo.toml" >&2

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+read_verlet_workspace_version() {
+  local cargo_toml="$1"
+
+  sed -n \
+    '/^\[workspace\.package\][[:space:]]*$/,/^\[/ {
+      s/^[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p
+    }' \
+    "$cargo_toml" \
+    | head -n 1
+}

--- a/scripts/write-release-manifest.sh
+++ b/scripts/write-release-manifest.sh
@@ -8,6 +8,8 @@ TAG="${GITHUB_REF_NAME:-}"
 CHANNEL="${VERLET_RELEASE_CHANNEL:-stable}"
 BASE_URL=""
 
+source "$ROOT/scripts/release-version.sh"
+
 usage() {
   cat <<'USAGE'
 write-release-manifest.sh - write latest.json for Verlet release assets.
@@ -62,7 +64,7 @@ sha256_from_file() {
 }
 
 VERSION="$(
-  sed -n 's/^version = "\(.*\)"/\1/p' "$ROOT/crates/verlet-kernel/Cargo.toml" | head -n 1
+  read_verlet_workspace_version "$ROOT/Cargo.toml"
 )"
 if [[ -z "$VERSION" ]]; then
   echo "could not read verlet version from crates/verlet-kernel/Cargo.toml" >&2


### PR DESCRIPTION
The three release scripts read the crate version with a per-crate sed that broke when d99f065 moved to workspace inheritance. One shared section-aware helper (scripts/release-version.sh) now reads [workspace.package] in the root Cargo.toml. Verified: v0.5.0 tag check passes on main, wrong tag still exits 1, release-async dry run and packaging pass.

Linear: https://linear.app/emotionscientific/issue/EMO-596