### PR TITLE
agent-tools: standalone wasm-compatible file tool cores (read/write/edit/glob/grep)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4299,6 +4309,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "similar"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f66ca1f7aca2474dc10c942eb22feffc897735f54cd1db90138c2fddb490987"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
 name = "simsimd"
 version = "6.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6120,6 +6139,9 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "similar",
+ "tempfile",
+ "unicode-normalization",
  "verlet-tool-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6110,6 +6110,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 
@@ -6146,6 +6147,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tempfile",
  "verlet-tool-core",
 ]
 
@@ -6155,6 +6157,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tempfile",
  "verlet-tool-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6105,6 +6105,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "verlet-tool-core"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "verlet-tool-edit"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "verlet-tool-core",
+]
+
+[[package]]
+name = "verlet-tool-glob"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "verlet-tool-core",
+]
+
+[[package]]
+name = "verlet-tool-grep"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "verlet-tool-core",
+]
+
+[[package]]
+name = "verlet-tool-read"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "verlet-tool-core",
+]
+
+[[package]]
+name = "verlet-tool-write"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "verlet-tool-core",
+]
+
+[[package]]
 name = "verlet-trace-ab"
 version = "0.5.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -151,7 +151,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -475,6 +475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde_core",
 ]
 
@@ -1365,6 +1366,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba3fe847045ecff794b9c138293a80db914678c453ad63fbf0c6a9eb6e00b22"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "env_filter"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,7 +1427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1790,6 +1809,56 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "grep-matcher"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9417543f4870fc8f1c8e1af870afae2431007626d9e703fce6471c468d33847"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "grep-regex"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce0c256c3ad82bcc07b812c15a45ec1d398122e8e15124f96695234db7112ef"
+dependencies = [
+ "bstr",
+ "grep-matcher",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "grep-searcher"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72348823a0eafc4bc2e9051064f28b5b42cc100b571b3a35d67918d711efcbc6"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "encoding_rs_io",
+ "grep-matcher",
+ "log",
+ "memchr",
+ "memmap2",
+]
 
 [[package]]
 name = "h2"
