### PR TITLE
Guest ABI fs write leg (EMO-604)

### DIFF
--- a/crates/verlet-guest-sdk/src/lib.rs
+++ b/crates/verlet-guest-sdk/src/lib.rs
@@ -133,6 +133,9 @@ pub const STATUS_CANCELLED: i32 = 6;
 pub const STATUS_EOF: i32 = 7;
 /// File open mode for read-only VFS handles.
 pub const FS_MODE_READ: u32 = 0;
+/// File open mode for write VFS handles: bytes accumulate host-side and the
+/// file is created or wholly replaced only when the handle is closed.
+pub const FS_MODE_WRITE: u32 = 1;
 #[cfg(target_arch = "wasm32")]
 const STATUS_LEGACY_SOURCE_EOF: i32 = -1;
 
@@ -536,6 +539,35 @@ pub struct Invocation(pub u32);
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FileHandle(pub u32);
 
+/// Kind of filesystem entry reported by [`stat_path`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FileKind {
+    /// A regular file.
+    File,
+    /// A directory.
+    Dir,
+    /// Anything that is neither a regular file nor a directory.
+    Other,
+}
+
+/// Metadata for a VFS path, decoded from the host's 16-byte stat record.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FileStat {
+    /// What kind of entry the path names.
+    pub kind: FileKind,
+    /// Size in bytes for files; 0 for directories.
+    pub size: u64,
+}
+
+/// One directory entry from [`list_dir`].
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct DirEntry {
+    /// Entry name (name only, never a full path).
+    pub name: String,
+    /// Whether the entry is a directory.
+    pub is_dir: bool,
+}
+
 /// Source handles returned by an HTTP host request.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct HttpResponseSources {
@@ -623,9 +655,48 @@ pub fn read_file(handle: FileHandle, buffer: &mut [u8]) -> Result<usize, StatusC
     call_fs_read(handle, buffer)
 }
 
