### PR TITLE
agent-tools: Pi behavior parity pass

### DIFF
--- a/agent-tools/README.md
+++ b/agent-tools/README.md
@@ -1,7 +1,8 @@
 # Agent tools
 
 Standalone implementations of the model-facing file tools: `read`, `write`,
-`edit`, `glob`, `grep`. Each crate compiles on its own and exports both the
+`edit`, `find`, `grep`. The `find` implementation remains in the
+`tool-glob` crate. Each crate compiles on its own and exports both the
 tool logic and its model-facing contract (name, description, JSON schema,
 effect class), so the surface the model sees ships with the implementation.
 
@@ -12,20 +13,40 @@ Rules for every crate in this folder:
   wasm ABI imports) are supplied by the embedder. This is what keeps the
   native-vs-wasm packaging decision open: the tool cores compile to
   `wasm32-unknown-unknown` unchanged.
-- **Assume the lossless spill coupling exists.** Tools do not implement
-  clever truncation or continuation messaging. Oversized output is the
-  system's job: the runtime spills the full payload and hands the model an
-  addressable reference. Tools enforce only a dumb per-result byte cap
-  (`tool_core::MAX_RESULT_BYTES`) to protect the record and the wire.
+- **Match Pi's addressable truncation.** `read` head-truncates at 2,000 lines
+  or 50 KiB; `grep` and `find` head-truncate at 50 KiB. Their exact notices
+  tell the model to continue with `offset`, raise the limit, or refine the
+  query. `tool_core::MAX_RESULT_BYTES` remains a 4 MiB record/wire backstop.
 - **Deterministic.** Same inputs + same filesystem state = same output,
   byte for byte, on every backend. No wall clock, no randomness, no
   environment reads.
 - **Contract next to code.** `contract()` in each crate is the single source
-  of the tool's name, description, and input schema. Manifests may attach a
-  tool under a different name (e.g. `glob` attached as `find` for Pi
-  parity), but the schema and semantics come from here.
+  of the tool's name, Pi-compatible description, and input schema. The
+  `tool-glob` crate's model-facing contract is named `find`.
 
 Semantics are ported from Pi (`reference/pi-mono`, coding-agent tools) with
 the deviations recorded in each crate's doc comments. The `bash` sixth tool
 is not here: vbash is its own subsystem. Image viewing is deliberately not
 part of `read`; it will be a separate optional package.
+
+Paths apply only Pi's authority-preserving normalization inside the granted
+root: one leading `@` is stripped and Unicode space variants become ASCII
+spaces. Tilde and file URLs that cannot resolve as literal paths inside the
+root are treated as not found; they never introduce ambient home or URL
+authority.
+
+## Designed divergences from Pi
+
+- **Confinement.** Every filesystem operation remains inside the explicit
+  `ToolFs` root, including after benign path normalization and symlink checks.
+- **Determinism.** Shared traversal and result order are lexicographically
+  deterministic instead of preserving `fd`/`rg` process order.
+- **In-process engines.** `globset`, `grep-regex`, and `grep-searcher` replace
+  spawned or downloaded `fd`/`rg` binaries.
+- **4 MiB backstop.** `MAX_RESULT_BYTES` still protects structured receipts,
+  edit details, the record, and the wire after Pi's smaller text truncators.
+- **Cancellation layer.** Cancellation is enforced by the Verlet runtime
+  boundary rather than synchronous tool-core arguments.
+- **Mutation-queue deferral.** Same-path write/edit serialization belongs to
+  the kernel invocation layer and is deferred until the wasm integration
+  stage.

--- a/agent-tools/tool-core/src/lib.rs
+++ b/agent-tools/tool-core/src/lib.rs
@@ -11,12 +11,170 @@
 //! The trait is synchronous on purpose: wasm guests block on host calls,
 //! and async hosts wrap tool runs in `spawn_blocking` at the boundary.
 
-/// Hard cap on a single tool result, in bytes. Protects the record and the
-/// wire, not the context window: context protection is the lossless spill
-/// coupling's job, which is assumed present system-wide. Tools that hit
-/// this cap return [`ToolError::ResultTooLarge`] rather than truncating
-/// silently.
+/// Hard backstop on a single structured tool result, in bytes. Pi-compatible
+/// read, grep, and find output is truncated at its smaller tool-specific
+/// limits first. This cap protects the record and wire from unexpectedly large
+/// receipts and edit details.
 pub const MAX_RESULT_BYTES: usize = 4 * 1024 * 1024;
+
+/// Pi's automatic head-truncation line limit.
+pub const DEFAULT_MAX_LINES: usize = 2000;
+
+/// Pi's automatic head-truncation byte limit (50 KiB).
+pub const DEFAULT_MAX_BYTES: usize = 50 * 1024;
+
+#[derive(Clone, Copy, Debug, serde::Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TruncatedBy {
+    Lines,
+    Bytes,
+}
+
+/// Structured receipt for Pi-compatible complete-line head truncation.
+#[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TruncationResult {
+    pub content: String,
+    pub truncated: bool,
+    pub truncated_by: Option<TruncatedBy>,
+    pub total_lines: usize,
+    pub total_bytes: usize,
+    pub output_lines: usize,
+    pub output_bytes: usize,
+    pub last_line_partial: bool,
+    pub first_line_exceeds_limit: bool,
+    pub max_lines: usize,
+    pub max_bytes: usize,
+}
+
+/// Port of Pi `core/tools/truncate.ts::truncateHead`.
+pub fn truncate_head(content: &str, max_lines: usize, max_bytes: usize) -> TruncationResult {
+    let total_bytes = content.len();
+    let mut lines = if content.is_empty() {
+        Vec::new()
+    } else {
+        content.split('\n').collect::<Vec<_>>()
+    };
+    if content.ends_with('\n') {
+        lines.pop();
+    }
+    let total_lines = lines.len();
+
+    if total_lines <= max_lines && total_bytes <= max_bytes {
+        return TruncationResult {
+            content: content.to_owned(),
+            truncated: false,
+            truncated_by: None,
+            total_lines,
+            total_bytes,
+            output_lines: total_lines,
+            output_bytes: total_bytes,
+            last_line_partial: false,
+            first_line_exceeds_limit: false,
+            max_lines,
+            max_bytes,
+        };
+    }
+
+    if lines
+        .first()
+        .is_some_and(|first_line| first_line.len() > max_bytes)
+    {
+        return TruncationResult {
+            content: String::new(),
+            truncated: true,
+            truncated_by: Some(TruncatedBy::Bytes),
+            total_lines,
+            total_bytes,
+            output_lines: 0,
+            output_bytes: 0,
+            last_line_partial: false,
+            first_line_exceeds_limit: true,
+            max_lines,
+            max_bytes,
+        };
+    }
+
+    let mut output_lines = Vec::new();
+    let mut output_bytes = 0_usize;
+    let mut truncated_by = TruncatedBy::Lines;
+    for (index, line) in lines.iter().take(max_lines).enumerate() {
+        let line_bytes = line.len().saturating_add(usize::from(index > 0));
+        if output_bytes.saturating_add(line_bytes) > max_bytes {
+            truncated_by = TruncatedBy::Bytes;
+            break;
+        }
+        output_lines.push(*line);
+        output_bytes = output_bytes.saturating_add(line_bytes);
+    }
+    if output_lines.len() >= max_lines && output_bytes <= max_bytes {
+        truncated_by = TruncatedBy::Lines;
+    }
+    let output = output_lines.join("\n");
+
+    TruncationResult {
+        output_bytes: output.len(),
+        content: output,
+        truncated: true,
+        truncated_by: Some(truncated_by),
+        total_lines,
+        total_bytes,
+        output_lines: output_lines.len(),
+        last_line_partial: false,
+        first_line_exceeds_limit: false,
+        max_lines,
+        max_bytes,
+    }
+}
+
+/// Format a byte count exactly like Pi's `formatSize` helper.
+pub fn format_size(bytes: usize) -> String {
+    if bytes < 1024 {
+        format!("{bytes}B")
+    } else if bytes < 1024 * 1024 {
+        format!("{:.1}KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{:.1}MB", bytes as f64 / (1024.0 * 1024.0))
+    }
+}
+
+/// JavaScript string length: UTF-16 code units, not UTF-8 bytes or Unicode
+/// scalar values.
+pub fn utf16_len(text: &str) -> usize {
+    text.encode_utf16().count()
+}
+
+/// Port of JavaScript `slice(0, maxUnits)` for model-facing text. A split
+/// surrogate is decoded lossily because Rust strings cannot contain an
+/// unpaired surrogate and UTF-8 encoders render one as U+FFFD.
+pub fn truncate_utf16(text: &str, max_units: usize) -> (String, bool) {
+    let units = text.encode_utf16().collect::<Vec<_>>();
+    if units.len() <= max_units {
+        return (text.to_owned(), false);
+    }
+    (String::from_utf16_lossy(&units[..max_units]), true)
+}
+
+/// Apply the authority-preserving subset of Pi's path normalization: strip one
+/// leading `@` and map Unicode space variants to ASCII space. Tilde and file
+/// URLs deliberately remain literal so normalization cannot introduce ambient
+/// host authority outside the confinement root.
+pub fn normalize_tool_path(path: &std::path::Path) -> std::path::PathBuf {
+    let Some(path) = path.to_str() else {
+        return path.to_path_buf();
+    };
+    let mut normalized = path
+        .chars()
+        .map(|character| match character {
+            '\u{00a0}' | '\u{2000}'..='\u{200a}' | '\u{202f}' | '\u{205f}' | '\u{3000}' => ' ',
+            character => character,
+        })
+        .collect::<String>();
+    if normalized.starts_with('@') {
+        normalized.remove(0);
+    }
+    std::path::PathBuf::from(normalized)
+}
 
 /// Minimal synchronous filesystem access for tool cores.
 ///
@@ -79,6 +237,7 @@ pub enum ToolError {
 pub struct WalkFile {
     pub path: std::path::PathBuf,
     pub relative_path: String,
+    pub is_dir: bool,
 }
 
 /// Walk a file or directory using only [`ToolFs`].
@@ -86,8 +245,9 @@ pub struct WalkFile {
 /// Directory walks include hidden files, skip every `.git` directory, apply
 /// root `.git/info/exclude` plus nested `.gitignore` files, prune ignored
 /// directories, skip listed entries that disappear before they can be
-/// resolved, and return files sorted by root-relative path. Stat errors other
-/// than [`ToolFsError::NotFound`] still fail the walk.
+/// resolved, and return files and directories sorted by root-relative path.
+/// Directory relative paths carry a trailing `/`. Stat errors other than
+/// [`ToolFsError::NotFound`] still fail the walk.
 pub fn walk_files(root: &std::path::Path, fs: &dyn ToolFs) -> Result<Vec<WalkFile>, ToolError> {
     let stat = fs.stat(root)?;
     if stat.is_file {
@@ -99,6 +259,7 @@ pub fn walk_files(root: &std::path::Path, fs: &dyn ToolFs) -> Result<Vec<WalkFil
         return Ok(vec![WalkFile {
             path: root.to_path_buf(),
             relative_path,
+            is_dir: false,
         }]);
     }
     if !stat.is_dir {
@@ -147,6 +308,11 @@ fn walk_directory(
                 continue;
             }
 
+            files.push(WalkFile {
+                path: path.clone(),
+                relative_path: format!("{}/", relative_path_string(&relative)),
+                is_dir: true,
+            });
             let matcher_count = ignore_matchers.len();
             add_ignore_file(fs, &path, &path.join(".gitignore"), ignore_matchers)?;
             walk_directory(fs, &path, &relative, ignore_matchers, files)?;
@@ -161,6 +327,7 @@ fn walk_directory(
                 files.push(WalkFile {
                     path,
                     relative_path: relative_path_string(&relative),
+                    is_dir: false,
                 });
             }
         }
@@ -597,7 +764,7 @@ mod tests {
                 .iter()
                 .map(|file| file.relative_path.as_str())
                 .collect::<Vec<_>>(),
-            vec![".gitignore", "dir", "nested/foo"]
+            vec![".gitignore", "dir", "nested/", "nested/foo"]
         );
     }
 
@@ -641,5 +808,31 @@ mod tests {
             error,
             crate::ToolError::Fs(crate::ToolFsError::Denied(_))
         ));
+    }
+
+    #[test]
+    fn pi_helpers_pin_truncation_utf16_and_path_normalization() {
+        // Pi source: core/tools/truncate.ts:47-160,264-275 and utils/paths.ts:7,75-99.
+        let truncated = crate::truncate_head("one\ntwo\nthree", 2, 50 * 1024);
+        assert_eq!(truncated.content, "one\ntwo");
+        assert_eq!(truncated.truncated_by, Some(crate::TruncatedBy::Lines));
+        assert_eq!(crate::format_size(50 * 1024), "50.0KB");
+        assert_eq!(crate::utf16_len("é🙂"), 3);
+        assert_eq!(
+            crate::truncate_utf16(&"🙂".repeat(251), 500),
+            ("🙂".repeat(250), true)
+        );
+        assert_eq!(
+            crate::normalize_tool_path(std::path::Path::new("@a\u{00a0}b\u{2000}c\u{3000}d")),
+            std::path::PathBuf::from("a b c d")
+        );
+        assert_eq!(
+            crate::normalize_tool_path(std::path::Path::new("~/literal")),
+            std::path::PathBuf::from("~/literal")
+        );
+        assert_eq!(
+            crate::normalize_tool_path(std::path::Path::new("file:///literal")),
+            std::path::PathBuf::from("file:///literal")
+        );
     }
 }

--- a/agent-tools/tool-core/src/lib.rs
+++ b/agent-tools/tool-core/src/lib.rs
@@ -639,6 +639,56 @@ where
     }
 }
 
+/// Run a native CLI with a tool-specific prepare/coerce/validate step.
+///
+/// Pi's edit tool prepares several legacy argument shapes before schema
+/// validation. Keeping this hook at the JSON boundary lets that tool return
+/// Pi's validation envelope without weakening the typed [`run_cli`] path used
+/// by the other tools.
+#[cfg(feature = "std-fs")]
+pub fn run_cli_with_parser<Args, Output>(
+    parse_args: fn(serde_json::Value) -> Result<Args, String>,
+    run: fn(Args, &dyn ToolFs) -> Result<Output, ToolError>,
+) -> std::process::ExitCode
+where
+    Output: serde::Serialize,
+{
+    #[derive(serde::Deserialize)]
+    struct CliInput {
+        root: std::path::PathBuf,
+        args: serde_json::Value,
+    }
+
+    let mut input = String::new();
+    if let Err(error) = std::io::Read::read_to_string(&mut std::io::stdin(), &mut input) {
+        return write_cli_error(format!("failed to read stdin: {error}"));
+    }
+    let input = match serde_json::from_str::<CliInput>(&input) {
+        Ok(input) => input,
+        Err(error) => return write_cli_error(format!("invalid input JSON: {error}")),
+    };
+    let args = match parse_args(input.args) {
+        Ok(args) => args,
+        Err(error) => return write_cli_error(error),
+    };
+    let fs = match StdFs::new(&input.root) {
+        Ok(fs) => fs,
+        Err(error) => return write_cli_error(error.to_string()),
+    };
+
+    match run(args, &fs) {
+        Ok(output) => match serde_json::to_value(output) {
+            Ok(output) => {
+                let mut result = serde_json::Map::new();
+                result.insert("ok".to_owned(), output);
+                write_cli_json(serde_json::Value::Object(result), true)
+            }
+            Err(error) => write_cli_error(format!("failed to serialize result: {error}")),
+        },
+        Err(error) => write_cli_error(error.to_string()),
+    }
+}
+
 #[cfg(feature = "std-fs")]
 fn write_cli_error(error: String) -> std::process::ExitCode {
     write_cli_json(serde_json::json!({"error": error}), false)
@@ -833,6 +883,77 @@ mod tests {
         assert_eq!(
             crate::normalize_tool_path(std::path::Path::new("file:///literal")),
             std::path::PathBuf::from("file:///literal")
+        );
+    }
+
+    #[test]
+    fn truncate_head_pins_exact_line_and_byte_boundaries() {
+        // Pi source: core/tools/truncate.ts:78-160.
+        let exactly_two_thousand = std::iter::repeat_n("x", crate::DEFAULT_MAX_LINES)
+            .collect::<Vec<_>>()
+            .join("\n");
+        let over_two_thousand = format!("{exactly_two_thousand}\nx");
+        let exact_line_boundary = crate::truncate_head(
+            &exactly_two_thousand,
+            crate::DEFAULT_MAX_LINES,
+            crate::DEFAULT_MAX_BYTES,
+        );
+        let over_line_boundary = crate::truncate_head(
+            &over_two_thousand,
+            crate::DEFAULT_MAX_LINES,
+            crate::DEFAULT_MAX_BYTES,
+        );
+
+        assert!(!exact_line_boundary.truncated);
+        assert!(over_line_boundary.truncated);
+        assert_eq!(
+            over_line_boundary.truncated_by,
+            Some(crate::TruncatedBy::Lines)
+        );
+        assert_eq!(over_line_boundary.output_lines, crate::DEFAULT_MAX_LINES);
+
+        let exactly_fifty_kib = "🙂".repeat(crate::DEFAULT_MAX_BYTES / 4);
+        let exact_byte_boundary = crate::truncate_head(
+            &exactly_fifty_kib,
+            crate::DEFAULT_MAX_LINES,
+            crate::DEFAULT_MAX_BYTES,
+        );
+        let complete_first_line = crate::truncate_head(
+            &format!("{exactly_fifty_kib}\nx"),
+            crate::DEFAULT_MAX_LINES,
+            crate::DEFAULT_MAX_BYTES,
+        );
+        let oversized_first_line = crate::truncate_head(
+            &format!("{exactly_fifty_kib}x\ny"),
+            crate::DEFAULT_MAX_LINES,
+            crate::DEFAULT_MAX_BYTES,
+        );
+
+        assert!(!exact_byte_boundary.truncated);
+        assert_eq!(exact_byte_boundary.output_bytes, crate::DEFAULT_MAX_BYTES);
+        assert!(complete_first_line.truncated);
+        assert_eq!(complete_first_line.content, exactly_fifty_kib);
+        assert_eq!(complete_first_line.output_lines, 1);
+        assert!(!complete_first_line.first_line_exceeds_limit);
+        assert!(oversized_first_line.truncated);
+        assert!(oversized_first_line.content.is_empty());
+        assert!(oversized_first_line.first_line_exceeds_limit);
+    }
+
+    #[test]
+    fn truncate_utf16_pins_surrogate_pair_boundaries() {
+        // JavaScript slice(0, 500) keeps a split high surrogate. Rust strings
+        // represent that unpaired surrogate as U+FFFD in model-facing UTF-8.
+        let exact_pair_boundary = format!("{}🙂tail", "x".repeat(498));
+        let split_pair_boundary = format!("{}🙂tail", "x".repeat(499));
+
+        assert_eq!(
+            crate::truncate_utf16(&exact_pair_boundary, 500),
+            (format!("{}🙂", "x".repeat(498)), true)
+        );
+        assert_eq!(
+            crate::truncate_utf16(&split_pair_boundary, 500),
+            (format!("{}\u{fffd}", "x".repeat(499)), true)
         );
     }
 }