@@ -2236,6 +2305,22 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2767,7 +2852,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3786,9 +3871,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3972,7 +4057,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4369,7 +4454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4947,7 +5032,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4969,7 +5054,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6127,6 +6212,7 @@ dependencies = [
 name = "verlet-tool-core"
 version = "0.1.0"
 dependencies = [
+ "ignore",
  "serde",
  "serde_json",
  "tempfile",
@@ -6149,8 +6235,10 @@ dependencies = [
 name = "verlet-tool-glob"
 version = "0.1.0"
 dependencies = [
+ "globset",
  "serde",
  "serde_json",
+ "tempfile",
  "verlet-tool-core",
 ]
 
@@ -6158,9 +6246,14 @@ dependencies = [
 name = "verlet-tool-grep"
 version = "0.1.0"
 dependencies = [
+ "globset",
+ "grep-regex",
+ "grep-searcher",
  "serde",
  "serde_json",
+ "tempfile",
  "verlet-tool-core",
+ "verlet-tool-glob",
 ]
 
 [[package]]
@@ -6853,7 +6946,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,12 @@ members = [
     "crates/verlet-io-pgqrs",
     "crates/verlet-io-telegram",
     "tools/trace-ab",
+    "agent-tools/tool-core",
+    "agent-tools/tool-read",
+    "agent-tools/tool-write",
+    "agent-tools/tool-edit",
+    "agent-tools/tool-glob",
+    "agent-tools/tool-grep",
 ]
 default-members = ["crates/verlet-kernel"]
 resolver = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,13 @@ crossterm = { version = "0.29", features = ["event-stream"] }
 futures-executor = "0.3"
 futures-util = "0.3.32"
 getrandom = "0.3"
+globset = "0.4.20"
+grep-regex = "0.1.14"
+grep-searcher = "0.1.17"
 hex = "0.4"
 hmac = "0.13"
 humantime = "2.3"
+ignore = "0.4.33"
 libc = "0.2"
 log = "0.4"
 object_store = { version = "0.13.2", features = ["aws"] }

--- a/agent-tools/README.md
+++ b/agent-tools/README.md
@@ -1,0 +1,31 @@
+# Agent tools
+
+Standalone implementations of the model-facing file tools: `read`, `write`,
+`edit`, `glob`, `grep`. Each crate compiles on its own and exports both the
+tool logic and its model-facing contract (name, description, JSON schema,
+effect class), so the surface the model sees ships with the implementation.
+
+Rules for every crate in this folder:
+
+- **No direct `std::fs` in tool logic.** All filesystem access goes through
+  the `ToolFs` trait in `tool-core`. Backends (real filesystem, verlet-vfs,
+  wasm ABI imports) are supplied by the embedder. This is what keeps the
+  native-vs-wasm packaging decision open: the tool cores compile to
+  `wasm32-unknown-unknown` unchanged.
+- **Assume the lossless spill coupling exists.** Tools do not implement
+  clever truncation or continuation messaging. Oversized output is the
+  system's job: the runtime spills the full payload and hands the model an
+  addressable reference. Tools enforce only a dumb per-result byte cap
+  (`tool_core::MAX_RESULT_BYTES`) to protect the record and the wire.
+- **Deterministic.** Same inputs + same filesystem state = same output,
+  byte for byte, on every backend. No wall clock, no randomness, no
+  environment reads.
+- **Contract next to code.** `contract()` in each crate is the single source
+  of the tool's name, description, and input schema. Manifests may attach a
+  tool under a different name (e.g. `glob` attached as `find` for Pi
+  parity), but the schema and semantics come from here.
+
+Semantics are ported from Pi (`reference/pi-mono`, coding-agent tools) with
+the deviations recorded in each crate's doc comments. The `bash` sixth tool
+is not here: vbash is its own subsystem. Image viewing is deliberately not
+part of `read`; it will be a separate optional package.

--- a/agent-tools/tool-core/Cargo.toml
+++ b/agent-tools/tool-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "verlet-tool-core"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Shared trait and contract types for the standalone agent file tools"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[features]
+default = []
+# Native std::fs backend (`StdFs`). Off by default so tool cores stay
+# wasm32-compilable without it.
+std-fs = []

--- a/agent-tools/tool-core/Cargo.toml
+++ b/agent-tools/tool-core/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 description = "Shared trait and contract types for the standalone agent file tools"
 
 [dependencies]
+ignore = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/agent-tools/tool-core/Cargo.toml
+++ b/agent-tools/tool-core/Cargo.toml
@@ -15,3 +15,6 @@ default = []
 # Native std::fs backend (`StdFs`). Off by default so tool cores stay
 # wasm32-compilable without it.
 std-fs = []
+
+[dev-dependencies]
+tempfile = "3"

--- a/agent-tools/tool-core/src/lib.rs
+++ b/agent-tools/tool-core/src/lib.rs
@@ -85,7 +85,9 @@ pub struct WalkFile {
 ///
 /// Directory walks include hidden files, skip every `.git` directory, apply
 /// root `.git/info/exclude` plus nested `.gitignore` files, prune ignored
-/// directories, and return files sorted by root-relative path.
+/// directories, skip listed entries that disappear before they can be
+/// resolved, and return files sorted by root-relative path. Stat errors other
+/// than [`ToolFsError::NotFound`] still fail the walk.
 pub fn walk_files(root: &std::path::Path, fs: &dyn ToolFs) -> Result<Vec<WalkFile>, ToolError> {
     let stat = fs.stat(root)?;
     if stat.is_file {
@@ -150,7 +152,11 @@ fn walk_directory(
             walk_directory(fs, &path, &relative, ignore_matchers, files)?;
             ignore_matchers.truncate(matcher_count);
         } else if !is_ignored(ignore_matchers, &path, false) {
-            let stat = fs.stat(&path)?;
+            let stat = match fs.stat(&path) {
+                Ok(stat) => stat,
+                Err(ToolFsError::NotFound(_)) => continue,
+                Err(error) => return Err(error.into()),
+            };
             if stat.is_file {
                 files.push(WalkFile {
                     path,
@@ -511,5 +517,47 @@ mod tests {
         let error =
             crate::ToolFs::read_file(&fs, std::path::Path::new("link/secret.txt")).unwrap_err();
         assert!(matches!(error, crate::ToolFsError::Denied(_)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walk_skips_a_dangling_symlink_and_returns_real_files() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("real.txt"), "real").unwrap();
+        std::os::unix::fs::symlink(
+            root.path().join("missing-target"),
+            root.path().join("broken-link"),
+        )
+        .unwrap();
+        let fs = crate::StdFs::new(root.path()).unwrap();
+
+        let files = crate::walk_files(std::path::Path::new("."), &fs).unwrap();
+
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| file.relative_path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["real.txt"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walk_still_propagates_denied_entry_stats() {
+        let outer = tempfile::tempdir().unwrap();
+        let root = outer.path().join("root");
+        let outside = outer.path().join("outside.txt");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(&outside, "outside").unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("escaped-link")).unwrap();
+        let fs = crate::StdFs::new(&root).unwrap();
+
+        let error = crate::walk_files(std::path::Path::new("."), &fs).unwrap_err();
+
+        assert!(matches!(
+            error,
+            crate::ToolError::Fs(crate::ToolFsError::Denied(_))
+        ));
     }
 }

--- a/agent-tools/tool-core/src/lib.rs
+++ b/agent-tools/tool-core/src/lib.rs
@@ -11,8 +11,6 @@
 //! The trait is synchronous on purpose: wasm guests block on host calls,
 //! and async hosts wrap tool runs in `spawn_blocking` at the boundary.
 
-use std::path::{Path, PathBuf};
-
 /// Hard cap on a single tool result, in bytes. Protects the record and the
 /// wire, not the context window: context protection is the lossless spill
 /// coupling's job, which is assumed present system-wide. Tools that hit
@@ -26,13 +24,13 @@ pub const MAX_RESULT_BYTES: usize = 4 * 1024 * 1024;
 /// a path outside the granted scope returns [`ToolFsError::Denied`].
 /// Tool cores never re-check confinement.
 pub trait ToolFs {
-    fn read_file(&self, path: &Path) -> Result<Vec<u8>, ToolFsError>;
-    fn write_file(&self, path: &Path, content: &[u8]) -> Result<(), ToolFsError>;
+    fn read_file(&self, path: &std::path::Path) -> Result<Vec<u8>, ToolFsError>;
+    fn write_file(&self, path: &std::path::Path, content: &[u8]) -> Result<(), ToolFsError>;
     /// Create a directory. `recursive` = `mkdir -p`.
-    fn mkdir(&self, path: &Path, recursive: bool) -> Result<(), ToolFsError>;
-    fn stat(&self, path: &Path) -> Result<FileStat, ToolFsError>;
-    fn read_dir(&self, path: &Path) -> Result<Vec<DirEntry>, ToolFsError>;
-    fn exists(&self, path: &Path) -> Result<bool, ToolFsError>;
+    fn mkdir(&self, path: &std::path::Path, recursive: bool) -> Result<(), ToolFsError>;
+    fn stat(&self, path: &std::path::Path) -> Result<FileStat, ToolFsError>;
+    fn read_dir(&self, path: &std::path::Path) -> Result<Vec<DirEntry>, ToolFsError>;
+    fn exists(&self, path: &std::path::Path) -> Result<bool, ToolFsError>;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -51,9 +49,9 @@ pub struct DirEntry {
 #[derive(Debug, thiserror::Error)]
 pub enum ToolFsError {
     #[error("not found: {0}")]
-    NotFound(PathBuf),
+    NotFound(std::path::PathBuf),
     #[error("access denied: {0}")]
-    Denied(PathBuf),
+    Denied(std::path::PathBuf),
     #[error("{0}")]
     Io(String),
 }
@@ -97,31 +95,276 @@ pub struct ToolContract {
     pub effect_class: EffectClass,
 }
 
-/// Native backend over the real filesystem, for the standalone CLI bins
-/// and tests. Confinement: paths are resolved under `root`; escapes deny.
+/// Native backend over the real filesystem, for standalone CLI bins and tests.
+///
+/// Relative paths resolve beneath the configured root. Absolute paths are
+/// accepted only when they name the root or one of its descendants. The root
+/// and every existing path component are canonicalized before access, so both
+/// lexical `..` escapes and symlinks that leave the root return
+/// [`ToolFsError::Denied`]. Missing descendants are resolved only after their
+/// nearest existing ancestor has passed the same check.
 #[cfg(feature = "std-fs")]
 pub struct StdFs {
-    pub root: PathBuf,
+    pub root: std::path::PathBuf,
+}
+
+#[cfg(feature = "std-fs")]
+impl StdFs {
+    pub fn new(root: impl AsRef<std::path::Path>) -> Result<Self, ToolFsError> {
+        let root = root.as_ref().to_path_buf();
+        let fs = Self {
+            root: lexical_normalize(&root),
+        };
+        fs.canonical_root()?;
+        Ok(fs)
+    }
+
+    fn canonical_root(&self) -> Result<std::path::PathBuf, ToolFsError> {
+        if !self.root.is_absolute() {
+            return Err(ToolFsError::Denied(self.root.clone()));
+        }
+
+        let canonical_root =
+            std::fs::canonicalize(&self.root).map_err(|error| map_io_error(&self.root, error))?;
+        let metadata =
+            std::fs::metadata(&canonical_root).map_err(|error| map_io_error(&self.root, error))?;
+        if !metadata.is_dir() {
+            return Err(ToolFsError::Io(
+                "filesystem root is not a directory".to_owned(),
+            ));
+        }
+        Ok(canonical_root)
+    }
+
+    fn resolve(&self, path: &std::path::Path) -> Result<std::path::PathBuf, ToolFsError> {
+        let root = lexical_normalize(&self.root);
+        let canonical_root = self.canonical_root()?;
+        let normalized = if path.is_absolute() {
+            lexical_normalize(path)
+        } else {
+            lexical_normalize(&root.join(path))
+        };
+        let relative = normalized
+            .strip_prefix(&root)
+            .or_else(|_| normalized.strip_prefix(&canonical_root))
+            .map_err(|_| ToolFsError::Denied(path.to_path_buf()))?;
+
+        let components = relative.iter().collect::<Vec<_>>();
+        let mut resolved = canonical_root.clone();
+        for (index, component) in components.iter().enumerate() {
+            resolved.push(component);
+            match std::fs::symlink_metadata(&resolved) {
+                Ok(_) => {
+                    resolved = std::fs::canonicalize(&resolved)
+                        .map_err(|error| map_io_error(path, error))?;
+                    if !resolved.starts_with(&canonical_root) {
+                        return Err(ToolFsError::Denied(path.to_path_buf()));
+                    }
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    for missing in &components[index + 1..] {
+                        resolved.push(missing);
+                    }
+                    return Ok(resolved);
+                }
+                Err(error) => return Err(map_io_error(path, error)),
+            }
+        }
+
+        Ok(resolved)
+    }
 }
 
 #[cfg(feature = "std-fs")]
 impl ToolFs for StdFs {
-    fn read_file(&self, _path: &Path) -> Result<Vec<u8>, ToolFsError> {
-        todo!("EMO ticket: std::fs mapping with root confinement")
+    fn read_file(&self, path: &std::path::Path) -> Result<Vec<u8>, ToolFsError> {
+        let resolved = self.resolve(path)?;
+        std::fs::read(resolved).map_err(|error| map_io_error(path, error))
     }
-    fn write_file(&self, _path: &Path, _content: &[u8]) -> Result<(), ToolFsError> {
-        todo!("EMO ticket: std::fs mapping with root confinement")
+
+    fn write_file(&self, path: &std::path::Path, content: &[u8]) -> Result<(), ToolFsError> {
+        let resolved = self.resolve(path)?;
+        std::fs::write(resolved, content).map_err(|error| map_io_error(path, error))
     }
-    fn mkdir(&self, _path: &Path, _recursive: bool) -> Result<(), ToolFsError> {
-        todo!("EMO ticket: std::fs mapping with root confinement")
+
+    fn mkdir(&self, path: &std::path::Path, recursive: bool) -> Result<(), ToolFsError> {
+        let resolved = self.resolve(path)?;
+        let result = if recursive {
+            std::fs::create_dir_all(&resolved)
+        } else {
+            std::fs::create_dir(&resolved)
+        };
+        result.map_err(|error| map_io_error(path, error))?;
+
+        let canonical =
+            std::fs::canonicalize(&resolved).map_err(|error| map_io_error(path, error))?;
+        if !canonical.starts_with(self.canonical_root()?) {
+            return Err(ToolFsError::Denied(path.to_path_buf()));
+        }
+        Ok(())
     }
-    fn stat(&self, _path: &Path) -> Result<FileStat, ToolFsError> {
-        todo!("EMO ticket: std::fs mapping with root confinement")
+
+    fn stat(&self, path: &std::path::Path) -> Result<FileStat, ToolFsError> {
+        let resolved = self.resolve(path)?;
+        let metadata = std::fs::metadata(resolved).map_err(|error| map_io_error(path, error))?;
+        Ok(FileStat {
+            is_dir: metadata.is_dir(),
+            is_file: metadata.is_file(),
+            size: metadata.len(),
+        })
     }
-    fn read_dir(&self, _path: &Path) -> Result<Vec<DirEntry>, ToolFsError> {
-        todo!("EMO ticket: std::fs mapping with root confinement")
+
+    fn read_dir(&self, path: &std::path::Path) -> Result<Vec<DirEntry>, ToolFsError> {
+        let resolved = self.resolve(path)?;
+        let entries = std::fs::read_dir(resolved).map_err(|error| map_io_error(path, error))?;
+        let mut result = Vec::new();
+        for entry in entries {
+            let entry = entry.map_err(|error| map_io_error(path, error))?;
+            let file_type = entry
+                .file_type()
+                .map_err(|error| map_io_error(path, error))?;
+            result.push(DirEntry {
+                name: entry.file_name().to_string_lossy().into_owned(),
+                is_dir: file_type.is_dir(),
+            });
+        }
+        result.sort_by(|left, right| left.name.cmp(&right.name));
+        Ok(result)
     }
-    fn exists(&self, _path: &Path) -> Result<bool, ToolFsError> {
-        todo!("EMO ticket: std::fs mapping with root confinement")
+
+    fn exists(&self, path: &std::path::Path) -> Result<bool, ToolFsError> {
+        let resolved = self.resolve(path)?;
+        match std::fs::metadata(resolved) {
+            Ok(_) => Ok(true),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(map_io_error(path, error)),
+        }
+    }
+}
+
+#[cfg(feature = "std-fs")]
+fn lexical_normalize(path: &std::path::Path) -> std::path::PathBuf {
+    let mut normalized = std::path::PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            std::path::Component::RootDir => normalized.push(component.as_os_str()),
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            std::path::Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
+}
+
+#[cfg(feature = "std-fs")]
+fn map_io_error(path: &std::path::Path, error: std::io::Error) -> ToolFsError {
+    match error.kind() {
+        std::io::ErrorKind::NotFound => ToolFsError::NotFound(path.to_path_buf()),
+        std::io::ErrorKind::PermissionDenied => ToolFsError::Denied(path.to_path_buf()),
+        _ => ToolFsError::Io(error.to_string()),
+    }
+}
+
+/// Run one tool's native JSON-over-stdin CLI surface over [`StdFs`].
+///
+/// Input has the shape `{"root":"/absolute/path","args":{...}}`. Exactly one
+/// JSON object is written to stdout: `{"ok":...}` on success or
+/// `{"error":"..."}` on failure. The returned process exit status is zero
+/// for success and one for every input, filesystem, tool, or output error.
+#[cfg(feature = "std-fs")]
+pub fn run_cli<Args, Output>(
+    run: fn(Args, &dyn ToolFs) -> Result<Output, ToolError>,
+) -> std::process::ExitCode
+where
+    Args: serde::de::DeserializeOwned,
+    Output: serde::Serialize,
+{
+    #[derive(serde::Deserialize)]
+    struct CliInput<Args> {
+        root: std::path::PathBuf,
+        args: Args,
+    }
+
+    let mut input = String::new();
+    if let Err(error) = std::io::Read::read_to_string(&mut std::io::stdin(), &mut input) {
+        return write_cli_error(format!("failed to read stdin: {error}"));
+    }
+    let input = match serde_json::from_str::<CliInput<Args>>(&input) {
+        Ok(input) => input,
+        Err(error) => return write_cli_error(format!("invalid input JSON: {error}")),
+    };
+    let fs = match StdFs::new(&input.root) {
+        Ok(fs) => fs,
+        Err(error) => return write_cli_error(error.to_string()),
+    };
+
+    match run(input.args, &fs) {
+        Ok(output) => match serde_json::to_value(output) {
+            Ok(output) => {
+                let mut result = serde_json::Map::new();
+                result.insert("ok".to_owned(), output);
+                write_cli_json(serde_json::Value::Object(result), true)
+            }
+            Err(error) => write_cli_error(format!("failed to serialize result: {error}")),
+        },
+        Err(error) => write_cli_error(error.to_string()),
+    }
+}
+
+#[cfg(feature = "std-fs")]
+fn write_cli_error(error: String) -> std::process::ExitCode {
+    write_cli_json(serde_json::json!({"error": error}), false)
+}
+
+#[cfg(feature = "std-fs")]
+fn write_cli_json(value: serde_json::Value, success: bool) -> std::process::ExitCode {
+    let mut bytes = match serde_json::to_vec(&value) {
+        Ok(bytes) => bytes,
+        Err(_) => return std::process::ExitCode::FAILURE,
+    };
+    bytes.push(b'\n');
+    if std::io::Write::write_all(&mut std::io::stdout(), &bytes).is_err() {
+        return std::process::ExitCode::FAILURE;
+    }
+    if success {
+        std::process::ExitCode::SUCCESS
+    } else {
+        std::process::ExitCode::FAILURE
+    }
+}
+
+#[cfg(all(test, feature = "std-fs"))]
+mod tests {
+    #[test]
+    fn parent_escape_is_denied() {
+        let outer = tempfile::tempdir().unwrap();
+        let root = outer.path().join("root");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(outer.path().join("outside.txt"), "secret").unwrap();
+        let fs = crate::StdFs { root };
+
+        let error =
+            crate::ToolFs::read_file(&fs, std::path::Path::new("../outside.txt")).unwrap_err();
+        assert!(matches!(error, crate::ToolFsError::Denied(_)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_escape_is_denied() {
+        let outer = tempfile::tempdir().unwrap();
+        let root = outer.path().join("root");
+        let outside = outer.path().join("outside");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(outside.join("secret.txt"), "secret").unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("link")).unwrap();
+        let fs = crate::StdFs::new(&root).unwrap();
+
+        let error =
+            crate::ToolFs::read_file(&fs, std::path::Path::new("link/secret.txt")).unwrap_err();
+        assert!(matches!(error, crate::ToolFsError::Denied(_)));
     }
 }

--- a/agent-tools/tool-core/src/lib.rs
+++ b/agent-tools/tool-core/src/lib.rs
@@ -1,0 +1,127 @@
+//! Shared surface for the standalone agent file tools.
+//!
+//! Every tool in `agent-tools/` is a pure function over a filesystem it
+//! reaches only through [`ToolFs`]. The embedder picks the backend:
+//!
+//! - native: [`StdFs`] (feature `std-fs`) over the real filesystem,
+//! - kernel: an adapter over the thread's verlet-vfs,
+//! - wasm: an adapter over the guest ABI's fs imports.
+//!
+//! Tool crates must not depend on `std::fs`, tokio, or any host detail.
+//! The trait is synchronous on purpose: wasm guests block on host calls,
+//! and async hosts wrap tool runs in `spawn_blocking` at the boundary.
+
+use std::path::{Path, PathBuf};
+
+/// Hard cap on a single tool result, in bytes. Protects the record and the
+/// wire, not the context window: context protection is the lossless spill
+/// coupling's job, which is assumed present system-wide. Tools that hit
+/// this cap return [`ToolError::ResultTooLarge`] rather than truncating
+/// silently.
+pub const MAX_RESULT_BYTES: usize = 4 * 1024 * 1024;
+
+/// Minimal synchronous filesystem access for tool cores.
+///
+/// Backends enforce path confinement (workspace root, allowed roots):
+/// a path outside the granted scope returns [`ToolFsError::Denied`].
+/// Tool cores never re-check confinement.
+pub trait ToolFs {
+    fn read_file(&self, path: &Path) -> Result<Vec<u8>, ToolFsError>;
+    fn write_file(&self, path: &Path, content: &[u8]) -> Result<(), ToolFsError>;
+    /// Create a directory. `recursive` = `mkdir -p`.
+    fn mkdir(&self, path: &Path, recursive: bool) -> Result<(), ToolFsError>;
+    fn stat(&self, path: &Path) -> Result<FileStat, ToolFsError>;
+    fn read_dir(&self, path: &Path) -> Result<Vec<DirEntry>, ToolFsError>;
+    fn exists(&self, path: &Path) -> Result<bool, ToolFsError>;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FileStat {
+    pub is_dir: bool,
+    pub is_file: bool,
+    pub size: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DirEntry {
+    pub name: String,
+    pub is_dir: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ToolFsError {
+    #[error("not found: {0}")]
+    NotFound(PathBuf),
+    #[error("access denied: {0}")]
+    Denied(PathBuf),
+    #[error("{0}")]
+    Io(String),
+}
+
+/// Errors a tool run can produce. The embedder renders these as the
+/// tool-result error text the model sees; messages are written for the
+/// model (actionable, no host paths beyond what the model supplied).
+#[derive(Debug, thiserror::Error)]
+pub enum ToolError {
+    #[error(transparent)]
+    Fs(#[from] ToolFsError),
+    #[error("invalid arguments: {0}")]
+    InvalidArgs(String),
+    #[error("{0}")]
+    Failed(String),
+    #[error("result exceeds {MAX_RESULT_BYTES} bytes; narrow the request")]
+    ResultTooLarge,
+}
+
+/// How a tool call composes with retries and replay.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EffectClass {
+    /// No observable side effect. Safe to re-run any number of times.
+    Pure,
+    /// Re-running with identical arguments against the resulting state is
+    /// a no-op (write with same content, edit already applied).
+    Idempotent,
+}
+
+/// The model-facing contract of one tool. This is the single source of the
+/// surface the model sees; packaging (native op, wasm op, remote executor)
+/// carries it along unchanged.
+#[derive(Clone, Debug)]
+pub struct ToolContract {
+    /// Default model-facing name. Manifests may attach under another name.
+    pub name: &'static str,
+    /// Model-facing description, verbatim.
+    pub description: &'static str,
+    /// JSON Schema for the arguments object.
+    pub input_schema: serde_json::Value,
+    pub effect_class: EffectClass,
+}
+
+/// Native backend over the real filesystem, for the standalone CLI bins
+/// and tests. Confinement: paths are resolved under `root`; escapes deny.
+#[cfg(feature = "std-fs")]
+pub struct StdFs {
+    pub root: PathBuf,
+}
+
+#[cfg(feature = "std-fs")]
+impl ToolFs for StdFs {
+    fn read_file(&self, _path: &Path) -> Result<Vec<u8>, ToolFsError> {
+        todo!("EMO ticket: std::fs mapping with root confinement")
+    }
+    fn write_file(&self, _path: &Path, _content: &[u8]) -> Result<(), ToolFsError> {
+        todo!("EMO ticket: std::fs mapping with root confinement")
+    }
+    fn mkdir(&self, _path: &Path, _recursive: bool) -> Result<(), ToolFsError> {
+        todo!("EMO ticket: std::fs mapping with root confinement")
+    }
+    fn stat(&self, _path: &Path) -> Result<FileStat, ToolFsError> {
+        todo!("EMO ticket: std::fs mapping with root confinement")
+    }
+    fn read_dir(&self, _path: &Path) -> Result<Vec<DirEntry>, ToolFsError> {
+        todo!("EMO ticket: std::fs mapping with root confinement")
+    }
+    fn exists(&self, _path: &Path) -> Result<bool, ToolFsError> {
+        todo!("EMO ticket: std::fs mapping with root confinement")
+    }
+}

--- a/agent-tools/tool-core/src/lib.rs
+++ b/agent-tools/tool-core/src/lib.rs
@@ -290,35 +290,42 @@ impl StdFs {
     fn resolve(&self, path: &std::path::Path) -> Result<std::path::PathBuf, ToolFsError> {
         let root = lexical_normalize(&self.root);
         let canonical_root = self.canonical_root()?;
-        let normalized = if path.is_absolute() {
-            lexical_normalize(path)
+        let relative = if path.is_absolute() {
+            path.strip_prefix(&root)
+                .or_else(|_| path.strip_prefix(&canonical_root))
+                .map_err(|_| ToolFsError::Denied(path.to_path_buf()))?
         } else {
-            lexical_normalize(&root.join(path))
+            path
         };
-        let relative = normalized
-            .strip_prefix(&root)
-            .or_else(|_| normalized.strip_prefix(&canonical_root))
-            .map_err(|_| ToolFsError::Denied(path.to_path_buf()))?;
-
-        let components = relative.iter().collect::<Vec<_>>();
         let mut resolved = canonical_root.clone();
-        for (index, component) in components.iter().enumerate() {
-            resolved.push(component);
-            match std::fs::symlink_metadata(&resolved) {
-                Ok(_) => {
-                    resolved = std::fs::canonicalize(&resolved)
-                        .map_err(|error| map_io_error(path, error))?;
-                    if !resolved.starts_with(&canonical_root) {
+        for component in relative.components() {
+            match component {
+                std::path::Component::CurDir => {}
+                std::path::Component::ParentDir => {
+                    if resolved == canonical_root
+                        || !resolved.pop()
+                        || !resolved.starts_with(&canonical_root)
+                    {
                         return Err(ToolFsError::Denied(path.to_path_buf()));
                     }
                 }
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                    for missing in &components[index + 1..] {
-                        resolved.push(missing);
+                std::path::Component::Normal(part) => {
+                    resolved.push(part);
+                    match std::fs::symlink_metadata(&resolved) {
+                        Ok(_) => {
+                            resolved = std::fs::canonicalize(&resolved)
+                                .map_err(|error| map_io_error(path, error))?;
+                            if !resolved.starts_with(&canonical_root) {
+                                return Err(ToolFsError::Denied(path.to_path_buf()));
+                            }
+                        }
+                        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                        Err(error) => return Err(map_io_error(path, error)),
                     }
-                    return Ok(resolved);
                 }
-                Err(error) => return Err(map_io_error(path, error)),
+                std::path::Component::Prefix(_) | std::path::Component::RootDir => {
+                    return Err(ToolFsError::Denied(path.to_path_buf()));
+                }
             }
         }
 
@@ -504,19 +511,94 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn symlink_escape_is_denied() {
+    fn symlink_chain_escape_is_denied() {
         let outer = tempfile::tempdir().unwrap();
         let root = outer.path().join("root");
         let outside = outer.path().join("outside");
         std::fs::create_dir(&root).unwrap();
         std::fs::create_dir(&outside).unwrap();
         std::fs::write(outside.join("secret.txt"), "secret").unwrap();
+        std::os::unix::fs::symlink("second-link", root.join("first-link")).unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("second-link")).unwrap();
+        let fs = crate::StdFs::new(&root).unwrap();
+
+        let error = crate::ToolFs::read_file(&fs, std::path::Path::new("first-link/secret.txt"))
+            .unwrap_err();
+        assert!(matches!(error, crate::ToolFsError::Denied(_)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parent_after_an_escaping_symlink_is_denied_before_lexical_collapse() {
+        let outer = tempfile::tempdir().unwrap();
+        let root = outer.path().join("root");
+        let outside = outer.path().join("outside");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(root.join("secret.txt"), "inside").unwrap();
         std::os::unix::fs::symlink(&outside, root.join("link")).unwrap();
         let fs = crate::StdFs::new(&root).unwrap();
 
         let error =
-            crate::ToolFs::read_file(&fs, std::path::Path::new("link/secret.txt")).unwrap_err();
+            crate::ToolFs::read_file(&fs, std::path::Path::new("link/../secret.txt")).unwrap_err();
+
         assert!(matches!(error, crate::ToolFsError::Denied(_)));
+    }
+
+    #[test]
+    fn absolute_paths_use_component_prefixes_and_missing_parents_cannot_escape() {
+        let outer = tempfile::tempdir().unwrap();
+        let root = outer.path().join("root");
+        let colliding_root = outer.path().join("rootx");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::create_dir(&colliding_root).unwrap();
+        std::fs::write(root.join("inside.txt"), "inside").unwrap();
+        std::fs::write(colliding_root.join("outside.txt"), "outside").unwrap();
+        let fs = crate::StdFs::new(&root).unwrap();
+
+        assert_eq!(
+            crate::ToolFs::read_file(&fs, &root.join("inside.txt")).unwrap(),
+            b"inside"
+        );
+        let prefix_collision =
+            crate::ToolFs::read_file(&fs, &colliding_root.join("outside.txt")).unwrap_err();
+        let missing_tail = crate::ToolFs::write_file(
+            &fs,
+            std::path::Path::new("missing/../../outside.txt"),
+            b"escape",
+        )
+        .unwrap_err();
+
+        assert!(matches!(prefix_collision, crate::ToolFsError::Denied(_)));
+        assert!(matches!(missing_tail, crate::ToolFsError::Denied(_)));
+    }
+
+    #[test]
+    fn gitignore_matches_git_for_anchoring_directory_rules_and_pruned_negation() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("nested/dir")).unwrap();
+        std::fs::create_dir(root.path().join("pruned")).unwrap();
+        std::fs::write(
+            root.path().join(".gitignore"),
+            "/foo\ndir/\npruned/\n!pruned/keep.txt\n",
+        )
+        .unwrap();
+        std::fs::write(root.path().join("foo"), "ignored").unwrap();
+        std::fs::write(root.path().join("nested/foo"), "visible").unwrap();
+        std::fs::write(root.path().join("dir"), "visible file").unwrap();
+        std::fs::write(root.path().join("nested/dir/child"), "ignored").unwrap();
+        std::fs::write(root.path().join("pruned/keep.txt"), "still ignored").unwrap();
+        let fs = crate::StdFs::new(root.path()).unwrap();
+
+        let files = crate::walk_files(std::path::Path::new("."), &fs).unwrap();
+
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| file.relative_path.as_str())
+                .collect::<Vec<_>>(),
+            vec![".gitignore", "dir", "nested/foo"]
+        );
     }
 
     #[cfg(unix)]

--- a/agent-tools/tool-core/src/lib.rs
+++ b/agent-tools/tool-core/src/lib.rs
@@ -71,6 +71,151 @@ pub enum ToolError {
     ResultTooLarge,
 }
 
+/// One file discovered by [`walk_files`].
+///
+/// `path` is the path to pass back to [`ToolFs`]. `relative_path` is the
+/// deterministic, `/`-separated path exposed by model-facing tools.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WalkFile {
+    pub path: std::path::PathBuf,
+    pub relative_path: String,
+}
+
+/// Walk a file or directory using only [`ToolFs`].
+///
+/// Directory walks include hidden files, skip every `.git` directory, apply
+/// root `.git/info/exclude` plus nested `.gitignore` files, prune ignored
+/// directories, and return files sorted by root-relative path.
+pub fn walk_files(root: &std::path::Path, fs: &dyn ToolFs) -> Result<Vec<WalkFile>, ToolError> {
+    let stat = fs.stat(root)?;
+    if stat.is_file {
+        let relative_path = root
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| root.to_string_lossy().into_owned());
+        return Ok(vec![WalkFile {
+            path: root.to_path_buf(),
+            relative_path,
+        }]);
+    }
+    if !stat.is_dir {
+        return Err(ToolError::Failed(format!(
+            "path {} is not a file or directory",
+            root.display()
+        )));
+    }
+
+    let mut ignore_matchers = Vec::new();
+    add_ignore_file(
+        fs,
+        root,
+        &root.join(".git/info/exclude"),
+        &mut ignore_matchers,
+    )?;
+    add_ignore_file(fs, root, &root.join(".gitignore"), &mut ignore_matchers)?;
+
+    let mut files = Vec::new();
+    walk_directory(
+        fs,
+        root,
+        std::path::Path::new(""),
+        &mut ignore_matchers,
+        &mut files,
+    )?;
+    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    Ok(files)
+}
+
+fn walk_directory(
+    fs: &dyn ToolFs,
+    directory: &std::path::Path,
+    relative_directory: &std::path::Path,
+    ignore_matchers: &mut Vec<ignore::gitignore::Gitignore>,
+    files: &mut Vec<WalkFile>,
+) -> Result<(), ToolError> {
+    let mut entries = fs.read_dir(directory)?;
+    entries.sort_by(|left, right| left.name.cmp(&right.name));
+
+    for entry in entries {
+        let path = directory.join(&entry.name);
+        let relative = relative_directory.join(&entry.name);
+        if entry.is_dir {
+            if entry.name == ".git" || is_ignored(ignore_matchers, &path, true) {
+                continue;
+            }
+
+            let matcher_count = ignore_matchers.len();
+            add_ignore_file(fs, &path, &path.join(".gitignore"), ignore_matchers)?;
+            walk_directory(fs, &path, &relative, ignore_matchers, files)?;
+            ignore_matchers.truncate(matcher_count);
+        } else if !is_ignored(ignore_matchers, &path, false) {
+            let stat = fs.stat(&path)?;
+            if stat.is_file {
+                files.push(WalkFile {
+                    path,
+                    relative_path: relative_path_string(&relative),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn add_ignore_file(
+    fs: &dyn ToolFs,
+    match_root: &std::path::Path,
+    ignore_path: &std::path::Path,
+    ignore_matchers: &mut Vec<ignore::gitignore::Gitignore>,
+) -> Result<(), ToolError> {
+    if !fs.exists(ignore_path)? {
+        return Ok(());
+    }
+
+    let bytes = fs.read_file(ignore_path)?;
+    let content = String::from_utf8_lossy(&bytes);
+    let mut builder = ignore::gitignore::GitignoreBuilder::new(match_root);
+    for (index, line) in content.lines().enumerate() {
+        let line = if index == 0 {
+            line.trim_start_matches('\u{feff}')
+        } else {
+            line
+        };
+        let _ = builder.add_line(Some(ignore_path.to_path_buf()), line);
+    }
+    let matcher = builder
+        .build()
+        .map_err(|error| ToolError::Failed(format!("failed to parse ignore rules: {error}")))?;
+    ignore_matchers.push(matcher);
+    Ok(())
+}
+
+fn is_ignored(
+    ignore_matchers: &[ignore::gitignore::Gitignore],
+    path: &std::path::Path,
+    is_dir: bool,
+) -> bool {
+    let mut ignored = false;
+    for matcher in ignore_matchers {
+        match matcher.matched(path, is_dir) {
+            ignore::Match::None => {}
+            ignore::Match::Ignore(_) => ignored = true,
+            ignore::Match::Whitelist(_) => ignored = false,
+        }
+    }
+    ignored
+}
+
+fn relative_path_string(path: &std::path::Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(part) => Some(part.to_string_lossy()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 /// How a tool call composes with retries and replay.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EffectClass {

--- a/agent-tools/tool-edit/Cargo.toml
+++ b/agent-tools/tool-edit/Cargo.toml
@@ -9,6 +9,8 @@ description = "Exact-match file edit tool (model-facing `edit`)"
 verlet-tool-core = { path = "../tool-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+similar = { version = "3.2", default-features = false, features = ["std", "text"] }
+unicode-normalization = "0.1"
 
 [features]
 default = []
@@ -18,3 +20,7 @@ cli = ["verlet-tool-core/std-fs"]
 name = "tool-edit"
 path = "src/main.rs"
 required-features = ["cli"]
+
+[dev-dependencies]
+tempfile = "3"
+verlet-tool-core = { path = "../tool-core", features = ["std-fs"] }

--- a/agent-tools/tool-edit/Cargo.toml
+++ b/agent-tools/tool-edit/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "verlet-tool-edit"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Exact-match file edit tool (model-facing `edit`)"
+
+[dependencies]
+verlet-tool-core = { path = "../tool-core" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[features]
+default = []
+cli = ["verlet-tool-core/std-fs"]
+
+[[bin]]
+name = "tool-edit"
+path = "src/main.rs"
+required-features = ["cli"]

--- a/agent-tools/tool-edit/src/lib.rs
+++ b/agent-tools/tool-edit/src/lib.rs
@@ -1,0 +1,84 @@
+//! `edit` — replace exact text spans in one file.
+//!
+//! Ported from Pi's edit tool (`core/tools/edit.ts`, `edit-diff.ts`).
+//! This is the tool with the tricky logic; the implementation ticket ports
+//! Pi's test fixtures alongside it.
+//!
+//! Pinned semantics:
+//! - `edits` apply as one atomic batch: all succeed or the file is
+//!   untouched.
+//! - Each `old_text` must match exactly once. Match strategy per Pi:
+//!   exact match first, then a normalized pass (NFKC, smart quotes to
+//!   ASCII, en/em dashes to hyphens, trailing whitespace stripped per
+//!   line) that must still be unique.
+//! - Zero matches, multiple matches, or overlapping edit spans are
+//!   errors naming the offending `old_text` (first 100 chars).
+//! - `old_text == new_text` is an error ("no change").
+//! - Result returns a unified diff of the applied change; the model uses
+//!   it to confirm the edit landed where intended.
+//! - Line endings: file's existing endings are preserved; `old_text`
+//!   matching normalizes CRLF to LF for comparison.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use verlet_tool_core::{EffectClass, ToolContract, ToolError, ToolFs};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct EditArgs {
+    /// Path of the file to edit (relative to the workspace root or
+    /// absolute within the granted scope).
+    pub path: PathBuf,
+    /// Replacements to apply as one atomic batch.
+    pub edits: Vec<Edit>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Edit {
+    /// Text to find. Must match exactly one location in the file.
+    pub old_text: String,
+    /// Replacement text.
+    pub new_text: String,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct EditOutput {
+    /// Unified diff of the applied change.
+    pub diff: String,
+    pub edits_applied: u32,
+}
+
+pub fn contract() -> ToolContract {
+    ToolContract {
+        name: "edit",
+        description: "Edit a file by replacing exact text. Each old_text must \
+                      match exactly one location; all edits in one call apply \
+                      atomically. Returns a diff of the change. Read the file \
+                      first and copy old_text exactly, including whitespace.",
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "Path of the file to edit (relative or absolute)"},
+                "edits": {
+                    "type": "array",
+                    "description": "Replacements to apply atomically",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "old_text": {"type": "string", "description": "Text to find (must be unique in the file)"},
+                            "new_text": {"type": "string", "description": "Replacement text"}
+                        },
+                        "required": ["old_text", "new_text"]
+                    },
+                    "minItems": 1
+                }
+            },
+            "required": ["path", "edits"]
+        }),
+        effect_class: EffectClass::Idempotent,
+    }
+}
+
+pub fn run(_args: EditArgs, _fs: &dyn ToolFs) -> Result<EditOutput, ToolError> {
+    todo!("EMO ticket: port Pi edit semantics + fixtures per module docs")
+}

--- a/agent-tools/tool-edit/src/lib.rs
+++ b/agent-tools/tool-edit/src/lib.rs
@@ -109,6 +109,13 @@ pub fn run(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
+    let stat = fs.stat(&args.path)?;
+    if !stat.is_file {
+        return Err(verlet_tool_core::ToolError::Failed(format!(
+            "path {:?} is not a file",
+            args.path
+        )));
+    }
     let bytes = fs.read_file(&args.path)?;
     let (bom, text_bytes) = if bytes.starts_with(&[0xef, 0xbb, 0xbf]) {
         (&bytes[..3], &bytes[3..])
@@ -560,6 +567,58 @@ mod tests {
             std::fs::read_to_string(root.path().join("file.txt")).unwrap(),
             "XYZ789\ncoffee\n"
         );
+    }
+
+    #[test]
+    fn normalized_spans_remain_byte_aligned_after_multibyte_prefixes() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(
+            root.path().join("file.txt"),
+            "🙂 préface\nconsole.log(‘hello’);\n終わり\n",
+        )
+        .unwrap();
+
+        crate::run(
+            args(
+                "file.txt",
+                &[("console.log('hello');", "console.log('world');")],
+            ),
+            &fs(root.path()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("file.txt")).unwrap(),
+            "🙂 préface\nconsole.log('world');\n終わり\n"
+        );
+    }
+
+    #[test]
+    fn invalid_utf8_and_empty_files_return_structured_errors() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("invalid.txt"), [0xff]).unwrap();
+        std::fs::write(root.path().join("empty.txt"), b"").unwrap();
+        let fs = fs(root.path());
+
+        let invalid = crate::run(args("invalid.txt", &[("x", "y")]), &fs).unwrap_err();
+        let empty = crate::run(args("empty.txt", &[("x", "y")]), &fs).unwrap_err();
+
+        assert!(invalid
+            .to_string()
+            .starts_with("file invalid.txt is not valid UTF-8:"));
+        assert_eq!(
+            empty.to_string(),
+            "edits[0].old_text \"x\" was not found in empty.txt"
+        );
+    }
+
+    #[test]
+    fn rejects_a_directory_with_the_shared_file_error_shape() {
+        let root = tempfile::tempdir().unwrap();
+
+        let error = crate::run(args(".", &[("x", "y")]), &fs(root.path())).unwrap_err();
+
+        assert_eq!(error.to_string(), "path \".\" is not a file");
     }
 
     #[test]

--- a/agent-tools/tool-edit/src/lib.rs
+++ b/agent-tools/tool-edit/src/lib.rs
@@ -19,21 +19,18 @@
 //! - Line endings: file's existing endings are preserved; `old_text`
 //!   matching normalizes CRLF to LF for comparison.
 
-use std::path::PathBuf;
+use unicode_normalization::UnicodeNormalization as _;
 
-use serde::{Deserialize, Serialize};
-use verlet_tool_core::{EffectClass, ToolContract, ToolError, ToolFs};
-
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, serde::Deserialize)]
 pub struct EditArgs {
     /// Path of the file to edit (relative to the workspace root or
     /// absolute within the granted scope).
-    pub path: PathBuf,
+    pub path: std::path::PathBuf,
     /// Replacements to apply as one atomic batch.
     pub edits: Vec<Edit>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, serde::Deserialize)]
 pub struct Edit {
     /// Text to find. Must match exactly one location in the file.
     pub old_text: String,
@@ -41,15 +38,15 @@ pub struct Edit {
     pub new_text: String,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
 pub struct EditOutput {
     /// Unified diff of the applied change.
     pub diff: String,
     pub edits_applied: u32,
 }
 
-pub fn contract() -> ToolContract {
-    ToolContract {
+pub fn contract() -> verlet_tool_core::ToolContract {
+    verlet_tool_core::ToolContract {
         name: "edit",
         description: "Edit a file by replacing exact text. Each old_text must \
                       match exactly one location; all edits in one call apply \
@@ -75,10 +72,780 @@ pub fn contract() -> ToolContract {
             },
             "required": ["path", "edits"]
         }),
-        effect_class: EffectClass::Idempotent,
+        effect_class: verlet_tool_core::EffectClass::Idempotent,
     }
 }
 
-pub fn run(_args: EditArgs, _fs: &dyn ToolFs) -> Result<EditOutput, ToolError> {
-    todo!("EMO ticket: port Pi edit semantics + fixtures per module docs")
+pub fn run(
+    args: EditArgs,
+    fs: &dyn verlet_tool_core::ToolFs,
+) -> Result<EditOutput, verlet_tool_core::ToolError> {
+    if args.edits.is_empty() {
+        return Err(verlet_tool_core::ToolError::InvalidArgs(
+            "edits must contain at least one replacement".to_owned(),
+        ));
+    }
+
+    let edits = args
+        .edits
+        .iter()
+        .enumerate()
+        .map(|(index, edit)| {
+            if edit.old_text.is_empty() {
+                return Err(verlet_tool_core::ToolError::InvalidArgs(format!(
+                    "edits[{index}].old_text must not be empty"
+                )));
+            }
+            if edit.old_text == edit.new_text {
+                return Err(verlet_tool_core::ToolError::InvalidArgs(format!(
+                    "{} equals new_text; the edit would make no change",
+                    edit_label(index, &edit.old_text)
+                )));
+            }
+            Ok(NormalizedEdit {
+                old_text: normalize_to_lf(&edit.old_text),
+                new_text: normalize_to_lf(&edit.new_text),
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let bytes = fs.read_file(&args.path)?;
+    let (bom, text_bytes) = if bytes.starts_with(&[0xef, 0xbb, 0xbf]) {
+        (&bytes[..3], &bytes[3..])
+    } else {
+        (&bytes[..0], bytes.as_slice())
+    };
+    let content = std::str::from_utf8(text_bytes).map_err(|error| {
+        verlet_tool_core::ToolError::Failed(format!(
+            "file {} is not valid UTF-8: {error}",
+            args.path.display()
+        ))
+    })?;
+    let line_ending = detect_line_ending(content);
+    let base_content = normalize_to_lf(content);
+
+    let uses_normalized_match = edits
+        .iter()
+        .any(|edit| find_text(&base_content, &edit.old_text).used_normalized_match);
+    let replacement_base = if uses_normalized_match {
+        normalize_for_match(&base_content)
+    } else {
+        base_content.clone()
+    };
+
+    let mut matched_edits = Vec::with_capacity(edits.len());
+    for (index, edit) in edits.iter().enumerate() {
+        let match_result = find_text(&replacement_base, &edit.old_text);
+        if !match_result.found {
+            return Err(verlet_tool_core::ToolError::Failed(format!(
+                "{} was not found in {}",
+                edit_label(index, &args.edits[index].old_text),
+                args.path.display()
+            )));
+        }
+
+        let occurrences = count_occurrences(&replacement_base, &edit.old_text);
+        if occurrences != 1 {
+            return Err(verlet_tool_core::ToolError::Failed(format!(
+                "{} matched {occurrences} locations in {}; old_text must match exactly once",
+                edit_label(index, &args.edits[index].old_text),
+                args.path.display()
+            )));
+        }
+
+        matched_edits.push(MatchedEdit {
+            edit_index: index,
+            match_index: match_result.index,
+            match_length: match_result.match_length,
+            new_text: edit.new_text.clone(),
+        });
+    }
+
+    matched_edits.sort_by_key(|edit| edit.match_index);
+    for pair in matched_edits.windows(2) {
+        let previous = &pair[0];
+        let current = &pair[1];
+        if previous.match_index + previous.match_length > current.match_index {
+            return Err(verlet_tool_core::ToolError::Failed(format!(
+                "{} overlaps {} in {}",
+                edit_label(
+                    previous.edit_index,
+                    &args.edits[previous.edit_index].old_text
+                ),
+                edit_label(current.edit_index, &args.edits[current.edit_index].old_text),
+                args.path.display()
+            )));
+        }
+    }
+
+    let new_content = if uses_normalized_match {
+        apply_replacements_preserving_unchanged_lines(
+            &base_content,
+            &replacement_base,
+            &matched_edits,
+        )?
+    } else {
+        apply_replacements(&replacement_base, &matched_edits, 0)
+    };
+    if new_content == base_content {
+        return Err(verlet_tool_core::ToolError::InvalidArgs(format!(
+            "{} produced no change",
+            edit_label(0, &args.edits[0].old_text)
+        )));
+    }
+
+    let path = args.path.display().to_string();
+    let text_diff = similar::TextDiff::from_lines(&base_content, &new_content);
+    let diff = text_diff
+        .unified_diff()
+        .context_radius(4)
+        .header(&path, &path)
+        .to_string();
+    if diff.len() > verlet_tool_core::MAX_RESULT_BYTES {
+        return Err(verlet_tool_core::ToolError::ResultTooLarge);
+    }
+
+    let restored_content = restore_line_endings(&new_content, line_ending);
+    let mut output_bytes = Vec::with_capacity(bom.len() + restored_content.len());
+    output_bytes.extend_from_slice(bom);
+    output_bytes.extend_from_slice(restored_content.as_bytes());
+    fs.write_file(&args.path, &output_bytes)?;
+
+    Ok(EditOutput {
+        diff,
+        edits_applied: u32::try_from(args.edits.len()).unwrap_or(u32::MAX),
+    })
+}
+
+#[derive(Clone, Copy)]
+enum LineEnding {
+    Lf,
+    CrLf,
+}
+
+struct NormalizedEdit {
+    old_text: String,
+    new_text: String,
+}
+
+struct MatchResult {
+    found: bool,
+    index: usize,
+    match_length: usize,
+    used_normalized_match: bool,
+}
+
+#[derive(Clone)]
+struct MatchedEdit {
+    edit_index: usize,
+    match_index: usize,
+    match_length: usize,
+    new_text: String,
+}
+
+#[derive(Clone, Copy)]
+struct LineSpan {
+    start: usize,
+    end: usize,
+}
+
+struct ReplacementGroup {
+    start_line: usize,
+    end_line: usize,
+    replacements: Vec<MatchedEdit>,
+}
+
+fn edit_label(index: usize, old_text: &str) -> String {
+    let preview = old_text.chars().take(100).collect::<String>();
+    format!("edits[{index}].old_text {preview:?}")
+}
+
+fn detect_line_ending(content: &str) -> LineEnding {
+    match (content.find("\r\n"), content.find('\n')) {
+        (Some(crlf), Some(lf)) if crlf == lf.saturating_sub(1) => LineEnding::CrLf,
+        _ => LineEnding::Lf,
+    }
+}
+
+fn normalize_to_lf(text: &str) -> String {
+    text.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+fn restore_line_endings(text: &str, ending: LineEnding) -> String {
+    match ending {
+        LineEnding::Lf => text.to_owned(),
+        LineEnding::CrLf => text.replace('\n', "\r\n"),
+    }
+}
+
+fn normalize_for_match(text: &str) -> String {
+    text.nfkc()
+        .map(|character| match character {
+            '\u{2018}' | '\u{2019}' | '\u{201a}' | '\u{201b}' => '\'',
+            '\u{201c}' | '\u{201d}' | '\u{201e}' | '\u{201f}' => '"',
+            '\u{2013}' | '\u{2014}' => '-',
+            character => character,
+        })
+        .collect::<String>()
+        .split('\n')
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn find_text(content: &str, old_text: &str) -> MatchResult {
+    if let Some(index) = content.find(old_text) {
+        return MatchResult {
+            found: true,
+            index,
+            match_length: old_text.len(),
+            used_normalized_match: false,
+        };
+    }
+
+    let normalized_content = normalize_for_match(content);
+    let normalized_old_text = normalize_for_match(old_text);
+    if normalized_old_text.is_empty() {
+        return MatchResult {
+            found: false,
+            index: 0,
+            match_length: 0,
+            used_normalized_match: false,
+        };
+    }
+    match normalized_content.find(&normalized_old_text) {
+        Some(index) => MatchResult {
+            found: true,
+            index,
+            match_length: normalized_old_text.len(),
+            used_normalized_match: true,
+        },
+        None => MatchResult {
+            found: false,
+            index: 0,
+            match_length: 0,
+            used_normalized_match: false,
+        },
+    }
+}
+
+fn count_occurrences(content: &str, old_text: &str) -> usize {
+    let normalized_content = normalize_for_match(content);
+    let normalized_old_text = normalize_for_match(old_text);
+    if normalized_old_text.is_empty() {
+        return 0;
+    }
+    normalized_content
+        .match_indices(&normalized_old_text)
+        .count()
+}
+
+fn split_lines_with_endings(content: &str) -> Vec<&str> {
+    let mut lines = Vec::new();
+    let mut start = 0;
+    for (index, character) in content.char_indices() {
+        if character == '\n' {
+            lines.push(&content[start..index + 1]);
+            start = index + 1;
+        }
+    }
+    if start < content.len() {
+        lines.push(&content[start..]);
+    }
+    lines
+}
+
+fn line_spans(content: &str) -> Vec<LineSpan> {
+    let mut offset = 0;
+    split_lines_with_endings(content)
+        .into_iter()
+        .map(|line| {
+            let span = LineSpan {
+                start: offset,
+                end: offset + line.len(),
+            };
+            offset = span.end;
+            span
+        })
+        .collect()
+}
+
+fn replacement_line_range(
+    lines: &[LineSpan],
+    replacement: &MatchedEdit,
+) -> Result<(usize, usize), verlet_tool_core::ToolError> {
+    let replacement_start = replacement.match_index;
+    let replacement_end = replacement.match_index + replacement.match_length;
+    let start_line = lines
+        .iter()
+        .position(|line| replacement_start >= line.start && replacement_start < line.end)
+        .ok_or_else(|| {
+            verlet_tool_core::ToolError::Failed(
+                "replacement range is outside the normalized file content".to_owned(),
+            )
+        })?;
+    let mut end_line = start_line;
+    while end_line < lines.len() && lines[end_line].end < replacement_end {
+        end_line += 1;
+    }
+    if end_line >= lines.len() {
+        return Err(verlet_tool_core::ToolError::Failed(
+            "replacement range is outside the normalized file content".to_owned(),
+        ));
+    }
+    Ok((start_line, end_line + 1))
+}
+
+fn apply_replacements(content: &str, replacements: &[MatchedEdit], offset: usize) -> String {
+    let mut result = content.to_owned();
+    for replacement in replacements.iter().rev() {
+        let start = replacement.match_index - offset;
+        result.replace_range(
+            start..start + replacement.match_length,
+            &replacement.new_text,
+        );
+    }
+    result
+}
+
+fn apply_replacements_preserving_unchanged_lines(
+    original_content: &str,
+    normalized_content: &str,
+    replacements: &[MatchedEdit],
+) -> Result<String, verlet_tool_core::ToolError> {
+    let original_lines = split_lines_with_endings(original_content);
+    let normalized_lines = line_spans(normalized_content);
+    if original_lines.len() != normalized_lines.len() {
+        return Err(verlet_tool_core::ToolError::Failed(
+            "normalized matching changed the file's line count".to_owned(),
+        ));
+    }
+
+    let mut groups = Vec::<ReplacementGroup>::new();
+    for replacement in replacements {
+        let (start_line, end_line) = replacement_line_range(&normalized_lines, replacement)?;
+        if let Some(group) = groups.last_mut() {
+            if start_line < group.end_line {
+                group.end_line = group.end_line.max(end_line);
+                group.replacements.push(replacement.clone());
+                continue;
+            }
+        }
+        groups.push(ReplacementGroup {
+            start_line,
+            end_line,
+            replacements: vec![replacement.clone()],
+        });
+    }
+
+    let mut original_line_index = 0;
+    let mut result = String::new();
+    for group in groups {
+        result.push_str(&original_lines[original_line_index..group.start_line].concat());
+        let group_start = normalized_lines[group.start_line].start;
+        let group_end = normalized_lines[group.end_line - 1].end;
+        result.push_str(&apply_replacements(
+            &normalized_content[group_start..group_end],
+            &group.replacements,
+            group_start,
+        ));
+        original_line_index = group.end_line;
+    }
+    result.push_str(&original_lines[original_line_index..].concat());
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    fn fs(root: &std::path::Path) -> verlet_tool_core::StdFs {
+        verlet_tool_core::StdFs::new(root).unwrap()
+    }
+
+    fn args(path: &str, edits: &[(&str, &str)]) -> crate::EditArgs {
+        crate::EditArgs {
+            path: std::path::PathBuf::from(path),
+            edits: edits
+                .iter()
+                .map(|(old_text, new_text)| crate::Edit {
+                    old_text: (*old_text).to_owned(),
+                    new_text: (*new_text).to_owned(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn replaces_one_exact_unique_match_and_returns_a_unified_diff() {
+        // Pi source case: packages/coding-agent/test/tools.test.ts,
+        // "should replace text in file".
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "Hello, world!\n").unwrap();
+
+        let output =
+            crate::run(args("file.txt", &[("world", "testing")]), &fs(root.path())).unwrap();
+
+        assert_eq!(output.edits_applied, 1);
+        assert!(output.diff.starts_with("--- file.txt\n+++ file.txt\n@@"));
+        assert!(output.diff.contains("-Hello, world!"));
+        assert!(output.diff.contains("+Hello, testing!"));
+        assert_eq!(
+            std::fs::read(root.path().join("file.txt")).unwrap(),
+            b"Hello, testing!\n"
+        );
+    }
+
+    #[test]
+    fn replaces_a_normalized_only_smart_quote_match() {
+        // Pi source case: packages/coding-agent/test/tools.test.ts,
+        // "should match smart single quotes to ASCII quotes".
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(
+            root.path().join("file.txt"),
+            "console.log(‘hello’);\nkeep trailing   \n",
+        )
+        .unwrap();
+
+        crate::run(
+            args(
+                "file.txt",
+                &[("console.log('hello');", "console.log('world');")],
+            ),
+            &fs(root.path()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("file.txt")).unwrap(),
+            "console.log('world');\nkeep trailing   \n"
+        );
+    }
+
+    #[test]
+    fn strips_trailing_whitespace_only_from_lines_touched_by_a_normalized_match() {
+        // Pi source case: packages/coding-agent/test/tools.test.ts,
+        // "should match text with trailing whitespace stripped".
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(
+            root.path().join("file.txt"),
+            "line one   \nline two  \nline three   \n",
+        )
+        .unwrap();
+
+        crate::run(
+            args("file.txt", &[("line one\nline two\n", "replacement\n")]),
+            &fs(root.path()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("file.txt")).unwrap(),
+            "replacement\nline three   \n"
+        );
+    }
+
+    #[test]
+    fn replaces_compatibility_equivalent_unicode_content() {
+        // Pi source case: packages/coding-agent/test/tools.test.ts,
+        // "should match compatibility-equivalent Unicode forms".
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "ＡＢＣ１２３\ncafe\u{301}\n").unwrap();
+
+        crate::run(
+            args("file.txt", &[("ABC123\ncafé\n", "XYZ789\ncoffee\n")]),
+            &fs(root.path()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("file.txt")).unwrap(),
+            "XYZ789\ncoffee\n"
+        );
+    }
+
+    #[test]
+    fn replaces_normalized_en_and_em_dashes() {
+        // Pi source case: packages/coding-agent/test/tools.test.ts,
+        // "should match Unicode dashes to ASCII hyphen".
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "range: 1–5\nbreak—here\n").unwrap();
+
+        crate::run(
+            args(
+                "file.txt",
+                &[("range: 1-5\nbreak-here", "range: 10-50\nbreak--here")],
+            ),
+            &fs(root.path()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("file.txt")).unwrap(),
+            "range: 10-50\nbreak--here\n"
+        );
+    }
+
+    #[test]
+    fn rejects_an_ambiguous_match_and_names_the_old_text() {
+        // Pi source case: packages/coding-agent/test/tools.test.ts,
+        // "should fail if text appears multiple times".
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "foo foo foo").unwrap();
+
+        let error = crate::run(args("file.txt", &[("foo", "bar")]), &fs(root.path())).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "edits[0].old_text \"foo\" matched 3 locations in file.txt; old_text must match exactly once"
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("file.txt")).unwrap(),
+            b"foo foo foo"
+        );
+    }
+
+    #[test]
+    fn rejects_ambiguity_after_normalization() {
+        // Pi source case: packages/coding-agent/test/tools.test.ts,
+        // "should detect duplicates after fuzzy normalization".
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "‘hello’\n’hello‘\n").unwrap();
+
+        let error = crate::run(
+            args("file.txt", &[("'hello'", "replacement")]),
+            &fs(root.path()),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "edits[0].old_text \"'hello'\" matched 2 locations in file.txt; old_text must match exactly once"
+        );
+    }
+
+    #[test]
+    fn rejects_a_zero_match_and_names_the_old_text() {
+        // Pi source case: packages/coding-agent/test/tools.test.ts,
+        // "should fail if text not found".
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "Hello, world!").unwrap();
+
+        let error = crate::run(
+            args("file.txt", &[("nonexistent", "testing")]),
+            &fs(root.path()),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "edits[0].old_text \"nonexistent\" was not found in file.txt"
+        );
+    }
+
+    #[test]
+    fn rejects_overlapping_edits_and_names_both_old_texts() {
+        // Pi source case: packages/coding-agent/test/tools.test.ts,
+        // "should fail when multi-edit regions overlap".
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "one\ntwo\nthree\n").unwrap();
+
+        let error = crate::run(
+            args(
+                "file.txt",
+                &[
+                    ("one\ntwo\n", "ONE\nTWO\n"),
+                    ("two\nthree\n", "TWO\nTHREE\n"),
+                ],
+            ),
+            &fs(root.path()),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "edits[0].old_text \"one\\ntwo\\n\" overlaps edits[1].old_text \"two\\nthree\\n\" in file.txt"
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("file.txt")).unwrap(),
+            b"one\ntwo\nthree\n"
+        );
+    }
+
+    #[test]
+    fn applies_a_reverse_ordered_multi_edit_batch_against_the_original() {
+        // Pi source cases: packages/coding-agent/test/tools.test.ts,
+        // "should replace multiple disjoint regions in one call" and
+        // "should match edits against the original file, not incrementally".
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "foo\nbar\nbaz\n").unwrap();
+
+        let output = crate::run(
+            args("file.txt", &[("bar\n", "BAR\n"), ("foo\n", "foo bar\n")]),
+            &fs(root.path()),
+        )
+        .unwrap();
+
+        assert_eq!(output.edits_applied, 2);
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("file.txt")).unwrap(),
+            "foo bar\nBAR\nbaz\n"
+        );
+    }
+
+    #[test]
+    fn applies_exact_and_normalized_matches_in_one_batch() {
+        // Pi source case: packages/coding-agent/test/tools.test.ts,
+        // "should support fuzzy matching in multi-edit mode".
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(
+            root.path().join("file.txt"),
+            "exact target\nconsole.log(‘hello’);\n",
+        )
+        .unwrap();
+
+        crate::run(
+            args(
+                "file.txt",
+                &[
+                    ("console.log('hello');\n", "console.log('world');\n"),
+                    ("exact target\n", "EXACT\n"),
+                ],
+            ),
+            &fs(root.path()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("file.txt")).unwrap(),
+            "EXACT\nconsole.log('world');\n"
+        );
+    }
+
+    #[test]
+    fn matches_lf_text_and_preserves_a_crlf_file_and_bom() {
+        // Pi source cases: packages/coding-agent/test/tools.test.ts,
+        // "should preserve CRLF line endings after edit" and
+        // "should preserve UTF-8 BOM after edit".
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(
+            root.path().join("file.txt"),
+            b"\xef\xbb\xbffirst\r\nsecond\r\nthird\r\n",
+        )
+        .unwrap();
+
+        let output = crate::run(
+            args("file.txt", &[("second\n", "REPLACED\n")]),
+            &fs(root.path()),
+        )
+        .unwrap();
+
+        assert!(!output.diff.contains('\r'));
+        assert_eq!(
+            std::fs::read(root.path().join("file.txt")).unwrap(),
+            b"\xef\xbb\xbffirst\r\nREPLACED\r\nthird\r\n"
+        );
+    }
+
+    #[test]
+    fn leaves_the_file_byte_identical_when_the_second_edit_fails() {
+        // Pi source case: packages/coding-agent/test/tools.test.ts,
+        // "should not partially apply edits when one edit fails".
+        let root = tempfile::tempdir().unwrap();
+        let original = b"alpha\r\nbeta\r\ngamma\r\n";
+        std::fs::write(root.path().join("file.txt"), original).unwrap();
+
+        let error = crate::run(
+            args(
+                "file.txt",
+                &[("alpha\n", "ALPHA\n"), ("missing\n", "MISSING\n")],
+            ),
+            &fs(root.path()),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "edits[1].old_text \"missing\\n\" was not found in file.txt"
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("file.txt")).unwrap(),
+            original
+        );
+    }
+
+    #[test]
+    fn rejects_an_empty_batch_empty_old_text_and_no_op_edit() {
+        // Pi source case for the empty batch:
+        // packages/coding-agent/test/tools.test.ts,
+        // "should fail when edits is empty".
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "content").unwrap();
+        let fs = fs(root.path());
+
+        let empty_batch = crate::run(args("file.txt", &[]), &fs).unwrap_err();
+        let empty_old = crate::run(args("file.txt", &[("", "new")]), &fs).unwrap_err();
+        let no_op = crate::run(args("file.txt", &[("content", "content")]), &fs).unwrap_err();
+
+        assert_eq!(
+            empty_batch.to_string(),
+            "invalid arguments: edits must contain at least one replacement"
+        );
+        assert_eq!(
+            empty_old.to_string(),
+            "invalid arguments: edits[0].old_text must not be empty"
+        );
+        assert_eq!(
+            no_op.to_string(),
+            "invalid arguments: edits[0].old_text \"content\" equals new_text; the edit would make no change"
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("file.txt")).unwrap(),
+            b"content"
+        );
+    }
+
+    #[test]
+    fn rejects_a_normalized_replacement_that_restores_the_original_text() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "‘hello’\n").unwrap();
+
+        let error = crate::run(
+            args("file.txt", &[("'hello'", "‘hello’")]),
+            &fs(root.path()),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "invalid arguments: edits[0].old_text \"'hello'\" produced no change"
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("file.txt")).unwrap(),
+            "‘hello’\n"
+        );
+    }
+
+    #[test]
+    fn error_previews_truncate_old_text_to_100_unicode_characters() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "content").unwrap();
+        let preview = "é".repeat(100);
+        let old_text = format!("{preview}not shown");
+
+        let error = crate::run(
+            crate::EditArgs {
+                path: std::path::PathBuf::from("file.txt"),
+                edits: vec![crate::Edit {
+                    old_text,
+                    new_text: "replacement".to_owned(),
+                }],
+            },
+            &fs(root.path()),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!("edits[0].old_text {preview:?} was not found in file.txt")
+        );
+    }
 }

--- a/agent-tools/tool-edit/src/main.rs
+++ b/agent-tools/tool-edit/src/main.rs
@@ -1,0 +1,7 @@
+//! Standalone CLI: JSON args on stdin -> JSON result on stdout.
+//! Doubles as the executor-side implementation for remote serving.
+//! Input: {"root": "/abs/dir", "args": {...ReadArgs}}
+
+fn main() {
+    todo!("EMO ticket: stdin/stdout JSON harness over StdFs (shared shape across all five bins)")
+}

--- a/agent-tools/tool-edit/src/main.rs
+++ b/agent-tools/tool-edit/src/main.rs
@@ -1,7 +1,7 @@
 //! Standalone CLI: JSON args on stdin -> JSON result on stdout.
 //! Doubles as the executor-side implementation for remote serving.
-//! Input: {"root": "/abs/dir", "args": {...ReadArgs}}
+//! Input: {"root": "/abs/dir", "args": {...EditArgs}}
 
-fn main() {
-    todo!("EMO ticket: stdin/stdout JSON harness over StdFs (shared shape across all five bins)")
+fn main() -> std::process::ExitCode {
+    verlet_tool_core::run_cli(verlet_tool_edit::run)
 }

--- a/agent-tools/tool-edit/tests/cli.rs
+++ b/agent-tools/tool-edit/tests/cli.rs
@@ -1,0 +1,35 @@
+#![cfg(feature = "cli")]
+
+#[test]
+fn cli_edits_a_file_within_its_confined_root() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::write(root.path().join("file.txt"), "hello\nworld\n").unwrap();
+    let input = serde_json::json!({
+        "root": root.path(),
+        "args": {
+            "path": "file.txt",
+            "edits": [{"old_text": "world", "new_text": "there"}]
+        }
+    });
+
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_tool-edit"))
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    std::io::Write::write_all(
+        &mut child.stdin.take().unwrap(),
+        serde_json::to_string(&input).unwrap().as_bytes(),
+    )
+    .unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    let value = serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
+    assert_eq!(value["ok"]["edits_applied"], 1);
+    assert!(value["ok"]["diff"].as_str().unwrap().contains("+there"));
+    assert_eq!(
+        std::fs::read_to_string(root.path().join("file.txt")).unwrap(),
+        "hello\nthere\n"
+    );
+}

--- a/agent-tools/tool-glob/Cargo.toml
+++ b/agent-tools/tool-glob/Cargo.toml
@@ -7,6 +7,7 @@ description = "Glob file finder (model-facing `glob`, attachable as `find`)"
 
 [dependencies]
 verlet-tool-core = { path = "../tool-core" }
+globset = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
@@ -18,3 +19,7 @@ cli = ["verlet-tool-core/std-fs"]
 name = "tool-glob"
 path = "src/main.rs"
 required-features = ["cli"]
+
+[dev-dependencies]
+tempfile = { workspace = true }
+verlet-tool-core = { path = "../tool-core", features = ["std-fs"] }

--- a/agent-tools/tool-glob/Cargo.toml
+++ b/agent-tools/tool-glob/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "verlet-tool-glob"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Glob file finder (model-facing `glob`, attachable as `find`)"
+
+[dependencies]
+verlet-tool-core = { path = "../tool-core" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[features]
+default = []
+cli = ["verlet-tool-core/std-fs"]
+
+[[bin]]
+name = "tool-glob"
+path = "src/main.rs"
+required-features = ["cli"]

--- a/agent-tools/tool-glob/src/lib.rs
+++ b/agent-tools/tool-glob/src/lib.rs
@@ -225,6 +225,22 @@ mod tests {
             .starts_with("invalid arguments: invalid glob pattern"));
     }
 
+    #[test]
+    fn zero_limit_is_rejected_and_maximum_u64_limit_is_safe() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "content").unwrap();
+
+        let zero = crate::run(args("**", Some(0)), &fs(root.path())).unwrap_err();
+        let maximum = crate::run(args("**", Some(u64::MAX)), &fs(root.path())).unwrap();
+
+        assert_eq!(
+            zero.to_string(),
+            "invalid arguments: limit must be at least 1"
+        );
+        assert_eq!(maximum.paths, vec!["file.txt"]);
+        assert!(!maximum.limit_reached);
+    }
+
     struct RecordingFs {
         inner: verlet_tool_core::StdFs,
         read_dirs: std::cell::RefCell<Vec<std::path::PathBuf>>,

--- a/agent-tools/tool-glob/src/lib.rs
+++ b/agent-tools/tool-glob/src/lib.rs
@@ -19,32 +19,27 @@
 //! - `limit` (default 1000) caps results; the result carries a
 //!   `limit_reached` flag so the model knows the listing is partial.
 
-use std::path::PathBuf;
-
-use serde::{Deserialize, Serialize};
-use verlet_tool_core::{EffectClass, ToolContract, ToolError, ToolFs};
-
 pub const DEFAULT_LIMIT: u64 = 1000;
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, serde::Deserialize)]
 pub struct GlobArgs {
     /// Glob pattern, e.g. `*.ts`, `**/*.json`, `src/**/*.spec.ts`.
     pub pattern: String,
     /// Directory to search in (default: workspace root).
-    pub path: Option<PathBuf>,
+    pub path: Option<std::path::PathBuf>,
     /// Maximum number of results (default 1000).
     pub limit: Option<u64>,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
 pub struct GlobOutput {
     /// Root-relative `/`-separated paths, sorted.
     pub paths: Vec<String>,
     pub limit_reached: bool,
 }
 
-pub fn contract() -> ToolContract {
-    ToolContract {
+pub fn contract() -> verlet_tool_core::ToolContract {
+    verlet_tool_core::ToolContract {
         name: "glob",
         description: "Search for files by glob pattern, e.g. '*.ts' or \
                       '**/*.spec.ts'. Returns matching file paths relative to \
@@ -58,10 +53,224 @@ pub fn contract() -> ToolContract {
             },
             "required": ["pattern"]
         }),
-        effect_class: EffectClass::Pure,
+        effect_class: verlet_tool_core::EffectClass::Pure,
     }
 }
 
-pub fn run(_args: GlobArgs, _fs: &dyn ToolFs) -> Result<GlobOutput, ToolError> {
-    todo!("EMO ticket: ToolFs walk + globset + gitignore per module docs")
+pub fn run(
+    args: GlobArgs,
+    fs: &dyn verlet_tool_core::ToolFs,
+) -> Result<GlobOutput, verlet_tool_core::ToolError> {
+    let limit = args.limit.unwrap_or(DEFAULT_LIMIT);
+    if limit == 0 {
+        return Err(verlet_tool_core::ToolError::InvalidArgs(
+            "limit must be at least 1".to_owned(),
+        ));
+    }
+    let matcher = globset::Glob::new(&args.pattern)
+        .map_err(|error| {
+            verlet_tool_core::ToolError::InvalidArgs(format!(
+                "invalid glob pattern {:?}: {error}",
+                args.pattern
+            ))
+        })?
+        .compile_matcher();
+    let root = args.path.unwrap_or_else(|| std::path::PathBuf::from("."));
+    let files = verlet_tool_core::walk_files(&root, fs)?;
+    let limit = usize::try_from(limit).unwrap_or(usize::MAX);
+    let mut paths = Vec::new();
+    let mut limit_reached = false;
+
+    for file in files {
+        if !matcher.is_match(std::path::Path::new(&file.relative_path)) {
+            continue;
+        }
+        if paths.len() == limit {
+            limit_reached = true;
+            break;
+        }
+        paths.push(file.relative_path);
+    }
+
+    let rendered_bytes = paths
+        .iter()
+        .map(String::len)
+        .sum::<usize>()
+        .saturating_add(paths.len().saturating_sub(1));
+    if rendered_bytes > verlet_tool_core::MAX_RESULT_BYTES {
+        return Err(verlet_tool_core::ToolError::ResultTooLarge);
+    }
+
+    Ok(GlobOutput {
+        paths,
+        limit_reached,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    fn args(pattern: &str, limit: Option<u64>) -> crate::GlobArgs {
+        crate::GlobArgs {
+            pattern: pattern.to_owned(),
+            path: None,
+            limit,
+        }
+    }
+
+    fn fs(root: &std::path::Path) -> verlet_tool_core::StdFs {
+        verlet_tool_core::StdFs::new(root).unwrap()
+    }
+
+    #[test]
+    fn double_star_matches_hidden_files_with_relative_sorted_paths() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        std::fs::create_dir_all(root.path().join(".git")).unwrap();
+        std::fs::write(root.path().join("src/b.json"), "b").unwrap();
+        std::fs::write(root.path().join("src/a.json"), "a").unwrap();
+        std::fs::write(root.path().join(".hidden.json"), "hidden").unwrap();
+        std::fs::write(root.path().join(".git/secret.json"), "secret").unwrap();
+
+        let output = crate::run(args("**/*.json", None), &fs(root.path())).unwrap();
+
+        assert_eq!(
+            output,
+            crate::GlobOutput {
+                paths: vec![
+                    ".hidden.json".to_owned(),
+                    "src/a.json".to_owned(),
+                    "src/b.json".to_owned(),
+                ],
+                limit_reached: false,
+            }
+        );
+    }
+
+    #[test]
+    fn nested_gitignore_negation_and_info_exclude_are_respected() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("nested")).unwrap();
+        std::fs::create_dir_all(root.path().join("ignored")).unwrap();
+        std::fs::create_dir_all(root.path().join(".git/info")).unwrap();
+        std::fs::write(
+            root.path().join(".gitignore"),
+            "ignored/\n*.tmp\n!keep.tmp\nnested/*.log\n",
+        )
+        .unwrap();
+        std::fs::write(root.path().join("nested/.gitignore"), "!important.log\n").unwrap();
+        std::fs::write(root.path().join(".git/info/exclude"), "excluded.txt\n").unwrap();
+        std::fs::write(root.path().join("ignored/unseen.txt"), "unseen").unwrap();
+        std::fs::write(root.path().join("drop.tmp"), "drop").unwrap();
+        std::fs::write(root.path().join("keep.tmp"), "keep").unwrap();
+        std::fs::write(root.path().join("excluded.txt"), "excluded").unwrap();
+        std::fs::write(root.path().join("nested/drop.log"), "drop").unwrap();
+        std::fs::write(root.path().join("nested/important.log"), "keep").unwrap();
+        std::fs::write(root.path().join("nested/keep.txt"), "keep").unwrap();
+
+        let output = crate::run(args("**", None), &fs(root.path())).unwrap();
+
+        assert_eq!(
+            output.paths,
+            vec![
+                ".gitignore".to_owned(),
+                "keep.tmp".to_owned(),
+                "nested/.gitignore".to_owned(),
+                "nested/important.log".to_owned(),
+                "nested/keep.txt".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn ignored_directories_are_pruned_without_being_read() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("ignored")).unwrap();
+        std::fs::write(root.path().join(".gitignore"), "ignored/\n").unwrap();
+        std::fs::write(root.path().join("ignored/file.txt"), "hidden").unwrap();
+        let recording = RecordingFs {
+            inner: fs(root.path()),
+            read_dirs: std::cell::RefCell::new(Vec::new()),
+        };
+
+        crate::run(args("**", None), &recording).unwrap();
+
+        assert!(!recording
+            .read_dirs
+            .borrow()
+            .iter()
+            .any(|path| path.ends_with("ignored")));
+    }
+
+    #[test]
+    fn limit_caps_sorted_results_and_reports_a_partial_listing() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("c.txt"), "c").unwrap();
+        std::fs::write(root.path().join("a.txt"), "a").unwrap();
+        std::fs::write(root.path().join("b.txt"), "b").unwrap();
+
+        let output = crate::run(args("**", Some(2)), &fs(root.path())).unwrap();
+
+        assert_eq!(output.paths, vec!["a.txt".to_owned(), "b.txt".to_owned()]);
+        assert!(output.limit_reached);
+    }
+
+    #[test]
+    fn invalid_patterns_are_argument_errors() {
+        let root = tempfile::tempdir().unwrap();
+
+        let error = crate::run(args("[", None), &fs(root.path())).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .starts_with("invalid arguments: invalid glob pattern"));
+    }
+
+    struct RecordingFs {
+        inner: verlet_tool_core::StdFs,
+        read_dirs: std::cell::RefCell<Vec<std::path::PathBuf>>,
+    }
+
+    impl verlet_tool_core::ToolFs for RecordingFs {
+        fn read_file(
+            &self,
+            path: &std::path::Path,
+        ) -> Result<Vec<u8>, verlet_tool_core::ToolFsError> {
+            verlet_tool_core::ToolFs::read_file(&self.inner, path)
+        }
+
+        fn write_file(
+            &self,
+            path: &std::path::Path,
+            content: &[u8],
+        ) -> Result<(), verlet_tool_core::ToolFsError> {
+            verlet_tool_core::ToolFs::write_file(&self.inner, path, content)
+        }
+
+        fn mkdir(
+            &self,
+            path: &std::path::Path,
+            recursive: bool,
+        ) -> Result<(), verlet_tool_core::ToolFsError> {
+            verlet_tool_core::ToolFs::mkdir(&self.inner, path, recursive)
+        }
+
+        fn stat(
+            &self,
+            path: &std::path::Path,
+        ) -> Result<verlet_tool_core::FileStat, verlet_tool_core::ToolFsError> {
+            verlet_tool_core::ToolFs::stat(&self.inner, path)
+        }
+
+        fn read_dir(
+            &self,
+            path: &std::path::Path,
+        ) -> Result<Vec<verlet_tool_core::DirEntry>, verlet_tool_core::ToolFsError> {
+            self.read_dirs.borrow_mut().push(path.to_path_buf());
+            verlet_tool_core::ToolFs::read_dir(&self.inner, path)
+        }
+
+        fn exists(&self, path: &std::path::Path) -> Result<bool, verlet_tool_core::ToolFsError> {
+            verlet_tool_core::ToolFs::exists(&self.inner, path)
+        }
+    }
 }

--- a/agent-tools/tool-glob/src/lib.rs
+++ b/agent-tools/tool-glob/src/lib.rs
@@ -1,0 +1,67 @@
+//! `glob` — find files by glob pattern (Pi calls this `find`).
+//!
+//! Pi's version shells out to `fd`; ours walks through [`ToolFs`] with
+//! `globset` matching so every backend (native, vfs, wasm) traverses
+//! identically. Gitignore awareness comes from parsing `.gitignore`
+//! files with the `ignore` crate's buffer-based gitignore module during
+//! the walk — not from the `ignore` crate's walker, which is welded to
+//! `std::fs`.
+//!
+//! Pinned semantics:
+//! - Pattern syntax: `globset` defaults with `**` support, matched
+//!   against paths relative to the search root, `/`-separated.
+//! - Respects `.gitignore` (per directory, nested, plus root
+//!   `.git/info/exclude`); hidden files are included; `.git/` is always
+//!   skipped.
+//! - Results are root-relative `/`-separated paths, sorted
+//!   lexicographically (Pi sorts by mtime for interactive use; we pin
+//!   deterministic order instead — recorded deviation).
+//! - `limit` (default 1000) caps results; the result carries a
+//!   `limit_reached` flag so the model knows the listing is partial.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use verlet_tool_core::{EffectClass, ToolContract, ToolError, ToolFs};
+
+pub const DEFAULT_LIMIT: u64 = 1000;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct GlobArgs {
+    /// Glob pattern, e.g. `*.ts`, `**/*.json`, `src/**/*.spec.ts`.
+    pub pattern: String,
+    /// Directory to search in (default: workspace root).
+    pub path: Option<PathBuf>,
+    /// Maximum number of results (default 1000).
+    pub limit: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct GlobOutput {
+    /// Root-relative `/`-separated paths, sorted.
+    pub paths: Vec<String>,
+    pub limit_reached: bool,
+}
+
+pub fn contract() -> ToolContract {
+    ToolContract {
+        name: "glob",
+        description: "Search for files by glob pattern, e.g. '*.ts' or \
+                      '**/*.spec.ts'. Returns matching file paths relative to \
+                      the search directory, sorted. Respects .gitignore.",
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pattern": {"type": "string", "description": "Glob pattern to match files, e.g. '*.ts', '**/*.json', or 'src/**/*.spec.ts'"},
+                "path": {"type": "string", "description": "Directory to search in (default: current directory)"},
+                "limit": {"type": "number", "description": "Maximum number of results (default: 1000)"}
+            },
+            "required": ["pattern"]
+        }),
+        effect_class: EffectClass::Pure,
+    }
+}
+
+pub fn run(_args: GlobArgs, _fs: &dyn ToolFs) -> Result<GlobOutput, ToolError> {
+    todo!("EMO ticket: ToolFs walk + globset + gitignore per module docs")
+}

--- a/agent-tools/tool-glob/src/main.rs
+++ b/agent-tools/tool-glob/src/main.rs
@@ -1,0 +1,7 @@
+//! Standalone CLI: JSON args on stdin -> JSON result on stdout.
+//! Doubles as the executor-side implementation for remote serving.
+//! Input: {"root": "/abs/dir", "args": {...ReadArgs}}
+
+fn main() {
+    todo!("EMO ticket: stdin/stdout JSON harness over StdFs (shared shape across all five bins)")
+}

--- a/agent-tools/tool-glob/src/main.rs
+++ b/agent-tools/tool-glob/src/main.rs
@@ -1,7 +1,7 @@
 //! Standalone CLI: JSON args on stdin -> JSON result on stdout.
 //! Doubles as the executor-side implementation for remote serving.
-//! Input: {"root": "/abs/dir", "args": {...ReadArgs}}
+//! Input: {"root": "/abs/dir", "args": {...GlobArgs}}
 
-fn main() {
-    todo!("EMO ticket: stdin/stdout JSON harness over StdFs (shared shape across all five bins)")
+fn main() -> std::process::ExitCode {
+    verlet_tool_core::run_cli(verlet_tool_glob::run)
 }

--- a/agent-tools/tool-glob/tests/cli.rs
+++ b/agent-tools/tool-glob/tests/cli.rs
@@ -1,0 +1,35 @@
+#![cfg(feature = "cli")]
+
+#[test]
+fn cli_globs_from_its_confined_root() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::create_dir(root.path().join("nested")).unwrap();
+    std::fs::write(root.path().join("nested/file.txt"), "content").unwrap();
+    let input = serde_json::json!({
+        "root": root.path(),
+        "args": {"pattern": "**/*.txt"}
+    });
+
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_tool-glob"))
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    std::io::Write::write_all(
+        &mut child.stdin.take().unwrap(),
+        serde_json::to_string(&input).unwrap().as_bytes(),
+    )
+    .unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success(), "{:?}", output);
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap(),
+        serde_json::json!({
+            "ok": {
+                "paths": ["nested/file.txt"],
+                "limit_reached": false
+            }
+        })
+    );
+}

--- a/agent-tools/tool-grep/Cargo.toml
+++ b/agent-tools/tool-grep/Cargo.toml
@@ -7,6 +7,9 @@ description = "Content search tool on the ripgrep engine (model-facing `grep`)"
 
 [dependencies]
 verlet-tool-core = { path = "../tool-core" }
+globset = { workspace = true }
+grep-regex = { workspace = true }
+grep-searcher = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
@@ -18,3 +21,8 @@ cli = ["verlet-tool-core/std-fs"]
 name = "tool-grep"
 path = "src/main.rs"
 required-features = ["cli"]
+
+[dev-dependencies]
+tempfile = { workspace = true }
+verlet-tool-core = { path = "../tool-core", features = ["std-fs"] }
+verlet-tool-glob = { path = "../tool-glob" }

--- a/agent-tools/tool-grep/Cargo.toml
+++ b/agent-tools/tool-grep/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "verlet-tool-grep"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Content search tool on the ripgrep engine (model-facing `grep`)"
+
+[dependencies]
+verlet-tool-core = { path = "../tool-core" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[features]
+default = []
+cli = ["verlet-tool-core/std-fs"]
+
+[[bin]]
+name = "tool-grep"
+path = "src/main.rs"
+required-features = ["cli"]

--- a/agent-tools/tool-grep/src/lib.rs
+++ b/agent-tools/tool-grep/src/lib.rs
@@ -1,0 +1,85 @@
+//! `grep` — search file contents for a pattern.
+//!
+//! Pi's version spawns `rg --json` (auto-downloading ripgrep when
+//! missing). Ours runs ripgrep's engine in-process — the `grep-regex` and
+//! `grep-searcher` crates search over any reader — fed by the same
+//! `ToolFs` walk as `tool-glob`. No spawned binaries, no downloads, and
+//! the whole reason this exists as a function tool is preserved: the
+//! pattern arrives as a JSON string, no shell quoting, and the output is
+//! bounded `file:line` rows.
+//!
+//! Pinned semantics (mirroring Pi's flags):
+//! - Regex by default; `literal: true` = fixed-string. `ignore_case`
+//!   as named. Same walk rules as `tool-glob` (gitignore, hidden files
+//!   included, `.git/` skipped), with optional `glob` file filter.
+//! - Output rows: `path:line: text` with root-relative paths; `context`
+//!   adds N lines before/after with `path:line- text` separators, blocks
+//!   joined by `--` lines (rg's grouped format).
+//! - Match lines longer than 500 chars are clipped with `…`.
+//! - `limit` (default 100) caps match count; search stops early when
+//!   reached and the result carries `limit_reached`.
+//! - Binary files (NUL in first 8KB) are skipped.
+//! - Deterministic file order (same as glob's sort), so identical state
+//!   yields identical output on every backend.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use verlet_tool_core::{EffectClass, ToolContract, ToolError, ToolFs};
+
+pub const DEFAULT_LIMIT: u64 = 100;
+pub const MAX_LINE_CHARS: usize = 500;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct GrepArgs {
+    /// Search pattern (regex, or literal string with `literal: true`).
+    pub pattern: String,
+    /// Directory or file to search (default: workspace root).
+    pub path: Option<PathBuf>,
+    /// Filter files by glob pattern, e.g. `*.ts`.
+    pub glob: Option<String>,
+    #[serde(default)]
+    pub ignore_case: bool,
+    #[serde(default)]
+    pub literal: bool,
+    /// Lines of context before and after each match (default 0).
+    pub context: Option<u64>,
+    /// Maximum number of matches (default 100).
+    pub limit: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct GrepOutput {
+    /// Rendered match rows (`path:line: text`).
+    pub text: String,
+    pub match_count: u64,
+    pub limit_reached: bool,
+}
+
+pub fn contract() -> ToolContract {
+    ToolContract {
+        name: "grep",
+        description: "Search file contents for a pattern. Returns matching lines \
+                      with file paths and line numbers. Regex by default; set \
+                      literal for exact strings. Respects .gitignore. Stops at \
+                      the match limit and says so.",
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pattern": {"type": "string", "description": "Search pattern (regex or literal string)"},
+                "path": {"type": "string", "description": "Directory or file to search (default: current directory)"},
+                "glob": {"type": "string", "description": "Filter files by glob pattern, e.g. '*.ts' or '**/*.spec.ts'"},
+                "ignore_case": {"type": "boolean", "description": "Case-insensitive search (default: false)"},
+                "literal": {"type": "boolean", "description": "Treat pattern as literal string instead of regex (default: false)"},
+                "context": {"type": "number", "description": "Number of lines to show before and after each match (default: 0)"},
+                "limit": {"type": "number", "description": "Maximum number of matches to return (default: 100)"}
+            },
+            "required": ["pattern"]
+        }),
+        effect_class: EffectClass::Pure,
+    }
+}
+
+pub fn run(_args: GrepArgs, _fs: &dyn ToolFs) -> Result<GrepOutput, ToolError> {
+    todo!("EMO ticket: grep-searcher over ToolFs walk per module docs")
+}

--- a/agent-tools/tool-grep/src/lib.rs
+++ b/agent-tools/tool-grep/src/lib.rs
@@ -22,20 +22,16 @@
 //! - Deterministic file order (same as glob's sort), so identical state
 //!   yields identical output on every backend.
 
-use std::path::PathBuf;
-
-use serde::{Deserialize, Serialize};
-use verlet_tool_core::{EffectClass, ToolContract, ToolError, ToolFs};
-
 pub const DEFAULT_LIMIT: u64 = 100;
 pub const MAX_LINE_CHARS: usize = 500;
+const BINARY_SNIFF_BYTES: usize = 8 * 1024;
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, serde::Deserialize)]
 pub struct GrepArgs {
     /// Search pattern (regex, or literal string with `literal: true`).
     pub pattern: String,
     /// Directory or file to search (default: workspace root).
-    pub path: Option<PathBuf>,
+    pub path: Option<std::path::PathBuf>,
     /// Filter files by glob pattern, e.g. `*.ts`.
     pub glob: Option<String>,
     #[serde(default)]
@@ -48,7 +44,7 @@ pub struct GrepArgs {
     pub limit: Option<u64>,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
 pub struct GrepOutput {
     /// Rendered match rows (`path:line: text`).
     pub text: String,
@@ -56,8 +52,8 @@ pub struct GrepOutput {
     pub limit_reached: bool,
 }
 
-pub fn contract() -> ToolContract {
-    ToolContract {
+pub fn contract() -> verlet_tool_core::ToolContract {
+    verlet_tool_core::ToolContract {
         name: "grep",
         description: "Search file contents for a pattern. Returns matching lines \
                       with file paths and line numbers. Regex by default; set \
@@ -76,10 +72,480 @@ pub fn contract() -> ToolContract {
             },
             "required": ["pattern"]
         }),
-        effect_class: EffectClass::Pure,
+        effect_class: verlet_tool_core::EffectClass::Pure,
     }
 }
 
-pub fn run(_args: GrepArgs, _fs: &dyn ToolFs) -> Result<GrepOutput, ToolError> {
-    todo!("EMO ticket: grep-searcher over ToolFs walk per module docs")
+pub fn run(
+    args: GrepArgs,
+    fs: &dyn verlet_tool_core::ToolFs,
+) -> Result<GrepOutput, verlet_tool_core::ToolError> {
+    let limit = args.limit.unwrap_or(DEFAULT_LIMIT);
+    if limit == 0 {
+        return Err(verlet_tool_core::ToolError::InvalidArgs(
+            "limit must be at least 1".to_owned(),
+        ));
+    }
+
+    let mut matcher_builder = grep_regex::RegexMatcherBuilder::new();
+    matcher_builder
+        .case_insensitive(args.ignore_case)
+        .fixed_strings(args.literal);
+    let matcher = matcher_builder.build(&args.pattern).map_err(|error| {
+        verlet_tool_core::ToolError::InvalidArgs(format!(
+            "invalid search pattern {:?}: {error}",
+            args.pattern
+        ))
+    })?;
+    let glob_matcher = args
+        .glob
+        .as_deref()
+        .map(|pattern| {
+            globset::Glob::new(pattern)
+                .map(|glob| glob.compile_matcher())
+                .map_err(|error| {
+                    verlet_tool_core::ToolError::InvalidArgs(format!(
+                        "invalid glob pattern {pattern:?}: {error}"
+                    ))
+                })
+        })
+        .transpose()?;
+    let root = args.path.unwrap_or_else(|| std::path::PathBuf::from("."));
+    let files = verlet_tool_core::walk_files(&root, fs)?;
+    let context = usize::try_from(args.context.unwrap_or(0)).unwrap_or(usize::MAX);
+    let mut blocks = Vec::new();
+    let mut rows = Vec::new();
+    let mut match_count = 0_u64;
+    let mut limit_reached = false;
+
+    for file in files {
+        if glob_matcher
+            .as_ref()
+            .is_some_and(|glob| !glob.is_match(std::path::Path::new(&file.relative_path)))
+        {
+            continue;
+        }
+
+        let bytes = fs.read_file(&file.path)?;
+        if bytes.iter().take(BINARY_SNIFF_BYTES).any(|byte| *byte == 0) {
+            continue;
+        }
+
+        let remaining = limit.saturating_sub(match_count);
+        let mut searcher_builder = grep_searcher::SearcherBuilder::new();
+        searcher_builder
+            .line_number(true)
+            .bom_sniffing(false)
+            .max_matches(Some(remaining));
+        let mut searcher = searcher_builder.build();
+        let mut sink = MatchLineSink { lines: Vec::new() };
+        searcher
+            .search_slice(&matcher, &bytes, &mut sink)
+            .map_err(|error| {
+                verlet_tool_core::ToolError::Failed(format!(
+                    "failed to search {}: {error}",
+                    file.relative_path
+                ))
+            })?;
+
+        match_count =
+            match_count.saturating_add(u64::try_from(sink.lines.len()).unwrap_or(u64::MAX));
+        let lines = file_lines(&bytes);
+        if context == 0 {
+            for line_number in sink.lines {
+                rows.push(render_line(
+                    &file.relative_path,
+                    line_number,
+                    true,
+                    line_at(&lines, line_number),
+                ));
+            }
+        } else {
+            blocks.extend(render_context_blocks(
+                &file.relative_path,
+                &lines,
+                &sink.lines,
+                context,
+            ));
+        }
+
+        if match_count >= limit {
+            limit_reached = true;
+            break;
+        }
+    }
+
+    let text = if context == 0 {
+        rows.join("\n")
+    } else {
+        blocks
+            .into_iter()
+            .map(|block| block.join("\n"))
+            .collect::<Vec<_>>()
+            .join("\n--\n")
+    };
+    if text.len() > verlet_tool_core::MAX_RESULT_BYTES {
+        return Err(verlet_tool_core::ToolError::ResultTooLarge);
+    }
+
+    Ok(GrepOutput {
+        text,
+        match_count,
+        limit_reached,
+    })
+}
+
+struct MatchLineSink {
+    lines: Vec<u64>,
+}
+
+impl grep_searcher::Sink for MatchLineSink {
+    type Error = std::io::Error;
+
+    fn matched(
+        &mut self,
+        _searcher: &grep_searcher::Searcher,
+        matched: &grep_searcher::SinkMatch<'_>,
+    ) -> Result<bool, Self::Error> {
+        if let Some(line_number) = matched.line_number() {
+            self.lines.push(line_number);
+        }
+        Ok(true)
+    }
+}
+
+fn render_context_blocks(
+    path: &str,
+    lines: &[&[u8]],
+    matches: &[u64],
+    context: usize,
+) -> Vec<Vec<String>> {
+    if matches.is_empty() {
+        return Vec::new();
+    }
+    let line_count = u64::try_from(lines.len()).unwrap_or(u64::MAX);
+    let context = u64::try_from(context).unwrap_or(u64::MAX);
+    let mut ranges: Vec<(u64, u64)> = Vec::new();
+    for &line_number in matches {
+        let start = line_number.saturating_sub(context).max(1);
+        let end = line_number.saturating_add(context).min(line_count);
+        match ranges.last_mut() {
+            Some((_, previous_end)) if start <= previous_end.saturating_add(1) => {
+                *previous_end = (*previous_end).max(end);
+            }
+            _ => ranges.push((start, end)),
+        }
+    }
+
+    ranges
+        .into_iter()
+        .map(|(start, end)| {
+            (start..=end)
+                .map(|line_number| {
+                    render_line(
+                        path,
+                        line_number,
+                        matches.binary_search(&line_number).is_ok(),
+                        line_at(lines, line_number),
+                    )
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn render_line(path: &str, line_number: u64, is_match: bool, bytes: &[u8]) -> String {
+    let text = String::from_utf8_lossy(bytes);
+    let text = text.strip_suffix('\r').unwrap_or(&text);
+    let mut clipped = text.chars().take(MAX_LINE_CHARS).collect::<String>();
+    if text.chars().count() > MAX_LINE_CHARS {
+        clipped.push('…');
+    }
+    if is_match {
+        format!("{path}:{line_number}: {clipped}")
+    } else {
+        format!("{path}:{line_number}- {clipped}")
+    }
+}
+
+fn line_at<'a>(lines: &'a [&'a [u8]], line_number: u64) -> &'a [u8] {
+    let index = usize::try_from(line_number.saturating_sub(1)).unwrap_or(usize::MAX);
+    lines.get(index).copied().unwrap_or_default()
+}
+
+fn file_lines(bytes: &[u8]) -> Vec<&[u8]> {
+    let mut lines = bytes.split(|byte| *byte == b'\n').collect::<Vec<_>>();
+    if bytes.ends_with(b"\n") {
+        lines.pop();
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    fn args(pattern: &str) -> crate::GrepArgs {
+        crate::GrepArgs {
+            pattern: pattern.to_owned(),
+            path: None,
+            glob: None,
+            ignore_case: false,
+            literal: false,
+            context: None,
+            limit: None,
+        }
+    }
+
+    fn fs(root: &std::path::Path) -> verlet_tool_core::StdFs {
+        verlet_tool_core::StdFs::new(root).unwrap()
+    }
+
+    #[test]
+    fn renders_plain_rows_in_deterministic_file_order() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("b.txt"), "needle b\n").unwrap();
+        std::fs::write(root.path().join("a.txt"), "zero\nNeedle a\n").unwrap();
+        let mut search = args("needle");
+        search.ignore_case = true;
+
+        let output = crate::run(search, &fs(root.path())).unwrap();
+
+        assert_eq!(output.text, "a.txt:2: Needle a\nb.txt:1: needle b");
+        assert_eq!(output.match_count, 2);
+        assert!(!output.limit_reached);
+    }
+
+    #[test]
+    fn renders_grouped_context_blocks_with_separators() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(
+            root.path().join("file.txt"),
+            "before a\nhit one\nafter a\ngap one\ngap two\nbefore b\nhit two\nafter b\n",
+        )
+        .unwrap();
+        let mut search = args("hit");
+        search.context = Some(1);
+
+        let output = crate::run(search, &fs(root.path())).unwrap();
+
+        assert_eq!(
+            output.text,
+            "file.txt:1- before a\n\
+             file.txt:2: hit one\n\
+             file.txt:3- after a\n\
+             --\n\
+             file.txt:6- before b\n\
+             file.txt:7: hit two\n\
+             file.txt:8- after b"
+        );
+    }
+
+    #[test]
+    fn clips_long_rendered_lines_at_five_hundred_characters() {
+        let root = tempfile::tempdir().unwrap();
+        let line = format!("{}needle", "x".repeat(crate::MAX_LINE_CHARS));
+        std::fs::write(root.path().join("long.txt"), line).unwrap();
+
+        let output = crate::run(args("needle"), &fs(root.path())).unwrap();
+
+        assert_eq!(
+            output.text,
+            format!("long.txt:1: {}…", "x".repeat(crate::MAX_LINE_CHARS))
+        );
+    }
+
+    #[test]
+    fn literal_mode_matches_regex_metacharacters_exactly() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("literal.txt"), "value a+b [x] done\n").unwrap();
+        let mut search = args("a+b [x]");
+        search.literal = true;
+
+        let output = crate::run(search, &fs(root.path())).unwrap();
+
+        assert_eq!(output.text, "literal.txt:1: value a+b [x] done");
+        assert_eq!(output.match_count, 1);
+    }
+
+    #[test]
+    fn match_limit_stops_before_reading_the_next_file() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("a.txt"), "hit\n").unwrap();
+        std::fs::write(root.path().join("b.txt"), "hit\n").unwrap();
+        let recording = RecordingFs {
+            inner: fs(root.path()),
+            reads: std::cell::RefCell::new(Vec::new()),
+        };
+        let mut search = args("hit");
+        search.limit = Some(1);
+
+        let output = crate::run(search, &recording).unwrap();
+
+        assert_eq!(output.text, "a.txt:1: hit");
+        assert_eq!(output.match_count, 1);
+        assert!(output.limit_reached);
+        assert!(!recording
+            .reads
+            .borrow()
+            .iter()
+            .any(|path| path.ends_with("b.txt")));
+    }
+
+    #[test]
+    fn skips_binary_files_with_a_nul_in_the_first_eight_kibibytes() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("binary.dat"), b"hit\0more").unwrap();
+        std::fs::write(root.path().join("text.txt"), b"hit\n").unwrap();
+
+        let output = crate::run(args("hit"), &fs(root.path())).unwrap();
+
+        assert_eq!(output.text, "text.txt:1: hit");
+        assert_eq!(output.match_count, 1);
+    }
+
+    #[test]
+    fn a_nul_after_the_binary_sniff_window_does_not_skip_the_file() {
+        let root = tempfile::tempdir().unwrap();
+        let mut content = vec![b'x'; 8 * 1024];
+        content.extend_from_slice(b"\0hit\n");
+        std::fs::write(root.path().join("late-nul.dat"), content).unwrap();
+
+        let output = crate::run(args("hit"), &fs(root.path())).unwrap();
+
+        assert_eq!(
+            output.text,
+            "late-nul.dat:1: ".to_owned() + &"x".repeat(500) + "…"
+        );
+        assert_eq!(output.match_count, 1);
+    }
+
+    #[test]
+    fn optional_glob_filters_root_relative_file_paths() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("src")).unwrap();
+        std::fs::write(root.path().join("src/code.rs"), "hit\n").unwrap();
+        std::fs::write(root.path().join("src/code.txt"), "hit\n").unwrap();
+        let mut search = args("hit");
+        search.glob = Some("**/*.rs".to_owned());
+
+        let output = crate::run(search, &fs(root.path())).unwrap();
+
+        assert_eq!(output.text, "src/code.rs:1: hit");
+    }
+
+    #[test]
+    fn a_direct_file_search_uses_the_file_name_as_its_relative_path() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("one.txt"), "hit\n").unwrap();
+        let mut search = args("hit");
+        search.path = Some(std::path::PathBuf::from("one.txt"));
+
+        let output = crate::run(search, &fs(root.path())).unwrap();
+
+        assert_eq!(output.text, "one.txt:1: hit");
+    }
+
+    #[test]
+    fn invalid_regex_and_glob_patterns_are_argument_errors() {
+        let root = tempfile::tempdir().unwrap();
+        let regex_error = crate::run(args("["), &fs(root.path())).unwrap_err();
+        let mut invalid_glob = args("hit");
+        invalid_glob.glob = Some("[".to_owned());
+        let glob_error = crate::run(invalid_glob, &fs(root.path())).unwrap_err();
+
+        assert!(regex_error
+            .to_string()
+            .starts_with("invalid arguments: invalid search pattern"));
+        assert!(glob_error
+            .to_string()
+            .starts_with("invalid arguments: invalid glob pattern"));
+    }
+
+    #[test]
+    fn glob_and_grep_observe_the_same_shared_walk_file_set() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("nested")).unwrap();
+        std::fs::create_dir(root.path().join("ignored")).unwrap();
+        std::fs::create_dir(root.path().join(".git")).unwrap();
+        std::fs::write(root.path().join(".gitignore"), "# needle\nignored/\n").unwrap();
+        std::fs::write(
+            root.path().join("nested/.gitignore"),
+            "# needle\n*.skip\n!keep.skip\n",
+        )
+        .unwrap();
+        std::fs::write(root.path().join("visible.txt"), "needle\n").unwrap();
+        std::fs::write(root.path().join(".hidden"), "needle\n").unwrap();
+        std::fs::write(root.path().join("nested/visible.txt"), "needle\n").unwrap();
+        std::fs::write(root.path().join("nested/drop.skip"), "needle\n").unwrap();
+        std::fs::write(root.path().join("nested/keep.skip"), "needle\n").unwrap();
+        std::fs::write(root.path().join("ignored/unseen.txt"), "needle\n").unwrap();
+        std::fs::write(root.path().join(".git/unseen.txt"), "needle\n").unwrap();
+        let filesystem = fs(root.path());
+
+        let glob = verlet_tool_glob::run(
+            verlet_tool_glob::GlobArgs {
+                pattern: "**".to_owned(),
+                path: None,
+                limit: None,
+            },
+            &filesystem,
+        )
+        .unwrap();
+        let grep = crate::run(args("needle"), &filesystem).unwrap();
+        let grep_paths = grep
+            .text
+            .lines()
+            .map(|line| line.split(':').next().unwrap().to_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(glob.paths, grep_paths);
+    }
+
+    struct RecordingFs {
+        inner: verlet_tool_core::StdFs,
+        reads: std::cell::RefCell<Vec<std::path::PathBuf>>,
+    }
+
+    impl verlet_tool_core::ToolFs for RecordingFs {
+        fn read_file(
+            &self,
+            path: &std::path::Path,
+        ) -> Result<Vec<u8>, verlet_tool_core::ToolFsError> {
+            self.reads.borrow_mut().push(path.to_path_buf());
+            verlet_tool_core::ToolFs::read_file(&self.inner, path)
+        }
+
+        fn write_file(
+            &self,
+            path: &std::path::Path,
+            content: &[u8],
+        ) -> Result<(), verlet_tool_core::ToolFsError> {
+            verlet_tool_core::ToolFs::write_file(&self.inner, path, content)
+        }
+
+        fn mkdir(
+            &self,
+            path: &std::path::Path,
+            recursive: bool,
+        ) -> Result<(), verlet_tool_core::ToolFsError> {
+            verlet_tool_core::ToolFs::mkdir(&self.inner, path, recursive)
+        }
+
+        fn stat(
+            &self,
+            path: &std::path::Path,
+        ) -> Result<verlet_tool_core::FileStat, verlet_tool_core::ToolFsError> {
+            verlet_tool_core::ToolFs::stat(&self.inner, path)
+        }
+
+        fn read_dir(
+            &self,
+            path: &std::path::Path,
+        ) -> Result<Vec<verlet_tool_core::DirEntry>, verlet_tool_core::ToolFsError> {
+            verlet_tool_core::ToolFs::read_dir(&self.inner, path)
+        }
+
+        fn exists(&self, path: &std::path::Path) -> Result<bool, verlet_tool_core::ToolFsError> {
+            verlet_tool_core::ToolFs::exists(&self.inner, path)
+        }
+    }
 }

--- a/agent-tools/tool-grep/src/lib.rs
+++ b/agent-tools/tool-grep/src/lib.rs
@@ -419,6 +419,24 @@ mod tests {
     }
 
     #[test]
+    fn renders_non_utf8_match_lines_lossily_without_confusing_char_and_byte_caps() {
+        let root = tempfile::tempdir().unwrap();
+        let mut content = "🙂".repeat(crate::MAX_LINE_CHARS).into_bytes();
+        content.extend_from_slice(&[0xff]);
+        content.extend_from_slice(b"hit\n");
+        std::fs::write(root.path().join("invalid.txt"), content).unwrap();
+
+        let output = crate::run(args("hit"), &fs(root.path())).unwrap();
+
+        assert_eq!(
+            output.text,
+            format!("invalid.txt:1: {}…", "🙂".repeat(crate::MAX_LINE_CHARS))
+        );
+        assert!(output.text.len() > crate::MAX_LINE_CHARS);
+        assert!(output.text.len() < verlet_tool_core::MAX_RESULT_BYTES);
+    }
+
+    #[test]
     fn optional_glob_filters_root_relative_file_paths() {
         let root = tempfile::tempdir().unwrap();
         std::fs::create_dir(root.path().join("src")).unwrap();
@@ -458,6 +476,44 @@ mod tests {
         assert!(glob_error
             .to_string()
             .starts_with("invalid arguments: invalid glob pattern"));
+    }
+
+    #[test]
+    fn zero_limit_is_rejected_and_maximum_u64_bounds_are_safe() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "before\nhit\nafter\n").unwrap();
+
+        let mut zero_search = args("hit");
+        zero_search.limit = Some(0);
+        let zero = crate::run(zero_search, &fs(root.path())).unwrap_err();
+        let mut maximum_search = args("hit");
+        maximum_search.limit = Some(u64::MAX);
+        maximum_search.context = Some(u64::MAX);
+        let maximum = crate::run(maximum_search, &fs(root.path())).unwrap();
+
+        assert_eq!(
+            zero.to_string(),
+            "invalid arguments: limit must be at least 1"
+        );
+        assert_eq!(
+            maximum.text,
+            "file.txt:1- before\nfile.txt:2: hit\nfile.txt:3- after"
+        );
+        assert!(!maximum.limit_reached);
+    }
+
+    #[test]
+    fn multibyte_clipped_rows_still_obey_the_result_byte_cap() {
+        let root = tempfile::tempdir().unwrap();
+        let line = format!("{}hit\n", "🙂".repeat(crate::MAX_LINE_CHARS + 1));
+        let line_count = 2200;
+        std::fs::write(root.path().join("large.txt"), line.repeat(line_count)).unwrap();
+        let mut search = args("hit");
+        search.limit = Some(line_count as u64);
+
+        let error = crate::run(search, &fs(root.path())).unwrap_err();
+
+        assert!(matches!(error, verlet_tool_core::ToolError::ResultTooLarge));
     }
 
     #[test]

--- a/agent-tools/tool-grep/src/main.rs
+++ b/agent-tools/tool-grep/src/main.rs
@@ -1,0 +1,7 @@
+//! Standalone CLI: JSON args on stdin -> JSON result on stdout.
+//! Doubles as the executor-side implementation for remote serving.
+//! Input: {"root": "/abs/dir", "args": {...ReadArgs}}
+
+fn main() {
+    todo!("EMO ticket: stdin/stdout JSON harness over StdFs (shared shape across all five bins)")
+}

--- a/agent-tools/tool-grep/src/main.rs
+++ b/agent-tools/tool-grep/src/main.rs
@@ -1,7 +1,7 @@
 //! Standalone CLI: JSON args on stdin -> JSON result on stdout.
 //! Doubles as the executor-side implementation for remote serving.
-//! Input: {"root": "/abs/dir", "args": {...ReadArgs}}
+//! Input: {"root": "/abs/dir", "args": {...GrepArgs}}
 
-fn main() {
-    todo!("EMO ticket: stdin/stdout JSON harness over StdFs (shared shape across all five bins)")
+fn main() -> std::process::ExitCode {
+    verlet_tool_core::run_cli(verlet_tool_grep::run)
 }

--- a/agent-tools/tool-grep/tests/cli.rs
+++ b/agent-tools/tool-grep/tests/cli.rs
@@ -1,0 +1,35 @@
+#![cfg(feature = "cli")]
+
+#[test]
+fn cli_greps_from_its_confined_root() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::write(root.path().join("file.txt"), "first\nneedle\n").unwrap();
+    let input = serde_json::json!({
+        "root": root.path(),
+        "args": {"pattern": "needle"}
+    });
+
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_tool-grep"))
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    std::io::Write::write_all(
+        &mut child.stdin.take().unwrap(),
+        serde_json::to_string(&input).unwrap().as_bytes(),
+    )
+    .unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success(), "{:?}", output);
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap(),
+        serde_json::json!({
+            "ok": {
+                "text": "file.txt:2: needle",
+                "match_count": 1,
+                "limit_reached": false
+            }
+        })
+    );
+}

--- a/agent-tools/tool-read/Cargo.toml
+++ b/agent-tools/tool-read/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "verlet-tool-read"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Line-range file read tool (model-facing `read`)"
+
+[dependencies]
+verlet-tool-core = { path = "../tool-core" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[features]
+default = []
+cli = ["verlet-tool-core/std-fs"]
+
+[[bin]]
+name = "tool-read"
+path = "src/main.rs"
+required-features = ["cli"]

--- a/agent-tools/tool-read/Cargo.toml
+++ b/agent-tools/tool-read/Cargo.toml
@@ -18,3 +18,7 @@ cli = ["verlet-tool-core/std-fs"]
 name = "tool-read"
 path = "src/main.rs"
 required-features = ["cli"]
+
+[dev-dependencies]
+tempfile = "3"
+verlet-tool-core = { path = "../tool-core", features = ["std-fs"] }

--- a/agent-tools/tool-read/src/lib.rs
+++ b/agent-tools/tool-read/src/lib.rs
@@ -19,24 +19,23 @@
 //!   UTF-8 with lossy replacement for invalid bytes.
 //! - Trailer line `[lines {start}-{end} of {total}]` is appended after a
 //!   blank line whenever the returned range is not the whole file.
+//! - Line accounting follows Pi's newline split: an empty file is one empty
+//!   logical line, and a terminal newline creates a final empty line.
+//! - The result byte cap applies to the final rendered text, after lossy UTF-8
+//!   conversion and after adding any partial-range trailer.
 
-use std::path::PathBuf;
-
-use serde::{Deserialize, Serialize};
-use verlet_tool_core::{EffectClass, ToolContract, ToolError, ToolFs};
-
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, serde::Deserialize)]
 pub struct ReadArgs {
     /// Path to the file to read (relative to the workspace root or absolute
     /// within the granted scope).
-    pub path: PathBuf,
+    pub path: std::path::PathBuf,
     /// Line number to start reading from (1-indexed).
     pub offset: Option<u64>,
     /// Maximum number of lines to read.
     pub limit: Option<u64>,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
 pub struct ReadOutput {
     /// File content for the selected range, verbatim, plus the range
     /// trailer when partial.
@@ -49,8 +48,8 @@ pub struct ReadOutput {
     pub total_lines: u64,
 }
 
-pub fn contract() -> ToolContract {
-    ToolContract {
+pub fn contract() -> verlet_tool_core::ToolContract {
+    verlet_tool_core::ToolContract {
         name: "read",
         description: "Read the contents of a text file. Returns the file verbatim. \
                       For large files use offset (1-indexed start line) and limit \
@@ -65,10 +64,190 @@ pub fn contract() -> ToolContract {
             },
             "required": ["path"]
         }),
-        effect_class: EffectClass::Pure,
+        effect_class: verlet_tool_core::EffectClass::Pure,
     }
 }
 
-pub fn run(_args: ReadArgs, _fs: &dyn ToolFs) -> Result<ReadOutput, ToolError> {
-    todo!("EMO ticket: port Pi read semantics per module docs")
+pub fn run(
+    args: ReadArgs,
+    fs: &dyn verlet_tool_core::ToolFs,
+) -> Result<ReadOutput, verlet_tool_core::ToolError> {
+    let offset = args.offset.unwrap_or(1);
+    if offset == 0 {
+        return Err(verlet_tool_core::ToolError::InvalidArgs(
+            "offset must be at least 1".to_owned(),
+        ));
+    }
+    if args.limit == Some(0) {
+        return Err(verlet_tool_core::ToolError::InvalidArgs(
+            "limit must be at least 1".to_owned(),
+        ));
+    }
+
+    let bytes = fs.read_file(&args.path)?;
+    let content = String::from_utf8_lossy(&bytes);
+    let lines = content.split('\n').collect::<Vec<_>>();
+    let total_lines = u64::try_from(lines.len()).unwrap_or(u64::MAX);
+
+    if offset > total_lines {
+        return Err(offset_past_end(offset, total_lines));
+    }
+
+    let start_index = usize::try_from(offset - 1)
+        .map_err(|_| verlet_tool_core::ToolError::InvalidArgs("offset is too large".to_owned()))?;
+    let available = lines.len() - start_index;
+    let selected_count = match args.limit {
+        Some(limit) => usize::try_from(limit).unwrap_or(usize::MAX).min(available),
+        None => available,
+    };
+    let end_index = start_index + selected_count;
+    let mut text = lines[start_index..end_index].join("\n");
+    let end_line = u64::try_from(end_index).unwrap_or(u64::MAX);
+
+    if offset != 1 || end_line != total_lines {
+        if text.ends_with('\n') {
+            text.push('\n');
+        } else {
+            text.push_str("\n\n");
+        }
+        text.push_str(&format!("[lines {offset}-{end_line} of {total_lines}]"));
+    }
+    if text.len() > verlet_tool_core::MAX_RESULT_BYTES {
+        return Err(verlet_tool_core::ToolError::ResultTooLarge);
+    }
+
+    Ok(ReadOutput {
+        text,
+        start_line: offset,
+        end_line,
+        total_lines,
+    })
+}
+
+fn offset_past_end(offset: u64, total_lines: u64) -> verlet_tool_core::ToolError {
+    verlet_tool_core::ToolError::Failed(format!(
+        "offset {offset} is past end of file ({total_lines} total lines)"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    fn fs(root: &std::path::Path) -> verlet_tool_core::StdFs {
+        verlet_tool_core::StdFs::new(root).unwrap()
+    }
+
+    fn args(path: &str, offset: Option<u64>, limit: Option<u64>) -> crate::ReadArgs {
+        crate::ReadArgs {
+            path: std::path::PathBuf::from(path),
+            offset,
+            limit,
+        }
+    }
+
+    #[test]
+    fn reads_a_whole_file_verbatim() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "first\nsecond\n").unwrap();
+
+        let output = crate::run(args("file.txt", None, None), &fs(root.path())).unwrap();
+
+        assert_eq!(
+            output,
+            crate::ReadOutput {
+                text: "first\nsecond\n".to_owned(),
+                start_line: 1,
+                end_line: 3,
+                total_lines: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn reads_an_offset_and_limit_window_with_a_trailer() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "one\ntwo\nthree\nfour").unwrap();
+
+        let output = crate::run(args("file.txt", Some(2), Some(2)), &fs(root.path())).unwrap();
+
+        assert_eq!(
+            output,
+            crate::ReadOutput {
+                text: "two\nthree\n\n[lines 2-3 of 4]".to_owned(),
+                start_line: 2,
+                end_line: 3,
+                total_lines: 4,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_an_offset_past_the_end_and_names_the_total() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "one\ntwo").unwrap();
+
+        let error = crate::run(args("file.txt", Some(3), None), &fs(root.path())).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "offset 3 is past end of file (2 total lines)"
+        );
+    }
+
+    #[test]
+    fn reads_an_empty_file() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("empty.txt"), "").unwrap();
+
+        let output = crate::run(args("empty.txt", None, None), &fs(root.path())).unwrap();
+
+        assert_eq!(
+            output,
+            crate::ReadOutput {
+                text: String::new(),
+                start_line: 1,
+                end_line: 1,
+                total_lines: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_a_result_larger_than_the_cap() {
+        let root = tempfile::tempdir().unwrap();
+        let content = vec![b'x'; verlet_tool_core::MAX_RESULT_BYTES + 1];
+        std::fs::write(root.path().join("large.txt"), content).unwrap();
+
+        let error = crate::run(args("large.txt", None, None), &fs(root.path())).unwrap_err();
+
+        assert!(matches!(error, verlet_tool_core::ToolError::ResultTooLarge));
+    }
+
+    #[test]
+    fn replaces_invalid_utf8_lossily() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("invalid.txt"), [b'a', 0xff, b'\n']).unwrap();
+
+        let output = crate::run(args("invalid.txt", None, None), &fs(root.path())).unwrap();
+
+        assert_eq!(output.text, "a\u{fffd}\n");
+    }
+
+    #[test]
+    fn rejects_zero_offset_and_limit() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "content").unwrap();
+        let fs = fs(root.path());
+
+        let offset_error = crate::run(args("file.txt", Some(0), None), &fs).unwrap_err();
+        let limit_error = crate::run(args("file.txt", None, Some(0)), &fs).unwrap_err();
+
+        assert_eq!(
+            offset_error.to_string(),
+            "invalid arguments: offset must be at least 1"
+        );
+        assert_eq!(
+            limit_error.to_string(),
+            "invalid arguments: limit must be at least 1"
+        );
+    }
 }

--- a/agent-tools/tool-read/src/lib.rs
+++ b/agent-tools/tool-read/src/lib.rs
@@ -1,0 +1,74 @@
+//! `read` — line-range file access.
+//!
+//! Ported from Pi's read tool (`core/tools/read.ts`), slimmed per design:
+//!
+//! - **No image branch.** Image viewing is a separate optional package.
+//! - **No smart truncation messaging.** The lossless spill coupling owns
+//!   context protection. `read` keeps `offset`/`limit` because line
+//!   addressing is the primitive that makes spill files (and any large
+//!   file) walkable; the result reports the range returned and the total
+//!   line count so the model can continue on its own.
+//!
+//! Pinned semantics (implementation ticket must match, with fixtures):
+//! - `offset` is 1-indexed; `offset` past end of file is an error naming
+//!   the file's total line count.
+//! - No `limit` → to end of file, subject to `MAX_RESULT_BYTES` (error,
+//!   not silent truncation, when exceeded — the model narrows with
+//!   offset/limit).
+//! - Content is returned verbatim (no line numbering, no tab expansion);
+//!   UTF-8 with lossy replacement for invalid bytes.
+//! - Trailer line `[lines {start}-{end} of {total}]` is appended after a
+//!   blank line whenever the returned range is not the whole file.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use verlet_tool_core::{EffectClass, ToolContract, ToolError, ToolFs};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ReadArgs {
+    /// Path to the file to read (relative to the workspace root or absolute
+    /// within the granted scope).
+    pub path: PathBuf,
+    /// Line number to start reading from (1-indexed).
+    pub offset: Option<u64>,
+    /// Maximum number of lines to read.
+    pub limit: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct ReadOutput {
+    /// File content for the selected range, verbatim, plus the range
+    /// trailer when partial.
+    pub text: String,
+    /// 1-indexed first line returned.
+    pub start_line: u64,
+    /// 1-indexed last line returned.
+    pub end_line: u64,
+    /// Total lines in the file.
+    pub total_lines: u64,
+}
+
+pub fn contract() -> ToolContract {
+    ToolContract {
+        name: "read",
+        description: "Read the contents of a text file. Returns the file verbatim. \
+                      For large files use offset (1-indexed start line) and limit \
+                      (max lines) to read in ranges; the result reports which lines \
+                      of how many were returned.",
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "Path to the file to read (relative or absolute)"},
+                "offset": {"type": "number", "description": "Line number to start reading from (1-indexed)"},
+                "limit": {"type": "number", "description": "Maximum number of lines to read"}
+            },
+            "required": ["path"]
+        }),
+        effect_class: EffectClass::Pure,
+    }
+}
+
+pub fn run(_args: ReadArgs, _fs: &dyn ToolFs) -> Result<ReadOutput, ToolError> {
+    todo!("EMO ticket: port Pi read semantics per module docs")
+}