-/// Close a VFS file handle.
+/// Close a VFS file handle. For write handles this is the commit point: the
+/// host replaces the whole file with the accumulated buffer, and the returned
+/// status is the outcome of that write.
 pub fn close_file(handle: FileHandle) -> Result<(), StatusCode> {
     call_fs_close(handle).into_result()
+}
+
+/// Open a write VFS file handle. Bytes passed to [`write_file`] accumulate
+/// host-side; the file is created or wholly replaced only when
+/// [`close_file`] commits the buffer. Parent directories are not created on
+/// commit; create them first with [`mkdir`]. Requires the `fs.write`
+/// capability grant in addition to an attached VFS.
+pub fn open_file_write(path: &str) -> Result<FileHandle, StatusCode> {
+    call_fs_open(path, FS_MODE_WRITE)
+}
+
+/// Append bytes to the pending buffer of a write VFS file handle.
+/// All-or-nothing: on `Ok(())` the whole slice was appended.
+pub fn write_file(handle: FileHandle, bytes: &[u8]) -> Result<(), StatusCode> {
+    call_fs_write(handle, bytes).into_result()
+}
+
+/// Stat an absolute VFS path. `Err(StatusCode::NotFound)` doubles as the
+/// existence check; there is no separate exists import.
+pub fn stat_path(path: &str) -> Result<FileStat, StatusCode> {
+    call_fs_stat(path)
+}
+
+/// List an absolute VFS directory, name-sorted (byte order). Drains the
+/// host's listing source and decodes the JSON array of entries.
+pub fn list_dir(path: &str) -> Result<Vec<DirEntry>, StatusCode> {
+    let _source = call_fs_list(path)?;
+    // Drain `_source` with `call_source_read` until EOF, then decode the
+    // bytes as a JSON array of `DirEntry`; decode failures map to
+    // `StatusCode::TransportError`.
+    todo!("fs write leg: drain and decode the fs_list source")
+}
+
+/// Create a directory at an absolute VFS path. Requires the `fs.write`
+/// capability grant in addition to an attached VFS.
+pub fn mkdir(path: &str, recursive: bool) -> Result<(), StatusCode> {
+    call_fs_mkdir(path, recursive).into_result()
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -790,6 +861,74 @@ fn call_fs_close(_handle: FileHandle) -> StatusCode {
 }
 
 #[cfg(target_arch = "wasm32")]
+fn call_fs_write(handle: FileHandle, bytes: &[u8]) -> StatusCode {
+    StatusCode::from_raw(unsafe {
+        imports::fs_write(handle.0, bytes.as_ptr() as u32, bytes.len() as u32)
+    })
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn call_fs_write(_handle: FileHandle, _bytes: &[u8]) -> StatusCode {
+    StatusCode::TransportError
+}
+
+#[cfg(target_arch = "wasm32")]
+fn call_fs_stat(path: &str) -> Result<FileStat, StatusCode> {
+    let mut record = [0u8; 16];
+    let status = unsafe {
+        imports::fs_stat(
+            path.as_ptr() as u32,
+            path.len() as u32,
+            record.as_mut_ptr() as u32,
+        )
+    };
+    StatusCode::from_raw(status).into_result()?;
+    let kind = match u32::from_le_bytes(record[0..4].try_into().unwrap()) {
+        0 => FileKind::File,
+        1 => FileKind::Dir,
+        _ => FileKind::Other,
+    };
+    let size = u64::from_le_bytes(record[8..16].try_into().unwrap());
+    Ok(FileStat { kind, size })
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn call_fs_stat(_path: &str) -> Result<FileStat, StatusCode> {
+    Err(StatusCode::TransportError)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn call_fs_list(path: &str) -> Result<Source, StatusCode> {
+    let mut source = 0u32;
+    let status = unsafe {
+        imports::fs_list(
+            path.as_ptr() as u32,
+            path.len() as u32,
+            &mut source as *mut u32 as u32,
+        )
+    };
+    StatusCode::from_raw(status).into_result()?;
+    Ok(Source(source))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn call_fs_list(_path: &str) -> Result<Source, StatusCode> {
+    Err(StatusCode::TransportError)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn call_fs_mkdir(path: &str, recursive: bool) -> StatusCode {
+    StatusCode::from_raw(unsafe {
+        imports::fs_mkdir(path.as_ptr() as u32, path.len() as u32, recursive as u32)
+    })
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn call_fs_mkdir(_path: &str, _recursive: bool) -> StatusCode {
+    StatusCode::TransportError
+}
+
+#[cfg(target_arch = "wasm32")]
 mod imports {
     #[link(wasm_import_module = "cooldis_0.1")]
     unsafe extern "C" {
@@ -809,6 +948,10 @@ mod imports {
         pub fn fs_open(path_ptr: u32, path_len: u32, mode: u32, out_handle_ptr: u32) -> i32;
         pub fn fs_read(handle: u32, ptr: u32, len_ptr: u32) -> i32;
         pub fn fs_close(handle: u32) -> i32;
+        pub fn fs_write(handle: u32, ptr: u32, len: u32) -> i32;
+        pub fn fs_stat(path_ptr: u32, path_len: u32, out_ptr: u32) -> i32;
+        pub fn fs_list(path_ptr: u32, path_len: u32, out_source_ptr: u32) -> i32;
+        pub fn fs_mkdir(path_ptr: u32, path_len: u32, recursive: u32) -> i32;
     }
 }
 

--- a/crates/verlet-guest-sdk/src/lib.rs
+++ b/crates/verlet-guest-sdk/src/lib.rs
@@ -686,11 +686,17 @@ pub fn stat_path(path: &str) -> Result<FileStat, StatusCode> {
 /// List an absolute VFS directory, name-sorted (byte order). Drains the
 /// host's listing source and decodes the JSON array of entries.
 pub fn list_dir(path: &str) -> Result<Vec<DirEntry>, StatusCode> {
-    let _source = call_fs_list(path)?;
-    // Drain `_source` with `call_source_read` until EOF, then decode the
-    // bytes as a JSON array of `DirEntry`; decode failures map to
-    // `StatusCode::TransportError`.
-    todo!("fs write leg: drain and decode the fs_list source")
+    let source = call_fs_list(path)?;
+    let mut bytes = Vec::new();
+    let mut buffer = [0u8; 1024];
+    loop {
+        let n = call_source_read(source, &mut buffer)?;
+        if n == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&buffer[..n]);
+    }
+    serde_json::from_slice(&bytes).map_err(|_| StatusCode::TransportError)
 }
 
 /// Create a directory at an absolute VFS path. Requires the `fs.write`

--- a/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
+++ b/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
@@ -403,14 +403,136 @@ fn wasm_vfs_probe_guest() -> String {
                 "events": "none",
                 "mode": "sync",
                 "required_capabilities": []
+            },
+            {
+                "id": 4,
+                "name": "unclosed_write",
+                "input": "bytes",
+                "output": "bytes",
+                "events": "none",
+                "mode": "sync",
+                "required_capabilities": []
+            },
+            {
+                "id": 5,
+                "name": "mkdir_recursive",
+                "input": "bytes",
+                "output": "bytes",
+                "events": "none",
+                "mode": "sync",
+                "required_capabilities": []
+            },
+            {
+                "id": 6,
+                "name": "mkdir_non_recursive",
+                "input": "bytes",
+                "output": "bytes",
+                "events": "none",
+                "mode": "sync",
+                "required_capabilities": []
+            },
+            {
+                "id": 7,
+                "name": "write_to_read",
+                "input": "bytes",
+                "output": "bytes",
+                "events": "none",
+                "mode": "sync",
+                "required_capabilities": []
+            },
+            {
+                "id": 8,
+                "name": "read_from_write",
+                "input": "bytes",
+                "output": "bytes",
+                "events": "none",
+                "mode": "sync",
+                "required_capabilities": []
+            },
+            {
+                "id": 9,
+                "name": "unknown_write",
+                "input": "bytes",
+                "output": "bytes",
+                "events": "none",
+                "mode": "sync",
+                "required_capabilities": []
+            },
+            {
+                "id": 10,
+                "name": "stat_record",
+                "input": "bytes",
+                "output": "bytes",
+                "events": "none",
+                "mode": "sync",
+                "required_capabilities": []
+            },
+            {
+                "id": 11,
+                "name": "mkdir_missing_parent",
+                "input": "bytes",
+                "output": "bytes",
+                "events": "none",
+                "mode": "sync",
+                "required_capabilities": []
+            },
+            {
+                "id": 12,
+                "name": "bad_write_pointer",
+                "input": "bytes",
+                "output": "bytes",
+                "events": "none",
+                "mode": "sync",
+                "required_capabilities": []
+            },
+            {
+                "id": 13,
+                "name": "failed_close_consumes_handle",
+                "input": "bytes",
+                "output": "bytes",
+                "events": "none",
+                "mode": "sync",
+                "required_capabilities": []
+            },
+            {
+                "id": 14,
+                "name": "mkdir_invalid_recursive",
+                "input": "bytes",
+                "output": "bytes",
+                "events": "none",
+                "mode": "sync",
+                "required_capabilities": []
             }
         ]
     })
     .to_string();
     let path = b"/workspace/input.txt";
+    let pending_path = b"/workspace/pending.txt";
+    let recursive_path = b"/workspace/recursive/child";
+    let nonrecursive_path = b"/workspace/nonrecursive";
+    let missing_parent_dir = b"/workspace/missing";
+    let missing_parent_path = b"/workspace/missing/child.txt";
     render_vfs_fixture(WASM_VFS_PROBE_FIXTURE_TEMPLATE, &manifest)
         .replace("{{path}}", &wat_bytes(path))
         .replace("{{path_len}}", &path.len().to_string())
+        .replace("{{pending_path}}", &wat_bytes(pending_path))
+        .replace("{{pending_path_len}}", &pending_path.len().to_string())
+        .replace("{{recursive_path}}", &wat_bytes(recursive_path))
+        .replace("{{recursive_path_len}}", &recursive_path.len().to_string())
+        .replace("{{nonrecursive_path}}", &wat_bytes(nonrecursive_path))
+        .replace(
+            "{{nonrecursive_path_len}}",
+            &nonrecursive_path.len().to_string(),
+        )
+        .replace("{{missing_parent_path}}", &wat_bytes(missing_parent_path))
+        .replace(
+            "{{missing_parent_path_len}}",
+            &missing_parent_path.len().to_string(),
+        )
+        .replace(
+            "{{missing_parent_dir_len}}",
+            &missing_parent_dir.len().to_string(),
+        )
 }
 
 fn render_vfs_fixture(template: &str, manifest: &str) -> String {
@@ -424,6 +546,18 @@ fn render_vfs_fixture(template: &str, manifest: &str) -> String {
         .replace(
             "{{read_mode}}",
             &verlet_wasm::runner::FS_MODE_READ.to_string(),
+        )
+        .replace(
+            "{{write_mode}}",
+            &verlet_wasm::runner::FS_MODE_WRITE.to_string(),
+        )
+        .replace(
+            "{{invalid_mode}}",
+            &(verlet_wasm::runner::FS_MODE_WRITE + 1).to_string(),
+        )
+        .replace(
+            "{{invalid_argument}}",
+            &verlet_wasm::runner::STATUS_INVALID_ARGUMENT.to_string(),
         )
         .replace("{{eof}}", &verlet_wasm::runner::STATUS_EOF.to_string())
 }
@@ -448,6 +582,18 @@ async fn wasm_cat_vfs() -> std::sync::Arc<verlet_vfs::VerletVfs> {
         bashkit::InMemoryFs::new(),
     )));
     vfs.mount("/workspace", workspace).unwrap();
+    vfs
+}
+
+async fn writable_vfs() -> std::sync::Arc<verlet_vfs::VerletVfs> {
+    let vfs = std::sync::Arc::new(verlet_vfs::VerletVfs::new(std::sync::Arc::new(
+        bashkit::InMemoryFs::new(),
+    )));
+    vfs.mount(
+        "/workspace",
+        std::sync::Arc::new(bashkit::InMemoryFs::new()),
+    )
+    .unwrap();
     vfs
 }
 
@@ -1080,6 +1226,367 @@ async fn wasm_vfs_close_drops_invocation_local_handles() {
         .unwrap_err()
         .to_string();
     assert!(err.contains("returned status 2"));
+}
+
+#[tokio::test]
+async fn wasm_vfs_write_guest_creates_replaces_stats_and_lists() {
+    let vfs = writable_vfs().await;
+    let factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
+        verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(
+            wasm_vfs_tools_guest(),
+        ))
+        .with_vfs(vfs.clone())
+        .with_capability_grant(verlet_wasm::runner::FS_WRITE_CAPABILITY),
+    )
+    .unwrap();
+
+    factory
+        .invoke_operation_bytes(
+            "put",
+            serde_json::to_vec(&serde_json::json!({
+                "path": "/workspace/nested/file.txt",
+                "content": "first payload",
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        vfs.read_file(std::path::Path::new("/workspace/nested/file.txt"))
+            .await
+            .unwrap(),
+        b"first payload"
+    );
+
+    factory
+        .invoke_operation_bytes(
+            "put",
+            serde_json::to_vec(&serde_json::json!({
+                "path": "/workspace/nested/file.txt",
+                "content": "replacement",
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        vfs.read_file(std::path::Path::new("/workspace/nested/file.txt"))
+            .await
+            .unwrap(),
+        b"replacement"
+    );
+
+    for (path, content) in [
+        ("/workspace/z.txt", "z"),
+        ("/workspace/a.txt", "alpha"),
+        ("/workspace/é.txt", "accent"),
+    ] {
+        factory
+            .invoke_operation_bytes(
+                "put",
+                serde_json::to_vec(&serde_json::json!({
+                    "path": path,
+                    "content": content,
+                }))
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+    }
+
+    let stat = factory
+        .invoke_operation_bytes("stat", b"/workspace/nested/file.txt".to_vec())
+        .await
+        .unwrap();
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&stat.output).unwrap(),
+        serde_json::json!({"kind": "file", "size": 11})
+    );
+    let stat = factory
+        .invoke_operation_bytes("stat", b"/workspace/nested".to_vec())
+        .await
+        .unwrap();
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&stat.output).unwrap(),
+        serde_json::json!({"kind": "dir", "size": 0})
+    );
+    let missing = factory
+        .invoke_operation_bytes("stat", b"/workspace/missing.txt".to_vec())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(missing.contains("returned status 2"), "{missing}");
+    let missing = factory
+        .invoke_operation_bytes("ls", b"/workspace/missing".to_vec())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(missing.contains("returned status 2"), "{missing}");
+
+    let list = factory
+        .invoke_operation_bytes("ls", b"/workspace".to_vec())
+        .await
+        .unwrap();
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&list.output).unwrap(),
+        serde_json::json!([
+            {"name": "a.txt", "is_dir": false},
+            {"name": "dev", "is_dir": true},
+            {"name": "home", "is_dir": true},
+            {"name": "nested", "is_dir": true},
+            {"name": "tmp", "is_dir": true},
+            {"name": "z.txt", "is_dir": false},
+            {"name": "é.txt", "is_dir": false},
+        ])
+    );
+}
+
+#[tokio::test]
+async fn wasm_vfs_write_guest_requires_declared_capability_before_execution() {
+    let vfs = writable_vfs().await;
+    let factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
+        verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(
+            wasm_vfs_tools_guest(),
+        ))
+        .with_vfs(vfs.clone()),
+    )
+    .unwrap();
+
+    let err = factory
+        .invoke_operation_bytes(
+            "put",
+            br#"{"path":"/workspace/denied/file.txt","content":"denied"}"#.to_vec(),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(err.contains("requires ungranted capabilities"), "{err}");
+    assert!(err.contains(verlet_wasm::runner::FS_WRITE_CAPABILITY));
+    assert!(
+        !vfs.exists(std::path::Path::new("/workspace/denied"))
+            .await
+            .unwrap()
+    );
+    factory
+        .invoke_operation_bytes("stat", b"/workspace".to_vec())
+        .await
+        .unwrap();
+    factory
+        .invoke_operation_bytes("ls", b"/workspace".to_vec())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn wasm_vfs_mutation_imports_require_exact_write_capability() {
+    let vfs = wasm_cat_vfs().await;
+    for grant in [None, Some("fs.write:/workspace")] {
+        let mut config = verlet_wasm::WasmRuntimeConfig::new(
+            verlet_wasm::WasmRuntimeArtifact::bytes(wat_guest(wasm_vfs_probe_guest())),
+        )
+        .with_vfs(vfs.clone());
+        if let Some(grant) = grant {
+            config = config.with_capability_grant(grant);
+        }
+        let factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(config).unwrap();
+        for operation in ["unclosed_write", "mkdir_recursive"] {
+            let err = factory
+                .invoke_operation_bytes(operation, Vec::new())
+                .await
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("returned status 3"), "{operation}: {err}");
+        }
+    }
+
+    let factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
+        verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(wat_guest(
+            wasm_vfs_probe_guest(),
+        )))
+        .with_vfs(vfs.clone())
+        .with_capability_grant(verlet_wasm::runner::FS_WRITE_CAPABILITY),
+    )
+    .unwrap();
+    factory
+        .invoke_operation_bytes("unclosed_write", Vec::new())
+        .await
+        .unwrap();
+    assert!(
+        !vfs.exists(std::path::Path::new("/workspace/pending.txt"))
+            .await
+            .unwrap()
+    );
+    factory
+        .invoke_operation_bytes("mkdir_recursive", Vec::new())
+        .await
+        .unwrap();
+    factory
+        .invoke_operation_bytes("mkdir_recursive", Vec::new())
+        .await
+        .unwrap();
+    assert!(
+        vfs.stat(std::path::Path::new("/workspace/recursive/child"))
+            .await
+            .unwrap()
+            .file_type
+            .is_dir()
+    );
+}
+
+#[tokio::test]
+async fn wasm_vfs_write_handles_fail_closed_and_failed_close_consumes_handle() {
+    let vfs = wasm_cat_vfs().await;
+    let factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
+        verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(wat_guest(
+            wasm_vfs_probe_guest(),
+        )))
+        .with_vfs(vfs.clone())
+        .with_capability_grant(verlet_wasm::runner::FS_WRITE_CAPABILITY),
+    )
+    .unwrap();
+
+    for operation in ["write_to_read", "read_from_write"] {
+        let err = factory
+            .invoke_operation_bytes(operation, Vec::new())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("returned status 1"), "{operation}: {err}");
+    }
+    let err = factory
+        .invoke_operation_bytes("unknown_write", Vec::new())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("returned status 2"), "{err}");
+    factory
+        .invoke_operation_bytes("bad_write_pointer", Vec::new())
+        .await
+        .unwrap();
+    assert_eq!(
+        vfs.read_file(std::path::Path::new("/workspace/pending.txt"))
+            .await
+            .unwrap(),
+        b"pending"
+    );
+
+    let err = factory
+        .invoke_operation_bytes("failed_close_consumes_handle", Vec::new())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("returned status 2"), "{err}");
+    assert!(
+        vfs.exists(std::path::Path::new("/workspace/missing"))
+            .await
+            .unwrap()
+    );
+    assert!(
+        !vfs.exists(std::path::Path::new("/workspace/missing/child.txt"))
+            .await
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn wasm_vfs_mkdir_honors_recursive_and_non_recursive_semantics() {
+    let vfs = wasm_cat_vfs().await;
+    let factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
+        verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(wat_guest(
+            wasm_vfs_probe_guest(),
+        )))
+        .with_vfs(vfs)
+        .with_capability_grant(verlet_wasm::runner::FS_WRITE_CAPABILITY),
+    )
+    .unwrap();
+
+    let missing_parent = factory
+        .invoke_operation_bytes("mkdir_missing_parent", Vec::new())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        missing_parent.contains("returned status 2"),
+        "{missing_parent}"
+    );
+    let invalid_recursive = factory
+        .invoke_operation_bytes("mkdir_invalid_recursive", Vec::new())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        invalid_recursive.contains("returned status 1"),
+        "{invalid_recursive}"
+    );
+
+    factory
+        .invoke_operation_bytes("mkdir_non_recursive", Vec::new())
+        .await
+        .unwrap();
+    let existing = factory
+        .invoke_operation_bytes("mkdir_non_recursive", Vec::new())
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(existing.contains("returned status 4"), "{existing}");
+}
+
+#[tokio::test]
+async fn wasm_vfs_stat_writes_exact_little_endian_record() {
+    let content = b"alpha\nbeta\ngamma from verlet vfs\n";
+    let factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
+        verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(wat_guest(
+            wasm_vfs_probe_guest(),
+        )))
+        .with_vfs(wasm_cat_vfs().await),
+    )
+    .unwrap();
+
+    let output = factory
+        .invoke_operation_bytes("stat_record", Vec::new())
+        .await
+        .unwrap();
+    let mut expected = [0u8; 16];
+    expected[8..16].copy_from_slice(&(content.len() as u64).to_le_bytes());
+    assert_eq!(output.output, expected);
+}
+
+#[tokio::test]
+async fn pure_compute_policy_rejects_every_fs_import() {
+    let guest = r#"
+        (module
+          (import "cooldis_0.1" "fs_open" (func $fs_open (param i32 i32 i32 i32) (result i32)))
+          (import "cooldis_0.1" "fs_read" (func $fs_read (param i32 i32 i32) (result i32)))
+          (import "cooldis_0.1" "fs_close" (func $fs_close (param i32) (result i32)))
+          (import "cooldis_0.1" "fs_write" (func $fs_write (param i32 i32 i32) (result i32)))
+          (import "cooldis_0.1" "fs_stat" (func $fs_stat (param i32 i32 i32) (result i32)))
+          (import "cooldis_0.1" "fs_list" (func $fs_list (param i32 i32 i32) (result i32)))
+          (import "cooldis_0.1" "fs_mkdir" (func $fs_mkdir (param i32 i32 i32) (result i32)))
+          (memory (export "memory") 1)
+          (func (export "__verlet_describe_module__") (param i32) (result i32)
+            i32.const 0)
+          (func (export "__verlet_call_operation__") (param i32 i32 i32 i32 i32) (result i32)
+            i32.const 0))
+        "#;
+    let factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
+        verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(wat_guest(
+            guest,
+        )))
+        .with_host_import_policy(verlet_wasm::WasmHostImportPolicy::PureCompute),
+    )
+    .unwrap();
+
+    let err = factory
+        .validate_operation_artifact()
+        .await
+        .unwrap_err()
+        .to_string();
+    for import in [
+        "fs_open", "fs_read", "fs_close", "fs_write", "fs_stat", "fs_list", "fs_mkdir",
+    ] {
+        assert!(err.contains(import), "missing {import} in {err}");
+    }
 }
 
 #[tokio::test]

