### PR TITLE
Name known 137 causes in Linux lane diagnostics (EMO-595)

### DIFF
--- a/scripts/verify-linux.sh
+++ b/scripts/verify-linux.sh
@@ -461,6 +461,7 @@ if compgen -G '$CARGO_LANE_ROOT/*.lock' >/dev/null; then
 fi
 if ((verify_status == 137)); then
   print_process_snapshot_diagnostics >&2 || true
+  printf 'known 137 causes (EMO-595): Docker Desktop Resource Saver stopping the VM (machine-local GUI setting under Settings > Resources; re-disable on any new machine) and, before EMO-603, procps kill negative-pid mangling in trace-ab.\\n' >&2
 fi
 if ((verify_status == 0)); then
   rm -f \"\$snapshot_log\" || true


### PR DESCRIPTION
One printf added to the exit-137 diagnostics branch of scripts/verify-linux.sh, naming the two known causes: Docker Desktop Resource Saver stopping the VM (a machine-local GUI setting that must be re-disabled on any new machine) and, before EMO-603, procps kill negative-pid mangling in trace-ab. Closes the last EMO-595 acceptance criterion. No behavior change on any non-137 path; dry-run and full macOS verify green.