--- a/agent-tools/tool-read/src/lib.rs
+++ b/agent-tools/tool-read/src/lib.rs
@@ -84,6 +84,13 @@ pub fn run(
         ));
     }
 
+    let stat = fs.stat(&args.path)?;
+    if !stat.is_file {
+        return Err(verlet_tool_core::ToolError::Failed(format!(
+            "path {:?} is not a file",
+            args.path
+        )));
+    }
     let bytes = fs.read_file(&args.path)?;
     let content = String::from_utf8_lossy(&bytes);
     let lines = content.split('\n').collect::<Vec<_>>();
@@ -212,6 +219,15 @@ mod tests {
     }
 
     #[test]
+    fn rejects_a_directory_with_a_stable_error() {
+        let root = tempfile::tempdir().unwrap();
+
+        let error = crate::run(args(".", None, None), &fs(root.path())).unwrap_err();
+
+        assert_eq!(error.to_string(), "path \".\" is not a file");
+    }
+
+    #[test]
     fn rejects_a_result_larger_than_the_cap() {
         let root = tempfile::tempdir().unwrap();
         let content = vec![b'x'; verlet_tool_core::MAX_RESULT_BYTES + 1];
@@ -233,6 +249,18 @@ mod tests {
     }
 
     #[test]
+    fn applies_the_result_cap_after_lossy_utf8_expansion() {
+        let root = tempfile::tempdir().unwrap();
+        let bytes = vec![0xff; verlet_tool_core::MAX_RESULT_BYTES / 3 + 1];
+        assert!(bytes.len() < verlet_tool_core::MAX_RESULT_BYTES);
+        std::fs::write(root.path().join("invalid.txt"), bytes).unwrap();
+
+        let error = crate::run(args("invalid.txt", None, None), &fs(root.path())).unwrap_err();
+
+        assert!(matches!(error, verlet_tool_core::ToolError::ResultTooLarge));
+    }
+
+    #[test]
     fn rejects_zero_offset_and_limit() {
         let root = tempfile::tempdir().unwrap();
         std::fs::write(root.path().join("file.txt"), "content").unwrap();
@@ -248,6 +276,26 @@ mod tests {
         assert_eq!(
             limit_error.to_string(),
             "invalid arguments: limit must be at least 1"
+        );
+    }
+
+    #[test]
+    fn maximum_u64_limit_is_bounded_by_the_available_lines() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "one\ntwo").unwrap();
+
+        let output =
+            crate::run(args("file.txt", Some(1), Some(u64::MAX)), &fs(root.path())).unwrap();
+        let offset_error = crate::run(
+            args("file.txt", Some(u64::MAX), Some(u64::MAX)),
+            &fs(root.path()),
+        )
+        .unwrap_err();
+
+        assert_eq!(output.text, "one\ntwo");
+        assert_eq!(
+            offset_error.to_string(),
+            format!("offset {} is past end of file (2 total lines)", u64::MAX)
         );
     }
 }