--- a/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
+++ b/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
@@ -1211,7 +1211,7 @@ async fn wasm_vfs_read_imports_fail_closed_for_invalid_mode_and_handle() {
 }
 
 #[tokio::test]
-async fn wasm_vfs_close_drops_invocation_local_handles() {
+async fn wasm_vfs_close_accepts_read_handle_and_rejects_double_close() {
     let factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
         verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(wat_guest(
             wasm_vfs_probe_guest(),

--- a/crates/verlet-kernel/tests/fixtures/wasm-vfs-tools/Cargo.lock
+++ b/crates/verlet-kernel/tests/fixtures/wasm-vfs-tools/Cargo.lock
@@ -114,6 +114,7 @@ dependencies = [
 name = "verlet-wasm-vfs-tools"
 version = "0.1.0"
 dependencies = [
+ "serde_json",
  "verlet-guest-sdk",
 ]
 

--- a/crates/verlet-kernel/tests/fixtures/wasm-vfs-tools/Cargo.toml
+++ b/crates/verlet-kernel/tests/fixtures/wasm-vfs-tools/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
+serde_json = "1"
 verlet-guest-sdk = { path = "../../../../verlet-guest-sdk" }
 
 [profile.release]

--- a/crates/verlet-kernel/tests/fixtures/wasm-vfs-tools/src/lib.rs
+++ b/crates/verlet-kernel/tests/fixtures/wasm-vfs-tools/src/lib.rs
@@ -1,11 +1,17 @@
 const CAT_ID: u32 = 1;
 const TAIL_ID: u32 = 2;
+const PUT_ID: u32 = 3;
+const STAT_ID: u32 = 4;
+const LS_ID: u32 = 5;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __verlet_describe_module__(sink: u32) -> i32 {
     let manifest = verlet_guest_sdk::OperationManifest::new(vec![
-        operation(CAT_ID, "cat"),
-        operation(TAIL_ID, "tail"),
+        operation(CAT_ID, "cat", &[]),
+        operation(TAIL_ID, "tail", &[]),
+        operation(PUT_ID, "put", &["fs.write"]),
+        operation(STAT_ID, "stat", &[]),
+        operation(LS_ID, "ls", &[]),
     ]);
     let bytes = match manifest.to_json_vec() {
         Ok(bytes) => bytes,
@@ -31,11 +37,24 @@ pub extern "C" fn __verlet_call_operation__(
             verlet_guest_sdk::Source(source),
             verlet_guest_sdk::Sink(output),
         )),
+        PUT_ID => status(put(verlet_guest_sdk::Source(source))),
+        STAT_ID => status(stat(
+            verlet_guest_sdk::Source(source),
+            verlet_guest_sdk::Sink(output),
+        )),
+        LS_ID => status(ls(
+            verlet_guest_sdk::Source(source),
+            verlet_guest_sdk::Sink(output),
+        )),
         _ => verlet_guest_sdk::STATUS_NOT_FOUND,
     }
 }
 
-fn operation(id: u32, name: &str) -> verlet_guest_sdk::OperationDefinition {
+fn operation(
+    id: u32,
+    name: &str,
+    required_capabilities: &[&str],
+) -> verlet_guest_sdk::OperationDefinition {
     verlet_guest_sdk::OperationDefinition {
         id,
         name: name.to_string(),
@@ -43,7 +62,10 @@ fn operation(id: u32, name: &str) -> verlet_guest_sdk::OperationDefinition {
         output: verlet_guest_sdk::OperationValueKind::Bytes,
         events: verlet_guest_sdk::OperationEventKind::None,
         mode: verlet_guest_sdk::OperationMode::Sync,
-        required_capabilities: Vec::new(),
+        required_capabilities: required_capabilities
+            .iter()
+            .map(|capability| (*capability).to_string())
+            .collect(),
     }
 }
 
@@ -86,12 +108,81 @@ fn tail(
     Ok(())
 }
 
+fn put(source: verlet_guest_sdk::Source) -> Result<(), verlet_guest_sdk::StatusCode> {
+    let input = read_all(source)?;
+    let input: serde_json::Value = serde_json::from_slice(&input)
+        .map_err(|_| verlet_guest_sdk::StatusCode::InvalidArgument)?;
+    let path = input
+        .get("path")
+        .and_then(serde_json::Value::as_str)
+        .ok_or(verlet_guest_sdk::StatusCode::InvalidArgument)?;
+    let content = input
+        .get("content")
+        .and_then(serde_json::Value::as_str)
+        .ok_or(verlet_guest_sdk::StatusCode::InvalidArgument)?
+        .as_bytes();
+    let parent = std::path::Path::new(path)
+        .parent()
+        .and_then(std::path::Path::to_str)
+        .ok_or(verlet_guest_sdk::StatusCode::InvalidArgument)?;
+    verlet_guest_sdk::mkdir(parent, true)?;
+    let handle = verlet_guest_sdk::open_file_write(path)?;
+    let split = content.len() / 2;
+    verlet_guest_sdk::write_file(handle, &content[..split])?;
+    verlet_guest_sdk::write_file(handle, &content[split..])?;
+    verlet_guest_sdk::close_file(handle)
+}
+
+fn stat(
+    source: verlet_guest_sdk::Source,
+    output: verlet_guest_sdk::Sink,
+) -> Result<(), verlet_guest_sdk::StatusCode> {
+    let path = read_path(source)?;
+    let stat = verlet_guest_sdk::stat_path(&path)?;
+    let kind = match stat.kind {
+        verlet_guest_sdk::FileKind::File => "file",
+        verlet_guest_sdk::FileKind::Dir => "dir",
+        verlet_guest_sdk::FileKind::Other => "other",
+    };
+    let bytes = serde_json::to_vec(&serde_json::json!({
+        "kind": kind,
+        "size": stat.size,
+    }))
+    .map_err(|_| verlet_guest_sdk::StatusCode::TransportError)?;
+    verlet_guest_sdk::write_sink(output, &bytes)?;
+    Ok(())
+}
+
+fn ls(
+    source: verlet_guest_sdk::Source,
+    output: verlet_guest_sdk::Sink,
+) -> Result<(), verlet_guest_sdk::StatusCode> {
+    let path = read_path(source)?;
+    let entries = verlet_guest_sdk::list_dir(&path)?;
+    let bytes =
+        serde_json::to_vec(&entries).map_err(|_| verlet_guest_sdk::StatusCode::TransportError)?;
+    verlet_guest_sdk::write_sink(output, &bytes)?;
+    Ok(())
+}
+
 fn read_path(source: verlet_guest_sdk::Source) -> Result<String, verlet_guest_sdk::StatusCode> {
-    let mut buffer = [0u8; 512];
-    let n = verlet_guest_sdk::read_source(source, &mut buffer)?;
-    core::str::from_utf8(&buffer[..n])
+    let bytes = read_all(source)?;
+    core::str::from_utf8(&bytes)
         .map(str::to_string)
         .map_err(|_| verlet_guest_sdk::StatusCode::InvalidArgument)
+}
+
+fn read_all(source: verlet_guest_sdk::Source) -> Result<Vec<u8>, verlet_guest_sdk::StatusCode> {
+    let mut bytes = Vec::new();
+    let mut buffer = [0u8; 512];
+    loop {
+        let n = verlet_guest_sdk::read_source(source, &mut buffer)?;
+        if n == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&buffer[..n]);
+    }
+    Ok(bytes)
 }
 
 fn last_two_lines_start(bytes: &[u8]) -> usize {

--- a/crates/verlet-kernel/tests/fixtures/wasm_vfs_probe_operation.wat.tpl
+++ b/crates/verlet-kernel/tests/fixtures/wasm_vfs_probe_operation.wat.tpl
@@ -5,9 +5,17 @@
   (import "cooldis_0.1" "fs_open" (func $fs_open (param i32 i32 i32 i32) (result i32)))
   (import "cooldis_0.1" "fs_read" (func $fs_read (param i32 i32 i32) (result i32)))
   (import "cooldis_0.1" "fs_close" (func $fs_close (param i32) (result i32)))
+  (import "cooldis_0.1" "fs_write" (func $fs_write (param i32 i32 i32) (result i32)))
+  (import "cooldis_0.1" "fs_stat" (func $fs_stat (param i32 i32 i32) (result i32)))
+  (import "cooldis_0.1" "fs_mkdir" (func $fs_mkdir (param i32 i32 i32) (result i32)))
   (memory (export "memory") 1)
   (data (i32.const 4096) "{{manifest}}")
   (data (i32.const 8192) "{{path}}")
+  (data (i32.const 8256) "{{pending_path}}")
+  (data (i32.const 8320) "{{recursive_path}}")
+  (data (i32.const 8384) "{{nonrecursive_path}}")
+  (data (i32.const 8448) "{{missing_parent_path}}")
+  (data (i32.const 8512) "pending")
   (func (export "__verlet_describe_module__") (param $sink i32) (result i32)
     i32.const 0
     i32.const {{manifest_len}}
@@ -31,7 +39,7 @@
     if
       i32.const 8192
       i32.const {{path_len}}
-      i32.const 1
+      i32.const {{invalid_mode}}
       i32.const 64
       call $fs_open
       return
@@ -81,6 +89,261 @@
       end
       local.get $handle
       call $fs_close
+      return
+    end
+    local.get $op
+    i32.const 4
+    i32.eq
+    if
+      i32.const 8256
+      i32.const {{pending_path_len}}
+      i32.const {{write_mode}}
+      i32.const 64
+      call $fs_open
+      local.set $status
+      local.get $status
+      i32.const 0
+      i32.ne
+      if
+        local.get $status
+        return
+      end
+      i32.const 64
+      i32.load
+      i32.const 8512
+      i32.const 7
+      call $fs_write
+      return
+    end
+    local.get $op
+    i32.const 5
+    i32.eq
+    if
+      i32.const 8320
+      i32.const {{recursive_path_len}}
+      i32.const 1
+      call $fs_mkdir
+      return
+    end
+    local.get $op
+    i32.const 6
+    i32.eq
+    if
+      i32.const 8384
+      i32.const {{nonrecursive_path_len}}
+      i32.const 0
+      call $fs_mkdir
+      return
+    end
+    local.get $op
+    i32.const 7
+    i32.eq
+    if
+      i32.const 8192
+      i32.const {{path_len}}
+      i32.const {{read_mode}}
+      i32.const 64
+      call $fs_open
+      local.set $status
+      local.get $status
+      i32.const 0
+      i32.ne
+      if
+        local.get $status
+        return
+      end
+      i32.const 64
+      i32.load
+      i32.const 8512
+      i32.const 7
+      call $fs_write
+      return
+    end
+    local.get $op
+    i32.const 8
+    i32.eq
+    if
+      i32.const 8256
+      i32.const {{pending_path_len}}
+      i32.const {{write_mode}}
+      i32.const 64
+      call $fs_open
+      local.set $status
+      local.get $status
+      i32.const 0
+      i32.ne
+      if
+        local.get $status
+        return
+      end
+      i32.const 0
+      i32.const 4
+      i32.store
+      i32.const 64
+      i32.load
+      i32.const 2048
+      i32.const 0
+      call $fs_read
+      return
+    end
+    local.get $op
+    i32.const 9
+    i32.eq
+    if
+      i32.const 9999
+      i32.const 8512
+      i32.const 7
+      call $fs_write
+      return
+    end
+    local.get $op
+    i32.const 10
+    i32.eq
+    if
+      i32.const 8192
+      i32.const {{path_len}}
+      i32.const 128
+      call $fs_stat
+      local.set $status
+      local.get $status
+      i32.const 0
+      i32.ne
+      if
+        local.get $status
+        return
+      end
+      i32.const 0
+      i32.const 16
+      i32.store
+      local.get $output
+      i32.const 128
+      i32.const 0
+      call $sink_write
+      return
+    end
+    local.get $op
+    i32.const 11
+    i32.eq
+    if
+      i32.const 8448
+      i32.const {{missing_parent_path_len}}
+      i32.const 0
+      call $fs_mkdir
+      return
+    end
+    local.get $op
+    i32.const 12
+    i32.eq
+    if
+      i32.const 8256
+      i32.const {{pending_path_len}}
+      i32.const {{write_mode}}
+      i32.const 64
+      call $fs_open
+      local.set $status
+      local.get $status
+      i32.const 0
+      i32.ne
+      if
+        local.get $status
+        return
+      end
+      i32.const 64
+      i32.load
+      local.set $handle
+      local.get $handle
+      i32.const 8512
+      i32.const 7
+      call $fs_write
+      local.set $status
+      local.get $status
+      i32.const 0
+      i32.ne
+      if
+        local.get $status
+        return
+      end
+      local.get $handle
+      i32.const 65530
+      i32.const 20
+      call $fs_write
+      local.set $status
+      local.get $status
+      i32.const {{invalid_argument}}
+      i32.ne
+      if
+        unreachable
+      end
+      local.get $handle
+      call $fs_close
+      return
+    end
+    local.get $op
+    i32.const 13
+    i32.eq
+    if
+      i32.const 8448
+      i32.const {{missing_parent_path_len}}
+      i32.const {{write_mode}}
+      i32.const 64
+      call $fs_open
+      local.set $status
+      local.get $status
+      i32.const 0
+      i32.ne
+      if
+        local.get $status
+        return
+      end
+      i32.const 64
+      i32.load
+      local.set $handle
+      local.get $handle
+      i32.const 8512
+      i32.const 7
+      call $fs_write
+      local.set $status
+      local.get $status
+      i32.const 0
+      i32.ne
+      if
+        local.get $status
+        return
+      end
+      local.get $handle
+      call $fs_close
+      local.set $status
+      local.get $status
+      i32.const {{not_found}}
+      i32.ne
+      if
+        local.get $status
+        return
+      end
+      i32.const 8448
+      i32.const {{missing_parent_dir_len}}
+      i32.const 0
+      call $fs_mkdir
+      local.set $status
+      local.get $status
+      i32.const 0
+      i32.ne
+      if
+        local.get $status
+        return
+      end
+      local.get $handle
+      call $fs_close
+      return
+    end
+    local.get $op
+    i32.const 14
+    i32.eq
+    if
+      i32.const 8320
+      i32.const {{recursive_path_len}}
+      i32.const 2
+      call $fs_mkdir
       return
     end
     i32.const {{not_found}}))

--- a/crates/verlet-kernel/tests/fixtures/wasm_vfs_probe_operation.wat.tpl
+++ b/crates/verlet-kernel/tests/fixtures/wasm_vfs_probe_operation.wat.tpl
@@ -71,7 +71,7 @@
       i32.const 0
       i32.ne
       if
-        local.get $status
+        i32.const {{invalid_argument}}
         return
       end
       i32.const 64
@@ -84,7 +84,7 @@
       i32.const 0
       i32.ne
       if
-        local.get $status
+        i32.const {{invalid_argument}}
         return
       end
       local.get $handle
@@ -149,7 +149,7 @@
       i32.const 0
       i32.ne
       if
-        local.get $status
+        i32.const {{not_found}}
         return
       end
       i32.const 64
@@ -173,7 +173,7 @@
       i32.const 0
       i32.ne
       if
-        local.get $status
+        i32.const {{not_found}}
         return
       end
       i32.const 0

--- a/crates/verlet-kernel/tests/plugin_path3.rs
+++ b/crates/verlet-kernel/tests/plugin_path3.rs
@@ -25,7 +25,9 @@ async fn path3_local_plugin_build_publish_mount_and_agent_confirm() {
                     release: true,
                 },
                 interface: None,
-                capability_grants: std::collections::BTreeSet::new(),
+                capability_grants: std::collections::BTreeSet::from([
+                    verlet_wasm::runner::FS_WRITE_CAPABILITY.to_string(),
+                ]),
                 metadata: std::collections::BTreeMap::new(),
             },
         )
@@ -201,7 +203,9 @@ async fn publish_workspace_reader(registry_root: &std::path::Path, module_path: 
                     release: true,
                 },
                 interface: None,
-                capability_grants: std::collections::BTreeSet::new(),
+                capability_grants: std::collections::BTreeSet::from([
+                    verlet_wasm::runner::FS_WRITE_CAPABILITY.to_string(),
+                ]),
                 metadata: std::collections::BTreeMap::new(),
             },
         )

--- a/crates/verlet-kernel/tests/smokes/verlet-plugin-live-smoke.rs
+++ b/crates/verlet-kernel/tests/smokes/verlet-plugin-live-smoke.rs
@@ -28,7 +28,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     release: true,
                 },
                 interface: None,
