### PR TITLE
Retry socket-release assertions (EMO-600)

### DIFF
--- a/crates/verlet-kernel/src/cli/host/tests.rs
+++ b/crates/verlet-kernel/src/cli/host/tests.rs
@@ -729,8 +729,7 @@ async fn pending_config_failure_releases_reservations_before_listener_bind() {
         "{error}"
     );
 
-    let rebound = tokio::net::TcpListener::bind(addr).await.unwrap();
-    drop(rebound);
+    crate::support::address::assert_addr_released(addr).await;
     let (_, successor) = crate::cli::host::hosted_instance_config(&first).unwrap();
     drop(successor);
     std::fs::remove_dir_all(root).unwrap();

--- a/crates/verlet-kernel/tests/host_facade.rs
+++ b/crates/verlet-kernel/tests/host_facade.rs
@@ -261,8 +261,7 @@ provider = "local_offline"
         .unwrap();
     assert!(status.success(), "host process exited with {status}");
 
-    let rebound = tokio::net::TcpListener::bind(addr).await.unwrap();
-    drop(rebound);
+    support::address::assert_addr_released(addr).await;
     std::fs::remove_dir_all(root).unwrap();
 }
 
@@ -331,8 +330,7 @@ provider = "local_offline"
     assert!(!output.status.success(), "host boot unexpectedly succeeded");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(!stderr.contains("verlet host listening"), "{stderr}");
-    let rebound = tokio::net::TcpListener::bind(addr).await.unwrap();
-    drop(rebound);
+    support::address::assert_addr_released(addr).await;
     std::fs::remove_dir_all(root).unwrap();
 }
 

--- a/crates/verlet-kernel/tests/remote_store_sync.rs
+++ b/crates/verlet-kernel/tests/remote_store_sync.rs
@@ -7,6 +7,8 @@ use verlet::daemon::remote_store::lease::SyncCredentialAuthority as _;
 use verlet::daemon::remote_store::propagator::StreamPropagator as _;
 use verlet_history::EventStore as _;
 
+#[path = "support/address.rs"]
+mod address_test_support;
 #[path = "support/model_catalog.rs"]
 mod model_catalog_test_support;
 
@@ -717,8 +719,7 @@ async fn localhost_http_projection_preserves_wire_records_and_releases_tasks_and
 
     task.abort();
     assert!(task.await.unwrap_err().is_cancelled());
-    let rebound = tokio::net::TcpListener::bind(addr).await.unwrap();
-    drop(rebound);
+    address_test_support::assert_addr_released(addr).await;
 }
 
 #[cfg(unix)]

--- a/crates/verlet-kernel/tests/support/address.rs
+++ b/crates/verlet-kernel/tests/support/address.rs
@@ -1,0 +1,27 @@
+/// Asserts `addr` becomes bindable within a bounded window.
+///
+/// A freed socket binds on the first try; the window only absorbs an
+/// unrelated test briefly holding the port.
+pub(crate) async fn assert_addr_released(addr: std::net::SocketAddr) {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        match tokio::net::TcpListener::bind(addr).await {
+            Ok(listener) => {
+                drop(listener);
+                return;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {
+                let now = tokio::time::Instant::now();
+                if now >= deadline {
+                    panic!("address {addr} was not released within 10 seconds: {error}");
+                }
+                tokio::time::sleep(std::cmp::min(
+                    std::time::Duration::from_millis(100),
+                    deadline - now,
+                ))
+                .await;
+            }
+            Err(error) => panic!("failed to bind released address {addr}: {error}"),
+        }
+    }
+}

--- a/crates/verlet-kernel/tests/support/lib_mount.rs
+++ b/crates/verlet-kernel/tests/support/lib_mount.rs
@@ -11,6 +11,8 @@
 //! `scenario_unit_harness()` that returns `false`, so integration binaries skip
 //! the scenario bodies that need those seams.
 
+#[path = "address.rs"]
+pub(crate) mod address;
 #[path = "event_trace.rs"]
 pub(crate) mod event_trace;
 #[path = "fault.rs"]

--- a/crates/verlet-kernel/tests/support/test_mount.rs
+++ b/crates/verlet-kernel/tests/support/test_mount.rs
@@ -13,6 +13,8 @@
 
 #![allow(dead_code)]
 
+#[path = "address.rs"]
+pub(crate) mod address;
 #[path = "event_trace.rs"]
 pub(crate) mod event_trace;
 #[path = "fault.rs"]


### PR DESCRIPTION
Tests that prove a cancelled server released its TCP port used to rebind the port immediately, which races every other port-0 bind during a full-suite run (blocked the EMO-596 push twice). One shared helper, assert_addr_released, now retries only AddrInUse for up to 10 seconds; any other bind error and a port still held past the budget remain hard failures, so a real listener leak is still caught. All four sites converted; sweep found no other applicable sites.

Linear: https://linear.app/emotionscientific/issue/EMO-600