--- a/agent-tools/tool-read/src/main.rs
+++ b/agent-tools/tool-read/src/main.rs
@@ -1,0 +1,7 @@
+//! Standalone CLI: JSON args on stdin -> JSON result on stdout.
+//! Doubles as the executor-side implementation for remote serving.
+//! Input: {"root": "/abs/dir", "args": {...ReadArgs}}
+
+fn main() {
+    todo!("EMO ticket: stdin/stdout JSON harness over StdFs (shared shape across all five bins)")
+}

--- a/agent-tools/tool-read/src/main.rs
+++ b/agent-tools/tool-read/src/main.rs
@@ -2,6 +2,6 @@
 //! Doubles as the executor-side implementation for remote serving.
 //! Input: {"root": "/abs/dir", "args": {...ReadArgs}}
 
-fn main() {
-    todo!("EMO ticket: stdin/stdout JSON harness over StdFs (shared shape across all five bins)")
+fn main() -> std::process::ExitCode {
+    verlet_tool_core::run_cli(verlet_tool_read::run)
 }

--- a/agent-tools/tool-read/tests/cli.rs
+++ b/agent-tools/tool-read/tests/cli.rs
@@ -1,0 +1,66 @@
+#![cfg(feature = "cli")]
+
+#[test]
+fn cli_reads_from_its_confined_root() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::write(root.path().join("file.txt"), "hello\nworld\n").unwrap();
+    let input = serde_json::json!({
+        "root": root.path(),
+        "args": {"path": "file.txt"}
+    });
+
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_tool-read"))
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    std::io::Write::write_all(
+        &mut child.stdin.take().unwrap(),
+        serde_json::to_string(&input).unwrap().as_bytes(),
+    )
+    .unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success(), "{:?}", output);
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap(),
+        serde_json::json!({
+            "ok": {
+                "text": "hello\nworld\n",
+                "start_line": 1,
+                "end_line": 3,
+                "total_lines": 3
+            }
+        })
+    );
+}
+
+#[test]
+fn cli_returns_json_and_exit_one_for_a_tool_error() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::write(root.path().join("file.txt"), "one line").unwrap();
+    let input = serde_json::json!({
+        "root": root.path(),
+        "args": {"path": "file.txt", "offset": 2}
+    });
+
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_tool-read"))
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    std::io::Write::write_all(
+        &mut child.stdin.take().unwrap(),
+        serde_json::to_string(&input).unwrap().as_bytes(),
+    )
+    .unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap(),
+        serde_json::json!({
+            "error": "offset 2 is past end of file (1 total lines)"
+        })
+    );
+}