-                capability_grants: std::collections::BTreeSet::new(),
+                capability_grants: std::collections::BTreeSet::from([
+                    verlet_wasm::runner::FS_WRITE_CAPABILITY.to_string(),
+                ]),
                 metadata: std::collections::BTreeMap::new(),
             },
         )

--- a/crates/verlet-kernel/tests/verlet_cli_publish.rs
+++ b/crates/verlet-kernel/tests/verlet_cli_publish.rs
@@ -2664,7 +2664,7 @@ schema_version = 0
 [identity]
 name = "{name}"
 version = "0.1.0"
-description = "Read files from a mounted VFS."
+description = "Read and write files on a mounted VFS."
 
 [runtime]
 kind = "wasm32-unknown-unknown"
@@ -2692,6 +2692,18 @@ required_capabilities = []
 
 [operations.command]
 name = "tail"
+stdin = "text"
+stdout = "bytes"
+
+[[operations]]
+name = "put"
+description = "Write a full file."
+input_schema = "schemas/path.input.json"
+output_schema = "schemas/bytes.output.json"
+required_capabilities = ["fs.write"]
+
+[operations.command]
+name = "put"
 stdin = "text"
 stdout = "bytes"
 "#,

--- a/crates/verlet-wasm/src/runner.rs
+++ b/crates/verlet-wasm/src/runner.rs
@@ -652,7 +652,6 @@ impl WasmTurnState {
 
     /// Open a pending write buffer for `path`. The buffer lives host-side
     /// and is committed to the VFS only by `fs_close`.
-    #[expect(dead_code, reason = "fs write leg: wired up by the implementation")]
     fn insert_write_file(&mut self, path: std::path::PathBuf) -> u32 {
         self.insert_file(WasmFileState::Write {
             path,
@@ -1729,11 +1728,22 @@ fn wildcard_match(pattern: &str, value: &str) -> bool {
 /// it. Parent directories are NOT created on commit; guests create them
 /// explicitly with `fs_mkdir`.
 fn fs_open_write_impl(
-    _caller: &mut wasmtime::Caller<'_, WasmTurnState>,
-    _path: std::path::PathBuf,
-    _out_handle_ptr: usize,
+    caller: &mut wasmtime::Caller<'_, WasmTurnState>,
+    path: std::path::PathBuf,
+    out_handle_ptr: usize,
 ) -> i32 {
-    todo!("fs write leg: open write handles")
+    if !caller
+        .data()
+        .capability_grants
+        .contains(FS_WRITE_CAPABILITY)
+    {
+        return STATUS_CAPABILITY_DENIED;
+    }
+    let handle = caller.data_mut().insert_write_file(path);
+    if !write_guest_u32_at(caller, out_handle_ptr, handle) {
+        return STATUS_INVALID_ARGUMENT;
+    }
+    STATUS_OK
 }
 
 /// `fs_close` on a write handle: commit the pending buffer to the VFS.
@@ -1744,11 +1754,17 @@ fn fs_open_write_impl(
 /// removed from the file table by the caller: it is consumed whether or not
 /// the commit succeeds, and there is no retry.
 async fn fs_close_commit_impl(
-    _caller: &mut wasmtime::Caller<'_, WasmTurnState>,
-    _path: std::path::PathBuf,
-    _buffer: Vec<u8>,
+    caller: &mut wasmtime::Caller<'_, WasmTurnState>,
+    path: std::path::PathBuf,
+    buffer: Vec<u8>,
 ) -> i32 {
-    todo!("fs write leg: commit write handles on close")
+    let Some(vfs) = caller.data().vfs.clone() else {
+        return STATUS_CAPABILITY_DENIED;
+    };
+    match vfs.write_file(&path, &buffer).await {
+        Ok(()) => STATUS_OK,
+        Err(err) => vfs_error_status(err),
+    }
 }
 
 /// `fs_write`: append `len` bytes from guest memory at `ptr` to the pending
@@ -1759,12 +1775,28 @@ async fn fs_close_commit_impl(
 /// -> `STATUS_INVALID_ARGUMENT`. No size cap beyond host memory: the read leg
 /// buffers whole files host-side with the same asymmetry.
 fn fs_write_impl(
-    _caller: &mut wasmtime::Caller<'_, WasmTurnState>,
-    _handle: i32,
-    _ptr: i32,
-    _len: i32,
+    caller: &mut wasmtime::Caller<'_, WasmTurnState>,
+    handle: i32,
+    ptr: i32,
+    len: i32,
 ) -> i32 {
-    todo!("fs write leg: append to write handles")
+    let Some(handle) = nonnegative_u32(handle) else {
+        return STATUS_INVALID_ARGUMENT;
+    };
+    let Some(state) = caller.data().files.get(&handle) else {
+        return STATUS_NOT_FOUND;
+    };
+    if !matches!(state, WasmFileState::Write { .. }) {
+        return STATUS_INVALID_ARGUMENT;
+    }
+    let Some(bytes) = read_guest_memory(caller, ptr, len) else {
+        return STATUS_INVALID_ARGUMENT;
+    };
+    let Some(WasmFileState::Write { buffer, .. }) = caller.data_mut().files.get_mut(&handle) else {
+        return STATUS_INVALID_ARGUMENT;
+    };
+    buffer.extend_from_slice(&bytes);
+    STATUS_OK
 }
 
 /// `fs_stat`: stat an absolute UTF-8 VFS path into a 16-byte record.
@@ -1779,12 +1811,56 @@ fn fs_write_impl(
 ///   bytes 4..8   reserved (u32): always zero
 ///   bytes 8..16  size (u64): size in bytes for files, 0 for directories
 async fn fs_stat_impl(
-    _caller: &mut wasmtime::Caller<'_, WasmTurnState>,
-    _path_ptr: i32,
-    _path_len: i32,
-    _out_ptr: i32,
+    caller: &mut wasmtime::Caller<'_, WasmTurnState>,
+    path_ptr: i32,
+    path_len: i32,
+    out_ptr: i32,
 ) -> i32 {
-    todo!("fs write leg: stat VFS paths")
+    let Some(out_ptr) = nonnegative_usize(out_ptr) else {
+        return STATUS_INVALID_ARGUMENT;
+    };
+    let Some(path_bytes) = read_guest_memory(caller, path_ptr, path_len) else {
+        return STATUS_INVALID_ARGUMENT;
+    };
+    let Ok(path) = String::from_utf8(path_bytes) else {
+        return STATUS_INVALID_ARGUMENT;
+    };
+    let path = std::path::PathBuf::from(path);
+    if !path.is_absolute() {
+        return STATUS_INVALID_ARGUMENT;
+    }
+    let Some(vfs) = caller.data().vfs.clone() else {
+        return STATUS_CAPABILITY_DENIED;
+    };
+    let metadata = match vfs.stat(&path).await {
+        Ok(metadata) => metadata,
+        Err(err) => return vfs_error_status(err),
+    };
+    let kind = match metadata.file_type {
+        bashkit::FileType::File => 0u32,
+        bashkit::FileType::Directory => 1u32,
+        bashkit::FileType::Symlink | bashkit::FileType::Fifo => 2u32,
+    };
+    let size = if metadata.file_type == bashkit::FileType::Directory {
+        0
+    } else {
+        metadata.size
+    };
+    let mut record = [0u8; 16];
+    record[0..4].copy_from_slice(&kind.to_le_bytes());
+    record[8..16].copy_from_slice(&size.to_le_bytes());
+    let Some(memory) = exported_memory(caller) else {
+        return STATUS_INVALID_ARGUMENT;
+    };
+    let data = memory.data_mut(caller);
+    let Some(end) = out_ptr.checked_add(record.len()) else {
+        return STATUS_INVALID_ARGUMENT;
+    };
+    if end > data.len() {
+        return STATUS_INVALID_ARGUMENT;
+    }
+    data[out_ptr..end].copy_from_slice(&record);
+    STATUS_OK
 }
 
 /// `fs_list`: list an absolute UTF-8 VFS directory as a readable source.
@@ -1798,12 +1874,54 @@ async fn fs_stat_impl(
 /// `out_source_ptr`. The guest drains it with `source_read`. Names are entry
 /// names only, never full paths.
 async fn fs_list_impl(
-    _caller: &mut wasmtime::Caller<'_, WasmTurnState>,
-    _path_ptr: i32,
-    _path_len: i32,
-    _out_source_ptr: i32,
+    caller: &mut wasmtime::Caller<'_, WasmTurnState>,
+    path_ptr: i32,
+    path_len: i32,
+    out_source_ptr: i32,
 ) -> i32 {
-    todo!("fs write leg: list VFS directories")
+    #[derive(serde::Serialize)]
+    struct ListingEntry {
+        name: String,
+        is_dir: bool,
+    }
+
+    let Some(out_source_ptr) = nonnegative_usize(out_source_ptr) else {
+        return STATUS_INVALID_ARGUMENT;
+    };
+    let Some(path_bytes) = read_guest_memory(caller, path_ptr, path_len) else {
+        return STATUS_INVALID_ARGUMENT;
+    };
+    let Ok(path) = String::from_utf8(path_bytes) else {
+        return STATUS_INVALID_ARGUMENT;
+    };
+    let path = std::path::PathBuf::from(path);
+    if !path.is_absolute() {
+        return STATUS_INVALID_ARGUMENT;
+    }
+    let Some(vfs) = caller.data().vfs.clone() else {
+        return STATUS_CAPABILITY_DENIED;
+    };
+    let mut entries = match vfs.read_dir(&path).await {
+        Ok(entries) => entries,
+        Err(err) => return vfs_error_status(err),
+    };
+    entries.sort_by(|left, right| left.name.as_bytes().cmp(right.name.as_bytes()));
+    let listing: Vec<_> = entries
+        .into_iter()
+        .map(|entry| ListingEntry {
+            name: entry.name,
+            is_dir: entry.metadata.file_type == bashkit::FileType::Directory,
+        })
+        .collect();
+    let bytes = match serde_json::to_vec(&listing) {
+        Ok(bytes) => bytes,
+        Err(_) => return STATUS_TRANSPORT_ERROR,
+    };
+    let source = caller.data_mut().insert_source(bytes);
+    if !write_guest_u32_at(caller, out_source_ptr, source) {
+        return STATUS_INVALID_ARGUMENT;
+    }
+    STATUS_OK
 }
 
 /// `fs_mkdir`: create a directory at an absolute UTF-8 VFS path.
@@ -1816,12 +1934,40 @@ async fn fs_list_impl(
 /// non-recursive creation with a missing parent or an existing target maps
 /// the backend error through `vfs_error_status`.
 async fn fs_mkdir_impl(
-    _caller: &mut wasmtime::Caller<'_, WasmTurnState>,
-    _path_ptr: i32,
-    _path_len: i32,
-    _recursive: i32,
+    caller: &mut wasmtime::Caller<'_, WasmTurnState>,
+    path_ptr: i32,
+    path_len: i32,
+    recursive: i32,
 ) -> i32 {
-    todo!("fs write leg: create VFS directories")
+    let recursive = match recursive {
+        0 => false,
+        1 => true,
+        _ => return STATUS_INVALID_ARGUMENT,
+    };
+    let Some(path_bytes) = read_guest_memory(caller, path_ptr, path_len) else {
+        return STATUS_INVALID_ARGUMENT;
+    };
+    let Ok(path) = String::from_utf8(path_bytes) else {
+        return STATUS_INVALID_ARGUMENT;
+    };
+    let path = std::path::PathBuf::from(path);
+    if !path.is_absolute() {
+        return STATUS_INVALID_ARGUMENT;
+    }
+    let Some(vfs) = caller.data().vfs.clone() else {
+        return STATUS_CAPABILITY_DENIED;
+    };
+    if !caller
+        .data()
+        .capability_grants
+        .contains(FS_WRITE_CAPABILITY)
+    {
+        return STATUS_CAPABILITY_DENIED;
+    }
+    match vfs.mkdir(&path, recursive).await {
+        Ok(()) => STATUS_OK,
+        Err(err) => vfs_error_status(err),
+    }
 }
 
 fn vfs_error_status(err: bashkit::Error) -> i32 {

--- a/crates/verlet-wasm/src/runner.rs
+++ b/crates/verlet-wasm/src/runner.rs
@@ -26,6 +26,14 @@ const FIRST_DYNAMIC_SOURCE: u32 = 10;
 const FIRST_DYNAMIC_FILE: u32 = 1_000;
 #[doc(hidden)]
 pub const FS_MODE_READ: u32 = 0;
+#[doc(hidden)]
+pub const FS_MODE_WRITE: u32 = 1;
+/// Capability grant required for guest-initiated VFS mutation (`fs_open` in
+/// `FS_MODE_WRITE` and `fs_mkdir`). Read-side fs imports (`fs_open` in
+/// `FS_MODE_READ`, `fs_read`, `fs_stat`, `fs_list`) are gated only by whether
+/// a VFS is attached to the turn.
+#[doc(hidden)]
+pub const FS_WRITE_CAPABILITY: &str = "fs.write";
 const BLOCKED_HTTP_ADDRESS_ERROR: &str =
     "refusing to connect to private or special-purpose address";
 
@@ -488,6 +496,10 @@ fn allowed_import(
                     | ("cooldis_0.1", "fs_open")
                     | ("cooldis_0.1", "fs_read")
                     | ("cooldis_0.1", "fs_close")
+                    | ("cooldis_0.1", "fs_write")
+                    | ("cooldis_0.1", "fs_stat")
+                    | ("cooldis_0.1", "fs_list")
+                    | ("cooldis_0.1", "fs_mkdir")
                     | ("cooldis_0.1", "log")
             ),
             crate::WasmHostImportPolicy::PureCompute => matches!(
@@ -565,9 +577,17 @@ struct WasmSourceState {
     offset: usize,
 }
 
-struct WasmFileState {
-    bytes: Vec<u8>,
-    offset: usize,
+enum WasmFileState {
+    /// Read handle: the whole file is buffered host-side at `fs_open` time
+    /// and drained by `fs_read`.
+    Read { bytes: Vec<u8>, offset: usize },
+    /// Write handle: `fs_write` appends into the host-side buffer; nothing
+    /// touches the VFS until `fs_close` commits the buffer as one whole-file
+    /// replace of `path`. A handle dropped without `fs_close` is discarded.
+    Write {
+        path: std::path::PathBuf,
+        buffer: Vec<u8>,
+    },
 }
 
 impl WasmTurnState {
@@ -626,26 +646,44 @@ impl WasmTurnState {
         Some((bytes, exhausted))
     }
 
-    fn insert_file(&mut self, bytes: Vec<u8>) -> u32 {
+    fn insert_read_file(&mut self, bytes: Vec<u8>) -> u32 {
+        self.insert_file(WasmFileState::Read { bytes, offset: 0 })
+    }
+
+    /// Open a pending write buffer for `path`. The buffer lives host-side
+    /// and is committed to the VFS only by `fs_close`.
+    #[expect(dead_code, reason = "fs write leg: wired up by the implementation")]
+    fn insert_write_file(&mut self, path: std::path::PathBuf) -> u32 {
+        self.insert_file(WasmFileState::Write {
+            path,
+            buffer: Vec::new(),
+        })
+    }
+
+    fn insert_file(&mut self, state: WasmFileState) -> u32 {
         let handle = self.next_file;
         self.next_file = self.next_file.saturating_add(1);
-        self.files
-            .insert(handle, WasmFileState { bytes, offset: 0 });
+        self.files.insert(handle, state);
         handle
     }
 
-    fn read_file_chunk(&mut self, handle: u32, capacity: usize) -> Option<(Vec<u8>, bool)> {
-        let file = self.files.get_mut(&handle)?;
-        let remaining = file.bytes.len().saturating_sub(file.offset);
+    fn read_file_chunk(&mut self, handle: u32, capacity: usize) -> Result<(Vec<u8>, bool), i32> {
+        let Some(state) = self.files.get_mut(&handle) else {
+            return Err(STATUS_NOT_FOUND);
+        };
+        let WasmFileState::Read { bytes, offset } = state else {
+            return Err(STATUS_INVALID_ARGUMENT);
+        };
+        let remaining = bytes.len().saturating_sub(*offset);
         let copied = remaining.min(capacity);
-        let bytes = file.bytes[file.offset..file.offset + copied].to_vec();
-        file.offset += copied;
-        let exhausted = file.offset >= file.bytes.len();
-        Some((bytes, exhausted))
+        let chunk = bytes[*offset..*offset + copied].to_vec();
+        *offset += copied;
+        let exhausted = *offset >= bytes.len();
+        Ok((chunk, exhausted))
     }
 
-    fn close_file(&mut self, handle: u32) -> bool {
-        self.files.remove(&handle).is_some()
+    fn take_file(&mut self, handle: u32) -> Option<WasmFileState> {
+        self.files.remove(&handle)
     }
 }
 
@@ -908,7 +946,7 @@ fn add_verlet_imports(linker: &mut wasmtime::Linker<WasmTurnState>) -> wasmtime:
                 let Some(mode) = nonnegative_u32(mode) else {
                     return STATUS_INVALID_ARGUMENT;
                 };
-                if mode != FS_MODE_READ {
+                if mode != FS_MODE_READ && mode != FS_MODE_WRITE {
                     return STATUS_INVALID_ARGUMENT;
                 }
                 let Some(out_handle_ptr) = nonnegative_usize(out_handle_ptr) else {
@@ -927,11 +965,14 @@ fn add_verlet_imports(linker: &mut wasmtime::Linker<WasmTurnState>) -> wasmtime:
                 let Some(vfs) = caller.data().vfs.clone() else {
                     return STATUS_CAPABILITY_DENIED;
                 };
+                if mode == FS_MODE_WRITE {
+                    return fs_open_write_impl(&mut caller, path, out_handle_ptr);
+                }
                 let bytes = match vfs.read_file(&path).await {
                     Ok(bytes) => bytes,
                     Err(err) => return vfs_error_status(err),
                 };
-                let handle = caller.data_mut().insert_file(bytes);
+                let handle = caller.data_mut().insert_read_file(bytes);
                 if !write_guest_u32_at(&mut caller, out_handle_ptr, handle) {
                     return STATUS_INVALID_ARGUMENT;
                 }
@@ -961,9 +1002,9 @@ fn add_verlet_imports(linker: &mut wasmtime::Linker<WasmTurnState>) -> wasmtime:
                 return STATUS_INVALID_ARGUMENT;
             };
             let capacity = capacity as usize;
-            let Some((bytes, exhausted)) = caller.data_mut().read_file_chunk(handle, capacity)
-            else {
-                return STATUS_NOT_FOUND;
+            let (bytes, exhausted) = match caller.data_mut().read_file_chunk(handle, capacity) {
+                Ok(chunk) => chunk,
+                Err(status) => return status,
             };
             let copied = bytes.len();
             let Some(memory) = exported_memory(&mut caller) else {
@@ -988,18 +1029,59 @@ fn add_verlet_imports(linker: &mut wasmtime::Linker<WasmTurnState>) -> wasmtime:
         },
     )?;
 
-    linker.func_wrap(
+    linker.func_wrap_async(
         "cooldis_0.1",
         "fs_close",
-        |mut caller: wasmtime::Caller<'_, WasmTurnState>, handle: i32| -> i32 {
-            let Some(handle) = nonnegative_u32(handle) else {
-                return STATUS_INVALID_ARGUMENT;
-            };
-            if caller.data_mut().close_file(handle) {
-                STATUS_OK
-            } else {
-                STATUS_NOT_FOUND
-            }
+        |mut caller: wasmtime::Caller<'_, WasmTurnState>, (handle,): (i32,)| {
+            Box::new(async move {
+                let Some(handle) = nonnegative_u32(handle) else {
+                    return STATUS_INVALID_ARGUMENT;
+                };
+                match caller.data_mut().take_file(handle) {
+                    None => STATUS_NOT_FOUND,
+                    Some(WasmFileState::Read { .. }) => STATUS_OK,
+                    Some(WasmFileState::Write { path, buffer }) => {
+                        fs_close_commit_impl(&mut caller, path, buffer).await
+                    }
+                }
+            })
+        },
+    )?;
+
+    linker.func_wrap(
+        "cooldis_0.1",
+        "fs_write",
+        |mut caller: wasmtime::Caller<'_, WasmTurnState>, handle: i32, ptr: i32, len: i32| -> i32 {
+            fs_write_impl(&mut caller, handle, ptr, len)
+        },
+    )?;
+
+    linker.func_wrap_async(
+        "cooldis_0.1",
+        "fs_stat",
+        |mut caller: wasmtime::Caller<'_, WasmTurnState>,
+         (path_ptr, path_len, out_ptr): (i32, i32, i32)| {
+            Box::new(async move { fs_stat_impl(&mut caller, path_ptr, path_len, out_ptr).await })
+        },
+    )?;
+
+    linker.func_wrap_async(
+        "cooldis_0.1",
+        "fs_list",
+        |mut caller: wasmtime::Caller<'_, WasmTurnState>,
+         (path_ptr, path_len, out_source_ptr): (i32, i32, i32)| {
+            Box::new(
+                async move { fs_list_impl(&mut caller, path_ptr, path_len, out_source_ptr).await },
+            )
+        },
+    )?;
+
+    linker.func_wrap_async(
+        "cooldis_0.1",
+        "fs_mkdir",
+        |mut caller: wasmtime::Caller<'_, WasmTurnState>,
+         (path_ptr, path_len, recursive): (i32, i32, i32)| {
+            Box::new(async move { fs_mkdir_impl(&mut caller, path_ptr, path_len, recursive).await })
         },
     )?;
 
@@ -1632,6 +1714,114 @@ fn wildcard_match(pattern: &str, value: &str) -> bool {
         pattern_index += 1;
     }
     pattern_index == pattern.len()
+}
+
+/// `fs_open` in `FS_MODE_WRITE`: open a pending write buffer for `path`.
+///
+/// Contract (fs write leg, guest ABI `cooldis_0.1`): the caller has already
+/// validated the mode, decoded an absolute UTF-8 `path`, and confirmed a VFS
+/// is attached to the turn. Mutation additionally requires the
+/// [`FS_WRITE_CAPABILITY`] grant in `capability_grants`; return
+/// `STATUS_CAPABILITY_DENIED` without it. On success, insert a write handle
+/// via `insert_write_file` and write it to guest memory at `out_handle_ptr`
+/// (`STATUS_INVALID_ARGUMENT` if that write fails). The VFS is not touched
+/// here: `fs_write` appends into the host-side buffer and `fs_close` commits
+/// it. Parent directories are NOT created on commit; guests create them
+/// explicitly with `fs_mkdir`.
+fn fs_open_write_impl(
+    _caller: &mut wasmtime::Caller<'_, WasmTurnState>,
+    _path: std::path::PathBuf,
+    _out_handle_ptr: usize,
+) -> i32 {
+    todo!("fs write leg: open write handles")
+}
+
+/// `fs_close` on a write handle: commit the pending buffer to the VFS.
+///
+/// Contract: one whole-file replace of `path` via `VerletVfs::write_file`
+/// (create if missing, truncate-replace if present; parents must already
+/// exist). Failures map through `vfs_error_status`. The handle was already
+/// removed from the file table by the caller: it is consumed whether or not
+/// the commit succeeds, and there is no retry.
+async fn fs_close_commit_impl(
+    _caller: &mut wasmtime::Caller<'_, WasmTurnState>,
+    _path: std::path::PathBuf,
+    _buffer: Vec<u8>,
+) -> i32 {
+    todo!("fs write leg: commit write handles on close")
+}
+
+/// `fs_write`: append `len` bytes from guest memory at `ptr` to the pending
+/// buffer of a write handle.
+///
+/// Contract: all-or-nothing: on `STATUS_OK` the whole slice was appended.
+/// Unknown handle -> `STATUS_NOT_FOUND`; a read handle or bad guest pointers
+/// -> `STATUS_INVALID_ARGUMENT`. No size cap beyond host memory: the read leg
+/// buffers whole files host-side with the same asymmetry.
+fn fs_write_impl(
+    _caller: &mut wasmtime::Caller<'_, WasmTurnState>,
+    _handle: i32,
+    _ptr: i32,
+    _len: i32,
+) -> i32 {
+    todo!("fs write leg: append to write handles")
+}
+
+/// `fs_stat`: stat an absolute UTF-8 VFS path into a 16-byte record.
+///
+/// Contract: decode `path_ptr`/`path_len` like `fs_open` (absolute UTF-8,
+/// else `STATUS_INVALID_ARGUMENT`); no VFS attached ->
+/// `STATUS_CAPABILITY_DENIED`; missing path -> `STATUS_NOT_FOUND`, which
+/// doubles as the existence check (there is no separate exists import).
+/// Read-side: no `fs.write` grant required. On success write exactly 16
+/// little-endian bytes at `out_ptr`:
+///   bytes 0..4   kind (u32): 0 = file, 1 = directory, 2 = other
+///   bytes 4..8   reserved (u32): always zero
+///   bytes 8..16  size (u64): size in bytes for files, 0 for directories
+async fn fs_stat_impl(
+    _caller: &mut wasmtime::Caller<'_, WasmTurnState>,
+    _path_ptr: i32,
+    _path_len: i32,
+    _out_ptr: i32,
+) -> i32 {
+    todo!("fs write leg: stat VFS paths")
+}
+
+/// `fs_list`: list an absolute UTF-8 VFS directory as a readable source.
+///
+/// Contract: path decoding, VFS-attachment, and not-found behavior match
+/// `fs_stat`; read-side, no `fs.write` grant required. On success,
+/// materialize the listing host-side as one UTF-8 JSON array
+/// `[{"name": <entry name>, "is_dir": <bool>}, ...]`, sorted by `name` in
+/// byte order (deterministic, like the agent-tools walker), insert it as a
+/// dynamic source, and write the source handle to guest memory at
+/// `out_source_ptr`. The guest drains it with `source_read`. Names are entry
+/// names only, never full paths.
+async fn fs_list_impl(
+    _caller: &mut wasmtime::Caller<'_, WasmTurnState>,
+    _path_ptr: i32,
+    _path_len: i32,
+    _out_source_ptr: i32,
+) -> i32 {
+    todo!("fs write leg: list VFS directories")
+}
+
+/// `fs_mkdir`: create a directory at an absolute UTF-8 VFS path.
+///
+/// Contract: path decoding and VFS-attachment behavior match `fs_stat`.
+/// Mutation: requires the [`FS_WRITE_CAPABILITY`] grant ->
+/// `STATUS_CAPABILITY_DENIED` without it. `recursive` must be 0 or 1 (any
+/// other value -> `STATUS_INVALID_ARGUMENT`) and maps to the backend's
+/// recursive flag: recursive creation of an existing directory succeeds;
+/// non-recursive creation with a missing parent or an existing target maps
+/// the backend error through `vfs_error_status`.
+async fn fs_mkdir_impl(
+    _caller: &mut wasmtime::Caller<'_, WasmTurnState>,
+    _path_ptr: i32,
+    _path_len: i32,
+    _recursive: i32,
+) -> i32 {
+    todo!("fs write leg: create VFS directories")
 }
 
 fn vfs_error_status(err: bashkit::Error) -> i32 {


### PR DESCRIPTION
Implements the guest ABI filesystem write leg (EMO-604): the `cooldis_0.1` wasm ABI gains `fs_open` in write mode, `fs_write`, write-commit on `fs_close`, `fs_stat`, `fs_list`, and `fs_mkdir`, unblocking the Pi-parity tool pack's write/edit/search wrapper modules.

Design (settled in the issue):

- Write handles buffer host-side; `fs_close` commits the buffer as one whole-file replace via the VFS. A handle never closed leaves the VFS untouched.
- Mutation (write-mode open, mkdir) requires the `fs.write` capability grant, exact match. Read-side imports stay gated by VFS attachment only.
- `fs_stat` returns a fixed 16-byte little-endian record (kind, reserved, size); not-found doubles as the existence check.
- `fs_list` returns a name-sorted JSON listing as a standard source; `fs_mkdir` takes a recursive flag since commit does not create parents.

Guest SDK ships the full typed surface: `open_file_write`, `write_file`, `stat_path`, `list_dir`, `mkdir`, with the byte layouts pinned in the marshaling.

Tests: raw WAT probes against the ABI contract (including capability denial, handle confusion, double close, bad pointers, failed-close consumption), a compiled Rust guest exercising put/stat/ls end to end through the SDK, and a PureCompute policy check that all fs imports stay rejected.

Verification: full `scripts/verify.sh` green on macOS and `scripts/verify-linux.sh` green. Independent Codex review pass over the branch found one Low test-integrity issue (vacuous probe setup statuses), fixed in `b9ef15d`.

Linear: EMO-604.
