### PR TITLE
Instrument Linux verify SIGKILL failures (EMO-595)

### DIFF
--- a/scripts/verify-linux-test.sh
+++ b/scripts/verify-linux-test.sh
@@ -189,6 +189,8 @@ case "${1:-}" in
     expect_arg -c "${1-}"
     shift
     (($# == 1)) || die 'container command must be one bash -c argument'
+    bash -n <<<"$1" \
+      || die 'container command is not syntactically valid Bash'
     [[ "$1" == *"trap 'exit 130' INT"* ]] \
       || die 'container command does not map Ctrl-C to status 130'
     [[ "$1" == *"trap 'exit 143' TERM"* ]] \
@@ -201,6 +203,30 @@ case "${1:-}" in
       || die 'container command does not settle platform-specific lane locks'
     [[ "$1" == *'bash scripts/verify.sh'* ]] \
       || die 'container command does not run the full verifier'
+    [[ "$1" == *'ps -eo pid,pgid,sid,stat,args'* ]] \
+      || die 'container command does not capture process snapshots'
+    [[ "$1" == *'>> "$snapshot_log"'* ]] \
+      || die 'process snapshots are not appended to the diagnostic log'
+    [[ "$1" == *'date -u +%Y-%m-%dT%H:%M:%SZ'* ]] \
+      || die 'process snapshots do not carry UTC timestamps'
+    [[ "$1" == *'snapshot_limit_bytes=$((20 * 1024 * 1024))'* ]] \
+      || die 'process snapshot log is not bounded to about 20 MB'
+    [[ "$1" == *'mktemp "$snapshot_log.trim.XXXXXX"'* ]] \
+      && [[ "$1" == *'rm -f "$snapshot_log".trim.* 2>/dev/null || true'* ]] \
+      || die 'snapshot trim files are not unique and cleaned across runs'
+    [[ "$1" == *"trap 'stop_snapshot_sleep; exit 0' HUP INT QUIT TERM"* ]] \
+      || die 'stopping the snapshot watcher can orphan its sleep process'
+    [[ "$1" == *'if ((verify_status == 137)); then'* ]] \
+      || die 'container command does not diagnose a killed verifier'
+    [[ "$1" == *"grep -n '^=== process snapshot ' \"\$snapshot_log\" 2>/dev/null | tail -n 3"* ]] \
+      || die 'killed verifier diagnostics do not select recent snapshots'
+    [[ "$1" == *'capture Docker Desktop VM dmesg before the VM restarts'* ]] \
+      || die 'killed verifier diagnostics omit the dmesg reminder'
+    [[ "$1" == *'print_process_snapshot_diagnostics >&2 || true'* ]] \
+      || die 'snapshot diagnostics can replace the verifier status on output failure'
+    [[ "$1" == *'if ((verify_status == 0)); then'* ]] \
+      && [[ "$1" == *'rm -f "$snapshot_log" || true'* ]] \
+      || die 'clean verification does not remove the snapshot log'
     [[ "$1" == *'exit "$verify_status"'* ]] \
       || die 'container command does not preserve the verifier status'
     exit "${FAKE_DOCKER_RUN_EXIT:-0}"
@@ -272,6 +298,17 @@ assert_file_contains "$TMP_DIR/main-dry.out" \
   'poisoned toolchain cache fails closed with the documented reset command'
 assert_file_contains "$TMP_DIR/main-dry.out" 'verify_status=' \
   'container shutdown preserves the verify status while locks settle'
+assert_file_contains "$TMP_DIR/main-dry.out" \
+  'ps -eo pid,pgid,sid,stat,args' \
+  'container bootstrap captures process identity snapshots'
+# This is a literal from the generated command.
+# shellcheck disable=SC2016
+assert_file_contains "$TMP_DIR/main-dry.out" \
+  'snapshot_limit_bytes=$((20 * 1024 * 1024))' \
+  'container bootstrap bounds the process snapshot log'
+assert_file_contains "$TMP_DIR/main-dry.out" \
+  'capture Docker Desktop VM dmesg before the VM restarts' \
+  'container bootstrap carries the host dmesg reminder'
 assert_file_contains "$TMP_DIR/main-dry.out" "trap \\'exit 130\\' INT" \
   'container bootstrap maps Ctrl-C to status 130 while blocked'
 assert_file_contains "$TMP_DIR/main-dry.out" "trap \\'exit 143\\' TERM" \

--- a/scripts/verify-linux.sh
+++ b/scripts/verify-linux.sh
@@ -148,9 +148,74 @@ else
   ln -s \"\$pinned_toolchain\" \"\$stable_toolchain\"
 fi
 rustup target list --installed --toolchain stable | grep -Fx wasm32-unknown-unknown >/dev/null
+snapshot_log=$CACHE_ROOT/verify-process-snapshots.log
+snapshot_limit_bytes=\$((20 * 1024 * 1024))
+cleanup_snapshot_trims() {
+  rm -f \"\$snapshot_log\".trim.* 2>/dev/null || true
+}
+capture_process_snapshot() {
+  {
+    printf '\\n=== process snapshot %s ===\\n' \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
+    ps -eo pid,pgid,sid,stat,args
+  } >> \"\$snapshot_log\" 2>/dev/null
+}
+bound_snapshot_log() {
+  snapshot_size=\$(stat -c %s \"\$snapshot_log\" 2>/dev/null) || return 0
+  if ((snapshot_size > snapshot_limit_bytes)); then
+    if snapshot_tmp=\$(mktemp \"\$snapshot_log.trim.XXXXXX\" 2>/dev/null); then
+      if tail -c \"\$snapshot_limit_bytes\" \"\$snapshot_log\" > \"\$snapshot_tmp\" 2>/dev/null; then
+        mv \"\$snapshot_tmp\" \"\$snapshot_log\" 2>/dev/null \
+          || rm -f \"\$snapshot_tmp\" 2>/dev/null \
+          || true
+      else
+        rm -f \"\$snapshot_tmp\" 2>/dev/null || true
+      fi
+    fi
+  fi
+}
+print_process_snapshot_diagnostics() {
+  printf '\\nverify shell exited 137; recent in-container process snapshots:\\n'
+  if [[ ! -s \"\$snapshot_log\" ]]; then
+    printf '(process snapshot log is missing or empty)\\n'
+  elif snapshot_tail_line=\$(grep -n '^=== process snapshot ' \"\$snapshot_log\" 2>/dev/null | tail -n 3 | head -n 1 | cut -d: -f1); then
+    tail -n \"+\$snapshot_tail_line\" \"\$snapshot_log\" 2>/dev/null \
+      || printf '(process snapshot log became unavailable while reading it)\\n'
+  else
+    tail -n 400 \"\$snapshot_log\" 2>/dev/null \
+      || printf '(process snapshot log became unavailable while reading it)\\n'
+  fi
+  printf 'process snapshot log: %s (Docker volume $VOLUME)\\n' \"\$snapshot_log\"
+  printf 'reminder: capture Docker Desktop VM dmesg before the VM restarts.\\n'
+}
+cleanup_snapshot_trims
+: > \"\$snapshot_log\" 2>/dev/null || true
+(
+  snapshot_sleep_pid=
+  stop_snapshot_sleep() {
+    if [[ -n \"\$snapshot_sleep_pid\" ]]; then
+      kill \"\$snapshot_sleep_pid\" 2>/dev/null || true
+      wait \"\$snapshot_sleep_pid\" 2>/dev/null || true
+    fi
+  }
+  trap 'stop_snapshot_sleep; exit 0' HUP INT QUIT TERM
+  while :; do
+    capture_process_snapshot || true
+    bound_snapshot_log || true
+    sleep 1 &
+    snapshot_sleep_pid=\$!
+    wait \"\$snapshot_sleep_pid\" || exit 0
+    snapshot_sleep_pid=
+  done
+) &
+snapshot_watcher_pid=\$!
 set +e
 bash scripts/verify.sh
 verify_status=\$?
+kill \"\$snapshot_watcher_pid\" 2>/dev/null || true
+wait \"\$snapshot_watcher_pid\" 2>/dev/null || true
+cleanup_snapshot_trims
+capture_process_snapshot || true
+bound_snapshot_log || true
 set -e
 for attempt in 1 2 3 4 5 6 7 8 9 10; do
   if ! compgen -G '$CARGO_LANE_ROOT/*.lock' >/dev/null; then
@@ -163,6 +228,13 @@ if compgen -G '$CARGO_LANE_ROOT/*.lock' >/dev/null; then
   if ((verify_status == 0)); then
     verify_status=1
   fi
+fi
+if ((verify_status == 137)); then
+  print_process_snapshot_diagnostics >&2 || true
+fi
+if ((verify_status == 0)); then
+  rm -f \"\$snapshot_log\" || true
+  cleanup_snapshot_trims
 fi
 exit \"\$verify_status\""
 


### PR DESCRIPTION
Builds the EMO-595 capture plan into the lane: an in-container watcher appends timestamped process-table snapshots every second to a bounded log on the shared volume; on verify exit 137 the bootstrap prints the last snapshots, the log path, and a dmesg reminder; clean runs remove the log. The lane test harness pins the behavior and bash -n validates the generated bootstrap.

Review pass fixed three issues pre-landing: exit-137 diagnostics could alter the exit status under set -e, trim temp files could collide or orphan, and the watcher left an unreaped sleep child.

Linear: https://linear.app/emotionscientific/issue/EMO-595