--- a/agent-tools/tool-write/Cargo.toml
+++ b/agent-tools/tool-write/Cargo.toml
@@ -18,3 +18,7 @@ cli = ["verlet-tool-core/std-fs"]
 name = "tool-write"
 path = "src/main.rs"
 required-features = ["cli"]
+
+[dev-dependencies]
+tempfile = "3"
+verlet-tool-core = { path = "../tool-core", features = ["std-fs"] }

--- a/agent-tools/tool-write/Cargo.toml
+++ b/agent-tools/tool-write/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "verlet-tool-write"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "File creation tool with overwrite guard (model-facing `write`)"
+
+[dependencies]
+verlet-tool-core = { path = "../tool-core" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[features]
+default = []
+cli = ["verlet-tool-core/std-fs"]
+
+[[bin]]
+name = "tool-write"
+path = "src/main.rs"
+required-features = ["cli"]

--- a/agent-tools/tool-write/src/lib.rs
+++ b/agent-tools/tool-write/src/lib.rs
@@ -1,0 +1,65 @@
+//! `write` — create or overwrite a file, with an overwrite guard.
+//!
+//! Ported from Pi's write tool (`core/tools/write.ts`) with one deliberate
+//! deviation: Pi's write overwrites unconditionally; ours refuses to
+//! overwrite an existing file unless the model says so.
+//!
+//! Pinned semantics:
+//! - Parent directories are created as needed (`mkdir -p`).
+//! - If the target exists and `overwrite` is not `true`, the call fails
+//!   with an error stating the file exists, its size, and that the model
+//!   should read it first and pass `overwrite: true` to replace it. This
+//!   is the stateless half of clobber protection; the stateful half
+//!   ("was this path actually read this thread?") is a controller
+//!   coupling on the record, out of scope here.
+//! - Content is written exactly as given (no trailing-newline fixups).
+//! - Result reports bytes written and whether a file was created or
+//!   replaced.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use verlet_tool_core::{EffectClass, ToolContract, ToolError, ToolFs};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct WriteArgs {
+    /// Path of the file to write (relative to the workspace root or
+    /// absolute within the granted scope).
+    pub path: PathBuf,
+    /// Full file content.
+    pub content: String,
+    /// Must be `true` to replace an existing file. Default: false.
+    #[serde(default)]
+    pub overwrite: bool,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct WriteOutput {
+    pub bytes_written: u64,
+    /// True when an existing file was replaced (only possible with
+    /// `overwrite: true`).
+    pub replaced: bool,
+}
+
+pub fn contract() -> ToolContract {
+    ToolContract {
+        name: "write",
+        description: "Write content to a file, creating parent directories as \
+                      needed. Fails if the file already exists unless overwrite \
+                      is true; read the existing file before overwriting it.",
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "Path of the file to write (relative or absolute)"},
+                "content": {"type": "string", "description": "Full content to write"},
+                "overwrite": {"type": "boolean", "description": "Set true to replace an existing file (default false)"}
+            },
+            "required": ["path", "content"]
+        }),
+        effect_class: EffectClass::Idempotent,
+    }
+}
+
+pub fn run(_args: WriteArgs, _fs: &dyn ToolFs) -> Result<WriteOutput, ToolError> {
+    todo!("EMO ticket: implement per module docs")
+}

