### PR TITLE
Fix Cargo lane lock staleness across containers (EMO-594)

### DIFF
--- a/scripts/cargo-lane-test.sh
+++ b/scripts/cargo-lane-test.sh
@@ -148,12 +148,13 @@ wait_for_pid() {
   local pid=$1
   local expected=$2
   local name=$3
+  local timeout_seconds=${4:-10}
   local status
   local timeout_marker="$TMP_DIR/wait-timeout-$pid"
   local watchdog_pid
 
   (
-    sleep 10
+    sleep "$timeout_seconds"
     : >"$timeout_marker"
     kill -TERM "$pid" 2>/dev/null || exit 0
     sleep 1
@@ -208,6 +209,10 @@ reset_call_environment() {
   CALLER_CACHE_SIZE=
   CALLER_CI_SET=0
   CALLER_CI=
+  CALLER_PROC_ROOT_SET=0
+  CALLER_PROC_ROOT=
+  CALLER_WAIT_TIMEOUT_SET=0
+  CALLER_WAIT_TIMEOUT=
 }
 
 prepare_call_environment() {
@@ -219,6 +224,7 @@ prepare_call_environment() {
   unset SCCACHE_BASEDIRS SCCACHE_CACHE_SIZE VERLET_REAL_CARGO VERLET_CARGO_LANE_SCRIPT
   unset VERLET_CARGO_SHIM_DIR VERLET_VERIFY_MANAGED_CARGO
   unset VERLET_CARGO_LANE_INCREMENTAL CARGO_ALIAS_ESCAPE
+  unset VERLET_CARGO_LANE_PROC_ROOT VERLET_CARGO_LANE_WAIT_TIMEOUT_SECONDS
   unset CI
 
   export PATH="$TEST_PATH"
@@ -275,6 +281,12 @@ prepare_call_environment() {
   fi
   if ((CALLER_CI_SET)); then
     export CI="$CALLER_CI"
+  fi
+  if ((CALLER_PROC_ROOT_SET)); then
+    export VERLET_CARGO_LANE_PROC_ROOT="$CALLER_PROC_ROOT"
+  fi
+  if ((CALLER_WAIT_TIMEOUT_SET)); then
+    export VERLET_CARGO_LANE_WAIT_TIMEOUT_SECONDS="$CALLER_WAIT_TIMEOUT"
   fi
 }
 
@@ -441,6 +453,7 @@ cp "$SCRIPT_DIR/cargo-lane.sh" "$REPO/scripts/cargo-lane.sh"
 cp "$SCRIPT_DIR/check-pre-commit.sh" "$REPO/scripts/check-pre-commit.sh"
 cp "$SCRIPT_DIR/check-pre-push.sh" "$REPO/scripts/check-pre-push.sh"
 cp "$SCRIPT_DIR/guard-rails.sh" "$REPO/scripts/guard-rails.sh"
+cp "$SCRIPT_DIR/guard-rails-test.sh" "$REPO/scripts/guard-rails-test.sh"
 cp "$SCRIPT_DIR/test-timeout-lint.pl" "$REPO/scripts/test-timeout-lint.pl"
 cp "$SCRIPT_DIR/test-timeout-lint.sh" "$REPO/scripts/test-timeout-lint.sh"
 cp "$SCRIPT_DIR/threat-model-lint.sh" "$REPO/scripts/threat-model-lint.sh"
@@ -802,6 +815,181 @@ run_lane "$FEATURE_A" "$STALE_ROOT" "$TMP_DIR/stale.record" "$TMP_DIR/stale.out"
 assert_eq 0 "$?" 'stale holder was reclaimed'
 wait_for_no_path "$STALE_ROOT/feature.lock" 'stale recovery released the lane lock'
 
+# A live PID from another boot/container identity does not keep a stale lock.
+IDENTITY_PROC_ROOT="$TMP_DIR/identity-proc"
+mkdir -p "$IDENTITY_PROC_ROOT/self/ns" \
+  "$IDENTITY_PROC_ROOT/sys/kernel/random"
+printf 'current-boot-id\n' >"$IDENTITY_PROC_ROOT/sys/kernel/random/boot_id"
+ln -s 'pid:[4026532000]' "$IDENTITY_PROC_ROOT/self/ns/pid"
+CURRENT_LOCK_IDENTITY='boot-id:current-boot-id;pid-namespace:pid:[4026532000]'
+IDENTITY_STALE_ROOT="$TMP_DIR/lanes-identity-stale"
+mkdir -p "$IDENTITY_STALE_ROOT/feature.lock"
+printf '%s\n' "$$" >"$IDENTITY_STALE_ROOT/feature.lock/pid"
+printf 'identity-stale-token\n' >"$IDENTITY_STALE_ROOT/feature.lock/token"
+printf '%s\n' \
+  'boot-id:previous-boot-id;pid-namespace:pid:[4026532000]' \
+  >"$IDENTITY_STALE_ROOT/feature.lock/identity"
+CALLER_PROC_ROOT_SET=1
+CALLER_PROC_ROOT="$IDENTITY_PROC_ROOT"
+start_lane "$FEATURE_A" "$IDENTITY_STALE_ROOT" "$TMP_DIR/identity-stale.record" "$TMP_DIR/identity-stale.out" "$TMP_DIR/identity-stale.err" check
+identity_stale_pid=$STARTED_PID
+wait_for_pid "$identity_stale_pid" 0 'live PID with mismatched boot identity was reclaimed' 2
+wait_for_no_path "$IDENTITY_STALE_ROOT/feature.lock" 'identity-stale recovery released the lane lock'
+
+NAMESPACE_STALE_ROOT="$TMP_DIR/lanes-namespace-stale"
+mkdir -p "$NAMESPACE_STALE_ROOT/feature.lock"
+printf '%s\n' "$$" >"$NAMESPACE_STALE_ROOT/feature.lock/pid"
+printf 'namespace-stale-token\n' >"$NAMESPACE_STALE_ROOT/feature.lock/token"
+printf '%s\n' \
+  'boot-id:current-boot-id;pid-namespace:pid:[4026531999]' \
+  >"$NAMESPACE_STALE_ROOT/feature.lock/identity"
+start_lane "$FEATURE_A" "$NAMESPACE_STALE_ROOT" "$TMP_DIR/namespace-stale.record" "$TMP_DIR/namespace-stale.out" "$TMP_DIR/namespace-stale.err" check
+namespace_stale_pid=$STARTED_PID
+wait_for_pid "$namespace_stale_pid" 0 'live PID with mismatched namespace identity was reclaimed' 2
+wait_for_no_path "$NAMESPACE_STALE_ROOT/feature.lock" 'namespace-stale recovery released the lane lock'
+
+# Partial identities cannot prove that a live PID belongs to another namespace.
+# Treat them like old identity-free locks instead of reclaiming a live holder.
+PARTIAL_IDENTITY_ROOT="$TMP_DIR/lanes-partial-identity"
+mkdir -p "$PARTIAL_IDENTITY_ROOT/feature.lock"
+printf '%s\n' "$$" >"$PARTIAL_IDENTITY_ROOT/feature.lock/pid"
+printf 'partial-identity-token\n' >"$PARTIAL_IDENTITY_ROOT/feature.lock/token"
+printf 'boot-id:current-boot-id\n' >"$PARTIAL_IDENTITY_ROOT/feature.lock/identity"
+CALLER_WAIT_TIMEOUT_SET=1
+CALLER_WAIT_TIMEOUT=1
+start_lane "$FEATURE_A" "$PARTIAL_IDENTITY_ROOT" "$TMP_DIR/partial-identity.record" "$TMP_DIR/partial-identity.out" "$TMP_DIR/partial-identity.err" check
+partial_identity_pid=$STARTED_PID
+wait_for_pid "$partial_identity_pid" 1 'partial holder identity fell back to live-PID waiting' 3
+assert_no_path "$TMP_DIR/partial-identity.record" 'partial holder identity did not permit overlapping Cargo'
+
+# A partial current identity also falls back to PID-only behavior. This covers a
+# host where only part of the Linux proc identity surface is readable.
+PARTIAL_PROC_ROOT="$TMP_DIR/partial-proc"
+mkdir -p "$PARTIAL_PROC_ROOT/sys/kernel/random"
+printf 'current-boot-id\n' >"$PARTIAL_PROC_ROOT/sys/kernel/random/boot_id"
+PARTIAL_WAITER_ROOT="$TMP_DIR/lanes-partial-waiter"
+mkdir -p "$PARTIAL_WAITER_ROOT/feature.lock"
+printf '%s\n' "$$" >"$PARTIAL_WAITER_ROOT/feature.lock/pid"
+printf 'partial-waiter-token\n' >"$PARTIAL_WAITER_ROOT/feature.lock/token"
+printf '%s\n' "$CURRENT_LOCK_IDENTITY" >"$PARTIAL_WAITER_ROOT/feature.lock/identity"
+CALLER_PROC_ROOT="$PARTIAL_PROC_ROOT"
+start_lane "$FEATURE_A" "$PARTIAL_WAITER_ROOT" "$TMP_DIR/partial-waiter.record" "$TMP_DIR/partial-waiter.out" "$TMP_DIR/partial-waiter.err" check
+partial_waiter_pid=$STARTED_PID
+wait_for_pid "$partial_waiter_pid" 1 'partial current identity fell back to live-PID waiting' 3
+assert_no_path "$TMP_DIR/partial-waiter.record" 'partial current identity did not permit overlapping Cargo'
+
+# Identity-bearing waiters remain compatible with live old-format lock files.
+OLD_LOCK_ROOT="$TMP_DIR/lanes-old-lock-format"
+mkdir -p "$OLD_LOCK_ROOT/feature.lock"
+printf '%s\n' "$$" >"$OLD_LOCK_ROOT/feature.lock/pid"
+printf 'old-lock-token\n' >"$OLD_LOCK_ROOT/feature.lock/token"
+CALLER_PROC_ROOT="$IDENTITY_PROC_ROOT"
+start_lane "$FEATURE_A" "$OLD_LOCK_ROOT" "$TMP_DIR/old-lock.record" "$TMP_DIR/old-lock.out" "$TMP_DIR/old-lock.err" check
+old_lock_pid=$STARTED_PID
+wait_for_pid "$old_lock_pid" 1 'identity-free live holder kept its old-format lock' 3
+assert_no_path "$TMP_DIR/old-lock.record" 'identity-bearing waiter preserved a live old-format holder'
+
+# Hosts without the complete proc identity use PID-only checks even when the
+# recorded holder came from the new identity-bearing format.
+NO_IDENTITY_PROC_ROOT="$TMP_DIR/no-identity-proc"
+mkdir -p "$NO_IDENTITY_PROC_ROOT"
+NEW_LOCK_ROOT="$TMP_DIR/lanes-new-lock-format"
+mkdir -p "$NEW_LOCK_ROOT/feature.lock"
+printf '%s\n' "$$" >"$NEW_LOCK_ROOT/feature.lock/pid"
+printf 'new-lock-token\n' >"$NEW_LOCK_ROOT/feature.lock/token"
+printf '%s\n' "$CURRENT_LOCK_IDENTITY" >"$NEW_LOCK_ROOT/feature.lock/identity"
+CALLER_PROC_ROOT="$NO_IDENTITY_PROC_ROOT"
+start_lane "$FEATURE_A" "$NEW_LOCK_ROOT" "$TMP_DIR/new-lock.record" "$TMP_DIR/new-lock.out" "$TMP_DIR/new-lock.err" check
+new_lock_pid=$STARTED_PID
+wait_for_pid "$new_lock_pid" 1 'identity-free waiter used the recorded live PID' 3
+assert_no_path "$TMP_DIR/new-lock.record" 'identity-free waiter preserved a live new-format holder'
+
+# Reclaim-claim owner records accept the old PID-only format conservatively.
+# A live old-format claimant must not be discarded by an identity-bearing peer.
+OLD_CLAIM_ROOT="$TMP_DIR/lanes-old-reclaim-claim"
+mkdir -p "$OLD_CLAIM_ROOT/feature.lock/reclaim"
+printf '99999999\n' >"$OLD_CLAIM_ROOT/feature.lock/pid"
+printf 'old-claim-lock-token\n' >"$OLD_CLAIM_ROOT/feature.lock/token"
+printf '%s\n' "$CURRENT_LOCK_IDENTITY" >"$OLD_CLAIM_ROOT/feature.lock/identity"
+printf '%s\n' "$$" >"$OLD_CLAIM_ROOT/feature.lock/reclaim/owner.old.format"
+touch -t 200001010000 "$OLD_CLAIM_ROOT/feature.lock/reclaim"
+CALLER_PROC_ROOT="$IDENTITY_PROC_ROOT"
+CALLER_WAIT_TIMEOUT_SET=1
+CALLER_WAIT_TIMEOUT=1
+start_lane "$FEATURE_A" "$OLD_CLAIM_ROOT" "$TMP_DIR/old-claim.record" "$TMP_DIR/old-claim.out" "$TMP_DIR/old-claim.err" check
+old_claim_pid=$STARTED_PID
+wait_for_pid "$old_claim_pid" 1 'live PID-only reclaim claimant was preserved until timeout' 3
+assert_no_path "$TMP_DIR/old-claim.record" 'old-format live reclaim claimant prevented overlapping Cargo'
+
+# The second owner-record line participates in abandoned-claim recovery. A
+# recycled live PID from a foreign identity cannot pin the reclaim mutex.
+STALE_CLAIM_ROOT="$TMP_DIR/lanes-stale-reclaim-claim"
+mkdir -p "$STALE_CLAIM_ROOT/feature.lock/reclaim"
+printf '99999999\n' >"$STALE_CLAIM_ROOT/feature.lock/pid"
+printf 'stale-claim-lock-token\n' >"$STALE_CLAIM_ROOT/feature.lock/token"
+printf '%s\n' "$CURRENT_LOCK_IDENTITY" >"$STALE_CLAIM_ROOT/feature.lock/identity"
+printf '%s\n%s\n' "$$" \
+  'boot-id:previous-boot-id;pid-namespace:pid:[4026532000]' \
+  >"$STALE_CLAIM_ROOT/feature.lock/reclaim/owner.new.format"
+touch -t 200001010000 "$STALE_CLAIM_ROOT/feature.lock/reclaim"
+start_lane "$FEATURE_A" "$STALE_CLAIM_ROOT" "$TMP_DIR/stale-claim.record" "$TMP_DIR/stale-claim.out" "$TMP_DIR/stale-claim.err" check
+stale_claim_pid=$STARTED_PID
+wait_for_pid "$stale_claim_pid" 0 'foreign two-line reclaim claimant was recovered' 2
+wait_for_no_path "$STALE_CLAIM_ROOT/feature.lock" 'two-line reclaim recovery released the lane lock'
+
+# A current live holder eventually fails a waiter with actionable lock details.
+TIMEOUT_ROOT="$TMP_DIR/lanes-timeout"
+mkdir -p "$TIMEOUT_ROOT/feature.lock"
+printf '%s\n' "$$" >"$TIMEOUT_ROOT/feature.lock/pid"
+printf 'timeout-token\n' >"$TIMEOUT_ROOT/feature.lock/token"
+printf '%s\n' "$CURRENT_LOCK_IDENTITY" >"$TIMEOUT_ROOT/feature.lock/identity"
+CALLER_PROC_ROOT="$IDENTITY_PROC_ROOT"
+CALLER_WAIT_TIMEOUT_SET=1
+CALLER_WAIT_TIMEOUT=1
+start_lane "$FEATURE_A" "$TIMEOUT_ROOT" "$TMP_DIR/timeout.record" "$TMP_DIR/timeout.out" "$TMP_DIR/timeout.err" check
+timeout_pid=$STARTED_PID
+wait_for_pid "$timeout_pid" 1 'live holder wait stopped at the configured timeout' 3
+assert_no_path "$TMP_DIR/timeout.record" 'timed-out waiter did not invoke Cargo'
+assert_file_contains "$TMP_DIR/timeout.err" 'timed out after 1s on current holder' 'timeout named the current-holder budget'
+assert_file_contains "$TMP_DIR/timeout.err" "$TIMEOUT_ROOT/feature.lock" 'timeout named the lock path'
+assert_file_contains "$TMP_DIR/timeout.err" "recorded holder pid $$" 'timeout named the recorded holder'
+assert_file_contains "$TMP_DIR/timeout.err" "identity $CURRENT_LOCK_IDENTITY" 'timeout named the recorded holder identity'
+
+# A new pid+token holder gets a fresh timeout budget instead of inheriting the
+# time already spent waiting on its predecessor.
+RESET_TIMEOUT_ROOT="$TMP_DIR/lanes-timeout-reset"
+mkdir -p "$RESET_TIMEOUT_ROOT/feature.lock"
+sleep 5 &
+first_timeout_holder_pid=$!
+printf '%s\n' "$first_timeout_holder_pid" >"$RESET_TIMEOUT_ROOT/feature.lock/pid"
+printf 'timeout-reset-first-token\n' >"$RESET_TIMEOUT_ROOT/feature.lock/token"
+printf '%s\n' "$CURRENT_LOCK_IDENTITY" >"$RESET_TIMEOUT_ROOT/feature.lock/identity"
+start_lane "$FEATURE_A" "$RESET_TIMEOUT_ROOT" "$TMP_DIR/timeout-reset.record" "$TMP_DIR/timeout-reset.out" "$TMP_DIR/timeout-reset.err" check
+timeout_reset_pid=$STARTED_PID
+wait_for_text "$TMP_DIR/timeout-reset.err" 'waiting for feature Cargo lane' 'holder-change waiter started its first timeout budget'
+sleep 0.6
+sleep 5 &
+second_timeout_holder_pid=$!
+printf 'timeout-reset-second-token\n' >"$RESET_TIMEOUT_ROOT/feature.lock/token"
+printf '%s\n' "$second_timeout_holder_pid" >"$RESET_TIMEOUT_ROOT/feature.lock/pid"
+kill -TERM "$first_timeout_holder_pid"
+wait "$first_timeout_holder_pid" 2>/dev/null
+sleep 0.6
+if ! kill -0 "$timeout_reset_pid" 2>/dev/null; then
+  fail 'holder change did not grant the successor a fresh timeout budget'
+fi
+wait_for_pid "$timeout_reset_pid" 1 'successor holder received one fresh bounded timeout' 3
+assert_file_contains "$TMP_DIR/timeout-reset.err" \
+  "recorded holder pid $second_timeout_holder_pid" \
+  'successor timeout named the replacement holder'
+kill -TERM "$second_timeout_holder_pid"
+wait "$second_timeout_holder_pid" 2>/dev/null
+rm -f "$RESET_TIMEOUT_ROOT/feature.lock/pid" \
+  "$RESET_TIMEOUT_ROOT/feature.lock/token" \
+  "$RESET_TIMEOUT_ROOT/feature.lock/identity"
+rmdir "$RESET_TIMEOUT_ROOT/feature.lock"
+reset_call_environment
+
 EMPTY_ROOT="$TMP_DIR/lanes-empty-stale"
 mkdir -p "$EMPTY_ROOT/feature.lock"
 touch -t 200001010000 "$EMPTY_ROOT/feature.lock"
@@ -904,8 +1092,8 @@ assert_no_path "$FAKE_STATE/started-parallel-pre-push-b" 'concurrent pre-push Ca
 : >"$FAKE_STATE/release-parallel-pre-push-a"
 wait_for_path "$FAKE_STATE/started-parallel-pre-push-b" 'second concurrent pre-push entered Cargo after release'
 : >"$FAKE_STATE/release-parallel-pre-push-b"
-wait_for_pid "$parallel_pre_push_a_pid" 0 'first concurrent pre-push succeeded'
-wait_for_pid "$parallel_pre_push_b_pid" 0 'second concurrent pre-push succeeded'
+wait_for_pid "$parallel_pre_push_a_pid" 0 'first concurrent pre-push succeeded' 30
+wait_for_pid "$parallel_pre_push_b_pid" 0 'second concurrent pre-push succeeded' 30
 assert_file_line_count "$FAKE_STATE/calls-parallel-pre-push-a" 6 "$HOOK_PARALLEL_ROOT/targets/feature" 'first concurrent pre-push kept every Cargo call in the feature lane'
 assert_file_line_count "$FAKE_STATE/calls-parallel-pre-push-b" 6 "$HOOK_PARALLEL_ROOT/targets/feature" 'second concurrent pre-push kept every Cargo call in the feature lane'
 assert_no_path "$FAKE_STATE/overlap-feature" 'concurrent pre-push hooks never overlapped lane writers'

--- a/scripts/cargo-lane.sh
+++ b/scripts/cargo-lane.sh
@@ -6,10 +6,9 @@
 #
 # Set VERLET_CARGO_LANE_INCREMENTAL=1 for an incremental, sccache-free edit
 # loop backed by a separate target directory, lock, and owner record.
+# Set VERLET_CARGO_LANE_WAIT_TIMEOUT_SECONDS to bound each holder wait (default 1800).
 
 set -euo pipefail
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 REAL_CARGO=
 ACTIVE_CARGO_SHIM_DIR=
@@ -25,11 +24,14 @@ TARGET_DIR=
 LOCK_DIR=
 OWNER_FILE=
 LOCK_TOKEN=
+LOCK_IDENTITY=
 LOCK_HELD=0
 LOCK_READY=0
 OWNER_TEMP=
 RECLAIM_OWNER_FILE=
+# Known limitation: a live initializer stalled past this grace may be reclaimed.
 INITIALIZATION_GRACE_SECONDS=5
+LOCK_WAIT_TIMEOUT_SECONDS=1800
 
 usage() {
   printf 'usage: scripts/cargo-lane.sh <cargo-arguments...>\n'
@@ -257,8 +259,72 @@ read_lock_field() {
   printf '%s' "$value"
 }
 
+read_claim_identity() {
+  local file=$1
+  local value=
+
+  if [[ -r "$file" ]]; then
+    {
+      IFS= read -r value || true
+      IFS= read -r value || true
+    } <"$file"
+  fi
+  printf '%s' "$value"
+}
+
+complete_lock_identity() {
+  local identity_pattern='^boot-id:[^;]+;pid-namespace:pid:\[[0-9]+\]$'
+
+  [[ "$1" =~ $identity_pattern ]]
+}
+
+resolve_lock_identity() {
+  local proc_root=${VERLET_CARGO_LANE_PROC_ROOT:-/proc}
+  local boot_id=
+  local identity=
+  local pid_namespace=
+
+  if [[ -r "$proc_root/sys/kernel/random/boot_id" ]]; then
+    IFS= read -r boot_id <"$proc_root/sys/kernel/random/boot_id" || true
+  fi
+  if [[ -L "$proc_root/self/ns/pid" ]]; then
+    pid_namespace=$(readlink "$proc_root/self/ns/pid" 2>/dev/null || true)
+  fi
+
+  if [[ -n "$boot_id" && -n "$pid_namespace" ]]; then
+    identity="boot-id:$boot_id;pid-namespace:$pid_namespace"
+    if complete_lock_identity "$identity"; then
+      LOCK_IDENTITY=$identity
+    fi
+  fi
+}
+
+resolve_lock_wait_timeout() {
+  local configured=${VERLET_CARGO_LANE_WAIT_TIMEOUT_SECONDS:-1800}
+
+  if [[ ! "$configured" =~ ^[1-9][0-9]*$ ]]; then
+    die 'VERLET_CARGO_LANE_WAIT_TIMEOUT_SECONDS must be a positive integer'
+  fi
+  LOCK_WAIT_TIMEOUT_SECONDS=$configured
+}
+
 valid_holder_pid() {
   [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
+holder_is_live() {
+  local holder_pid=$1
+  local holder_identity=$2
+
+  if ! valid_holder_pid "$holder_pid"; then
+    return 1
+  fi
+  if complete_lock_identity "$LOCK_IDENTITY" \
+    && complete_lock_identity "$holder_identity" \
+    && [[ "$holder_identity" != "$LOCK_IDENTITY" ]]; then
+    return 1
+  fi
+  kill -0 "$holder_pid" 2>/dev/null
 }
 
 path_older_than_initialization_grace() {
@@ -286,7 +352,7 @@ release_lane_lock() {
 
   recorded_token=$(read_lock_field "$LOCK_DIR/token")
   if [[ -n "$LOCK_TOKEN" && "$recorded_token" == "$LOCK_TOKEN" ]]; then
-    rm -f "$LOCK_DIR/pid" "$LOCK_DIR/token"
+    rm -f "$LOCK_DIR/pid" "$LOCK_DIR/token" "$LOCK_DIR/identity"
     rmdir "$LOCK_DIR" 2>/dev/null || true
   elif ((LOCK_READY == 0)) && [[ -d "$LOCK_DIR" && -z "$recorded_token" ]]; then
     rmdir "$LOCK_DIR" 2>/dev/null || true
@@ -315,8 +381,10 @@ handle_signal() {
 try_reclaim_stale_lock() {
   local observed_pid=$1
   local observed_token=$2
+  local observed_identity=$3
   local current_pid
   local current_token
+  local current_identity
 
   if ! acquire_reclaim_claim; then
     return 1
@@ -324,17 +392,19 @@ try_reclaim_stale_lock() {
 
   current_pid=$(read_lock_field "$LOCK_DIR/pid")
   current_token=$(read_lock_field "$LOCK_DIR/token")
+  current_identity=$(read_lock_field "$LOCK_DIR/identity")
   if [[ "$current_pid" != "$observed_pid" \
-    || "$current_token" != "$observed_token" ]]; then
+    || "$current_token" != "$observed_token" \
+    || "$current_identity" != "$observed_identity" ]]; then
     release_reclaim_claim
     return 1
   fi
-  if valid_holder_pid "$current_pid" && kill -0 "$current_pid" 2>/dev/null; then
+  if holder_is_live "$current_pid" "$current_identity"; then
     release_reclaim_claim
     return 1
   fi
 
-  rm -f "$LOCK_DIR/pid" "$LOCK_DIR/token"
+  rm -f "$LOCK_DIR/pid" "$LOCK_DIR/token" "$LOCK_DIR/identity"
   release_reclaim_claim
   rmdir "$LOCK_DIR" 2>/dev/null || return 1
   return 0
@@ -342,6 +412,7 @@ try_reclaim_stale_lock() {
 
 recover_abandoned_reclaim_claim() {
   local owner_file
+  local owner_identity
   local owner_pid
 
   if [[ ! -d "$LOCK_DIR/reclaim" ]]; then
@@ -356,8 +427,8 @@ recover_abandoned_reclaim_claim() {
       continue
     fi
     owner_pid=$(read_lock_field "$owner_file")
-    if ! valid_holder_pid "$owner_pid" \
-      || ! kill -0 "$owner_pid" 2>/dev/null; then
+    owner_identity=$(read_claim_identity "$owner_file")
+    if ! holder_is_live "$owner_pid" "$owner_identity"; then
       rm -f "$owner_file"
     fi
   done
@@ -365,6 +436,7 @@ recover_abandoned_reclaim_claim() {
 }
 
 acquire_reclaim_claim() {
+  local claimant_identity
   local claimant_pid
   local owner_file
 
@@ -374,13 +446,14 @@ acquire_reclaim_claim() {
   fi
 
   owner_file="$LOCK_DIR/reclaim/owner.$RANDOM.$RANDOM"
-  if ! sh -c 'printf "%s\n" "$PPID" >"$1"' sh "$owner_file" 2>/dev/null; then
+  if ! sh -c 'printf "%s\n%s\n" "$PPID" "$2" >"$1"' \
+    sh "$owner_file" "$LOCK_IDENTITY" 2>/dev/null; then
     rmdir "$LOCK_DIR/reclaim" 2>/dev/null || true
     return 1
   fi
   claimant_pid=$(read_lock_field "$owner_file")
-  if ! valid_holder_pid "$claimant_pid" \
-    || ! kill -0 "$claimant_pid" 2>/dev/null; then
+  claimant_identity=$(read_claim_identity "$owner_file")
+  if ! holder_is_live "$claimant_pid" "$claimant_identity"; then
     rm -f "$owner_file"
     rmdir "$LOCK_DIR/reclaim" 2>/dev/null || true
     return 1
@@ -398,11 +471,16 @@ release_reclaim_claim() {
 }
 
 acquire_lane_lock() {
+  local holder_identity
   local holder_pid
   local holder_token
   local missing_checks=0
   local missing_token=
   local printed_wait=0
+  local wait_checks=0
+  local wait_holder_pid=
+  local wait_holder_set=0
+  local wait_holder_token=
 
   LOCK_TOKEN="$$.$RANDOM.$RANDOM"
   while true; do
@@ -416,6 +494,10 @@ acquire_lane_lock() {
 
       if ! printf '%s\n' "$LOCK_TOKEN" >"$LOCK_DIR/token"; then
         die "could not write $LANE_INSTANCE Cargo lane lock token"
+      fi
+      if [[ -n "$LOCK_IDENTITY" ]] \
+        && ! printf '%s\n' "$LOCK_IDENTITY" >"$LOCK_DIR/identity"; then
+        die "could not write $LANE_INSTANCE Cargo lane lock identity"
       fi
       if ! printf '%s\n' "$$" >"$LOCK_DIR/pid"; then
         die "could not write $LANE_INSTANCE Cargo lane holder PID"
@@ -437,6 +519,15 @@ acquire_lane_lock() {
 
     holder_pid=$(read_lock_field "$LOCK_DIR/pid")
     holder_token=$(read_lock_field "$LOCK_DIR/token")
+    holder_identity=$(read_lock_field "$LOCK_DIR/identity")
+    if ((wait_holder_set == 0)) \
+      || [[ "$holder_pid" != "$wait_holder_pid" \
+        || "$holder_token" != "$wait_holder_token" ]]; then
+      wait_holder_pid=$holder_pid
+      wait_holder_token=$holder_token
+      wait_checks=0
+      wait_holder_set=1
+    fi
     if ((printed_wait == 0)); then
       if valid_holder_pid "$holder_pid"; then
         printf 'cargo-lane: waiting for %s Cargo lane (holder pid %s)\n' \
@@ -451,14 +542,16 @@ acquire_lane_lock() {
     if valid_holder_pid "$holder_pid"; then
       missing_checks=0
       missing_token=
-      if ! kill -0 "$holder_pid" 2>/dev/null; then
-        try_reclaim_stale_lock "$holder_pid" "$holder_token" || true
+      if ! holder_is_live "$holder_pid" "$holder_identity"; then
+        try_reclaim_stale_lock \
+          "$holder_pid" "$holder_token" "$holder_identity" || true
       fi
     elif [[ -z "$holder_token" ]]; then
       missing_checks=0
       missing_token=
       if path_older_than_initialization_grace "$LOCK_DIR"; then
-        try_reclaim_stale_lock "$holder_pid" "$holder_token" || true
+        try_reclaim_stale_lock \
+          "$holder_pid" "$holder_token" "$holder_identity" || true
       fi
     else
       if [[ "$holder_token" != "$missing_token" ]]; then
@@ -467,16 +560,47 @@ acquire_lane_lock() {
       fi
       missing_checks=$((missing_checks + 1))
       if ((missing_checks * 1 >= INITIALIZATION_GRACE_SECONDS * 10)); then
-        try_reclaim_stale_lock "$holder_pid" "$holder_token" || true
+        try_reclaim_stale_lock \
+          "$holder_pid" "$holder_token" "$holder_identity" || true
         missing_checks=0
       fi
     fi
 
     sleep 0.1
+    wait_checks=$((wait_checks + 1))
+    if ((wait_checks >= LOCK_WAIT_TIMEOUT_SECONDS * 10)); then
+      if [[ ! -d "$LOCK_DIR" ]]; then
+        continue
+      fi
+      holder_pid=$(read_lock_field "$LOCK_DIR/pid")
+      holder_token=$(read_lock_field "$LOCK_DIR/token")
+      holder_identity=$(read_lock_field "$LOCK_DIR/identity")
+      if [[ "$holder_pid" != "$wait_holder_pid" \
+        || "$holder_token" != "$wait_holder_token" ]]; then
+        wait_holder_pid=$holder_pid
+        wait_holder_token=$holder_token
+        wait_checks=0
+        continue
+      fi
+      if valid_holder_pid "$holder_pid"; then
+        printf 'cargo-lane: timed out after %ss on current holder of %s Cargo lane lock %s (recorded holder pid %s' \
+          "$LOCK_WAIT_TIMEOUT_SECONDS" "$LANE_INSTANCE" "$LOCK_DIR" \
+          "$holder_pid" >&2
+      else
+        printf 'cargo-lane: timed out after %ss on current holder of %s Cargo lane lock %s (recorded holder initializing' \
+          "$LOCK_WAIT_TIMEOUT_SECONDS" "$LANE_INSTANCE" "$LOCK_DIR" >&2
+      fi
+      if [[ -n "$holder_identity" ]]; then
+        printf ', identity %s' "$holder_identity" >&2
+      fi
+      printf ')\n' >&2
+      exit 1
+    fi
   done
 }
 
 start_lock_monitor() {
+  local lock_identity=$LOCK_IDENTITY
   local holder_pid=$$
   local lock_token=$LOCK_TOKEN
 
@@ -486,7 +610,7 @@ start_lock_monitor() {
     while kill -0 "$holder_pid" 2>/dev/null; do
       sleep 0.5
     done
-    try_reclaim_stale_lock "$holder_pid" "$lock_token" || true
+    try_reclaim_stale_lock "$holder_pid" "$lock_token" "$lock_identity" || true
   ) </dev/null >/dev/null 2>&1 &
 }
 
@@ -569,6 +693,7 @@ run_cargo() {
     remove_path_entry "$ACTIVE_CARGO_SHIM_DIR"
   fi
   unset VERLET_CARGO_LANE_SCRIPT VERLET_CARGO_SHIM_DIR VERLET_REAL_CARGO
+  unset VERLET_CARGO_LANE_PROC_ROOT VERLET_CARGO_LANE_WAIT_TIMEOUT_SECONDS
 
   start_lock_monitor
   exec "$REAL_CARGO" "$@"
@@ -584,6 +709,8 @@ main() {
   resolve_git_context
   select_lane
   reject_target_override "$@"
+  resolve_lock_identity
+  resolve_lock_wait_timeout
   acquire_lane_lock
   rotate_lane_owner
   run_cargo "$@"

--- a/scripts/verify-linux-test.sh
+++ b/scripts/verify-linux-test.sh
@@ -8,6 +8,8 @@ TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/verify-linux-test.XXXXXX")" || exit 1
 TMP_DIR="$(cd "$TMP_DIR" && pwd -P)"
 FAKE_BIN="$TMP_DIR/bin"
 DOCKER_RECORD="$TMP_DIR/docker-record"
+FAKE_DOCKER_STATE="$TMP_DIR/docker-state"
+HOST_LOCK_ROOT="$TMP_DIR/host-locks"
 FAILURES=0
 RUN_STATUS=0
 MAIN_REPO="$TMP_DIR/repo"
@@ -17,6 +19,12 @@ COMMA_WORKTREE="$TMP_DIR/comma-common-worktree"
 SPACE_REPO="$TMP_DIR/repo with space=ok"
 
 cleanup() {
+  local pid
+
+  for pid in $(jobs -pr); do
+    kill -TERM "$pid" >/dev/null 2>&1 || true
+  done
+  wait >/dev/null 2>&1 || true
   rm -rf "$TMP_DIR"
 }
 trap cleanup EXIT
@@ -61,6 +69,80 @@ assert_file_excludes() {
   fi
 }
 
+assert_path_exists() {
+  if [[ ! -e "$1" ]]; then
+    fail "$2"
+  fi
+}
+
+assert_no_path() {
+  if [[ -e "$1" || -L "$1" ]]; then
+    fail "$2"
+  fi
+}
+
+wait_for_path() {
+  local path=$1
+  local name=$2
+  local attempts=0
+
+  while [[ ! -e "$path" && $attempts -lt 200 ]]; do
+    sleep 0.05
+    attempts=$((attempts + 1))
+  done
+  if [[ ! -e "$path" ]]; then
+    fail "$name"
+    return 1
+  fi
+}
+
+wait_for_text() {
+  local file=$1
+  local needle=$2
+  local name=$3
+  local attempts=0
+
+  while { [[ ! -f "$file" ]] || ! grep -Fq -- "$needle" "$file"; } \
+    && ((attempts < 200)); do
+    sleep 0.05
+    attempts=$((attempts + 1))
+  done
+  if [[ ! -f "$file" ]] || ! grep -Fq -- "$needle" "$file"; then
+    fail "$name"
+    return 1
+  fi
+}
+
+wait_for_pid() {
+  local pid=$1
+  local expected=$2
+  local name=$3
+  local status
+  local timeout_marker="$TMP_DIR/wait-timeout-$pid"
+  local watchdog_pid
+
+  (
+    sleep 15
+    : >"$timeout_marker"
+    kill -TERM "$pid" 2>/dev/null || exit 0
+    sleep 1
+    kill -KILL "$pid" 2>/dev/null || true
+  ) &
+  watchdog_pid=$!
+
+  wait "$pid" 2>/dev/null
+  status=$?
+  kill -TERM "$watchdog_pid" 2>/dev/null || true
+  wait "$watchdog_pid" 2>/dev/null || true
+  if [[ -e "$timeout_marker" ]]; then
+    fail "$name timed out"
+    return
+  fi
+  if ((status != expected)); then
+    fail "$name (expected status $expected, got $status)"
+  fi
+}
+
 run_wrapper() {
   local cwd=$1
   local name=$2
@@ -72,9 +154,34 @@ run_wrapper() {
       FAKE_DOCKER_RECORD="$DOCKER_RECORD" \
       FAKE_DOCKER_MEMORY="${FAKE_DOCKER_MEMORY:-17179869184}" \
       FAKE_DOCKER_RUN_EXIT="${FAKE_DOCKER_RUN_EXIT:-0}" \
+      FAKE_DOCKER_MODE="${FAKE_DOCKER_MODE:-record}" \
+      FAKE_DOCKER_LABEL="${FAKE_DOCKER_LABEL:-record}" \
+      FAKE_DOCKER_STATE="$FAKE_DOCKER_STATE" \
+      VERLET_VERIFY_LINUX_LOCK_ROOT="$HOST_LOCK_ROOT" \
       "$cwd/scripts/verify-linux.sh" "$@"
   ) >"$TMP_DIR/$name.out" 2>"$TMP_DIR/$name.err"
   RUN_STATUS=$?
+}
+
+STARTED_PID=
+start_wrapper() {
+  local cwd=$1
+  local name=$2
+  shift 2
+
+  (
+    cd "$cwd" || exit 1
+    PATH="$FAKE_BIN:/usr/bin:/bin" \
+      FAKE_DOCKER_RECORD="$DOCKER_RECORD" \
+      FAKE_DOCKER_MEMORY="${FAKE_DOCKER_MEMORY:-17179869184}" \
+      FAKE_DOCKER_RUN_EXIT="${FAKE_DOCKER_RUN_EXIT:-0}" \
+      FAKE_DOCKER_MODE="${FAKE_DOCKER_MODE:-record}" \
+      FAKE_DOCKER_LABEL="${FAKE_DOCKER_LABEL:-record}" \
+      FAKE_DOCKER_STATE="$FAKE_DOCKER_STATE" \
+      VERLET_VERIFY_LINUX_LOCK_ROOT="$HOST_LOCK_ROOT" \
+      exec "$cwd/scripts/verify-linux.sh" "$@"
+  ) >"$TMP_DIR/$name.out" 2>"$TMP_DIR/$name.err" &
+  STARTED_PID=$!
 }
 
 if [[ ! -x "$VERIFY_LINUX_SCRIPT" ]]; then
@@ -82,7 +189,8 @@ if [[ ! -x "$VERIFY_LINUX_SCRIPT" ]]; then
   exit 1
 fi
 
-mkdir -p "$FAKE_BIN" "$MAIN_REPO/scripts"
+mkdir -p "$FAKE_BIN" "$FAKE_DOCKER_STATE" "$HOST_LOCK_ROOT" \
+  "$MAIN_REPO/scripts"
 cp "$VERIFY_LINUX_SCRIPT" "$MAIN_REPO/scripts/verify-linux.sh"
 chmod +x "$MAIN_REPO/scripts/verify-linux.sh"
 
@@ -229,6 +337,12 @@ case "${1:-}" in
       || die 'clean verification does not remove the snapshot log'
     [[ "$1" == *'exit "$verify_status"'* ]] \
       || die 'container command does not preserve the verifier status'
+    if [[ "${FAKE_DOCKER_MODE:-record}" == hold ]]; then
+      : >"$FAKE_DOCKER_STATE/started-${FAKE_DOCKER_LABEL:-record}"
+      while [[ ! -e "$FAKE_DOCKER_STATE/release-${FAKE_DOCKER_LABEL:-record}" ]]; do
+        sleep 0.02
+      done
+    fi
     exit "${FAKE_DOCKER_RUN_EXIT:-0}"
     ;;
 esac
@@ -328,6 +442,66 @@ assert_file_excludes "$TMP_DIR/main-dry.out" \
   "$MAIN_REPO/.git/cargo-lanes" \
   'dry run does not target the host Cargo lane root'
 
+HOST_LOCK_DIR="$HOST_LOCK_ROOT/verlet-verify-linux.lock"
+assert_no_path "$HOST_LOCK_DIR" 'dry run did not acquire the host volume lock'
+
+run_wrapper "$MAIN_REPO" host-lock-normal
+assert_eq 0 "$RUN_STATUS" 'normal verification acquired and released the host lock'
+assert_no_path "$HOST_LOCK_DIR" 'normal verification removed the host lock'
+
+mkdir -p "$HOST_LOCK_DIR"
+printf '99999999\n' >"$HOST_LOCK_DIR/pid"
+printf 'dead-host-token\n' >"$HOST_LOCK_DIR/token"
+run_wrapper "$MAIN_REPO" host-lock-stale
+assert_eq 0 "$RUN_STATUS" 'dead host lock holder was reclaimed'
+assert_no_path "$HOST_LOCK_DIR" 'stale host lock was removed after verification'
+
+FAKE_DOCKER_MODE=hold
+FAKE_DOCKER_LABEL=host-lock-holder
+start_wrapper "$MAIN_REPO" host-lock-holder
+host_lock_holder_pid=$STARTED_PID
+wait_for_path "$FAKE_DOCKER_STATE/started-host-lock-holder" \
+  'first verification entered Docker while holding the host lock'
+wait_for_path "$HOST_LOCK_DIR/pid" 'first verification recorded its host lock PID'
+assert_file_contains "$HOST_LOCK_DIR/pid" "$host_lock_holder_pid" \
+  'host lock records the owning verification PID'
+
+FAKE_DOCKER_LABEL=host-lock-waiter
+set -m
+start_wrapper "$MAIN_REPO" host-lock-waiter
+host_lock_waiter_pid=$STARTED_PID
+set +m
+wait_for_text "$TMP_DIR/host-lock-waiter.err" \
+  "waiting for Docker volume verlet-verify-linux host lock (holder pid $host_lock_holder_pid)" \
+  'second verification named the live host lock holder while blocked'
+assert_no_path "$FAKE_DOCKER_STATE/started-host-lock-waiter" \
+  'second verification did not start a concurrent container'
+kill -INT -- "-$host_lock_waiter_pid"
+wait_for_pid "$host_lock_waiter_pid" 130 \
+  'Ctrl-C stopped the host-lock waiter with status 130'
+assert_file_contains "$HOST_LOCK_DIR/pid" "$host_lock_holder_pid" \
+  'interrupted waiter preserved the live holder lock'
+assert_no_path "$FAKE_DOCKER_STATE/started-host-lock-waiter" \
+  'interrupted waiter never entered Docker'
+: >"$FAKE_DOCKER_STATE/release-host-lock-holder"
+wait_for_pid "$host_lock_holder_pid" 0 'first host-lock holder exited normally'
+assert_no_path "$HOST_LOCK_DIR" 'normal holder exit released the host lock'
+
+FAKE_DOCKER_LABEL=host-lock-signal
+set -m
+start_wrapper "$MAIN_REPO" host-lock-signal
+host_lock_signal_pid=$STARTED_PID
+set +m
+wait_for_path "$FAKE_DOCKER_STATE/started-host-lock-signal" \
+  'signal test entered Docker while holding the host lock'
+wait_for_path "$HOST_LOCK_DIR/pid" 'signal test recorded its host lock PID'
+kill -TERM -- "-$host_lock_signal_pid"
+wait_for_pid "$host_lock_signal_pid" 143 \
+  'signaled verification preserved termination status'
+assert_no_path "$HOST_LOCK_DIR" 'signal exit released the host lock'
+FAKE_DOCKER_MODE=record
+FAKE_DOCKER_LABEL=record
+
 run_wrapper "$LINKED_WORKTREE" worktree-dry --dry-run
 assert_eq 0 "$RUN_STATUS" 'linked-worktree dry run succeeded'
 assert_file_contains "$TMP_DIR/worktree-dry.out" \
@@ -373,6 +547,7 @@ assert_file_contains "$TMP_DIR/docker-missing.err" \
 
 FAKE_DOCKER_RUN_EXIT=37 run_wrapper "$MAIN_REPO" exit-code
 assert_eq 37 "$RUN_STATUS" 'docker run exit status passed through unchanged'
+assert_no_path "$HOST_LOCK_DIR" 'nonzero Docker exit released the host lock'
 
 mkdir -p "$COMMA_REPO/scripts"
 cp "$VERIFY_LINUX_SCRIPT" "$COMMA_REPO/scripts/verify-linux.sh"

--- a/scripts/verify-linux.sh
+++ b/scripts/verify-linux.sh
@@ -12,6 +12,12 @@ CACHE_ROOT=/verlet-cache
 CONTAINER_WORKSPACE=/workspace
 DRY_RUN=0
 LOW_MEMORY=0
+HOST_LOCK_DIR=
+HOST_LOCK_TOKEN=
+HOST_LOCK_HELD=0
+HOST_LOCK_READY=0
+HOST_RECLAIM_OWNER_FILE=
+HOST_LOCK_INITIALIZATION_GRACE_SECONDS=5
 
 usage() {
   printf 'usage: scripts/verify-linux.sh [--amd64] [--dry-run]\n'
@@ -20,6 +26,230 @@ usage() {
 die() {
   printf 'error: %s\n' "$1" >&2
   exit "${2:-1}"
+}
+
+read_host_lock_field() {
+  local file=$1
+  local value=
+
+  if [[ -r "$file" ]]; then
+    IFS= read -r value <"$file" || true
+  fi
+  printf '%s' "$value"
+}
+
+valid_host_lock_pid() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
+host_lock_path_older_than_initialization_grace() {
+  local path=$1
+  local modified
+  local now
+
+  if modified=$(stat -f '%m' "$path" 2>/dev/null); then
+    :
+  elif modified=$(stat -c '%Y' "$path" 2>/dev/null); then
+    :
+  else
+    return 1
+  fi
+  now=$(date +%s)
+  ((now - modified >= HOST_LOCK_INITIALIZATION_GRACE_SECONDS))
+}
+
+release_host_reclaim_claim() {
+  if [[ -n "$HOST_RECLAIM_OWNER_FILE" ]]; then
+    rm -f "$HOST_RECLAIM_OWNER_FILE"
+    HOST_RECLAIM_OWNER_FILE=
+  fi
+  rmdir "$HOST_LOCK_DIR/reclaim" 2>/dev/null || true
+}
+
+recover_abandoned_host_reclaim_claim() {
+  local owner_file
+  local owner_pid
+
+  if [[ ! -d "$HOST_LOCK_DIR/reclaim" ]]; then
+    return
+  fi
+  if ! host_lock_path_older_than_initialization_grace \
+    "$HOST_LOCK_DIR/reclaim"; then
+    return
+  fi
+
+  for owner_file in "$HOST_LOCK_DIR"/reclaim/owner.*.*; do
+    if [[ ! -f "$owner_file" ]]; then
+      continue
+    fi
+    owner_pid=$(read_host_lock_field "$owner_file")
+    if ! valid_host_lock_pid "$owner_pid" \
+      || ! kill -0 "$owner_pid" 2>/dev/null; then
+      rm -f "$owner_file"
+    fi
+  done
+  rmdir "$HOST_LOCK_DIR/reclaim" 2>/dev/null || true
+}
+
+acquire_host_reclaim_claim() {
+  local owner_file
+  local owner_pid
+
+  if ! mkdir "$HOST_LOCK_DIR/reclaim" 2>/dev/null; then
+    recover_abandoned_host_reclaim_claim
+    return 1
+  fi
+
+  owner_file="$HOST_LOCK_DIR/reclaim/owner.$RANDOM.$RANDOM"
+  if ! printf '%s\n' "$$" >"$owner_file"; then
+    rmdir "$HOST_LOCK_DIR/reclaim" 2>/dev/null || true
+    return 1
+  fi
+  owner_pid=$(read_host_lock_field "$owner_file")
+  if ! valid_host_lock_pid "$owner_pid" \
+    || ! kill -0 "$owner_pid" 2>/dev/null; then
+    rm -f "$owner_file"
+    rmdir "$HOST_LOCK_DIR/reclaim" 2>/dev/null || true
+    return 1
+  fi
+  HOST_RECLAIM_OWNER_FILE=$owner_file
+  return 0
+}
+
+try_reclaim_stale_host_lock() {
+  local observed_pid=$1
+  local observed_token=$2
+  local current_pid
+  local current_token
+
+  if ! acquire_host_reclaim_claim; then
+    return 1
+  fi
+
+  current_pid=$(read_host_lock_field "$HOST_LOCK_DIR/pid")
+  current_token=$(read_host_lock_field "$HOST_LOCK_DIR/token")
+  if [[ "$current_pid" != "$observed_pid" \
+    || "$current_token" != "$observed_token" ]]; then
+    release_host_reclaim_claim
+    return 1
+  fi
+  if valid_host_lock_pid "$current_pid" \
+    && kill -0 "$current_pid" 2>/dev/null; then
+    release_host_reclaim_claim
+    return 1
+  fi
+
+  rm -f "$HOST_LOCK_DIR/pid" "$HOST_LOCK_DIR/token"
+  release_host_reclaim_claim
+  rmdir "$HOST_LOCK_DIR" 2>/dev/null || return 1
+  return 0
+}
+
+release_host_lock() {
+  local recorded_token
+
+  if ((HOST_LOCK_HELD == 0)); then
+    return
+  fi
+
+  recorded_token=$(read_host_lock_field "$HOST_LOCK_DIR/token")
+  if [[ -n "$HOST_LOCK_TOKEN" \
+    && "$recorded_token" == "$HOST_LOCK_TOKEN" ]]; then
+    rm -f "$HOST_LOCK_DIR/pid" "$HOST_LOCK_DIR/token"
+    rmdir "$HOST_LOCK_DIR" 2>/dev/null || true
+  elif ((HOST_LOCK_READY == 0)) \
+    && [[ -d "$HOST_LOCK_DIR" && -z "$recorded_token" ]]; then
+    rmdir "$HOST_LOCK_DIR" 2>/dev/null || true
+  fi
+
+  HOST_LOCK_HELD=0
+  HOST_LOCK_READY=0
+}
+
+cleanup_host_lock_on_exit() {
+  local status=$?
+
+  trap - EXIT HUP INT QUIT TERM
+  release_host_reclaim_claim
+  release_host_lock
+  exit "$status"
+}
+
+handle_host_signal() {
+  trap - "$1"
+  exit "$2"
+}
+
+resolve_host_lock_path() {
+  local lock_root=${VERLET_VERIFY_LINUX_LOCK_ROOT:-${TMPDIR:-/tmp}/verlet-verify-linux-locks}
+
+  if [[ "$lock_root" != /* ]]; then
+    die 'VERLET_VERIFY_LINUX_LOCK_ROOT must be an absolute path'
+  fi
+  mkdir -p "$lock_root"
+  if ! lock_root=$(cd "$lock_root" && pwd -P); then
+    die "could not resolve host lock root: $lock_root"
+  fi
+  HOST_LOCK_DIR="$lock_root/$VOLUME.lock"
+}
+
+acquire_host_lock() {
+  local holder_pid
+  local holder_token
+  local printed_wait=0
+
+  resolve_host_lock_path
+  HOST_LOCK_TOKEN="$$.$RANDOM.$RANDOM"
+  trap cleanup_host_lock_on_exit EXIT
+  trap 'handle_host_signal HUP 129' HUP
+  trap 'handle_host_signal INT 130' INT
+  trap 'handle_host_signal QUIT 131' QUIT
+  trap 'handle_host_signal TERM 143' TERM
+
+  while true; do
+    if mkdir "$HOST_LOCK_DIR" 2>/dev/null; then
+      HOST_LOCK_HELD=1
+      if ! printf '%s\n' "$HOST_LOCK_TOKEN" >"$HOST_LOCK_DIR/token"; then
+        die "could not write Docker volume $VOLUME host lock token"
+      fi
+      if ! printf '%s\n' "$$" >"$HOST_LOCK_DIR/pid"; then
+        die "could not write Docker volume $VOLUME host lock PID"
+      fi
+      HOST_LOCK_READY=1
+      return
+    fi
+
+    if [[ -L "$HOST_LOCK_DIR" \
+      || ( -e "$HOST_LOCK_DIR" && ! -d "$HOST_LOCK_DIR" ) ]]; then
+      die "refusing unexpected Docker volume $VOLUME host lock path: $HOST_LOCK_DIR"
+    fi
+    if [[ ! -d "$HOST_LOCK_DIR" ]]; then
+      sleep 0.1
+      continue
+    fi
+
+    holder_pid=$(read_host_lock_field "$HOST_LOCK_DIR/pid")
+    holder_token=$(read_host_lock_field "$HOST_LOCK_DIR/token")
+    if ((printed_wait == 0)); then
+      if valid_host_lock_pid "$holder_pid"; then
+        printf 'verify-linux: waiting for Docker volume %s host lock (holder pid %s)\n' \
+          "$VOLUME" "$holder_pid" >&2
+      else
+        printf 'verify-linux: waiting for Docker volume %s host lock (holder initializing)\n' \
+          "$VOLUME" >&2
+      fi
+      printed_wait=1
+    fi
+
+    if valid_host_lock_pid "$holder_pid"; then
+      if ! kill -0 "$holder_pid" 2>/dev/null; then
+        try_reclaim_stale_host_lock "$holder_pid" "$holder_token" || true
+      fi
+    elif host_lock_path_older_than_initialization_grace "$HOST_LOCK_DIR"; then
+      try_reclaim_stale_host_lock "$holder_pid" "$holder_token" || true
+    fi
+    sleep 0.1
+  done
 }
 
 print_command() {
@@ -264,4 +494,6 @@ if ((DRY_RUN)); then
   exit 0
 fi
 
+# Container identity mismatch is stale only under this per-volume exclusion.
+acquire_host_lock
 "${docker_run[@]}"


### PR DESCRIPTION
## Summary
- Cargo lane locks now record a lock identity (boot id plus pid namespace) next to the pid and token files, so a lock left behind by a killed container is recognized as stale instead of colliding with an unrelated live pid in a new container.
- Liveness checks treat an identity mismatch as stale only when both identities are complete; a partially readable /proc can never get a live holder reclaimed.
- The lane wait timeout is now per holder (resets when the holder changes, default 1800s, override via VERLET_CARGO_LANE_WAIT_TIMEOUT_SECONDS), so healthy queued builds are never failed for waiting behind a long build.
- scripts/verify-linux.sh takes a host-side per-volume lock before starting the container, which is the invariant that makes identity-mismatch-means-stale safe: at most one live container uses the lane volume at a time.
- Harness coverage in scripts/cargo-lane-test.sh and scripts/verify-linux-test.sh for identity handling, reclaim, timeout reset, and the host lock.

Note for worktrees not yet rebased past this change: the old cargo-lane cannot fully reclaim a lock left by a killed run of the new code (rmdir stops on the identity file it does not know) and will wait indefinitely; the manual fix is deleting the leftover identity file or the stale *.lock directory on the verlet-verify-linux volume.

## Verification
- scripts/verify.sh green on macOS (also rerun by the pre-push hook)
- scripts/verify-linux.sh green (arm64)
- scripts/cargo-lane-test.sh and scripts/verify-linux-test.sh green

Linear: EMO-594