--- a/agent-tools/tool-edit/src/lib.rs
+++ b/agent-tools/tool-edit/src/lib.rs
@@ -68,52 +68,102 @@ impl<'de> serde::Deserialize<'de> for EditArgs {
         D: serde::Deserializer<'de>,
     {
         let value = <serde_json::Value as serde::Deserialize>::deserialize(deserializer)?;
-        let mut object = value
-            .as_object()
-            .cloned()
-            .ok_or_else(|| serde::de::Error::custom("edit arguments must be an object"))?;
-        let path = object
-            .remove("path")
-            .ok_or_else(|| serde::de::Error::missing_field("path"))?;
-        let path = serde_json::from_value(path).map_err(serde::de::Error::custom)?;
+        parse_edit_args(value).map_err(serde::de::Error::custom)
+    }
+}
 
-        let legacy_edit = match (object.remove("oldText"), object.remove("newText")) {
-            (
-                Some(serde_json::Value::String(old_text)),
-                Some(serde_json::Value::String(new_text)),
-            ) => Some(Edit { old_text, new_text }),
-            _ => None,
-        };
-        let mut edits_value = object.remove("edits");
-        if let Some(serde_json::Value::String(encoded)) = edits_value.as_ref() {
-            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(encoded) {
-                if parsed.is_array() || is_single_edit_value(&parsed) {
-                    edits_value = Some(parsed);
-                }
+/// Pi-compatible prepare/coerce/validate parser for native and embedded JSON
+/// boundaries. Errors use Pi's validation envelope and validator messages.
+pub fn parse_cli_args(value: serde_json::Value) -> Result<EditArgs, String> {
+    parse_edit_args(value)
+}
+
+fn parse_edit_args(value: serde_json::Value) -> Result<EditArgs, String> {
+    let prepared = prepare_edit_arguments(value);
+    let mut converted = prepared.clone();
+    coerce_edit_arguments(&mut converted);
+    let validation_errors = validate_edit_arguments(&converted);
+    if !validation_errors.is_empty() {
+        let errors = validation_errors
+            .into_iter()
+            .map(|(path, message)| format!("  - {path}: {message}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let received = serde_json::to_string_pretty(&prepared)
+            .unwrap_or_else(|_| "<unserializable arguments>".to_owned());
+        return Err(format!(
+            "Validation failed for tool \"edit\":\n{errors}\n\nReceived arguments:\n{received}"
+        ));
+    }
+
+    let mut object = converted
+        .as_object()
+        .cloned()
+        .ok_or_else(|| "validated edit arguments were not an object".to_owned())?;
+    let path = object
+        .remove("path")
+        .and_then(|value| value.as_str().map(std::path::PathBuf::from))
+        .ok_or_else(|| "validated edit path was not a string".to_owned())?;
+    let edits = object
+        .remove("edits")
+        .and_then(|value| value.as_array().cloned())
+        .ok_or_else(|| "validated edits were not an array".to_owned())?
+        .into_iter()
+        .map(|value| {
+            let edit = value
+                .as_object()
+                .ok_or_else(|| "validated edit was not an object".to_owned())?;
+            let old_text = edit
+                .get("oldText")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| "validated oldText was not a string".to_owned())?;
+            let new_text = edit
+                .get("newText")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| "validated newText was not a string".to_owned())?;
+            Ok(Edit {
+                old_text: old_text.to_owned(),
+                new_text: new_text.to_owned(),
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    Ok(EditArgs { path, edits })
+}
+
+fn prepare_edit_arguments(mut value: serde_json::Value) -> serde_json::Value {
+    let Some(object) = value.as_object_mut() else {
+        return value;
+    };
+
+    if let Some(serde_json::Value::String(encoded)) = object.get("edits") {
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(encoded) {
+            if parsed.is_array() || is_single_edit_value(&parsed) {
+                object.insert("edits".to_owned(), parsed);
             }
         }
-        if edits_value.as_ref().is_some_and(is_single_edit_value) {
-            edits_value = Some(serde_json::Value::Array(vec![edits_value.unwrap()]));
+    } else if object.get("edits").is_some_and(is_single_edit_value) {
+        if let Some(edit) = object.remove("edits") {
+            object.insert("edits".to_owned(), serde_json::Value::Array(vec![edit]));
         }
-
-        let mut edits = match edits_value {
-            Some(value) => serde_json::from_value::<Vec<Edit>>(value)
-                .or_else(|error| {
-                    if legacy_edit.is_some() {
-                        Ok(Vec::new())
-                    } else {
-                        Err(error)
-                    }
-                })
-                .map_err(serde::de::Error::custom)?,
-            None => Vec::new(),
-        };
-        if let Some(edit) = legacy_edit {
-            edits.push(edit);
-        }
-
-        Ok(Self { path, edits })
     }
+
+    let legacy = match (object.get("oldText"), object.get("newText")) {
+        (Some(serde_json::Value::String(old_text)), Some(serde_json::Value::String(new_text))) => {
+            Some(serde_json::json!({"oldText": old_text, "newText": new_text}))
+        }
+        _ => None,
+    };
+    if let Some(legacy) = legacy {
+        let mut edits = object
+            .remove("edits")
+            .and_then(|value| value.as_array().cloned())
+            .unwrap_or_default();
+        edits.push(legacy);
+        object.remove("oldText");
+        object.remove("newText");
+        object.insert("edits".to_owned(), serde_json::Value::Array(edits));
+    }
+    value
 }
 
 fn is_single_edit_value(value: &serde_json::Value) -> bool {
@@ -124,6 +174,111 @@ fn is_single_edit_value(value: &serde_json::Value) -> bool {
                 .get("newText")
                 .is_some_and(serde_json::Value::is_string)
     })
+}
+
+fn coerce_edit_arguments(value: &mut serde_json::Value) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+    if let Some(path) = object.get_mut("path") {
+        coerce_string(path);
+    }
+    let Some(edits) = object.get_mut("edits") else {
+        return;
+    };
+    if !edits.is_array() {
+        let value = std::mem::take(edits);
+        *edits = serde_json::Value::Array(vec![value]);
+    }
+    let Some(edits) = edits.as_array_mut() else {
+        return;
+    };
+    for edit in edits {
+        let Some(edit) = edit.as_object_mut() else {
+            continue;
+        };
+        if let Some(old_text) = edit.get_mut("oldText") {
+            coerce_string(old_text);
+        }
+        if let Some(new_text) = edit.get_mut("newText") {
+            coerce_string(new_text);
+        }
+    }
+}
+
+fn coerce_string(value: &mut serde_json::Value) {
+    let converted = match value {
+        serde_json::Value::Null => Some("null".to_owned()),
+        serde_json::Value::Bool(value) => Some(value.to_string()),
+        serde_json::Value::Number(value) => value
+            .as_i64()
+            .map(|value| value.to_string())
+            .or_else(|| value.as_u64().map(|value| value.to_string()))
+            .or_else(|| value.as_f64().map(|value| value.to_string())),
+        serde_json::Value::String(_)
+        | serde_json::Value::Array(_)
+        | serde_json::Value::Object(_) => None,
+    };
+    if let Some(converted) = converted {
+        *value = serde_json::Value::String(converted);
+    }
+}
+
+fn validate_edit_arguments(value: &serde_json::Value) -> Vec<(String, String)> {
+    let Some(object) = value.as_object() else {
+        return vec![("root".to_owned(), "must be object".to_owned())];
+    };
+    let missing = ["path", "edits"]
+        .into_iter()
+        .filter(|property| !object.contains_key(*property))
+        .collect::<Vec<_>>();
+    let mut errors = Vec::new();
+    if let Some(first) = missing.first() {
+        errors.push((
+            (*first).to_owned(),
+            format!("must have required properties {}", missing.join(", ")),
+        ));
+    }
+    if object.get("path").is_some_and(|path| !path.is_string()) {
+        errors.push(("path".to_owned(), "must be string".to_owned()));
+    }
+    if let Some(serde_json::Value::Array(edits)) = object.get("edits") {
+        for (index, edit) in edits.iter().enumerate() {
+            let Some(edit) = edit.as_object() else {
+                errors.push((format!("edits.{index}"), "must be object".to_owned()));
+                continue;
+            };
+            let missing = ["oldText", "newText"]
+                .into_iter()
+                .filter(|property| !edit.contains_key(*property))
+                .collect::<Vec<_>>();
+            if let Some(first) = missing.first() {
+                errors.push((
+                    format!("edits.{index}.{first}"),
+                    format!("must have required properties {}", missing.join(", ")),
+                ));
+            }
+            if edit
+                .get("oldText")
+                .is_some_and(|old_text| !old_text.is_string())
+            {
+                errors.push((
+                    format!("edits.{index}.oldText"),
+                    "must be string".to_owned(),
+                ));
+            }
+            if edit
+                .get("newText")
+                .is_some_and(|new_text| !new_text.is_string())
+            {
+                errors.push((
+                    format!("edits.{index}.newText"),
+                    "must be string".to_owned(),
+                ));
+            }
+        }
+    }
+    errors
 }
 
 pub fn contract() -> verlet_tool_core::ToolContract {
@@ -1286,7 +1441,7 @@ mod tests {
     fn camel_case_schema_and_all_preparer_forms_match_pi() {
         // Pi behavior sheet item 15; source: core/tools/edit.ts:34-54,116-147.
         let root = tempfile::tempdir().unwrap();
-        std::fs::write(root.path().join("file.txt"), "one two three four").unwrap();
+        std::fs::write(root.path().join("file.txt"), "one two three four five").unwrap();
         let contract = crate::contract();
         assert!(
             contract.input_schema["properties"]["edits"]["items"]["properties"]
@@ -1333,6 +1488,11 @@ mod tests {
             "edits": "[{\"oldText\":\"two\",\"newText\":\"TWO\"}]"
         }))
         .unwrap();
+        let encoded_single: crate::EditArgs = serde_json::from_value(serde_json::json!({
+            "path": "file.txt",
+            "edits": "{\"oldText\":\"five\",\"newText\":\"FIVE\"}"
+        }))
+        .unwrap();
         let legacy: crate::EditArgs = serde_json::from_value(serde_json::json!({
             "path": "file.txt",
             "edits": [{"oldText": "three", "newText": "THREE"}],
@@ -1343,10 +1503,68 @@ mod tests {
 
         crate::run(single, &fs(root.path())).unwrap();
         crate::run(encoded, &fs(root.path())).unwrap();
+        crate::run(encoded_single, &fs(root.path())).unwrap();
         crate::run(legacy, &fs(root.path())).unwrap();
         assert_eq!(
             std::fs::read_to_string(root.path().join("file.txt")).unwrap(),
-            "ONE TWO THREE FOUR"
+            "ONE TWO THREE FOUR FIVE"
+        );
+    }
+
+    #[test]
+    fn preparer_coerces_values_before_validation_like_pi() {
+        // Pi source: agent validation.ts:317-349 and edit.ts:116-147.
+        let parsed = crate::parse_cli_args(serde_json::json!({
+            "path": 7,
+            "edits": [{"oldText": true, "newText": 2}]
+        }))
+        .unwrap();
+
+        assert_eq!(parsed.path, std::path::PathBuf::from("7"));
+        assert_eq!(parsed.edits.len(), 1);
+        assert_eq!(parsed.edits[0].old_text, "true");
+        assert_eq!(parsed.edits[0].new_text, "2");
+    }
+
+    #[test]
+    fn malformed_preparer_variants_return_pi_validation_envelopes() {
+        // Pi source: agent validation.ts:341-349 and edit.ts:116-147.
+        let malformed_string = crate::parse_cli_args(serde_json::json!({
+            "path": "file.txt",
+            "edits": "nope"
+        }))
+        .unwrap_err();
+        let partial_object = crate::parse_cli_args(serde_json::json!({
+            "path": "file.txt",
+            "edits": {"oldText": "old"}
+        }))
+        .unwrap_err();
+        let partial_legacy = crate::parse_cli_args(serde_json::json!({
+            "path": "file.txt",
+            "oldText": "old"
+        }))
+        .unwrap_err();
+        let malformed_encoded_array = crate::parse_cli_args(serde_json::json!({
+            "path": "file.txt",
+            "edits": "[{\"oldText\":\"old\"}]"
+        }))
+        .unwrap_err();
+
+        assert_eq!(
+            malformed_string,
+            "Validation failed for tool \"edit\":\n  - edits.0: must be object\n\nReceived arguments:\n{\n  \"edits\": \"nope\",\n  \"path\": \"file.txt\"\n}"
+        );
+        assert_eq!(
+            partial_object,
+            "Validation failed for tool \"edit\":\n  - edits.0.newText: must have required properties newText\n\nReceived arguments:\n{\n  \"edits\": {\n    \"oldText\": \"old\"\n  },\n  \"path\": \"file.txt\"\n}"
+        );
+        assert_eq!(
+            partial_legacy,
+            "Validation failed for tool \"edit\":\n  - edits: must have required properties edits\n\nReceived arguments:\n{\n  \"oldText\": \"old\",\n  \"path\": \"file.txt\"\n}"
+        );
+        assert_eq!(
+            malformed_encoded_array,
+            "Validation failed for tool \"edit\":\n  - edits.0.newText: must have required properties newText\n\nReceived arguments:\n{\n  \"edits\": [\n    {\n      \"oldText\": \"old\"\n    }\n  ],\n  \"path\": \"file.txt\"\n}"
         );
     }
 }

--- a/agent-tools/tool-edit/src/lib.rs
+++ b/agent-tools/tool-edit/src/lib.rs
@@ -7,21 +7,24 @@
 //! Pinned semantics:
 //! - `edits` apply as one atomic batch: all succeed or the file is
 //!   untouched.
-//! - Each `old_text` must match exactly once. Match strategy per Pi:
+//! - The public schema uses Pi's `oldText`/`newText` names and accepts Pi's
+//!   stringified, single-object, and legacy top-level preparer forms.
+//! - Each `oldText` must match exactly once. Match strategy per Pi:
 //!   exact match first, then a normalized pass (NFKC, smart quotes to
-//!   ASCII, en/em dashes to hyphens, trailing whitespace stripped per
-//!   line) that must still be unique.
+//!   ASCII, Pi's complete dash and special-space sets, trailing whitespace
+//!   stripped per line) that must still be unique.
 //! - Zero matches, multiple matches, or overlapping edit spans are
-//!   errors naming the offending `old_text` (first 100 chars).
-//! - `old_text == new_text` is an error ("no change").
-//! - Result returns a unified diff of the applied change; the model uses
-//!   it to confirm the edit landed where intended.
+//!   reported with Pi's exact singular/plural errors.
+//! - Model-facing text is Pi's success sentence; display diff and unified
+//!   patch are structured details.
 //! - Line endings: file's existing endings are preserved; `old_text`
 //!   matching normalizes CRLF to LF for comparison.
+//! - Invalid UTF-8 decodes lossily for matching; untouched lines are spliced
+//!   back from their original bytes.
 
 use unicode_normalization::UnicodeNormalization as _;
 
-#[derive(Clone, Debug, serde::Deserialize)]
+#[derive(Clone, Debug)]
 pub struct EditArgs {
     /// Path of the file to edit (relative to the workspace root or
     /// absolute within the granted scope).
@@ -31,6 +34,7 @@ pub struct EditArgs {
 }
 
 #[derive(Clone, Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Edit {
     /// Text to find. Must match exactly one location in the file.
     pub old_text: String,
@@ -40,34 +44,107 @@ pub struct Edit {
 
 #[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
 pub struct EditOutput {
-    /// Unified diff of the applied change.
-    pub diff: String,
+    /// Pi-compatible model-facing primary output.
+    pub text: String,
+    pub details: EditDetails,
     pub edits_applied: u32,
+}
+
+#[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct EditDetails {
+    /// Display-oriented diff with +/- markers and padded line numbers.
+    pub diff: String,
+    /// Standard unified patch.
+    pub patch: String,
+    /// First changed line in the new file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_changed_line: Option<u64>,
+}
+
+impl<'de> serde::Deserialize<'de> for EditArgs {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = <serde_json::Value as serde::Deserialize>::deserialize(deserializer)?;
+        let mut object = value
+            .as_object()
+            .cloned()
+            .ok_or_else(|| serde::de::Error::custom("edit arguments must be an object"))?;
+        let path = object
+            .remove("path")
+            .ok_or_else(|| serde::de::Error::missing_field("path"))?;
+        let path = serde_json::from_value(path).map_err(serde::de::Error::custom)?;
+
+        let legacy_edit = match (object.remove("oldText"), object.remove("newText")) {
+            (
+                Some(serde_json::Value::String(old_text)),
+                Some(serde_json::Value::String(new_text)),
+            ) => Some(Edit { old_text, new_text }),
+            _ => None,
+        };
+        let mut edits_value = object.remove("edits");
+        if let Some(serde_json::Value::String(encoded)) = edits_value.as_ref() {
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(encoded) {
+                if parsed.is_array() || is_single_edit_value(&parsed) {
+                    edits_value = Some(parsed);
+                }
+            }
+        }
+        if edits_value.as_ref().is_some_and(is_single_edit_value) {
+            edits_value = Some(serde_json::Value::Array(vec![edits_value.unwrap()]));
+        }
+
+        let mut edits = match edits_value {
+            Some(value) => serde_json::from_value::<Vec<Edit>>(value)
+                .or_else(|error| {
+                    if legacy_edit.is_some() {
+                        Ok(Vec::new())
+                    } else {
+                        Err(error)
+                    }
+                })
+                .map_err(serde::de::Error::custom)?,
+            None => Vec::new(),
+        };
+        if let Some(edit) = legacy_edit {
+            edits.push(edit);
+        }
+
+        Ok(Self { path, edits })
+    }
+}
+
+fn is_single_edit_value(value: &serde_json::Value) -> bool {
+    value.as_object().is_some_and(|edit| {
+        edit.get("oldText")
+            .is_some_and(serde_json::Value::is_string)
+            && edit
+                .get("newText")
+                .is_some_and(serde_json::Value::is_string)
+    })
 }
 
 pub fn contract() -> verlet_tool_core::ToolContract {
     verlet_tool_core::ToolContract {
         name: "edit",
-        description: "Edit a file by replacing exact text. Each old_text must \
-                      match exactly one location; all edits in one call apply \
-                      atomically. Returns a diff of the change. Read the file \
-                      first and copy old_text exactly, including whitespace.",
+        description: "Edit a single file using exact text replacement. Every edits[].oldText must match a unique, non-overlapping region of the original file. If two changes affect the same block or nearby lines, merge them into one edit instead of emitting overlapping edits. Do not include large unchanged regions just to connect distant changes.",
         input_schema: serde_json::json!({
             "type": "object",
             "properties": {
-                "path": {"type": "string", "description": "Path of the file to edit (relative or absolute)"},
+                "path": {"type": "string", "description": "Path to the file to edit (relative or absolute)"},
                 "edits": {
                     "type": "array",
-                    "description": "Replacements to apply atomically",
+                    "description": "One or more targeted replacements. Each edit is matched against the original file, not incrementally. Do not include overlapping or nested edits. If two changes touch the same block or nearby lines, merge them into one edit instead.",
                     "items": {
                         "type": "object",
                         "properties": {
-                            "old_text": {"type": "string", "description": "Text to find (must be unique in the file)"},
-                            "new_text": {"type": "string", "description": "Replacement text"}
+                            "oldText": {"type": "string", "description": "Exact text for one targeted replacement. It must be unique in the original file and must not overlap with any other edits[].oldText in the same call."},
+                            "newText": {"type": "string", "description": "Replacement text for this targeted edit."}
                         },
-                        "required": ["old_text", "new_text"]
-                    },
-                    "minItems": 1
+                        "required": ["oldText", "newText"]
+                    }
                 }
             },
             "required": ["path", "edits"]
@@ -81,55 +158,41 @@ pub fn run(
     fs: &dyn verlet_tool_core::ToolFs,
 ) -> Result<EditOutput, verlet_tool_core::ToolError> {
     if args.edits.is_empty() {
-        return Err(verlet_tool_core::ToolError::InvalidArgs(
-            "edits must contain at least one replacement".to_owned(),
+        return Err(verlet_tool_core::ToolError::Failed(
+            "Edit tool input is invalid. edits must contain at least one replacement.".to_owned(),
         ));
     }
 
     let edits = args
         .edits
         .iter()
-        .enumerate()
-        .map(|(index, edit)| {
-            if edit.old_text.is_empty() {
-                return Err(verlet_tool_core::ToolError::InvalidArgs(format!(
-                    "edits[{index}].old_text must not be empty"
-                )));
-            }
-            if edit.old_text == edit.new_text {
-                return Err(verlet_tool_core::ToolError::InvalidArgs(format!(
-                    "{} equals new_text; the edit would make no change",
-                    edit_label(index, &edit.old_text)
-                )));
-            }
-            Ok(NormalizedEdit {
-                old_text: normalize_to_lf(&edit.old_text),
-                new_text: normalize_to_lf(&edit.new_text),
-            })
+        .map(|edit| NormalizedEdit {
+            old_text: normalize_to_lf(&edit.old_text),
+            new_text: normalize_to_lf(&edit.new_text),
         })
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Vec<_>>();
+    let input_path = args.path;
+    let path_display = input_path.display().to_string();
+    let path = verlet_tool_core::normalize_tool_path(&input_path);
 
-    let stat = fs.stat(&args.path)?;
-    if !stat.is_file {
-        return Err(verlet_tool_core::ToolError::Failed(format!(
-            "path {:?} is not a file",
-            args.path
-        )));
+    if let Err(error) = fs.stat(&path) {
+        return Err(edit_access_error(&path_display, error));
     }
-    let bytes = fs.read_file(&args.path)?;
+    let bytes = fs.read_file(&path)?;
     let (bom, text_bytes) = if bytes.starts_with(&[0xef, 0xbb, 0xbf]) {
         (&bytes[..3], &bytes[3..])
     } else {
         (&bytes[..0], bytes.as_slice())
     };
-    let content = std::str::from_utf8(text_bytes).map_err(|error| {
-        verlet_tool_core::ToolError::Failed(format!(
-            "file {} is not valid UTF-8: {error}",
-            args.path.display()
-        ))
-    })?;
-    let line_ending = detect_line_ending(content);
-    let base_content = normalize_to_lf(content);
+    let content = String::from_utf8_lossy(text_bytes);
+    let line_ending = detect_line_ending(&content);
+    let base_content = normalize_to_lf(&content);
+
+    for (index, edit) in edits.iter().enumerate() {
+        if edit.old_text.is_empty() {
+            return Err(empty_old_text_error(&path_display, index, edits.len()));
+        }
+    }
 
     let uses_normalized_match = edits
         .iter()
@@ -144,20 +207,17 @@ pub fn run(
     for (index, edit) in edits.iter().enumerate() {
         let match_result = find_text(&replacement_base, &edit.old_text);
         if !match_result.found {
-            return Err(verlet_tool_core::ToolError::Failed(format!(
-                "{} was not found in {}",
-                edit_label(index, &args.edits[index].old_text),
-                args.path.display()
-            )));
+            return Err(not_found_error(&path_display, index, edits.len()));
         }
 
         let occurrences = count_occurrences(&replacement_base, &edit.old_text);
-        if occurrences != 1 {
-            return Err(verlet_tool_core::ToolError::Failed(format!(
-                "{} matched {occurrences} locations in {}; old_text must match exactly once",
-                edit_label(index, &args.edits[index].old_text),
-                args.path.display()
-            )));
+        if occurrences > 1 {
+            return Err(duplicate_error(
+                &path_display,
+                index,
+                edits.len(),
+                occurrences,
+            ));
         }
 
         matched_edits.push(MatchedEdit {
@@ -174,13 +234,10 @@ pub fn run(
         let current = &pair[1];
         if previous.match_index + previous.match_length > current.match_index {
             return Err(verlet_tool_core::ToolError::Failed(format!(
-                "{} overlaps {} in {}",
-                edit_label(
-                    previous.edit_index,
-                    &args.edits[previous.edit_index].old_text
-                ),
-                edit_label(current.edit_index, &args.edits[current.edit_index].old_text),
-                args.path.display()
+                "edits[{}] and edits[{}] overlap in {}. Merge them into one edit or target disjoint regions.",
+                previous.edit_index,
+                current.edit_index,
+                path_display,
             )));
         }
     }
@@ -195,32 +252,45 @@ pub fn run(
         apply_replacements(&replacement_base, &matched_edits, 0)
     };
     if new_content == base_content {
-        return Err(verlet_tool_core::ToolError::InvalidArgs(format!(
-            "{} produced no change",
-            edit_label(0, &args.edits[0].old_text)
-        )));
+        return Err(no_change_error(&path_display, edits.len()));
     }
 
-    let path = args.path.display().to_string();
     let text_diff = similar::TextDiff::from_lines(&base_content, &new_content);
-    let diff = text_diff
+    let patch = text_diff
         .unified_diff()
         .context_radius(4)
-        .header(&path, &path)
+        .header(&path_display, &path_display)
         .to_string();
-    if diff.len() > verlet_tool_core::MAX_RESULT_BYTES {
+    let (diff, first_changed_line) = generate_display_diff(&base_content, &new_content, 4);
+    let text = format!(
+        "Successfully replaced {} block(s) in {}.",
+        edits.len(),
+        path_display
+    );
+    if text
+        .len()
+        .saturating_add(diff.len())
+        .saturating_add(patch.len())
+        > verlet_tool_core::MAX_RESULT_BYTES
+    {
         return Err(verlet_tool_core::ToolError::ResultTooLarge);
     }
 
-    let restored_content = restore_line_endings(&new_content, line_ending);
-    let mut output_bytes = Vec::with_capacity(bom.len() + restored_content.len());
+    let edited_bytes =
+        splice_unchanged_original_lines(text_bytes, &base_content, &new_content, line_ending)?;
+    let mut output_bytes = Vec::with_capacity(bom.len() + edited_bytes.len());
     output_bytes.extend_from_slice(bom);
-    output_bytes.extend_from_slice(restored_content.as_bytes());
-    fs.write_file(&args.path, &output_bytes)?;
+    output_bytes.extend_from_slice(&edited_bytes);
+    fs.write_file(&path, &output_bytes)?;
 
     Ok(EditOutput {
-        diff,
-        edits_applied: u32::try_from(args.edits.len()).unwrap_or(u32::MAX),
+        text,
+        details: EditDetails {
+            diff,
+            patch,
+            first_changed_line,
+        },
+        edits_applied: u32::try_from(edits.len()).unwrap_or(u32::MAX),
     })
 }
 
@@ -262,9 +332,75 @@ struct ReplacementGroup {
     replacements: Vec<MatchedEdit>,
 }
 
-fn edit_label(index: usize, old_text: &str) -> String {
-    let preview = old_text.chars().take(100).collect::<String>();
-    format!("edits[{index}].old_text {preview:?}")
+fn edit_access_error(
+    path: &str,
+    error: verlet_tool_core::ToolFsError,
+) -> verlet_tool_core::ToolError {
+    let message = match error {
+        verlet_tool_core::ToolFsError::NotFound(_) => "Error code: ENOENT".to_owned(),
+        verlet_tool_core::ToolFsError::Denied(_) => "Error code: EACCES".to_owned(),
+        verlet_tool_core::ToolFsError::Io(message) => message,
+    };
+    verlet_tool_core::ToolError::Failed(format!("Could not edit file: {path}. {message}."))
+}
+
+fn not_found_error(
+    path: &str,
+    edit_index: usize,
+    total_edits: usize,
+) -> verlet_tool_core::ToolError {
+    if total_edits == 1 {
+        verlet_tool_core::ToolError::Failed(format!(
+            "Could not find the exact text in {path}. The old text must match exactly including all whitespace and newlines."
+        ))
+    } else {
+        verlet_tool_core::ToolError::Failed(format!(
+            "Could not find edits[{edit_index}] in {path}. The oldText must match exactly including all whitespace and newlines."
+        ))
+    }
+}
+
+fn duplicate_error(
+    path: &str,
+    edit_index: usize,
+    total_edits: usize,
+    occurrences: usize,
+) -> verlet_tool_core::ToolError {
+    if total_edits == 1 {
+        verlet_tool_core::ToolError::Failed(format!(
+            "Found {occurrences} occurrences of the text in {path}. The text must be unique. Please provide more context to make it unique."
+        ))
+    } else {
+        verlet_tool_core::ToolError::Failed(format!(
+            "Found {occurrences} occurrences of edits[{edit_index}] in {path}. Each oldText must be unique. Please provide more context to make it unique."
+        ))
+    }
+}
+
+fn empty_old_text_error(
+    path: &str,
+    edit_index: usize,
+    total_edits: usize,
+) -> verlet_tool_core::ToolError {
+    if total_edits == 1 {
+        verlet_tool_core::ToolError::Failed(format!("oldText must not be empty in {path}."))
+    } else {
+        verlet_tool_core::ToolError::Failed(format!(
+            "edits[{edit_index}].oldText must not be empty in {path}."
+        ))
+    }
+}
+
+fn no_change_error(path: &str, total_edits: usize) -> verlet_tool_core::ToolError {
+    if total_edits == 1 {
+        verlet_tool_core::ToolError::Failed(format!(
+            "No changes made to {path}. The replacement produced identical content. This might indicate an issue with special characters or the text not existing as expected."
+        ))
+    } else {
+        verlet_tool_core::ToolError::Failed(format!(
+            "No changes made to {path}. The replacements produced identical content."
+        ))
+    }
 }
 
 fn detect_line_ending(content: &str) -> LineEnding {
@@ -285,12 +421,174 @@ fn restore_line_endings(text: &str, ending: LineEnding) -> String {
     }
 }
 
+fn generate_display_diff(
+    old_content: &str,
+    new_content: &str,
+    context_lines: usize,
+) -> (String, Option<u64>) {
+    #[derive(Clone, Copy)]
+    enum RowKind {
+        Equal,
+        Delete,
+        Insert,
+    }
+
+    struct Row {
+        kind: RowKind,
+        line_number: usize,
+        text: String,
+    }
+
+    let line_number_width = old_content
+        .split('\n')
+        .count()
+        .max(new_content.split('\n').count())
+        .to_string()
+        .len();
+    let text_diff = similar::TextDiff::from_lines(old_content, new_content);
+    let mut old_line_number = 1_usize;
+    let mut new_line_number = 1_usize;
+    let mut first_changed_line = None;
+    let mut rows = Vec::new();
+
+    for change in text_diff.iter_all_changes() {
+        let text = change.value().strip_suffix('\n').unwrap_or(change.value());
+        match change.tag() {
+            similar::ChangeTag::Equal => {
+                rows.push(Row {
+                    kind: RowKind::Equal,
+                    line_number: old_line_number,
+                    text: text.to_owned(),
+                });
+                old_line_number = old_line_number.saturating_add(1);
+                new_line_number = new_line_number.saturating_add(1);
+            }
+            similar::ChangeTag::Delete => {
+                first_changed_line.get_or_insert(new_line_number);
+                rows.push(Row {
+                    kind: RowKind::Delete,
+                    line_number: old_line_number,
+                    text: text.to_owned(),
+                });
+                old_line_number = old_line_number.saturating_add(1);
+            }
+            similar::ChangeTag::Insert => {
+                first_changed_line.get_or_insert(new_line_number);
+                rows.push(Row {
+                    kind: RowKind::Insert,
+                    line_number: new_line_number,
+                    text: text.to_owned(),
+                });
+                new_line_number = new_line_number.saturating_add(1);
+            }
+        }
+    }
+
+    let mut visible = vec![false; rows.len()];
+    for (index, row) in rows.iter().enumerate() {
+        if !matches!(row.kind, RowKind::Equal) {
+            let start = index.saturating_sub(context_lines);
+            let end = index
+                .saturating_add(context_lines)
+                .min(rows.len().saturating_sub(1));
+            for item in &mut visible[start..=end] {
+                *item = true;
+            }
+        }
+    }
+
+    let gap = format!(" {} ...", " ".repeat(line_number_width));
+    let mut output = Vec::new();
+    let mut previous_visible = None;
+    for (index, row) in rows.iter().enumerate() {
+        if !visible[index] {
+            continue;
+        }
+        if previous_visible.map_or(index > 0, |previous| index > previous + 1) {
+            output.push(gap.clone());
+        }
+        let marker = match row.kind {
+            RowKind::Equal => ' ',
+            RowKind::Delete => '-',
+            RowKind::Insert => '+',
+        };
+        output.push(format!(
+            "{marker}{:>width$} {}",
+            row.line_number,
+            row.text,
+            width = line_number_width,
+        ));
+        previous_visible = Some(index);
+    }
+    if previous_visible.is_some_and(|previous| previous + 1 < rows.len()) {
+        output.push(gap);
+    }
+
+    (
+        output.join("\n"),
+        first_changed_line.map(|line| u64::try_from(line).unwrap_or(u64::MAX)),
+    )
+}
+
+fn split_byte_lines_with_endings(content: &[u8]) -> Vec<&[u8]> {
+    let mut lines = Vec::new();
+    let mut start = 0_usize;
+    for (index, byte) in content.iter().enumerate() {
+        if *byte == b'\n' {
+            lines.push(&content[start..=index]);
+            start = index.saturating_add(1);
+        }
+    }
+    if start < content.len() {
+        lines.push(&content[start..]);
+    }
+    lines
+}
+
+fn splice_unchanged_original_lines(
+    original_bytes: &[u8],
+    old_content: &str,
+    new_content: &str,
+    line_ending: LineEnding,
+) -> Result<Vec<u8>, verlet_tool_core::ToolError> {
+    let original_lines = split_byte_lines_with_endings(original_bytes);
+    let text_diff = similar::TextDiff::from_lines(old_content, new_content);
+    let mut old_line_index = 0_usize;
+    let mut output = Vec::new();
+
+    for change in text_diff.iter_all_changes() {
+        match change.tag() {
+            similar::ChangeTag::Equal => {
+                let line = original_lines.get(old_line_index).ok_or_else(|| {
+                    verlet_tool_core::ToolError::Failed(
+                        "Cannot preserve unchanged lines because the base content has a different line count."
+                            .to_owned(),
+                    )
+                })?;
+                output.extend_from_slice(line);
+                old_line_index = old_line_index.saturating_add(1);
+            }
+            similar::ChangeTag::Delete => {
+                old_line_index = old_line_index.saturating_add(1);
+            }
+            similar::ChangeTag::Insert => {
+                let restored = restore_line_endings(change.value(), line_ending);
+                output.extend_from_slice(restored.as_bytes());
+            }
+        }
+    }
+
+    Ok(output)
+}
+
 fn normalize_for_match(text: &str) -> String {
     text.nfkc()
         .map(|character| match character {
             '\u{2018}' | '\u{2019}' | '\u{201a}' | '\u{201b}' => '\'',
             '\u{201c}' | '\u{201d}' | '\u{201e}' | '\u{201f}' => '"',
-            '\u{2013}' | '\u{2014}' => '-',
+            '\u{2010}' | '\u{2011}' | '\u{2012}' | '\u{2013}' | '\u{2014}' | '\u{2015}'
+            | '\u{2212}' => '-',
+            '\u{00a0}' | '\u{2002}'..='\u{200a}' | '\u{202f}' | '\u{205f}' | '\u{3000}' => ' ',
             character => character,
         })
         .collect::<String>()
@@ -388,7 +686,7 @@ fn replacement_line_range(
         .position(|line| replacement_start >= line.start && replacement_start < line.end)
         .ok_or_else(|| {
             verlet_tool_core::ToolError::Failed(
-                "replacement range is outside the normalized file content".to_owned(),
+                "Replacement range is outside the base content.".to_owned(),
             )
         })?;
     let mut end_line = start_line;
@@ -397,7 +695,7 @@ fn replacement_line_range(
     }
     if end_line >= lines.len() {
         return Err(verlet_tool_core::ToolError::Failed(
-            "replacement range is outside the normalized file content".to_owned(),
+            "Replacement range is outside the base content.".to_owned(),
         ));
     }
     Ok((start_line, end_line + 1))
@@ -424,7 +722,8 @@ fn apply_replacements_preserving_unchanged_lines(
     let normalized_lines = line_spans(normalized_content);
     if original_lines.len() != normalized_lines.len() {
         return Err(verlet_tool_core::ToolError::Failed(
-            "normalized matching changed the file's line count".to_owned(),
+            "Cannot preserve unchanged lines because the base content has a different line count."
+                .to_owned(),
         ));
     }
 
@@ -492,13 +791,41 @@ mod tests {
             crate::run(args("file.txt", &[("world", "testing")]), &fs(root.path())).unwrap();
 
         assert_eq!(output.edits_applied, 1);
-        assert!(output.diff.starts_with("--- file.txt\n+++ file.txt\n@@"));
-        assert!(output.diff.contains("-Hello, world!"));
-        assert!(output.diff.contains("+Hello, testing!"));
+        assert_eq!(output.text, "Successfully replaced 1 block(s) in file.txt.");
+        assert_eq!(output.details.diff, "-1 Hello, world!\n+1 Hello, testing!");
+        assert!(output
+            .details
+            .patch
+            .starts_with("--- file.txt\n+++ file.txt\n@@"));
+        assert_eq!(output.details.first_changed_line, Some(1));
         assert_eq!(
             std::fs::read(root.path().join("file.txt")).unwrap(),
             b"Hello, testing!\n"
         );
+    }
+
+    #[test]
+    fn details_use_pi_display_diff_gap_and_four_line_context() {
+        // Pi behavior sheet item 21; source: core/tools/edit-diff.ts:364-499.
+        let root = tempfile::tempdir().unwrap();
+        let content = (1..=15)
+            .map(|line| format!("line {line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(root.path().join("file.txt"), content).unwrap();
+
+        let output = crate::run(
+            args("file.txt", &[("line 2", "LINE 2"), ("line 14", "LINE 14")]),
+            &fs(root.path()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            output.details.diff,
+            "  1 line 1\n- 2 line 2\n+ 2 LINE 2\n  3 line 3\n  4 line 4\n  5 line 5\n  6 line 6\n    ...\n 10 line 10\n 11 line 11\n 12 line 12\n 13 line 13\n-14 line 14\n+14 LINE 14\n 15 line 15"
+        );
+        assert_eq!(output.details.first_changed_line, Some(2));
+        assert!(output.details.patch.contains("@@ -1,6 +1,6 @@"));
     }
 
     #[test]
@@ -594,52 +921,87 @@ mod tests {
     }
 
     #[test]
-    fn invalid_utf8_and_empty_files_return_structured_errors() {
+    fn invalid_utf8_decodes_lossily_and_untouched_lines_remain_byte_exact() {
+        // Pi behavior sheet item 19; source: core/tools/edit.ts:358-370.
         let root = tempfile::tempdir().unwrap();
-        std::fs::write(root.path().join("invalid.txt"), [0xff]).unwrap();
+        std::fs::write(root.path().join("invalid.txt"), b"\xff\ntarget\n").unwrap();
         std::fs::write(root.path().join("empty.txt"), b"").unwrap();
         let fs = fs(root.path());
 
-        let invalid = crate::run(args("invalid.txt", &[("x", "y")]), &fs).unwrap_err();
+        crate::run(args("invalid.txt", &[("target", "done")]), &fs).unwrap();
         let empty = crate::run(args("empty.txt", &[("x", "y")]), &fs).unwrap_err();
 
-        assert!(invalid
-            .to_string()
-            .starts_with("file invalid.txt is not valid UTF-8:"));
+        assert_eq!(
+            std::fs::read(root.path().join("invalid.txt")).unwrap(),
+            b"\xff\ndone\n"
+        );
         assert_eq!(
             empty.to_string(),
-            "edits[0].old_text \"x\" was not found in empty.txt"
+            "Could not find the exact text in empty.txt. The old text must match exactly including all whitespace and newlines."
         );
     }
 
     #[test]
-    fn rejects_a_directory_with_the_shared_file_error_shape() {
+    fn access_and_directory_errors_follow_pi_compatibility_shape() {
+        // Pi behavior sheet item 20; source: core/tools/edit.ts:347-360.
         let root = tempfile::tempdir().unwrap();
 
-        let error = crate::run(args(".", &[("x", "y")]), &fs(root.path())).unwrap_err();
+        let missing = crate::run(args("missing.txt", &[("x", "y")]), &fs(root.path())).unwrap_err();
+        let directory = crate::run(args(".", &[("x", "y")]), &fs(root.path())).unwrap_err();
 
-        assert_eq!(error.to_string(), "path \".\" is not a file");
+        assert_eq!(
+            missing.to_string(),
+            "Could not edit file: missing.txt. Error code: ENOENT."
+        );
+        assert!(!directory.to_string().contains("is not a file"));
     }
 
     #[test]
-    fn replaces_normalized_en_and_em_dashes() {
+    fn replaces_pi_full_dash_and_special_space_normalization_sets() {
         // Pi source case: packages/coding-agent/test/tools.test.ts,
-        // "should match Unicode dashes to ASCII hyphen".
+        // "should match Unicode dashes to ASCII hyphen"; behavior sheet item 18,
+        // source: core/tools/edit-diff.ts:27-54.
         let root = tempfile::tempdir().unwrap();
-        std::fs::write(root.path().join("file.txt"), "range: 1–5\nbreak—here\n").unwrap();
+        let dashes = [
+            '\u{2010}', '\u{2011}', '\u{2012}', '\u{2013}', '\u{2014}', '\u{2015}', '\u{2212}',
+        ];
+        let spaces = [
+            '\u{00a0}', '\u{2002}', '\u{2003}', '\u{2004}', '\u{2005}', '\u{2006}', '\u{2007}',
+            '\u{2008}', '\u{2009}', '\u{200a}', '\u{202f}', '\u{205f}', '\u{3000}',
+        ];
+        let content = format!(
+            "{}\n{}\n",
+            dashes
+                .iter()
+                .map(|dash| format!("a{dash}b"))
+                .collect::<Vec<_>>()
+                .join(" "),
+            spaces
+                .iter()
+                .map(|space| format!("a{space}b"))
+                .collect::<Vec<_>>()
+                .join(" "),
+        );
+        let old_text = format!(
+            "{}\n{}",
+            std::iter::repeat_n("a-b", dashes.len())
+                .collect::<Vec<_>>()
+                .join(" "),
+            std::iter::repeat_n("a b", spaces.len())
+                .collect::<Vec<_>>()
+                .join(" "),
+        );
+        std::fs::write(root.path().join("file.txt"), content).unwrap();
 
         crate::run(
-            args(
-                "file.txt",
-                &[("range: 1-5\nbreak-here", "range: 10-50\nbreak--here")],
-            ),
+            args("file.txt", &[(&old_text, "normalized")]),
             &fs(root.path()),
         )
         .unwrap();
 
         assert_eq!(
             std::fs::read_to_string(root.path().join("file.txt")).unwrap(),
-            "range: 10-50\nbreak--here\n"
+            "normalized\n"
         );
     }
 
@@ -654,7 +1016,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "edits[0].old_text \"foo\" matched 3 locations in file.txt; old_text must match exactly once"
+            "Found 3 occurrences of the text in file.txt. The text must be unique. Please provide more context to make it unique."
         );
         assert_eq!(
             std::fs::read(root.path().join("file.txt")).unwrap(),
@@ -677,7 +1039,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "edits[0].old_text \"'hello'\" matched 2 locations in file.txt; old_text must match exactly once"
+            "Found 2 occurrences of the text in file.txt. The text must be unique. Please provide more context to make it unique."
         );
     }
 
@@ -696,7 +1058,44 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "edits[0].old_text \"nonexistent\" was not found in file.txt"
+            "Could not find the exact text in file.txt. The old text must match exactly including all whitespace and newlines."
+        );
+    }
+
+    #[test]
+    fn multi_edit_duplicate_empty_and_no_change_errors_are_exact() {
+        // Pi behavior sheet item 17; source: core/tools/edit-diff.ts:253-289,320-359.
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "foo foo\nbar\n").unwrap();
+        let filesystem = fs(root.path());
+
+        let duplicate = crate::run(
+            args("file.txt", &[("bar", "BAR"), ("foo", "FOO")]),
+            &filesystem,
+        )
+        .unwrap_err();
+        let empty = crate::run(
+            args("file.txt", &[("bar", "BAR"), ("", "empty")]),
+            &filesystem,
+        )
+        .unwrap_err();
+        let no_change = crate::run(
+            args("file.txt", &[("foo foo", "foo foo"), ("bar", "bar")]),
+            &filesystem,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            duplicate.to_string(),
+            "Found 2 occurrences of edits[1] in file.txt. Each oldText must be unique. Please provide more context to make it unique."
+        );
+        assert_eq!(
+            empty.to_string(),
+            "edits[1].oldText must not be empty in file.txt."
+        );
+        assert_eq!(
+            no_change.to_string(),
+            "No changes made to file.txt. The replacements produced identical content."
         );
     }
 
@@ -721,7 +1120,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "edits[0].old_text \"one\\ntwo\\n\" overlaps edits[1].old_text \"two\\nthree\\n\" in file.txt"
+            "edits[0] and edits[1] overlap in file.txt. Merge them into one edit or target disjoint regions."
         );
         assert_eq!(
             std::fs::read(root.path().join("file.txt")).unwrap(),
@@ -797,7 +1196,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(!output.diff.contains('\r'));
+        assert!(!output.details.diff.contains('\r'));
         assert_eq!(
             std::fs::read(root.path().join("file.txt")).unwrap(),
             b"\xef\xbb\xbffirst\r\nREPLACED\r\nthird\r\n"
@@ -823,7 +1222,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "edits[1].old_text \"missing\\n\" was not found in file.txt"
+            "Could not find edits[1] in file.txt. The oldText must match exactly including all whitespace and newlines."
         );
         assert_eq!(
             std::fs::read(root.path().join("file.txt")).unwrap(),
@@ -846,15 +1245,15 @@ mod tests {
 
         assert_eq!(
             empty_batch.to_string(),
-            "invalid arguments: edits must contain at least one replacement"
+            "Edit tool input is invalid. edits must contain at least one replacement."
         );
         assert_eq!(
             empty_old.to_string(),
-            "invalid arguments: edits[0].old_text must not be empty"
+            "oldText must not be empty in file.txt."
         );
         assert_eq!(
             no_op.to_string(),
-            "invalid arguments: edits[0].old_text \"content\" equals new_text; the edit would make no change"
+            "No changes made to file.txt. The replacement produced identical content. This might indicate an issue with special characters or the text not existing as expected."
         );
         assert_eq!(
             std::fs::read(root.path().join("file.txt")).unwrap(),
@@ -875,7 +1274,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "invalid arguments: edits[0].old_text \"'hello'\" produced no change"
+            "No changes made to file.txt. The replacement produced identical content. This might indicate an issue with special characters or the text not existing as expected."
         );
         assert_eq!(
             std::fs::read_to_string(root.path().join("file.txt")).unwrap(),
@@ -884,27 +1283,70 @@ mod tests {
     }
 
     #[test]
-    fn error_previews_truncate_old_text_to_100_unicode_characters() {
+    fn camel_case_schema_and_all_preparer_forms_match_pi() {
+        // Pi behavior sheet item 15; source: core/tools/edit.ts:34-54,116-147.
         let root = tempfile::tempdir().unwrap();
-        std::fs::write(root.path().join("file.txt"), "content").unwrap();
-        let preview = "é".repeat(100);
-        let old_text = format!("{preview}not shown");
-
-        let error = crate::run(
-            crate::EditArgs {
-                path: std::path::PathBuf::from("file.txt"),
-                edits: vec![crate::Edit {
-                    old_text,
-                    new_text: "replacement".to_owned(),
-                }],
-            },
-            &fs(root.path()),
-        )
-        .unwrap_err();
-
+        std::fs::write(root.path().join("file.txt"), "one two three four").unwrap();
+        let contract = crate::contract();
+        assert!(
+            contract.input_schema["properties"]["edits"]["items"]["properties"]
+                .get("oldText")
+                .is_some()
+        );
+        assert!(contract.input_schema["properties"]["edits"]
+            .get("minItems")
+            .is_none());
         assert_eq!(
-            error.to_string(),
-            format!("edits[0].old_text {preview:?} was not found in file.txt")
+            contract.description,
+            "Edit a single file using exact text replacement. Every edits[].oldText must match a unique, non-overlapping region of the original file. If two changes affect the same block or nearby lines, merge them into one edit instead of emitting overlapping edits. Do not include large unchanged regions just to connect distant changes."
+        );
+        assert_eq!(
+            contract.input_schema,
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Path to the file to edit (relative or absolute)"},
+                    "edits": {
+                        "type": "array",
+                        "description": "One or more targeted replacements. Each edit is matched against the original file, not incrementally. Do not include overlapping or nested edits. If two changes touch the same block or nearby lines, merge them into one edit instead.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "oldText": {"type": "string", "description": "Exact text for one targeted replacement. It must be unique in the original file and must not overlap with any other edits[].oldText in the same call."},
+                                "newText": {"type": "string", "description": "Replacement text for this targeted edit."}
+                            },
+                            "required": ["oldText", "newText"]
+                        }
+                    }
+                },
+                "required": ["path", "edits"]
+            })
+        );
+
+        let single: crate::EditArgs = serde_json::from_value(serde_json::json!({
+            "path": "file.txt",
+            "edits": {"oldText": "one", "newText": "ONE"}
+        }))
+        .unwrap();
+        let encoded: crate::EditArgs = serde_json::from_value(serde_json::json!({
+            "path": "file.txt",
+            "edits": "[{\"oldText\":\"two\",\"newText\":\"TWO\"}]"
+        }))
+        .unwrap();
+        let legacy: crate::EditArgs = serde_json::from_value(serde_json::json!({
+            "path": "file.txt",
+            "edits": [{"oldText": "three", "newText": "THREE"}],
+            "oldText": "four",
+            "newText": "FOUR"
+        }))
+        .unwrap();
+
+        crate::run(single, &fs(root.path())).unwrap();
+        crate::run(encoded, &fs(root.path())).unwrap();
+        crate::run(legacy, &fs(root.path())).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("file.txt")).unwrap(),
+            "ONE TWO THREE FOUR"
         );
     }
 }

--- a/agent-tools/tool-edit/src/main.rs
+++ b/agent-tools/tool-edit/src/main.rs
@@ -3,5 +3,5 @@
 //! Input: {"root": "/abs/dir", "args": {...EditArgs}}
 
 fn main() -> std::process::ExitCode {
-    verlet_tool_core::run_cli(verlet_tool_edit::run)
+    verlet_tool_core::run_cli_with_parser(verlet_tool_edit::parse_cli_args, verlet_tool_edit::run)
 }

--- a/agent-tools/tool-edit/tests/cli.rs
+++ b/agent-tools/tool-edit/tests/cli.rs
@@ -8,7 +8,7 @@ fn cli_edits_a_file_within_its_confined_root() {
         "root": root.path(),
         "args": {
             "path": "file.txt",
-            "edits": [{"old_text": "world", "new_text": "there"}]
+            "edits": [{"oldText": "world", "newText": "there"}]
         }
     });
 
@@ -27,7 +27,14 @@ fn cli_edits_a_file_within_its_confined_root() {
     assert!(output.status.success(), "{output:?}");
     let value = serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
     assert_eq!(value["ok"]["edits_applied"], 1);
-    assert!(value["ok"]["diff"].as_str().unwrap().contains("+there"));
+    assert_eq!(
+        value["ok"]["text"],
+        "Successfully replaced 1 block(s) in file.txt."
+    );
+    assert!(value["ok"]["details"]["diff"]
+        .as_str()
+        .unwrap()
+        .contains("+2 there"));
     assert_eq!(
         std::fs::read_to_string(root.path().join("file.txt")).unwrap(),
         "hello\nthere\n"

--- a/agent-tools/tool-edit/tests/cli.rs
+++ b/agent-tools/tool-edit/tests/cli.rs
@@ -40,3 +40,32 @@ fn cli_edits_a_file_within_its_confined_root() {
         "hello\nthere\n"
     );
 }
+
+#[test]
+fn cli_returns_pi_validation_envelope_for_malformed_preparer_input() {
+    let root = tempfile::tempdir().unwrap();
+    let input = serde_json::json!({
+        "root": root.path(),
+        "args": {"path": "file.txt", "edits": {"oldText": "old"}}
+    });
+
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_tool-edit"))
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    std::io::Write::write_all(
+        &mut child.stdin.take().unwrap(),
+        serde_json::to_string(&input).unwrap().as_bytes(),
+    )
+    .unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap(),
+        serde_json::json!({
+            "error": "Validation failed for tool \"edit\":\n  - edits.0.newText: must have required properties newText\n\nReceived arguments:\n{\n  \"edits\": {\n    \"oldText\": \"old\"\n  },\n  \"path\": \"file.txt\"\n}"
+        })
+    );
+}

--- a/agent-tools/tool-glob/Cargo.toml
+++ b/agent-tools/tool-glob/Cargo.toml
@@ -3,7 +3,7 @@ name = "verlet-tool-glob"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-description = "Glob file finder (model-facing `glob`, attachable as `find`)"
+description = "Glob file finder (model-facing `find`)"
 
 [dependencies]
 verlet-tool-core = { path = "../tool-core" }

--- a/agent-tools/tool-glob/src/lib.rs
+++ b/agent-tools/tool-glob/src/lib.rs
@@ -321,11 +321,38 @@ mod tests {
         let no_match = crate::run(args("*.nope", None), &fs(root.path())).unwrap();
         let directories = crate::run(args("bar", None), &fs(root.path())).unwrap();
         let path_pattern = crate::run(args("src/**/*.spec.ts", None), &fs(root.path())).unwrap();
+        let leading_double_star =
+            crate::run(args("**/src/**/*.spec.ts", None), &fs(root.path())).unwrap();
+        let root_pattern = crate::run(args("/", None), &fs(root.path())).unwrap();
 
         assert_eq!(no_match.text, "No files found matching pattern");
         assert_eq!(directories.paths, vec!["src/foo/bar/".to_owned()]);
         assert_eq!(directories.text, "src/foo/bar/");
         assert_eq!(path_pattern.paths, vec!["src/foo/bar/example.spec.ts"]);
+        assert_eq!(leading_double_star.paths, path_pattern.paths);
+        assert_eq!(root_pattern.text, "No files found matching pattern");
+    }
+
+    #[test]
+    fn absolute_search_root_stays_relative_and_preserves_directory_separators() {
+        // Pi regression 6104: root search paths must not drop the first segment.
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("home/user/project")).unwrap();
+        std::fs::write(root.path().join("home/user/project/file.txt"), "").unwrap();
+        let mut search = args("**", None);
+        search.path = Some(root.path().to_path_buf());
+
+        let output = crate::run(search, &fs(root.path())).unwrap();
+
+        assert_eq!(
+            output.paths,
+            vec![
+                "home/".to_owned(),
+                "home/user/".to_owned(),
+                "home/user/project/".to_owned(),
+                "home/user/project/file.txt".to_owned(),
+            ]
+        );
     }
 
     #[test]

--- a/agent-tools/tool-glob/src/lib.rs
+++ b/agent-tools/tool-glob/src/lib.rs
@@ -1,4 +1,4 @@
-//! `glob` — find files by glob pattern (Pi calls this `find`).
+//! `find` — find files and directories by glob pattern.
 //!
 //! Pi's version shells out to `fd`; ours walks through [`ToolFs`] with
 //! `globset` matching so every backend (native, vfs, wasm) traverses
@@ -8,18 +8,19 @@
 //! `std::fs`.
 //!
 //! Pinned semantics:
-//! - Pattern syntax: `globset` defaults with `**` support, matched
-//!   against paths relative to the search root, `/`-separated.
+//! - Pi's pattern preprocessing is preserved: basename patterns match at any
+//!   depth; slash-containing patterns use full paths and usually gain `**/`.
 //! - Respects `.gitignore` (per directory, nested, plus root
 //!   `.git/info/exclude`); hidden files are included; `.git/` is always
 //!   skipped.
-//! - Results are root-relative `/`-separated paths, sorted
-//!   lexicographically (Pi sorts by mtime for interactive use; we pin
-//!   deterministic order instead — recorded deviation).
-//! - `limit` (default 1000) caps results; the result carries a
-//!   `limit_reached` flag so the model knows the listing is partial.
+//! - Results include directories with trailing `/` and are root-relative,
+//!   `/`-separated, and sorted
+//!   lexicographically (Pi preserves backend process order; we pin deterministic
+//!   order instead — recorded deviation).
+//! - `limit` (default 1000) and the 50 KiB complete-line head limit emit Pi's
+//!   actionable notices.
 
-pub const DEFAULT_LIMIT: u64 = 1000;
+pub const DEFAULT_LIMIT: i64 = 1000;
 
 #[derive(Clone, Debug, serde::Deserialize)]
 pub struct GlobArgs {
@@ -28,22 +29,23 @@ pub struct GlobArgs {
     /// Directory to search in (default: workspace root).
     pub path: Option<std::path::PathBuf>,
     /// Maximum number of results (default 1000).
-    pub limit: Option<u64>,
+    pub limit: Option<i64>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
 pub struct GlobOutput {
+    /// Pi-compatible model-facing primary output.
+    pub text: String,
     /// Root-relative `/`-separated paths, sorted.
     pub paths: Vec<String>,
     pub limit_reached: bool,
+    pub truncated: bool,
 }
 
 pub fn contract() -> verlet_tool_core::ToolContract {
     verlet_tool_core::ToolContract {
-        name: "glob",
-        description: "Search for files by glob pattern, e.g. '*.ts' or \
-                      '**/*.spec.ts'. Returns matching file paths relative to \
-                      the search directory, sorted. Respects .gitignore.",
+        name: "find",
+        description: "Search for files by glob pattern. Returns matching file paths relative to the search directory. Respects .gitignore. Output is truncated to 1000 results or 50KB (whichever is hit first).",
         input_schema: serde_json::json!({
             "type": "object",
             "properties": {
@@ -61,13 +63,18 @@ pub fn run(
     args: GlobArgs,
     fs: &dyn verlet_tool_core::ToolFs,
 ) -> Result<GlobOutput, verlet_tool_core::ToolError> {
-    let limit = args.limit.unwrap_or(DEFAULT_LIMIT);
-    if limit == 0 {
-        return Err(verlet_tool_core::ToolError::InvalidArgs(
-            "limit must be at least 1".to_owned(),
-        ));
-    }
-    let matcher = globset::Glob::new(&args.pattern)
+    let effective_limit = args.limit.unwrap_or(DEFAULT_LIMIT).max(1);
+    let full_path = args.pattern.contains('/');
+    let effective_pattern = if full_path
+        && !args.pattern.starts_with('/')
+        && !args.pattern.starts_with("**/")
+        && args.pattern != "**"
+    {
+        format!("**/{}", args.pattern)
+    } else {
+        args.pattern.clone()
+    };
+    let matcher = globset::Glob::new(&effective_pattern)
         .map_err(|error| {
             verlet_tool_core::ToolError::InvalidArgs(format!(
                 "invalid glob pattern {:?}: {error}",
@@ -75,22 +82,35 @@ pub fn run(
             ))
         })?
         .compile_matcher();
-    let root = args.path.unwrap_or_else(|| std::path::PathBuf::from("."));
-    let files = verlet_tool_core::walk_files(&root, fs)?;
-    let limit = usize::try_from(limit).unwrap_or(usize::MAX);
+    let input_root = args.path.unwrap_or_else(|| std::path::PathBuf::from("."));
+    let root = verlet_tool_core::normalize_tool_path(&input_root);
+    let files = verlet_tool_core::walk_files(&root, fs).map_err(|error| match error {
+        verlet_tool_core::ToolError::Fs(verlet_tool_core::ToolFsError::NotFound(_)) => {
+            verlet_tool_core::ToolError::Failed(format!("Path not found: {}", root.display()))
+        }
+        error => error,
+    })?;
+    let limit = usize::try_from(effective_limit).unwrap_or(usize::MAX);
     let mut paths = Vec::new();
-    let mut limit_reached = false;
 
     for file in files {
-        if !matcher.is_match(std::path::Path::new(&file.relative_path)) {
+        let matches = if full_path {
+            matcher.is_match(&file.path)
+        } else {
+            let relative = file.relative_path.trim_end_matches('/');
+            std::path::Path::new(relative)
+                .file_name()
+                .is_some_and(|name| matcher.is_match(std::path::Path::new(name)))
+        };
+        if !matches {
             continue;
         }
-        if paths.len() == limit {
-            limit_reached = true;
+        paths.push(file.relative_path);
+        if paths.len() >= limit {
             break;
         }
-        paths.push(file.relative_path);
     }
+    let limit_reached = paths.len() >= limit;
 
     let rendered_bytes = paths
         .iter()
@@ -101,15 +121,50 @@ pub fn run(
         return Err(verlet_tool_core::ToolError::ResultTooLarge);
     }
 
+    if paths.is_empty() {
+        return Ok(GlobOutput {
+            text: "No files found matching pattern".to_owned(),
+            paths,
+            limit_reached: false,
+            truncated: false,
+        });
+    }
+
+    let raw_output = paths.join("\n");
+    let truncation = verlet_tool_core::truncate_head(
+        &raw_output,
+        usize::MAX,
+        verlet_tool_core::DEFAULT_MAX_BYTES,
+    );
+    let mut text = truncation.content.clone();
+    let mut notices = Vec::new();
+    if limit_reached {
+        notices.push(format!(
+            "{effective_limit} results limit reached. Use limit={} for more, or refine pattern",
+            effective_limit.saturating_mul(2),
+        ));
+    }
+    if truncation.truncated {
+        notices.push(format!(
+            "{} limit reached",
+            verlet_tool_core::format_size(verlet_tool_core::DEFAULT_MAX_BYTES)
+        ));
+    }
+    if !notices.is_empty() {
+        text.push_str(&format!("\n\n[{}]", notices.join(". ")));
+    }
+
     Ok(GlobOutput {
+        text,
         paths,
         limit_reached,
+        truncated: truncation.truncated,
     })
 }
 
 #[cfg(test)]
 mod tests {
-    fn args(pattern: &str, limit: Option<u64>) -> crate::GlobArgs {
+    fn args(pattern: &str, limit: Option<i64>) -> crate::GlobArgs {
         crate::GlobArgs {
             pattern: pattern.to_owned(),
             path: None,
@@ -136,14 +191,22 @@ mod tests {
         assert_eq!(
             output,
             crate::GlobOutput {
+                text: ".hidden.json\nsrc/a.json\nsrc/b.json".to_owned(),
                 paths: vec![
                     ".hidden.json".to_owned(),
                     "src/a.json".to_owned(),
                     "src/b.json".to_owned(),
                 ],
                 limit_reached: false,
+                truncated: false,
             }
         );
+    }
+
+    #[test]
+    fn model_facing_contract_is_named_find() {
+        // Pi behavior sheet item 34; source: core/tools/find.ts:123-133.
+        assert_eq!(crate::contract().name, "find");
     }
 
     #[test]
@@ -174,6 +237,7 @@ mod tests {
             vec![
                 ".gitignore".to_owned(),
                 "keep.tmp".to_owned(),
+                "nested/".to_owned(),
                 "nested/.gitignore".to_owned(),
                 "nested/important.log".to_owned(),
                 "nested/keep.txt".to_owned(),
@@ -212,6 +276,10 @@ mod tests {
 
         assert_eq!(output.paths, vec!["a.txt".to_owned(), "b.txt".to_owned()]);
         assert!(output.limit_reached);
+        assert_eq!(
+            output.text,
+            "a.txt\nb.txt\n\n[2 results limit reached. Use limit=4 for more, or refine pattern]"
+        );
     }
 
     #[test]
@@ -226,19 +294,77 @@ mod tests {
     }
 
     #[test]
-    fn zero_limit_is_rejected_and_maximum_u64_limit_is_safe() {
+    fn nonpositive_limit_floors_to_one_and_maximum_i64_limit_is_safe() {
         let root = tempfile::tempdir().unwrap();
         std::fs::write(root.path().join("file.txt"), "content").unwrap();
 
-        let zero = crate::run(args("**", Some(0)), &fs(root.path())).unwrap_err();
-        let maximum = crate::run(args("**", Some(u64::MAX)), &fs(root.path())).unwrap();
+        let zero = crate::run(args("**", Some(0)), &fs(root.path())).unwrap();
+        let negative = crate::run(args("**", Some(-10)), &fs(root.path())).unwrap();
+        let maximum = crate::run(args("**", Some(i64::MAX)), &fs(root.path())).unwrap();
 
         assert_eq!(
-            zero.to_string(),
-            "invalid arguments: limit must be at least 1"
+            zero.text,
+            "file.txt\n\n[1 results limit reached. Use limit=2 for more, or refine pattern]"
         );
+        assert_eq!(negative.text, zero.text);
         assert_eq!(maximum.paths, vec!["file.txt"]);
         assert!(!maximum.limit_reached);
+    }
+
+    #[test]
+    fn no_matches_directories_and_slash_patterns_match_pi() {
+        // Pi behavior sheet items 35, 36, and 39; source: core/tools/find.ts:254-267,303-352.
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("src/foo/bar")).unwrap();
+        std::fs::write(root.path().join("src/foo/bar/example.spec.ts"), "").unwrap();
+
+        let no_match = crate::run(args("*.nope", None), &fs(root.path())).unwrap();
+        let directories = crate::run(args("bar", None), &fs(root.path())).unwrap();
+        let path_pattern = crate::run(args("src/**/*.spec.ts", None), &fs(root.path())).unwrap();
+
+        assert_eq!(no_match.text, "No files found matching pattern");
+        assert_eq!(directories.paths, vec!["src/foo/bar/".to_owned()]);
+        assert_eq!(directories.text, "src/foo/bar/");
+        assert_eq!(path_pattern.paths, vec!["src/foo/bar/example.spec.ts"]);
+    }
+
+    #[test]
+    fn byte_truncation_and_contract_strings_match_pi() {
+        // Pi behavior sheet items 1, 39, and 42; source: core/tools/find.ts:123-133,328-352.
+        let root = tempfile::tempdir().unwrap();
+        for index in 0..240 {
+            std::fs::write(
+                root.path()
+                    .join(format!("{}-{index:03}.txt", "x".repeat(220))),
+                "",
+            )
+            .unwrap();
+        }
+
+        let output = crate::run(args("*.txt", None), &fs(root.path())).unwrap();
+        let combined = crate::run(args("*.txt", Some(240)), &fs(root.path())).unwrap();
+
+        assert!(output.truncated);
+        assert!(output.text.ends_with("\n\n[50.0KB limit reached]"));
+        assert!(combined.text.ends_with(
+            "\n\n[240 results limit reached. Use limit=480 for more, or refine pattern. 50.0KB limit reached]"
+        ));
+        assert_eq!(
+            crate::contract().description,
+            "Search for files by glob pattern. Returns matching file paths relative to the search directory. Respects .gitignore. Output is truncated to 1000 results or 50KB (whichever is hit first)."
+        );
+        assert_eq!(
+            crate::contract().input_schema,
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "pattern": {"type": "string", "description": "Glob pattern to match files, e.g. '*.ts', '**/*.json', or 'src/**/*.spec.ts'"},
+                    "path": {"type": "string", "description": "Directory to search in (default: current directory)"},
+                    "limit": {"type": "number", "description": "Maximum number of results (default: 1000)"}
+                },
+                "required": ["pattern"]
+            })
+        );
     }
 
     struct RecordingFs {

--- a/agent-tools/tool-glob/tests/cli.rs
+++ b/agent-tools/tool-glob/tests/cli.rs
@@ -27,8 +27,10 @@ fn cli_globs_from_its_confined_root() {
         serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap(),
         serde_json::json!({
             "ok": {
+                "text": "nested/file.txt",
                 "paths": ["nested/file.txt"],
-                "limit_reached": false
+                "limit_reached": false,
+                "truncated": false
             }
         })
     );

--- a/agent-tools/tool-grep/src/lib.rs
+++ b/agent-tools/tool-grep/src/lib.rs
@@ -9,20 +9,21 @@
 //! bounded `file:line` rows.
 //!
 //! Pinned semantics (mirroring Pi's flags):
-//! - Regex by default; `literal: true` = fixed-string. `ignore_case`
-//!   as named. Same walk rules as `tool-glob` (gitignore, hidden files
+//! - Regex by default; `literal: true` = fixed-string. Public argument
+//!   `ignoreCase` matches Pi. Same walk rules as `tool-glob` (gitignore, hidden files
 //!   included, `.git/` skipped), with optional `glob` file filter.
 //! - Output rows: `path:line: text` with root-relative paths; `context`
-//!   adds N lines before/after with `path:line- text` separators, blocks
-//!   joined by `--` lines (rg's grouped format).
-//! - Match lines longer than 500 chars are clipped with `…`.
+//!   emits one independent block per match and formats non-match rows as
+//!   `path-line- text`, with no block separators.
+//! - Lines longer than 500 UTF-16 code units are clipped with Pi's suffix.
 //! - `limit` (default 100) caps match count; search stops early when
-//!   reached and the result carries `limit_reached`.
+//!   reached and emits Pi's actionable notice.
+//! - Final text is complete-line head-truncated at 50 KiB.
 //! - Binary files (NUL in first 8KB) are skipped.
 //! - Deterministic file order (same as glob's sort), so identical state
 //!   yields identical output on every backend.
 
-pub const DEFAULT_LIMIT: u64 = 100;
+pub const DEFAULT_LIMIT: i64 = 100;
 pub const MAX_LINE_CHARS: usize = 500;
 const BINARY_SNIFF_BYTES: usize = 8 * 1024;
 
@@ -34,14 +35,14 @@ pub struct GrepArgs {
     pub path: Option<std::path::PathBuf>,
     /// Filter files by glob pattern, e.g. `*.ts`.
     pub glob: Option<String>,
-    #[serde(default)]
+    #[serde(default, rename = "ignoreCase")]
     pub ignore_case: bool,
     #[serde(default)]
     pub literal: bool,
     /// Lines of context before and after each match (default 0).
-    pub context: Option<u64>,
+    pub context: Option<i64>,
     /// Maximum number of matches (default 100).
-    pub limit: Option<u64>,
+    pub limit: Option<i64>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
@@ -50,22 +51,21 @@ pub struct GrepOutput {
     pub text: String,
     pub match_count: u64,
     pub limit_reached: bool,
+    pub truncated: bool,
+    pub lines_truncated: bool,
 }
 
 pub fn contract() -> verlet_tool_core::ToolContract {
     verlet_tool_core::ToolContract {
         name: "grep",
-        description: "Search file contents for a pattern. Returns matching lines \
-                      with file paths and line numbers. Regex by default; set \
-                      literal for exact strings. Respects .gitignore. Stops at \
-                      the match limit and says so.",
+        description: "Search file contents for a pattern. Returns matching lines with file paths and line numbers. Respects .gitignore. Output is truncated to 100 matches or 50KB (whichever is hit first). Long lines are truncated to 500 chars.",
         input_schema: serde_json::json!({
             "type": "object",
             "properties": {
                 "pattern": {"type": "string", "description": "Search pattern (regex or literal string)"},
                 "path": {"type": "string", "description": "Directory or file to search (default: current directory)"},
                 "glob": {"type": "string", "description": "Filter files by glob pattern, e.g. '*.ts' or '**/*.spec.ts'"},
-                "ignore_case": {"type": "boolean", "description": "Case-insensitive search (default: false)"},
+                "ignoreCase": {"type": "boolean", "description": "Case-insensitive search (default: false)"},
                 "literal": {"type": "boolean", "description": "Treat pattern as literal string instead of regex (default: false)"},
                 "context": {"type": "number", "description": "Number of lines to show before and after each match (default: 0)"},
                 "limit": {"type": "number", "description": "Maximum number of matches to return (default: 100)"}
@@ -80,12 +80,8 @@ pub fn run(
     args: GrepArgs,
     fs: &dyn verlet_tool_core::ToolFs,
 ) -> Result<GrepOutput, verlet_tool_core::ToolError> {
-    let limit = args.limit.unwrap_or(DEFAULT_LIMIT);
-    if limit == 0 {
-        return Err(verlet_tool_core::ToolError::InvalidArgs(
-            "limit must be at least 1".to_owned(),
-        ));
-    }
+    let effective_limit = args.limit.unwrap_or(DEFAULT_LIMIT).max(1);
+    let limit = u64::try_from(effective_limit).unwrap_or(u64::MAX);
 
     let mut matcher_builder = grep_regex::RegexMatcherBuilder::new();
     matcher_builder
@@ -110,15 +106,25 @@ pub fn run(
                 })
         })
         .transpose()?;
-    let root = args.path.unwrap_or_else(|| std::path::PathBuf::from("."));
-    let files = verlet_tool_core::walk_files(&root, fs)?;
-    let context = usize::try_from(args.context.unwrap_or(0)).unwrap_or(usize::MAX);
+    let input_root = args.path.unwrap_or_else(|| std::path::PathBuf::from("."));
+    let root = verlet_tool_core::normalize_tool_path(&input_root);
+    let files = verlet_tool_core::walk_files(&root, fs).map_err(|error| match error {
+        verlet_tool_core::ToolError::Fs(verlet_tool_core::ToolFsError::NotFound(_)) => {
+            verlet_tool_core::ToolError::Failed(format!("Path not found: {}", root.display()))
+        }
+        error => error,
+    })?;
+    let context = usize::try_from(args.context.unwrap_or(0).max(0)).unwrap_or(usize::MAX);
     let mut blocks = Vec::new();
     let mut rows = Vec::new();
     let mut match_count = 0_u64;
     let mut limit_reached = false;
+    let mut lines_truncated = false;
 
     for file in files {
+        if file.is_dir {
+            continue;
+        }
         if glob_matcher
             .as_ref()
             .is_some_and(|glob| !glob.is_match(std::path::Path::new(&file.relative_path)))
@@ -153,20 +159,20 @@ pub fn run(
         let lines = file_lines(&bytes);
         if context == 0 {
             for line_number in sink.lines {
-                rows.push(render_line(
+                let (row, truncated) = render_line(
                     &file.relative_path,
                     line_number,
                     true,
                     line_at(&lines, line_number),
-                ));
+                );
+                rows.push(row);
+                lines_truncated |= truncated;
             }
         } else {
-            blocks.extend(render_context_blocks(
-                &file.relative_path,
-                &lines,
-                &sink.lines,
-                context,
-            ));
+            let (file_blocks, truncated) =
+                render_context_blocks(&file.relative_path, &lines, &sink.lines, context);
+            blocks.extend(file_blocks);
+            lines_truncated |= truncated;
         }
 
         if match_count >= limit {
@@ -175,15 +181,52 @@ pub fn run(
         }
     }
 
-    let text = if context == 0 {
+    if match_count == 0 {
+        return Ok(GrepOutput {
+            text: "No matches found".to_owned(),
+            match_count,
+            limit_reached: false,
+            truncated: false,
+            lines_truncated: false,
+        });
+    }
+
+    let raw_output = if context == 0 {
         rows.join("\n")
     } else {
         blocks
             .into_iter()
             .map(|block| block.join("\n"))
             .collect::<Vec<_>>()
-            .join("\n--\n")
+            .join("\n")
     };
+    let truncation = verlet_tool_core::truncate_head(
+        &raw_output,
+        usize::MAX,
+        verlet_tool_core::DEFAULT_MAX_BYTES,
+    );
+    let mut text = truncation.content.clone();
+    let mut notices = Vec::new();
+    if limit_reached {
+        notices.push(format!(
+            "{effective_limit} matches limit reached. Use limit={} for more, or refine pattern",
+            effective_limit.saturating_mul(2),
+        ));
+    }
+    if truncation.truncated {
+        notices.push(format!(
+            "{} limit reached",
+            verlet_tool_core::format_size(verlet_tool_core::DEFAULT_MAX_BYTES)
+        ));
+    }
+    if lines_truncated {
+        notices.push(format!(
+            "Some lines truncated to {MAX_LINE_CHARS} chars. Use read tool to see full lines"
+        ));
+    }
+    if !notices.is_empty() {
+        text.push_str(&format!("\n\n[{}]", notices.join(". ")));
+    }
     if text.len() > verlet_tool_core::MAX_RESULT_BYTES {
         return Err(verlet_tool_core::ToolError::ResultTooLarge);
     }
@@ -192,6 +235,8 @@ pub fn run(
         text,
         match_count,
         limit_reached,
+        truncated: truncation.truncated,
+        lines_truncated,
     })
 }
 
@@ -219,53 +264,46 @@ fn render_context_blocks(
     lines: &[&[u8]],
     matches: &[u64],
     context: usize,
-) -> Vec<Vec<String>> {
+) -> (Vec<Vec<String>>, bool) {
     if matches.is_empty() {
-        return Vec::new();
+        return (Vec::new(), false);
     }
     let line_count = u64::try_from(lines.len()).unwrap_or(u64::MAX);
     let context = u64::try_from(context).unwrap_or(u64::MAX);
-    let mut ranges: Vec<(u64, u64)> = Vec::new();
+    let mut blocks = Vec::new();
+    let mut any_truncated = false;
     for &line_number in matches {
         let start = line_number.saturating_sub(context).max(1);
         let end = line_number.saturating_add(context).min(line_count);
-        match ranges.last_mut() {
-            Some((_, previous_end)) if start <= previous_end.saturating_add(1) => {
-                *previous_end = (*previous_end).max(end);
-            }
-            _ => ranges.push((start, end)),
+        let mut block = Vec::new();
+        for current in start..=end {
+            let (row, truncated) = render_line(
+                path,
+                current,
+                current == line_number,
+                line_at(lines, current),
+            );
+            block.push(row);
+            any_truncated |= truncated;
         }
+        blocks.push(block);
     }
-
-    ranges
-        .into_iter()
-        .map(|(start, end)| {
-            (start..=end)
-                .map(|line_number| {
-                    render_line(
-                        path,
-                        line_number,
-                        matches.binary_search(&line_number).is_ok(),
-                        line_at(lines, line_number),
-                    )
-                })
-                .collect::<Vec<_>>()
-        })
-        .collect()
+    (blocks, any_truncated)
 }
 
-fn render_line(path: &str, line_number: u64, is_match: bool, bytes: &[u8]) -> String {
+fn render_line(path: &str, line_number: u64, is_match: bool, bytes: &[u8]) -> (String, bool) {
     let text = String::from_utf8_lossy(bytes);
     let text = text.strip_suffix('\r').unwrap_or(&text);
-    let mut clipped = text.chars().take(MAX_LINE_CHARS).collect::<String>();
-    if text.chars().count() > MAX_LINE_CHARS {
-        clipped.push('…');
+    let (mut clipped, was_truncated) = verlet_tool_core::truncate_utf16(text, MAX_LINE_CHARS);
+    if was_truncated {
+        clipped.push_str("... [truncated]");
     }
-    if is_match {
+    let row = if is_match {
         format!("{path}:{line_number}: {clipped}")
     } else {
-        format!("{path}:{line_number}- {clipped}")
-    }
+        format!("{path}-{line_number}- {clipped}")
+    };
+    (row, was_truncated)
 }
 
 fn line_at<'a>(lines: &'a [&'a [u8]], line_number: u64) -> &'a [u8] {
@@ -315,7 +353,8 @@ mod tests {
     }
 
     #[test]
-    fn renders_grouped_context_blocks_with_separators() {
+    fn renders_independent_context_blocks_without_separators() {
+        // Pi behavior sheet items 26 and 27; source: core/tools/grep.ts:255-273,321-338.
         let root = tempfile::tempdir().unwrap();
         std::fs::write(
             root.path().join("file.txt"),
@@ -329,18 +368,38 @@ mod tests {
 
         assert_eq!(
             output.text,
-            "file.txt:1- before a\n\
+            "file.txt-1- before a\n\
              file.txt:2: hit one\n\
-             file.txt:3- after a\n\
-             --\n\
-             file.txt:6- before b\n\
+             file.txt-3- after a\n\
+             file.txt-6- before b\n\
              file.txt:7: hit two\n\
-             file.txt:8- after b"
+             file.txt-8- after b"
         );
     }
 
     #[test]
-    fn clips_long_rendered_lines_at_five_hundred_characters() {
+    fn overlapping_context_is_repeated_for_each_match() {
+        // Pi behavior sheet item 27; source: core/tools/grep.ts:321-338.
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(
+            root.path().join("file.txt"),
+            "before\nhit one\nhit two\nafter\n",
+        )
+        .unwrap();
+        let mut search = args("hit");
+        search.context = Some(1);
+
+        let output = crate::run(search, &fs(root.path())).unwrap();
+
+        assert_eq!(
+            output.text,
+            "file.txt-1- before\nfile.txt:2: hit one\nfile.txt-3- hit two\nfile.txt-2- hit one\nfile.txt:3: hit two\nfile.txt-4- after"
+        );
+    }
+
+    #[test]
+    fn clips_long_rendered_lines_at_five_hundred_utf16_units() {
+        // Pi behavior sheet item 28; source: core/tools/truncate.ts:264-275.
         let root = tempfile::tempdir().unwrap();
         let line = format!("{}needle", "x".repeat(crate::MAX_LINE_CHARS));
         std::fs::write(root.path().join("long.txt"), line).unwrap();
@@ -349,7 +408,10 @@ mod tests {
 
         assert_eq!(
             output.text,
-            format!("long.txt:1: {}…", "x".repeat(crate::MAX_LINE_CHARS))
+            format!(
+                "long.txt:1: {}... [truncated]\n\n[Some lines truncated to 500 chars. Use read tool to see full lines]",
+                "x".repeat(crate::MAX_LINE_CHARS)
+            )
         );
     }
 
@@ -367,6 +429,17 @@ mod tests {
     }
 
     #[test]
+    fn no_matches_uses_pi_text() {
+        // Pi behavior sheet item 25; source: core/tools/grep.ts:303-318.
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "haystack\n").unwrap();
+
+        let output = crate::run(args("needle"), &fs(root.path())).unwrap();
+
+        assert_eq!(output.text, "No matches found");
+    }
+
+    #[test]
     fn match_limit_stops_before_reading_the_next_file() {
         let root = tempfile::tempdir().unwrap();
         std::fs::write(root.path().join("a.txt"), "hit\n").unwrap();
@@ -380,7 +453,10 @@ mod tests {
 
         let output = crate::run(search, &recording).unwrap();
 
-        assert_eq!(output.text, "a.txt:1: hit");
+        assert_eq!(
+            output.text,
+            "a.txt:1: hit\n\n[1 matches limit reached. Use limit=2 for more, or refine pattern]"
+        );
         assert_eq!(output.match_count, 1);
         assert!(output.limit_reached);
         assert!(!recording
@@ -413,7 +489,9 @@ mod tests {
 
         assert_eq!(
             output.text,
-            "late-nul.dat:1: ".to_owned() + &"x".repeat(500) + "…"
+            "late-nul.dat:1: ".to_owned()
+                + &"x".repeat(500)
+                + "... [truncated]\n\n[Some lines truncated to 500 chars. Use read tool to see full lines]"
         );
         assert_eq!(output.match_count, 1);
     }
@@ -430,7 +508,10 @@ mod tests {
 
         assert_eq!(
             output.text,
-            format!("invalid.txt:1: {}…", "🙂".repeat(crate::MAX_LINE_CHARS))
+            format!(
+                "invalid.txt:1: {}... [truncated]\n\n[Some lines truncated to 500 chars. Use read tool to see full lines]",
+                "🙂".repeat(crate::MAX_LINE_CHARS / 2)
+            )
         );
         assert!(output.text.len() > crate::MAX_LINE_CHARS);
         assert!(output.text.len() < verlet_tool_core::MAX_RESULT_BYTES);
@@ -479,41 +560,47 @@ mod tests {
     }
 
     #[test]
-    fn zero_limit_is_rejected_and_maximum_u64_bounds_are_safe() {
+    fn numeric_edges_clamp_like_pi() {
+        // Pi behavior sheet item 32; source: core/tools/grep.ts:193-195.
         let root = tempfile::tempdir().unwrap();
         std::fs::write(root.path().join("file.txt"), "before\nhit\nafter\n").unwrap();
 
         let mut zero_search = args("hit");
         zero_search.limit = Some(0);
-        let zero = crate::run(zero_search, &fs(root.path())).unwrap_err();
+        zero_search.context = Some(-10);
+        let zero = crate::run(zero_search, &fs(root.path())).unwrap();
         let mut maximum_search = args("hit");
-        maximum_search.limit = Some(u64::MAX);
-        maximum_search.context = Some(u64::MAX);
+        maximum_search.limit = Some(i64::MAX);
+        maximum_search.context = Some(i64::MAX);
         let maximum = crate::run(maximum_search, &fs(root.path())).unwrap();
 
         assert_eq!(
-            zero.to_string(),
-            "invalid arguments: limit must be at least 1"
+            zero.text,
+            "file.txt:2: hit\n\n[1 matches limit reached. Use limit=2 for more, or refine pattern]"
         );
         assert_eq!(
             maximum.text,
-            "file.txt:1- before\nfile.txt:2: hit\nfile.txt:3- after"
+            "file.txt-1- before\nfile.txt:2: hit\nfile.txt-3- after"
         );
         assert!(!maximum.limit_reached);
     }
 
     #[test]
-    fn multibyte_clipped_rows_still_obey_the_result_byte_cap() {
+    fn result_is_head_truncated_at_fifty_kibibytes() {
+        // Pi behavior sheet item 25; source: core/tools/grep.ts:338-366.
         let root = tempfile::tempdir().unwrap();
         let line = format!("{}hit\n", "🙂".repeat(crate::MAX_LINE_CHARS + 1));
         let line_count = 2200;
         std::fs::write(root.path().join("large.txt"), line.repeat(line_count)).unwrap();
         let mut search = args("hit");
-        search.limit = Some(line_count as u64);
+        search.limit = Some(line_count as i64);
 
-        let error = crate::run(search, &fs(root.path())).unwrap_err();
+        let output = crate::run(search, &fs(root.path())).unwrap();
 
-        assert!(matches!(error, verlet_tool_core::ToolError::ResultTooLarge));
+        assert!(output.truncated);
+        assert!(output.text.ends_with(
+            "\n\n[2200 matches limit reached. Use limit=4400 for more, or refine pattern. 50.0KB limit reached. Some lines truncated to 500 chars. Use read tool to see full lines]"
+        ));
     }
 
     #[test]
@@ -553,7 +640,45 @@ mod tests {
             .map(|line| line.split(':').next().unwrap().to_owned())
             .collect::<Vec<_>>();
 
-        assert_eq!(glob.paths, grep_paths);
+        assert_eq!(
+            glob.paths
+                .into_iter()
+                .filter(|path| !path.ends_with('/'))
+                .collect::<Vec<_>>(),
+            grep_paths
+        );
+    }
+
+    #[test]
+    fn contract_and_camel_case_schema_match_pi() {
+        // Pi behavior sheet items 1 and 24; source: core/tools/grep.ts:24-36,128-138.
+        let contract = crate::contract();
+        assert_eq!(
+            contract.description,
+            "Search file contents for a pattern. Returns matching lines with file paths and line numbers. Respects .gitignore. Output is truncated to 100 matches or 50KB (whichever is hit first). Long lines are truncated to 500 chars."
+        );
+        assert_eq!(
+            contract.input_schema,
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "pattern": {"type": "string", "description": "Search pattern (regex or literal string)"},
+                    "path": {"type": "string", "description": "Directory or file to search (default: current directory)"},
+                    "glob": {"type": "string", "description": "Filter files by glob pattern, e.g. '*.ts' or '**/*.spec.ts'"},
+                    "ignoreCase": {"type": "boolean", "description": "Case-insensitive search (default: false)"},
+                    "literal": {"type": "boolean", "description": "Treat pattern as literal string instead of regex (default: false)"},
+                    "context": {"type": "number", "description": "Number of lines to show before and after each match (default: 0)"},
+                    "limit": {"type": "number", "description": "Maximum number of matches to return (default: 100)"}
+                },
+                "required": ["pattern"]
+            })
+        );
+        let parsed: crate::GrepArgs = serde_json::from_value(serde_json::json!({
+            "pattern": "needle",
+            "ignoreCase": true
+        }))
+        .unwrap();
+        assert!(parsed.ignore_case);
     }
 
     struct RecordingFs {

--- a/agent-tools/tool-grep/src/lib.rs
+++ b/agent-tools/tool-grep/src/lib.rs
@@ -416,6 +416,34 @@ mod tests {
     }
 
     #[test]
+    fn clips_emoji_on_exact_and_split_utf16_boundaries() {
+        // Pi source: core/tools/truncate.ts:264-275. A split surrogate is
+        // represented lossily because Rust model-facing text must remain UTF-8.
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(
+            root.path().join("a.txt"),
+            format!("{}🙂needle", "x".repeat(498)),
+        )
+        .unwrap();
+        std::fs::write(
+            root.path().join("b.txt"),
+            format!("{}🙂needle", "x".repeat(499)),
+        )
+        .unwrap();
+
+        let output = crate::run(args("needle"), &fs(root.path())).unwrap();
+
+        assert_eq!(
+            output.text,
+            format!(
+                "a.txt:1: {}🙂... [truncated]\nb.txt:1: {}\u{fffd}... [truncated]\n\n[Some lines truncated to 500 chars. Use read tool to see full lines]",
+                "x".repeat(498),
+                "x".repeat(499),
+            )
+        );
+    }
+
+    #[test]
     fn literal_mode_matches_regex_metacharacters_exactly() {
         let root = tempfile::tempdir().unwrap();
         std::fs::write(root.path().join("literal.txt"), "value a+b [x] done\n").unwrap();

--- a/agent-tools/tool-grep/tests/cli.rs
+++ b/agent-tools/tool-grep/tests/cli.rs
@@ -28,7 +28,9 @@ fn cli_greps_from_its_confined_root() {
             "ok": {
                 "text": "file.txt:2: needle",
                 "match_count": 1,
-                "limit_reached": false
+                "limit_reached": false,
+                "truncated": false,
+                "lines_truncated": false
             }
         })
     );

--- a/agent-tools/tool-read/src/lib.rs
+++ b/agent-tools/tool-read/src/lib.rs
@@ -1,28 +1,19 @@
-//! `read` — line-range file access.
+//! `read` — Pi-compatible line-range file access.
 //!
-//! Ported from Pi's read tool (`core/tools/read.ts`), slimmed per design:
+//! Image viewing remains a separate optional package. Text behavior follows
+//! Pi, including automatic complete-line head truncation at 2,000 lines or
+//! 50 KiB and addressable continuation notices.
 //!
-//! - **No image branch.** Image viewing is a separate optional package.
-//! - **No smart truncation messaging.** The lossless spill coupling owns
-//!   context protection. `read` keeps `offset`/`limit` because line
-//!   addressing is the primitive that makes spill files (and any large
-//!   file) walkable; the result reports the range returned and the total
-//!   line count so the model can continue on its own.
-//!
-//! Pinned semantics (implementation ticket must match, with fixtures):
+//! Pinned semantics:
 //! - `offset` is 1-indexed; `offset` past end of file is an error naming
 //!   the file's total line count.
-//! - No `limit` → to end of file, subject to `MAX_RESULT_BYTES` (error,
-//!   not silent truncation, when exceeded — the model narrows with
-//!   offset/limit).
+//! - No `limit` → to end of file before Pi's automatic truncation.
 //! - Content is returned verbatim (no line numbering, no tab expansion);
 //!   UTF-8 with lossy replacement for invalid bytes.
-//! - Trailer line `[lines {start}-{end} of {total}]` is appended after a
-//!   blank line whenever the returned range is not the whole file.
+//! - Caller limits and automatic truncation use Pi's exact continuation text.
 //! - Line accounting follows Pi's newline split: an empty file is one empty
 //!   logical line, and a terminal newline creates a final empty line.
-//! - The result byte cap applies to the final rendered text, after lossy UTF-8
-//!   conversion and after adding any partial-range trailer.
+//! - The 4 MiB result cap remains only as a final structured-result backstop.
 
 #[derive(Clone, Debug, serde::Deserialize)]
 pub struct ReadArgs {
@@ -30,9 +21,9 @@ pub struct ReadArgs {
     /// within the granted scope).
     pub path: std::path::PathBuf,
     /// Line number to start reading from (1-indexed).
-    pub offset: Option<u64>,
+    pub offset: Option<i64>,
     /// Maximum number of lines to read.
-    pub limit: Option<u64>,
+    pub limit: Option<i64>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
@@ -46,15 +37,15 @@ pub struct ReadOutput {
     pub end_line: u64,
     /// Total lines in the file.
     pub total_lines: u64,
+    /// Present only when automatic 2,000-line/50 KiB truncation occurred.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncation: Option<verlet_tool_core::TruncationResult>,
 }
 
 pub fn contract() -> verlet_tool_core::ToolContract {
     verlet_tool_core::ToolContract {
         name: "read",
-        description: "Read the contents of a text file. Returns the file verbatim. \
-                      For large files use offset (1-indexed start line) and limit \
-                      (max lines) to read in ranges; the result reports which lines \
-                      of how many were returned.",
+        description: "Read the contents of a file. For text files, output is truncated to 2000 lines or 50KB (whichever is hit first). Use offset/limit for large files. When you need the full file, continue with offset until complete.",
         input_schema: serde_json::json!({
             "type": "object",
             "properties": {
@@ -72,52 +63,87 @@ pub fn run(
     args: ReadArgs,
     fs: &dyn verlet_tool_core::ToolFs,
 ) -> Result<ReadOutput, verlet_tool_core::ToolError> {
-    let offset = args.offset.unwrap_or(1);
-    if offset == 0 {
-        return Err(verlet_tool_core::ToolError::InvalidArgs(
-            "offset must be at least 1".to_owned(),
-        ));
-    }
-    if args.limit == Some(0) {
-        return Err(verlet_tool_core::ToolError::InvalidArgs(
-            "limit must be at least 1".to_owned(),
-        ));
-    }
-
-    let stat = fs.stat(&args.path)?;
-    if !stat.is_file {
-        return Err(verlet_tool_core::ToolError::Failed(format!(
-            "path {:?} is not a file",
-            args.path
-        )));
-    }
-    let bytes = fs.read_file(&args.path)?;
+    let input_path = args.path;
+    let path = verlet_tool_core::normalize_tool_path(&input_path);
+    let bytes = fs.read_file(&path)?;
     let content = String::from_utf8_lossy(&bytes);
     let lines = content.split('\n').collect::<Vec<_>>();
     let total_lines = u64::try_from(lines.len()).unwrap_or(u64::MAX);
+    let requested_offset = args.offset;
+    let start_index_i64 = match requested_offset {
+        Some(offset) if offset != 0 => offset.saturating_sub(1).max(0),
+        _ => 0,
+    };
 
-    if offset > total_lines {
-        return Err(offset_past_end(offset, total_lines));
+    if i128::from(start_index_i64) >= lines.len() as i128 {
+        return Err(offset_past_end(requested_offset.unwrap_or(1), total_lines));
     }
 
-    let start_index = usize::try_from(offset - 1)
+    let start_index = usize::try_from(start_index_i64)
         .map_err(|_| verlet_tool_core::ToolError::InvalidArgs("offset is too large".to_owned()))?;
-    let available = lines.len() - start_index;
-    let selected_count = match args.limit {
-        Some(limit) => usize::try_from(limit).unwrap_or(usize::MAX).min(available),
-        None => available,
-    };
-    let end_index = start_index + selected_count;
-    let mut text = lines[start_index..end_index].join("\n");
-    let end_line = u64::try_from(end_index).unwrap_or(u64::MAX);
-
-    if offset != 1 || end_line != total_lines {
-        if text.ends_with('\n') {
-            text.push('\n');
-        } else {
-            text.push_str("\n\n");
+    let (end_index, user_limit_end) = match args.limit {
+        Some(limit) => {
+            let numeric_end =
+                (start_index_i64 as i128 + i128::from(limit)).min(lines.len() as i128);
+            let slice_end = if numeric_end < 0 {
+                (lines.len() as i128 + numeric_end).max(0)
+            } else {
+                numeric_end
+            }
+            .clamp(0, lines.len() as i128) as usize;
+            (slice_end.max(start_index), Some(numeric_end))
         }
-        text.push_str(&format!("[lines {offset}-{end_line} of {total_lines}]"));
+        None => (lines.len(), None),
+    };
+    let selected_content = lines[start_index..end_index].join("\n");
+    let truncation = verlet_tool_core::truncate_head(
+        &selected_content,
+        verlet_tool_core::DEFAULT_MAX_LINES,
+        verlet_tool_core::DEFAULT_MAX_BYTES,
+    );
+    let start_line = u64::try_from(start_index.saturating_add(1)).unwrap_or(u64::MAX);
+    let mut end_line = u64::try_from(end_index).unwrap_or(u64::MAX);
+    let mut text;
+    let mut truncation_details = None;
+
+    if truncation.first_line_exceeds_limit {
+        let first_line_size = lines.get(start_index).map_or(0, |line| line.len());
+        text = format!(
+            "[Line {start_line} is {}, exceeds {} limit. Use bash: sed -n '{start_line}p' {} | head -c {}]",
+            verlet_tool_core::format_size(first_line_size),
+            verlet_tool_core::format_size(verlet_tool_core::DEFAULT_MAX_BYTES),
+            input_path.display(),
+            verlet_tool_core::DEFAULT_MAX_BYTES,
+        );
+        end_line = start_line.saturating_sub(1);
+        truncation_details = Some(truncation);
+    } else if truncation.truncated {
+        let output_lines = u64::try_from(truncation.output_lines).unwrap_or(u64::MAX);
+        end_line = start_line.saturating_add(output_lines).saturating_sub(1);
+        let next_offset = end_line.saturating_add(1);
+        text = truncation.content.clone();
+        if truncation.truncated_by == Some(verlet_tool_core::TruncatedBy::Lines) {
+            text.push_str(&format!(
+                "\n\n[Showing lines {start_line}-{end_line} of {total_lines}. Use offset={next_offset} to continue.]"
+            ));
+        } else {
+            text.push_str(&format!(
+                "\n\n[Showing lines {start_line}-{end_line} of {total_lines} ({} limit). Use offset={next_offset} to continue.]",
+                verlet_tool_core::format_size(verlet_tool_core::DEFAULT_MAX_BYTES),
+            ));
+        }
+        truncation_details = Some(truncation);
+    } else if let Some(numeric_end) = user_limit_end {
+        text = truncation.content;
+        if numeric_end < lines.len() as i128 {
+            let remaining = lines.len() as i128 - numeric_end;
+            let next_offset = numeric_end + 1;
+            text.push_str(&format!(
+                "\n\n[{remaining} more lines in file. Use offset={next_offset} to continue.]"
+            ));
+        }
+    } else {
+        text = truncation.content;
     }
     if text.len() > verlet_tool_core::MAX_RESULT_BYTES {
         return Err(verlet_tool_core::ToolError::ResultTooLarge);
@@ -125,15 +151,16 @@ pub fn run(
 
     Ok(ReadOutput {
         text,
-        start_line: offset,
+        start_line,
         end_line,
         total_lines,
+        truncation: truncation_details,
     })
 }
 
-fn offset_past_end(offset: u64, total_lines: u64) -> verlet_tool_core::ToolError {
+fn offset_past_end(offset: i64, total_lines: u64) -> verlet_tool_core::ToolError {
     verlet_tool_core::ToolError::Failed(format!(
-        "offset {offset} is past end of file ({total_lines} total lines)"
+        "Offset {offset} is beyond end of file ({total_lines} lines total)"
     ))
 }
 
@@ -143,7 +170,7 @@ mod tests {
         verlet_tool_core::StdFs::new(root).unwrap()
     }
 
-    fn args(path: &str, offset: Option<u64>, limit: Option<u64>) -> crate::ReadArgs {
+    fn args(path: &str, offset: Option<i64>, limit: Option<i64>) -> crate::ReadArgs {
         crate::ReadArgs {
             path: std::path::PathBuf::from(path),
             offset,
@@ -165,6 +192,7 @@ mod tests {
                 start_line: 1,
                 end_line: 3,
                 total_lines: 3,
+                truncation: None,
             }
         );
     }
@@ -179,10 +207,11 @@ mod tests {
         assert_eq!(
             output,
             crate::ReadOutput {
-                text: "two\nthree\n\n[lines 2-3 of 4]".to_owned(),
+                text: "two\nthree\n\n[1 more lines in file. Use offset=4 to continue.]".to_owned(),
                 start_line: 2,
                 end_line: 3,
                 total_lines: 4,
+                truncation: None,
             }
         );
     }
@@ -196,7 +225,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "offset 3 is past end of file (2 total lines)"
+            "Offset 3 is beyond end of file (2 lines total)"
         );
     }
 
@@ -214,28 +243,34 @@ mod tests {
                 start_line: 1,
                 end_line: 1,
                 total_lines: 1,
+                truncation: None,
             }
         );
     }
 
     #[test]
-    fn rejects_a_directory_with_a_stable_error() {
+    fn a_directory_reaches_the_backend_read_error() {
         let root = tempfile::tempdir().unwrap();
 
         let error = crate::run(args(".", None, None), &fs(root.path())).unwrap_err();
 
-        assert_eq!(error.to_string(), "path \".\" is not a file");
+        assert!(!error.to_string().contains("is not a file"));
     }
 
     #[test]
-    fn rejects_a_result_larger_than_the_cap() {
+    fn reports_an_oversized_first_line_with_pi_text() {
+        // Pi behavior sheet item 9; source: core/tools/read.ts:297-301.
         let root = tempfile::tempdir().unwrap();
-        let content = vec![b'x'; verlet_tool_core::MAX_RESULT_BYTES + 1];
+        let content = vec![b'x'; verlet_tool_core::DEFAULT_MAX_BYTES + 1];
         std::fs::write(root.path().join("large.txt"), content).unwrap();
 
-        let error = crate::run(args("large.txt", None, None), &fs(root.path())).unwrap_err();
+        let output = crate::run(args("large.txt", None, None), &fs(root.path())).unwrap();
 
-        assert!(matches!(error, verlet_tool_core::ToolError::ResultTooLarge));
+        assert_eq!(
+            output.text,
+            "[Line 1 is 50.0KB, exceeds 50.0KB limit. Use bash: sed -n '1p' large.txt | head -c 51200]"
+        );
+        assert!(output.truncation.unwrap().first_line_exceeds_limit);
     }
 
     #[test]
@@ -249,45 +284,46 @@ mod tests {
     }
 
     #[test]
-    fn applies_the_result_cap_after_lossy_utf8_expansion() {
+    fn byte_truncation_uses_complete_lines_and_pi_notice() {
+        // Pi behavior sheet item 9; source: core/tools/read.ts:294-312.
         let root = tempfile::tempdir().unwrap();
-        let bytes = vec![0xff; verlet_tool_core::MAX_RESULT_BYTES / 3 + 1];
-        assert!(bytes.len() < verlet_tool_core::MAX_RESULT_BYTES);
-        std::fs::write(root.path().join("invalid.txt"), bytes).unwrap();
+        let line = format!("{}\n", "x".repeat(1024));
+        std::fs::write(root.path().join("large.txt"), line.repeat(60)).unwrap();
 
-        let error = crate::run(args("invalid.txt", None, None), &fs(root.path())).unwrap_err();
+        let output = crate::run(args("large.txt", None, None), &fs(root.path())).unwrap();
 
-        assert!(matches!(error, verlet_tool_core::ToolError::ResultTooLarge));
+        assert!(output.text.ends_with(
+            "\n\n[Showing lines 1-49 of 61 (50.0KB limit). Use offset=50 to continue.]"
+        ));
     }
 
     #[test]
-    fn rejects_zero_offset_and_limit() {
+    fn zero_and_negative_offsets_start_at_the_first_line_and_zero_limit_is_empty() {
         let root = tempfile::tempdir().unwrap();
         std::fs::write(root.path().join("file.txt"), "content").unwrap();
         let fs = fs(root.path());
 
-        let offset_error = crate::run(args("file.txt", Some(0), None), &fs).unwrap_err();
-        let limit_error = crate::run(args("file.txt", None, Some(0)), &fs).unwrap_err();
+        let zero_offset = crate::run(args("file.txt", Some(0), None), &fs).unwrap();
+        let negative_offset = crate::run(args("file.txt", Some(-5), None), &fs).unwrap();
+        let zero_limit = crate::run(args("file.txt", None, Some(0)), &fs).unwrap();
 
+        assert_eq!(zero_offset.text, "content");
+        assert_eq!(negative_offset.text, "content");
         assert_eq!(
-            offset_error.to_string(),
-            "invalid arguments: offset must be at least 1"
-        );
-        assert_eq!(
-            limit_error.to_string(),
-            "invalid arguments: limit must be at least 1"
+            zero_limit.text,
+            "\n\n[1 more lines in file. Use offset=1 to continue.]"
         );
     }
 
     #[test]
-    fn maximum_u64_limit_is_bounded_by_the_available_lines() {
+    fn maximum_i64_limit_is_bounded_by_the_available_lines() {
         let root = tempfile::tempdir().unwrap();
         std::fs::write(root.path().join("file.txt"), "one\ntwo").unwrap();
 
         let output =
-            crate::run(args("file.txt", Some(1), Some(u64::MAX)), &fs(root.path())).unwrap();
+            crate::run(args("file.txt", Some(1), Some(i64::MAX)), &fs(root.path())).unwrap();
         let offset_error = crate::run(
-            args("file.txt", Some(u64::MAX), Some(u64::MAX)),
+            args("file.txt", Some(i64::MAX), Some(i64::MAX)),
             &fs(root.path()),
         )
         .unwrap_err();
@@ -295,7 +331,56 @@ mod tests {
         assert_eq!(output.text, "one\ntwo");
         assert_eq!(
             offset_error.to_string(),
-            format!("offset {} is past end of file (2 total lines)", u64::MAX)
+            format!("Offset {} is beyond end of file (2 lines total)", i64::MAX)
         );
+    }
+
+    #[test]
+    fn automatically_truncates_at_two_thousand_lines_with_pi_notice() {
+        // Pi behavior sheet item 9; source: core/tools/read.ts:294-312.
+        let root = tempfile::tempdir().unwrap();
+        let content = (1..=2001)
+            .map(|line| format!("line {line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(root.path().join("large.txt"), content).unwrap();
+
+        let output = crate::run(args("large.txt", None, None), &fs(root.path())).unwrap();
+
+        assert!(output.text.ends_with(
+            "line 2000\n\n[Showing lines 1-2000 of 2001. Use offset=2001 to continue.]"
+        ));
+    }
+
+    #[test]
+    fn contract_and_benign_path_normalization_match_pi() {
+        // Pi behavior sheet items 1 and 4; source: read.ts:209-222 and path-utils.ts:40-49.
+        let contract = crate::contract();
+        assert_eq!(
+            contract.description,
+            "Read the contents of a file. For text files, output is truncated to 2000 lines or 50KB (whichever is hit first). Use offset/limit for large files. When you need the full file, continue with offset until complete."
+        );
+        assert_eq!(
+            contract.input_schema,
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Path to the file to read (relative or absolute)"},
+                    "offset": {"type": "number", "description": "Line number to start reading from (1-indexed)"},
+                    "limit": {"type": "number", "description": "Maximum number of lines to read"}
+                },
+                "required": ["path"]
+            })
+        );
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("unicode space.txt"), "ok").unwrap();
+
+        let output = crate::run(
+            args("@unicode\u{202f}space.txt", None, None),
+            &fs(root.path()),
+        )
+        .unwrap();
+
+        assert_eq!(output.text, "ok");
     }
 }

--- a/agent-tools/tool-read/src/lib.rs
+++ b/agent-tools/tool-read/src/lib.rs
@@ -353,6 +353,31 @@ mod tests {
     }
 
     #[test]
+    fn caller_limit_precedes_automatic_line_truncation_at_the_exact_boundary() {
+        // Pi source: core/tools/read.ts:284-317 and truncate.ts:78-160.
+        let root = tempfile::tempdir().unwrap();
+        let content = std::iter::repeat_n("x", 2002)
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(root.path().join("large.txt"), content).unwrap();
+        let filesystem = fs(root.path());
+
+        let exact = crate::run(args("large.txt", Some(2), Some(2000)), &filesystem).unwrap();
+        let over = crate::run(args("large.txt", Some(2), Some(2001)), &filesystem).unwrap();
+
+        assert!(exact.truncation.is_none());
+        assert!(exact
+            .text
+            .ends_with("\n\n[1 more lines in file. Use offset=2002 to continue.]"));
+        assert_eq!(exact.start_line, 2);
+        assert_eq!(exact.end_line, 2001);
+        assert!(over.truncation.is_some());
+        assert!(over
+            .text
+            .ends_with("\n\n[Showing lines 2-2001 of 2002. Use offset=2002 to continue.]"));
+    }
+
+    #[test]
     fn contract_and_benign_path_normalization_match_pi() {
         // Pi behavior sheet items 1 and 4; source: read.ts:209-222 and path-utils.ts:40-49.
         let contract = crate::contract();

--- a/agent-tools/tool-read/tests/cli.rs
+++ b/agent-tools/tool-read/tests/cli.rs
@@ -60,7 +60,7 @@ fn cli_returns_json_and_exit_one_for_a_tool_error() {
     assert_eq!(
         serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap(),
         serde_json::json!({
-            "error": "offset 2 is past end of file (1 total lines)"
+            "error": "Offset 2 is beyond end of file (1 lines total)"
         })
     );
 }

--- a/agent-tools/tool-write/Cargo.toml
+++ b/agent-tools/tool-write/Cargo.toml
@@ -3,7 +3,7 @@ name = "verlet-tool-write"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-description = "File creation tool with overwrite guard (model-facing `write`)"
+description = "Pi-compatible file creation and overwrite tool (model-facing `write`)"
 
 [dependencies]
 verlet-tool-core = { path = "../tool-core" }

--- a/agent-tools/tool-write/src/lib.rs
+++ b/agent-tools/tool-write/src/lib.rs
@@ -1,20 +1,12 @@
-//! `write` — create or overwrite a file, with an overwrite guard.
-//!
-//! Ported from Pi's write tool (`core/tools/write.ts`) with one deliberate
-//! deviation: Pi's write overwrites unconditionally; ours refuses to
-//! overwrite an existing file unless the model says so.
+//! `write` — create or overwrite a file with Pi-compatible behavior.
 //!
 //! Pinned semantics:
 //! - Parent directories are created as needed (`mkdir -p`).
-//! - If the target exists and `overwrite` is not `true`, the call fails
-//!   with an error stating the file exists, its size, and that the model
-//!   should read it first and pass `overwrite: true` to replace it. This
-//!   is the stateless half of clobber protection; the stateful half
-//!   ("was this path actually read this thread?") is a controller
-//!   coupling on the record, out of scope here.
+//! - Existing files are overwritten unconditionally; there is no prior-read
+//!   or stale-file guard in Pi.
 //! - Content is written exactly as given (no trailing-newline fixups).
-//! - Result reports bytes written and whether a file was created or
-//!   replaced.
+//! - Model-facing text reports JavaScript UTF-16 code units as "bytes", while
+//!   the structured receipt retains the true UTF-8 byte count.
 
 #[derive(Clone, Debug, serde::Deserialize)]
 pub struct WriteArgs {
@@ -23,31 +15,27 @@ pub struct WriteArgs {
     pub path: std::path::PathBuf,
     /// Full file content.
     pub content: String,
-    /// Must be `true` to replace an existing file. Default: false.
-    #[serde(default)]
-    pub overwrite: bool,
 }
 
 #[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
 pub struct WriteOutput {
+    /// Pi-compatible model-facing primary output.
+    pub text: String,
+    /// True UTF-8 byte count retained as a structured receipt.
     pub bytes_written: u64,
-    /// True when an existing file was replaced (only possible with
-    /// `overwrite: true`).
+    /// Whether the target existed immediately before the unconditional write.
     pub replaced: bool,
 }
 
 pub fn contract() -> verlet_tool_core::ToolContract {
     verlet_tool_core::ToolContract {
         name: "write",
-        description: "Write content to a file, creating parent directories as \
-                      needed. Fails if the file already exists unless overwrite \
-                      is true; read the existing file before overwriting it.",
+        description: "Write content to a file. Creates the file if it doesn't exist, overwrites if it does. Automatically creates parent directories.",
         input_schema: serde_json::json!({
             "type": "object",
             "properties": {
-                "path": {"type": "string", "description": "Path of the file to write (relative or absolute)"},
-                "content": {"type": "string", "description": "Full content to write"},
-                "overwrite": {"type": "boolean", "description": "Set true to replace an existing file (default false)"}
+                "path": {"type": "string", "description": "Path to the file to write (relative or absolute)"},
+                "content": {"type": "string", "description": "Content to write to the file"}
             },
             "required": ["path", "content"]
         }),
@@ -59,32 +47,23 @@ pub fn run(
     args: WriteArgs,
     fs: &dyn verlet_tool_core::ToolFs,
 ) -> Result<WriteOutput, verlet_tool_core::ToolError> {
-    let replaced = fs.exists(&args.path)?;
-    if replaced {
-        let stat = fs.stat(&args.path)?;
-        if !stat.is_file {
-            return Err(verlet_tool_core::ToolError::Failed(format!(
-                "path {:?} is not a file",
-                args.path
-            )));
-        }
-        if !args.overwrite {
-            return Err(verlet_tool_core::ToolError::Failed(format!(
-                "file {} exists ({} bytes); read it first and pass overwrite: true to replace it",
-                args.path.display(),
-                stat.size
-            )));
-        }
-    }
+    let input_path = args.path;
+    let path = verlet_tool_core::normalize_tool_path(&input_path);
+    let replaced = fs.exists(&path).unwrap_or(false);
 
-    if let Some(parent) = args.path.parent() {
+    if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
             fs.mkdir(parent, true)?;
         }
     }
-    fs.write_file(&args.path, args.content.as_bytes())?;
+    fs.write_file(&path, args.content.as_bytes())?;
 
     Ok(WriteOutput {
+        text: format!(
+            "Successfully wrote {} bytes to {}",
+            verlet_tool_core::utf16_len(&args.content),
+            input_path.display()
+        ),
         bytes_written: u64::try_from(args.content.len()).unwrap_or(u64::MAX),
         replaced,
     })
@@ -96,11 +75,10 @@ mod tests {
         verlet_tool_core::StdFs::new(root).unwrap()
     }
 
-    fn args(path: &str, content: &str, overwrite: bool) -> crate::WriteArgs {
+    fn args(path: &str, content: &str) -> crate::WriteArgs {
         crate::WriteArgs {
             path: std::path::PathBuf::from(path),
             content: content.to_owned(),
-            overwrite,
         }
     }
 
@@ -109,7 +87,7 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
 
         let output = crate::run(
-            args("nested/deeper/file.txt", "exact content", false),
+            args("nested/deeper/file.txt", "exact content"),
             &fs(root.path()),
         )
         .unwrap();
@@ -117,6 +95,7 @@ mod tests {
         assert_eq!(
             output,
             crate::WriteOutput {
+                text: "Successfully wrote 13 bytes to nested/deeper/file.txt".to_owned(),
                 bytes_written: 13,
                 replaced: false,
             }
@@ -128,55 +107,71 @@ mod tests {
     }
 
     #[test]
-    fn refuses_an_existing_file_without_overwrite() {
+    fn overwrites_an_existing_file_unconditionally() {
+        // Pi behavior sheet item 12; source: core/tools/write.ts:208-231.
         let root = tempfile::tempdir().unwrap();
         std::fs::write(root.path().join("file.txt"), "old").unwrap();
 
-        let error = crate::run(args("file.txt", "new", false), &fs(root.path())).unwrap_err();
-
-        assert_eq!(
-            error.to_string(),
-            "file file.txt exists (3 bytes); read it first and pass overwrite: true to replace it"
-        );
-        assert_eq!(std::fs::read(root.path().join("file.txt")).unwrap(), b"old");
-    }
-
-    #[test]
-    fn replaces_an_existing_file_when_allowed() {
-        let root = tempfile::tempdir().unwrap();
-        std::fs::write(root.path().join("file.txt"), "old").unwrap();
-
-        let output = crate::run(args("file.txt", "replacement", true), &fs(root.path())).unwrap();
+        let output = crate::run(args("file.txt", "new"), &fs(root.path())).unwrap();
 
         assert_eq!(
             output,
             crate::WriteOutput {
-                bytes_written: 11,
+                text: "Successfully wrote 3 bytes to file.txt".to_owned(),
+                bytes_written: 3,
                 replaced: true,
             }
         );
-        assert_eq!(
-            std::fs::read(root.path().join("file.txt")).unwrap(),
-            b"replacement"
-        );
+        assert_eq!(std::fs::read(root.path().join("file.txt")).unwrap(), b"new");
     }
 
     #[test]
-    fn reports_utf8_bytes_written() {
+    fn reports_utf16_units_in_text_and_utf8_bytes_in_the_receipt() {
+        // Pi behavior sheet item 13; source: core/tools/write.ts:224-231.
         let root = tempfile::tempdir().unwrap();
 
-        let output = crate::run(args("unicode.txt", "é", false), &fs(root.path())).unwrap();
+        let output = crate::run(args("unicode.txt", "é🙂"), &fs(root.path())).unwrap();
 
-        assert_eq!(output.bytes_written, 2);
+        assert_eq!(output.text, "Successfully wrote 3 bytes to unicode.txt");
+        assert_eq!(output.bytes_written, 6);
         assert!(!output.replaced);
     }
 
     #[test]
-    fn rejects_a_directory_with_the_shared_file_error_shape() {
+    fn an_existing_directory_reaches_the_backend_write_error() {
         let root = tempfile::tempdir().unwrap();
 
-        let error = crate::run(args("", "content", false), &fs(root.path())).unwrap_err();
+        let error = crate::run(args("", "content"), &fs(root.path())).unwrap_err();
 
-        assert_eq!(error.to_string(), "path \"\" is not a file");
+        assert!(!error.to_string().contains("is not a file"));
+    }
+
+    #[test]
+    fn contract_and_path_normalization_match_pi() {
+        // Pi behavior sheets items 1, 4, and 12; source: write.ts:15-18,187-231.
+        let root = tempfile::tempdir().unwrap();
+        let contract = crate::contract();
+        assert_eq!(
+            contract.description,
+            "Write content to a file. Creates the file if it doesn't exist, overwrites if it does. Automatically creates parent directories."
+        );
+        assert_eq!(
+            contract.input_schema,
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Path to the file to write (relative or absolute)"},
+                    "content": {"type": "string", "description": "Content to write to the file"}
+                },
+                "required": ["path", "content"]
+            })
+        );
+
+        crate::run(args("@unicode\u{2009}space.txt", "new"), &fs(root.path())).unwrap();
+
+        assert_eq!(
+            std::fs::read(root.path().join("unicode space.txt")).unwrap(),
+            b"new"
+        );
     }
 }

--- a/agent-tools/tool-write/tests/cli.rs
+++ b/agent-tools/tool-write/tests/cli.rs
@@ -23,7 +23,13 @@ fn cli_writes_to_its_confined_root() {
     assert!(output.status.success(), "{:?}", output);
     assert_eq!(
         serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap(),
-        serde_json::json!({"ok": {"bytes_written": 13, "replaced": false}})
+        serde_json::json!({
+            "ok": {
+                "text": "Successfully wrote 13 bytes to nested/file.txt",
+                "bytes_written": 13,
+                "replaced": false
+            }
+        })
     );
     assert_eq!(
         std::fs::read(root.path().join("nested/file.txt")).unwrap(),


### PR DESCRIPTION
Pi behavior-parity pass over the five `agent-tools/` crates (EMO-602), implementing the architect dispositions over the 44-item audit from EMO-601 (audited against Pi HEAD `dcd4619`).

What changed:

- `write`: the `overwrite` guard is removed; write overwrites unconditionally like Pi. Success text reports Pi's UTF-16 code-unit count; the structured receipt keeps the true UTF-8 byte count.
- `read`: Pi's 2,000-line / 50KiB head truncation with Pi's exact continuation messages ("Showing lines X-Y of Z. Use offset=N to continue.", oversized-first-line bash fallback).
- `edit`: Pi's camelCase `oldText`/`newText` schema, the full prepare/coerce/validate argument pipeline with Pi's validation envelope, the complete fuzzy-normalization character set, all error strings verbatim, lossy UTF-8 decode, diff/patch split into a details field.
- `grep`: per-match context blocks with `path-line-` rows and no `--` separators, 500-UTF-16-unit clip with `... [truncated]`, Pi's notice strings, 50KiB truncation, `ignoreCase`.
- `find` (glob crate's model-facing name): directories in results with trailing separator, Pi's slash-pattern preprocessing, exact limit semantics and notices, 50KiB truncation.
- Every ported string is pinned by a test citing the Pi source location. The README carries a "Designed divergences from Pi" section (confinement, determinism, in-process engines, 4MiB backstop, cancellation layer, mutation-queue deferral) as the baseline for future differential runs.

Verification: `scripts/verify.sh` and `scripts/verify-linux.sh` green on the rebased branch; agent-tools crates 86/86 under nextest all-features; wasm32 check clean; write-capable review pass over the diff (second commit) fixed malformed-input handling in edit's compatibility shims.