--- a/agent-tools/tool-write/src/lib.rs
+++ b/agent-tools/tool-write/src/lib.rs
@@ -16,16 +16,11 @@
 //! - Result reports bytes written and whether a file was created or
 //!   replaced.
 
-use std::path::PathBuf;
-
-use serde::{Deserialize, Serialize};
-use verlet_tool_core::{EffectClass, ToolContract, ToolError, ToolFs};
-
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, serde::Deserialize)]
 pub struct WriteArgs {
     /// Path of the file to write (relative to the workspace root or
     /// absolute within the granted scope).
-    pub path: PathBuf,
+    pub path: std::path::PathBuf,
     /// Full file content.
     pub content: String,
     /// Must be `true` to replace an existing file. Default: false.
@@ -33,7 +28,7 @@ pub struct WriteArgs {
     pub overwrite: bool,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
 pub struct WriteOutput {
     pub bytes_written: u64,
     /// True when an existing file was replaced (only possible with
@@ -41,8 +36,8 @@ pub struct WriteOutput {
     pub replaced: bool,
 }
 
-pub fn contract() -> ToolContract {
-    ToolContract {
+pub fn contract() -> verlet_tool_core::ToolContract {
+    verlet_tool_core::ToolContract {
         name: "write",
         description: "Write content to a file, creating parent directories as \
                       needed. Fails if the file already exists unless overwrite \
@@ -56,10 +51,115 @@ pub fn contract() -> ToolContract {
             },
             "required": ["path", "content"]
         }),
-        effect_class: EffectClass::Idempotent,
+        effect_class: verlet_tool_core::EffectClass::Idempotent,
     }
 }
 
-pub fn run(_args: WriteArgs, _fs: &dyn ToolFs) -> Result<WriteOutput, ToolError> {
-    todo!("EMO ticket: implement per module docs")
+pub fn run(
+    args: WriteArgs,
+    fs: &dyn verlet_tool_core::ToolFs,
+) -> Result<WriteOutput, verlet_tool_core::ToolError> {
+    let replaced = fs.exists(&args.path)?;
+    if replaced && !args.overwrite {
+        let stat = fs.stat(&args.path)?;
+        return Err(verlet_tool_core::ToolError::Failed(format!(
+            "file {} exists ({} bytes); read it first and pass overwrite: true to replace it",
+            args.path.display(),
+            stat.size
+        )));
+    }
+
+    if let Some(parent) = args.path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs.mkdir(parent, true)?;
+        }
+    }
+    fs.write_file(&args.path, args.content.as_bytes())?;
+
+    Ok(WriteOutput {
+        bytes_written: u64::try_from(args.content.len()).unwrap_or(u64::MAX),
+        replaced,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    fn fs(root: &std::path::Path) -> verlet_tool_core::StdFs {
+        verlet_tool_core::StdFs::new(root).unwrap()
+    }
+
+    fn args(path: &str, content: &str, overwrite: bool) -> crate::WriteArgs {
+        crate::WriteArgs {
+            path: std::path::PathBuf::from(path),
+            content: content.to_owned(),
+            overwrite,
+        }
+    }
+
+    #[test]
+    fn creates_a_file_and_nested_parents() {
+        let root = tempfile::tempdir().unwrap();
+
+        let output = crate::run(
+            args("nested/deeper/file.txt", "exact content", false),
+            &fs(root.path()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            output,
+            crate::WriteOutput {
+                bytes_written: 13,
+                replaced: false,
+            }
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("nested/deeper/file.txt")).unwrap(),
+            b"exact content"
+        );
+    }
+
+    #[test]
+    fn refuses_an_existing_file_without_overwrite() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "old").unwrap();
+
+        let error = crate::run(args("file.txt", "new", false), &fs(root.path())).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "file file.txt exists (3 bytes); read it first and pass overwrite: true to replace it"
+        );
+        assert_eq!(std::fs::read(root.path().join("file.txt")).unwrap(), b"old");
+    }
+
+    #[test]
+    fn replaces_an_existing_file_when_allowed() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "old").unwrap();
+
+        let output = crate::run(args("file.txt", "replacement", true), &fs(root.path())).unwrap();
+
+        assert_eq!(
+            output,
+            crate::WriteOutput {
+                bytes_written: 11,
+                replaced: true,
+            }
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("file.txt")).unwrap(),
+            b"replacement"
+        );
+    }
+
+    #[test]
+    fn reports_utf8_bytes_written() {
+        let root = tempfile::tempdir().unwrap();
+
+        let output = crate::run(args("unicode.txt", "é", false), &fs(root.path())).unwrap();
+
+        assert_eq!(output.bytes_written, 2);
+        assert!(!output.replaced);
+    }
 }

--- a/agent-tools/tool-write/src/lib.rs
+++ b/agent-tools/tool-write/src/lib.rs
@@ -60,13 +60,21 @@ pub fn run(
     fs: &dyn verlet_tool_core::ToolFs,
 ) -> Result<WriteOutput, verlet_tool_core::ToolError> {
     let replaced = fs.exists(&args.path)?;
-    if replaced && !args.overwrite {
+    if replaced {
         let stat = fs.stat(&args.path)?;
-        return Err(verlet_tool_core::ToolError::Failed(format!(
-            "file {} exists ({} bytes); read it first and pass overwrite: true to replace it",
-            args.path.display(),
-            stat.size
-        )));
+        if !stat.is_file {
+            return Err(verlet_tool_core::ToolError::Failed(format!(
+                "path {:?} is not a file",
+                args.path
+            )));
+        }
+        if !args.overwrite {
+            return Err(verlet_tool_core::ToolError::Failed(format!(
+                "file {} exists ({} bytes); read it first and pass overwrite: true to replace it",
+                args.path.display(),
+                stat.size
+            )));
+        }
     }
 
     if let Some(parent) = args.path.parent() {
@@ -161,5 +169,14 @@ mod tests {
 
         assert_eq!(output.bytes_written, 2);
         assert!(!output.replaced);
+    }
+
+    #[test]
+    fn rejects_a_directory_with_the_shared_file_error_shape() {
+        let root = tempfile::tempdir().unwrap();
+
+        let error = crate::run(args("", "content", false), &fs(root.path())).unwrap_err();
+
+        assert_eq!(error.to_string(), "path \"\" is not a file");
     }
 }

--- a/agent-tools/tool-write/src/main.rs
+++ b/agent-tools/tool-write/src/main.rs
@@ -1,7 +1,7 @@
 //! Standalone CLI: JSON args on stdin -> JSON result on stdout.
 //! Doubles as the executor-side implementation for remote serving.
-//! Input: {"root": "/abs/dir", "args": {...ReadArgs}}
+//! Input: {"root": "/abs/dir", "args": {...WriteArgs}}
 
-fn main() {
-    todo!("EMO ticket: stdin/stdout JSON harness over StdFs (shared shape across all five bins)")
+fn main() -> std::process::ExitCode {
+    verlet_tool_core::run_cli(verlet_tool_write::run)
 }

--- a/agent-tools/tool-write/src/main.rs
+++ b/agent-tools/tool-write/src/main.rs
@@ -1,0 +1,7 @@
+//! Standalone CLI: JSON args on stdin -> JSON result on stdout.
+//! Doubles as the executor-side implementation for remote serving.
+//! Input: {"root": "/abs/dir", "args": {...ReadArgs}}
+
+fn main() {
+    todo!("EMO ticket: stdin/stdout JSON harness over StdFs (shared shape across all five bins)")
+}

--- a/agent-tools/tool-write/tests/cli.rs
+++ b/agent-tools/tool-write/tests/cli.rs
@@ -1,0 +1,32 @@
+#![cfg(feature = "cli")]
+
+#[test]
+fn cli_writes_to_its_confined_root() {
+    let root = tempfile::tempdir().unwrap();
+    let input = serde_json::json!({
+        "root": root.path(),
+        "args": {"path": "nested/file.txt", "content": "exact content"}
+    });
+
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_tool-write"))
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    std::io::Write::write_all(
+        &mut child.stdin.take().unwrap(),
+        serde_json::to_string(&input).unwrap().as_bytes(),
+    )
+    .unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success(), "{:?}", output);
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap(),
+        serde_json::json!({"ok": {"bytes_written": 13, "replaced": false}})
+    );
+    assert_eq!(
+        std::fs::read(root.path().join("nested/file.txt")).unwrap(),
+        b"exact content"
+    );
+}


### PR DESCRIPTION
Standalone, wasm-compatible cores for the five model-facing file tools (EMO-597, EMO-598, EMO-599): read, write, edit, glob, grep, under `agent-tools/`.

Design points:

- All filesystem access goes through a minimal sync `ToolFs` trait in `verlet-tool-core`. Every tool core compiles on `wasm32-unknown-unknown`; the native `StdFs` backend (feature `std-fs`) confines paths to a configured root, resolving component by component so symlinks and `..` cannot escape.
- Tools assume a lossless spill coupling at the system level, so none of them carries its own truncation cleverness. A per-result byte cap (4MB) protects the record and the wire; `read` keeps offset/limit as the range primitive that walks large or spilled files.
- `write` refuses to overwrite an existing file unless asked, so a model cannot clobber content it never read.
- `edit` ports Pi's matching pipeline: exact match first, then a normalized match (NFKC, smart quotes, dashes, trailing whitespace) that still splices original bytes for untouched lines.
- `glob` and `grep` share one deterministic `ToolFs` walk (sorted, nested gitignore, `.git/` skipped, dangling symlinks skipped) and run globset and ripgrep's engine crates in-process. Output format matches rg's grouped context rendering.
- Each crate ships a stdin/stdout JSON CLI bin via a shared harness, usable directly as a remote-executor implementation later.

Every ticket ran the full loop: spec on Linear, implementation review, and a final write-capable review pass over the whole branch (commit `6c5bf7a`) that hardened path confinement and error shapes.

Verification: `scripts/verify.sh` and `scripts/verify-linux.sh` both green on the rebased branch; tool crates 67/67 under nextest all-features; wasm32 check clean for all five tool crates.
