### PR TITLE
Chat onboarding: install the pi kit (EMO-611)

### DIFF
--- a/crates/verlet-chat/src/app.rs
+++ b/crates/verlet-chat/src/app.rs
@@ -126,6 +126,12 @@ pub struct App {
     /// First-run tool offer: set with `needs_provider`, spent when the
     /// first real model selection triggers the kit offer (EMO-611).
     pub(crate) kit_offer_pending: bool,
+    /// Prevents a repeated first-run gate event from rearming the one-shot
+    /// offer after it has fired.
+    pub(crate) kit_offer_spent: bool,
+    /// A kit install remains busy even when the user leaves and reopens the
+    /// setup step. The matching result clears it.
+    pub(crate) kit_install_running: bool,
     /// Submitted keys retained until one host reply so late generic errors
     /// can be redacted after the user leaves the input step.
     pub(crate) pending_key_redactions: Vec<(String, String)>,
@@ -167,6 +173,8 @@ impl App {
             pending_selection: None,
             needs_provider: false,
             kit_offer_pending: false,
+            kit_offer_spent: false,
+            kit_install_running: false,
             pending_key_redactions: Vec::new(),
             meta,
             turn_state: "idle".to_string(),
@@ -777,6 +785,7 @@ impl App {
                         // First-run: provider and model are set; offer the
                         // recommended tools once.
                         self.kit_offer_pending = false;
+                        self.kit_offer_spent = true;
                         self.actions.push(crate::Action::FetchKitStatus {
                             intent: crate::KitStatusIntent::OfferIfMissing,
                         });

--- a/crates/verlet-chat/src/app.rs
+++ b/crates/verlet-chat/src/app.rs
@@ -123,6 +123,9 @@ pub struct App {
     /// First-run gate: no configured providers yet. The footer nags until a
     /// credential lands or a model is selected.
     pub(crate) needs_provider: bool,
+    /// First-run tool offer: set with `needs_provider`, spent when the
+    /// first real model selection triggers the kit offer (EMO-611).
+    pub(crate) kit_offer_pending: bool,
     /// Submitted keys retained until one host reply so late generic errors
     /// can be redacted after the user leaves the input step.
     pub(crate) pending_key_redactions: Vec<(String, String)>,
@@ -163,6 +166,7 @@ impl App {
             setup: None,
             pending_selection: None,
             needs_provider: false,
+            kit_offer_pending: false,
             pending_key_redactions: Vec::new(),
             meta,
             turn_state: "idle".to_string(),
@@ -769,6 +773,14 @@ impl App {
                 self.pending_selection = None;
                 if provider_id != "local" {
                     self.needs_provider = false;
+                    if self.kit_offer_pending {
+                        // First-run: provider and model are set; offer the
+                        // recommended tools once.
+                        self.kit_offer_pending = false;
+                        self.actions.push(crate::Action::FetchKitStatus {
+                            intent: crate::KitStatusIntent::OfferIfMissing,
+                        });
+                    }
                 }
                 self.meta.model_label = format!("{provider_id}/{model}");
                 let body = if self.turn_active {
@@ -799,6 +811,16 @@ impl App {
             crate::ChatEvent::CredentialCleared { provider_id } => {
                 self.apply_credential_cleared(provider_id);
             }
+            crate::ChatEvent::KitStatus {
+                intent,
+                installed,
+                recommended,
+            } => self.apply_kit_status(intent, installed, recommended),
+            crate::ChatEvent::KitInstallResult {
+                name,
+                error,
+                receipt,
+            } => self.apply_kit_install_result(name, error, receipt),
             crate::ChatEvent::ThreadStatus(status) => {
                 if !self.turn_active {
                     self.turn_state = status;

--- a/crates/verlet-chat/src/app/setup.rs
+++ b/crates/verlet-chat/src/app/setup.rs
@@ -40,6 +40,13 @@ pub(crate) enum CustomBusy {
     SavingKey,
 }
 
+/// Where Esc or Back from the kit step returns.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum KitOrigin {
+    Home,
+    FirstRunOffer,
+}
+
 /// The custom-provider form's fields, in focus order.
 pub(crate) const CUSTOM_FIELDS: usize = 8;
 
@@ -256,8 +263,8 @@ pub(crate) enum SetupStep {
     /// (EMO-611). Opened from the Home "Install tools" row or by the
     /// first-run offer after the first model lands.
     Kits {
-        /// Catalog rows for the Esc return to Home; empty when the step was
-        /// opened by the first-run offer (Esc then closes the window).
+        origin: KitOrigin,
+        /// Catalog rows used when returning to Home.
         rows: Vec<crate::CatalogProviderRow>,
         installed: Vec<crate::InstalledKitRow>,
         recommended: Vec<crate::RecommendedKitRow>,
@@ -555,7 +562,9 @@ impl crate::app::App {
     /// First-run gate: no configured providers, open the catalog picker.
     pub(crate) fn apply_no_configured_providers(&mut self) {
         self.needs_provider = true;
-        self.kit_offer_pending = true;
+        if !self.kit_offer_spent {
+            self.kit_offer_pending = true;
+        }
         if self.setup.is_none() && self.picker.is_none() {
             self.setup = Some(SetupStep::AwaitCatalog {
                 intent: CatalogIntent::Catalog,
@@ -704,6 +713,7 @@ impl crate::app::App {
                 })
             }
             Some(SetupStep::Kits {
+                origin,
                 installed,
                 recommended,
                 state,
@@ -713,6 +723,7 @@ impl crate::app::App {
                 ..
             }) => {
                 self.setup = Some(SetupStep::Kits {
+                    origin,
                     rows,
                     installed,
                     recommended,
@@ -848,6 +859,7 @@ impl crate::app::App {
                 error,
             } => self.handle_custom_form(event, rows, form, editing, busy, error),
             SetupStep::Kits {
+                origin,
                 rows,
                 installed,
                 recommended,
@@ -857,6 +869,7 @@ impl crate::app::App {
                 notice,
             } => self.handle_kits(
                 event,
+                origin,
                 rows,
                 installed,
                 recommended,
@@ -1940,6 +1953,7 @@ impl crate::app::App {
 
     fn open_kits(
         &mut self,
+        origin: KitOrigin,
         rows: Vec<crate::CatalogProviderRow>,
         installed: Vec<crate::InstalledKitRow>,
         recommended: Vec<crate::RecommendedKitRow>,
@@ -1948,11 +1962,12 @@ impl crate::app::App {
         let mut state = tuika::components::SelectState::new();
         state.select(Some(0));
         self.setup = Some(SetupStep::Kits {
+            origin,
             rows,
             installed,
             recommended,
             state,
-            busy: false,
+            busy: self.kit_install_running,
             error: None,
             notice: None,
         });
@@ -1969,19 +1984,21 @@ impl crate::app::App {
             // The step is open (install-result refresh): swap the lists in
             // place, keeping the busy flag and status lines.
             Some(SetupStep::Kits {
+                origin,
                 rows,
-                state,
-                busy,
+                mut state,
                 error,
                 notice,
                 ..
             }) => {
+                state.clamp(kit_step_options(&installed, &recommended).len() + 1);
                 self.setup = Some(SetupStep::Kits {
+                    origin,
                     rows,
                     installed,
                     recommended,
                     state,
-                    busy,
+                    busy: self.kit_install_running,
                     error,
                     notice,
                 })
@@ -1990,23 +2007,25 @@ impl crate::app::App {
             // while the window shows Home: open over the Home rows. The
             // offer only opens when a recommended kit is actually missing.
             Some(SetupStep::Home { rows, state }) => {
-                if intent == crate::KitStatusIntent::Open
-                    || any_recommended_missing(&installed, &recommended)
-                {
-                    self.open_kits(rows, installed, recommended);
+                let open = match intent {
+                    crate::KitStatusIntent::Open => true,
+                    crate::KitStatusIntent::Refresh => false,
+                    crate::KitStatusIntent::OfferIfMissing => {
+                        any_recommended_missing(&installed, &recommended)
+                    }
+                };
+                if open {
+                    self.open_kits(KitOrigin::Home, rows, installed, recommended);
                 } else {
                     self.setup = Some(SetupStep::Home { rows, state });
                 }
             }
             None => {
-                let open = match intent {
-                    crate::KitStatusIntent::Open => true,
-                    crate::KitStatusIntent::OfferIfMissing => {
-                        any_recommended_missing(&installed, &recommended) && self.picker.is_none()
-                    }
-                };
-                if open {
-                    self.open_kits(Vec::new(), installed, recommended);
+                if intent == crate::KitStatusIntent::OfferIfMissing
+                    && any_recommended_missing(&installed, &recommended)
+                    && self.picker.is_none()
+                {
+                    self.open_kits(KitOrigin::FirstRunOffer, Vec::new(), installed, recommended);
                 }
             }
             // Stale: the user moved into another step while the fetch was
@@ -2023,6 +2042,7 @@ impl crate::app::App {
         error: Option<String>,
         receipt: Vec<String>,
     ) {
+        self.kit_install_running = false;
         match &error {
             Some(message) => self.notice(
                 crate::cells::Tone::Error,
@@ -2035,37 +2055,41 @@ impl crate::app::App {
                 receipt,
             ),
         }
-        if let Some(SetupStep::Kits {
-            rows,
-            installed,
-            recommended,
-            state,
-            notice,
-            ..
-        }) = self.setup.take()
-        {
-            let succeeded = error.is_none();
-            self.setup = Some(SetupStep::Kits {
+        match self.setup.take() {
+            Some(SetupStep::Kits {
+                origin,
                 rows,
                 installed,
                 recommended,
                 state,
-                busy: false,
-                error,
-                notice: if succeeded {
-                    Some(format!(
-                        "installed {name}; tools load at the next daemon startup"
-                    ))
-                } else {
-                    notice
-                },
-            });
-            if succeeded {
-                // Refresh so the installed list reflects the new record.
-                self.actions.push(crate::Action::FetchKitStatus {
-                    intent: crate::KitStatusIntent::Open,
+                notice,
+                ..
+            }) => {
+                let succeeded = error.is_none();
+                self.setup = Some(SetupStep::Kits {
+                    origin,
+                    rows,
+                    installed,
+                    recommended,
+                    state,
+                    busy: false,
+                    error,
+                    notice: if succeeded {
+                        Some(format!(
+                            "installed {name}; tools load at the next daemon startup"
+                        ))
+                    } else {
+                        notice
+                    },
                 });
+                if succeeded {
+                    // Refresh so the installed list reflects the new record.
+                    self.actions.push(crate::Action::FetchKitStatus {
+                        intent: crate::KitStatusIntent::Refresh,
+                    });
+                }
             }
+            step => self.setup = step,
         }
     }
 
@@ -2073,6 +2097,7 @@ impl crate::app::App {
     fn handle_kits(
         &mut self,
         event: &tuika::event::Event,
+        origin: KitOrigin,
         rows: Vec<crate::CatalogProviderRow>,
         installed: Vec<crate::InstalledKitRow>,
         recommended: Vec<crate::RecommendedKitRow>,
@@ -2086,9 +2111,10 @@ impl crate::app::App {
         if busy {
             if matches!(event, tuika::event::Event::Key(key) if key.plain() && key.code == tuika::event::KeyCode::Esc)
             {
-                self.leave_kits(rows);
+                self.leave_kits(origin, rows);
             } else {
                 self.setup = Some(SetupStep::Kits {
+                    origin,
                     rows,
                     installed,
                     recommended,
@@ -2111,6 +2137,7 @@ impl crate::app::App {
                             // Unreachable by construction (options require a
                             // source); keep the step unchanged if it happens.
                             self.setup = Some(SetupStep::Kits {
+                                origin,
                                 rows,
                                 installed,
                                 recommended,
@@ -2125,7 +2152,9 @@ impl crate::app::App {
                             name: kit.name.clone(),
                             source,
                         });
+                        self.kit_install_running = true;
                         self.setup = Some(SetupStep::Kits {
+                            origin,
                             rows,
                             installed,
                             recommended,
@@ -2136,12 +2165,13 @@ impl crate::app::App {
                         });
                     }
                     // The trailing Back row (or no selection).
-                    _ => self.leave_kits(rows),
+                    _ => self.leave_kits(origin, rows),
                 }
             }
-            tuika::event::InputOutcome::Cancelled => self.leave_kits(rows),
+            tuika::event::InputOutcome::Cancelled => self.leave_kits(origin, rows),
             _ => {
                 self.setup = Some(SetupStep::Kits {
+                    origin,
                     rows,
                     installed,
                     recommended,
@@ -2156,11 +2186,10 @@ impl crate::app::App {
 
     /// Esc/Back from the kit step: Home when it was entered from Home,
     /// closed when the first-run offer opened it directly.
-    fn leave_kits(&mut self, rows: Vec<crate::CatalogProviderRow>) {
-        if rows.is_empty() {
-            self.setup = None;
-        } else {
-            self.open_home(rows);
+    fn leave_kits(&mut self, origin: KitOrigin, rows: Vec<crate::CatalogProviderRow>) {
+        match origin {
+            KitOrigin::Home => self.open_home(rows),
+            KitOrigin::FirstRunOffer => self.setup = None,
         }
     }
 }

--- a/crates/verlet-chat/src/app/setup.rs
+++ b/crates/verlet-chat/src/app/setup.rs
@@ -252,6 +252,23 @@ pub(crate) enum SetupStep {
         busy: CustomBusy,
         error: Option<String>,
     },
+    /// The tool-kit step: installed kits plus the host's recommendations
+    /// (EMO-611). Opened from the Home "Install tools" row or by the
+    /// first-run offer after the first model lands.
+    Kits {
+        /// Catalog rows for the Esc return to Home; empty when the step was
+        /// opened by the first-run offer (Esc then closes the window).
+        rows: Vec<crate::CatalogProviderRow>,
+        installed: Vec<crate::InstalledKitRow>,
+        recommended: Vec<crate::RecommendedKitRow>,
+        state: tuika::components::SelectState,
+        /// An install is in flight; only Esc works (the install keeps
+        /// running and reports to the transcript).
+        busy: bool,
+        error: Option<String>,
+        /// The post-install status line ("installed pi; ...").
+        notice: Option<String>,
+    },
     /// A model list was requested for the chosen provider; the window closes
     /// into the (scoped) model picker when [`crate::ChatEvent::Models`]
     /// arrives.
@@ -363,10 +380,35 @@ pub(crate) fn overview_rows(rows: &[crate::CatalogProviderRow]) -> Vec<&crate::C
 }
 
 /// Fixed actions appended under the overview rows.
-pub(crate) const HOME_ACTIONS: [(&str, &str); 2] = [
+pub(crate) const HOME_ACTIONS: [(&str, &str); 3] = [
     ("Connect a provider", "browse the catalog"),
     ("Add custom provider", "OpenAI- or Anthropic-compatible URL"),
+    ("Install tools", "kits of agent tools for this instance"),
 ];
+
+/// One selectable row of the kit step, ahead of the fixed Back row.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum KitOption {
+    /// Install `recommended[index]` (only rows with a found source and no
+    /// installed record become options).
+    Install { index: usize },
+}
+
+/// The selectable rows of the kit step. The Back row is appended by the
+/// renderer and handler as index `options.len()`.
+pub(crate) fn kit_step_options(
+    installed: &[crate::InstalledKitRow],
+    recommended: &[crate::RecommendedKitRow],
+) -> Vec<KitOption> {
+    recommended
+        .iter()
+        .enumerate()
+        .filter(|(_, kit)| {
+            kit.source.is_some() && !installed.iter().any(|record| record.name == kit.name)
+        })
+        .map(|(index, _)| KitOption::Install { index })
+        .collect()
+}
 
 /// The status suffix for a catalog row, pi-style.
 pub(crate) fn catalog_status(row: &crate::CatalogProviderRow) -> String {
@@ -513,6 +555,7 @@ impl crate::app::App {
     /// First-run gate: no configured providers, open the catalog picker.
     pub(crate) fn apply_no_configured_providers(&mut self) {
         self.needs_provider = true;
+        self.kit_offer_pending = true;
         if self.setup.is_none() && self.picker.is_none() {
             self.setup = Some(SetupStep::AwaitCatalog {
                 intent: CatalogIntent::Catalog,
@@ -660,6 +703,25 @@ impl crate::app::App {
                     error,
                 })
             }
+            Some(SetupStep::Kits {
+                installed,
+                recommended,
+                state,
+                busy,
+                error,
+                notice,
+                ..
+            }) => {
+                self.setup = Some(SetupStep::Kits {
+                    rows,
+                    installed,
+                    recommended,
+                    state,
+                    busy,
+                    error,
+                    notice,
+                })
+            }
             // Stale: the window was dismissed while the fetch was in flight.
             step @ (None | Some(SetupStep::AwaitModels { .. })) => self.setup = step,
         }
@@ -785,6 +847,24 @@ impl crate::app::App {
                 busy,
                 error,
             } => self.handle_custom_form(event, rows, form, editing, busy, error),
+            SetupStep::Kits {
+                rows,
+                installed,
+                recommended,
+                state,
+                busy,
+                error,
+                notice,
+            } => self.handle_kits(
+                event,
+                rows,
+                installed,
+                recommended,
+                state,
+                busy,
+                error,
+                notice,
+            ),
             step @ (SetupStep::AwaitModels { .. } | SetupStep::AwaitCatalog { .. }) => {
                 self.setup = Some(step);
             }
@@ -818,7 +898,7 @@ impl crate::app::App {
                     });
                 } else if index == overview_len {
                     self.open_catalog(rows);
-                } else {
+                } else if index == overview_len + 1 {
                     self.setup = Some(SetupStep::CustomForm {
                         rows,
                         form: Box::new(CustomForm::new()),
@@ -826,6 +906,13 @@ impl crate::app::App {
                         busy: CustomBusy::Idle,
                         error: None,
                     });
+                } else {
+                    // "Install tools": stay on Home until the status
+                    // arrives; ChatEvent::KitStatus opens the kit step.
+                    self.actions.push(crate::Action::FetchKitStatus {
+                        intent: crate::KitStatusIntent::Open,
+                    });
+                    self.setup = Some(SetupStep::Home { rows, state });
                 }
             }
             tuika::event::InputOutcome::Cancelled => {
@@ -1850,6 +1937,241 @@ impl crate::app::App {
         }
         self.notice(crate::cells::Tone::Error, title, body);
     }
+
+    fn open_kits(
+        &mut self,
+        rows: Vec<crate::CatalogProviderRow>,
+        installed: Vec<crate::InstalledKitRow>,
+        recommended: Vec<crate::RecommendedKitRow>,
+    ) {
+        self.popup = None;
+        let mut state = tuika::components::SelectState::new();
+        state.select(Some(0));
+        self.setup = Some(SetupStep::Kits {
+            rows,
+            installed,
+            recommended,
+            state,
+            busy: false,
+            error: None,
+            notice: None,
+        });
+    }
+
+    /// Fold an arrived kit status into the window per the fetch intent.
+    pub(crate) fn apply_kit_status(
+        &mut self,
+        intent: crate::KitStatusIntent,
+        installed: Vec<crate::InstalledKitRow>,
+        recommended: Vec<crate::RecommendedKitRow>,
+    ) {
+        match self.setup.take() {
+            // The step is open (install-result refresh): swap the lists in
+            // place, keeping the busy flag and status lines.
+            Some(SetupStep::Kits {
+                rows,
+                state,
+                busy,
+                error,
+                notice,
+                ..
+            }) => {
+                self.setup = Some(SetupStep::Kits {
+                    rows,
+                    installed,
+                    recommended,
+                    state,
+                    busy,
+                    error,
+                    notice,
+                })
+            }
+            // The Home "Install tools" row, or the first-run offer landing
+            // while the window shows Home: open over the Home rows. The
+            // offer only opens when a recommended kit is actually missing.
+            Some(SetupStep::Home { rows, state }) => {
+                if intent == crate::KitStatusIntent::Open
+                    || any_recommended_missing(&installed, &recommended)
+                {
+                    self.open_kits(rows, installed, recommended);
+                } else {
+                    self.setup = Some(SetupStep::Home { rows, state });
+                }
+            }
+            None => {
+                let open = match intent {
+                    crate::KitStatusIntent::Open => true,
+                    crate::KitStatusIntent::OfferIfMissing => {
+                        any_recommended_missing(&installed, &recommended) && self.picker.is_none()
+                    }
+                };
+                if open {
+                    self.open_kits(Vec::new(), installed, recommended);
+                }
+            }
+            // Stale: the user moved into another step while the fetch was
+            // in flight; never clobber a mid-flow screen.
+            step => self.setup = step,
+        }
+    }
+
+    /// An install finished: always post the receipt (or failure) to the
+    /// transcript; update the kit step if it is still open.
+    pub(crate) fn apply_kit_install_result(
+        &mut self,
+        name: String,
+        error: Option<String>,
+        receipt: Vec<String>,
+    ) {
+        match &error {
+            Some(message) => self.notice(
+                crate::cells::Tone::Error,
+                format!("kit install failed: {name}"),
+                vec![message.clone()],
+            ),
+            None => self.notice(
+                crate::cells::Tone::Info,
+                format!("installed kit {name}"),
+                receipt,
+            ),
+        }
+        if let Some(SetupStep::Kits {
+            rows,
+            installed,
+            recommended,
+            state,
+            notice,
+            ..
+        }) = self.setup.take()
+        {
+            let succeeded = error.is_none();
+            self.setup = Some(SetupStep::Kits {
+                rows,
+                installed,
+                recommended,
+                state,
+                busy: false,
+                error,
+                notice: if succeeded {
+                    Some(format!(
+                        "installed {name}; tools load at the next daemon startup"
+                    ))
+                } else {
+                    notice
+                },
+            });
+            if succeeded {
+                // Refresh so the installed list reflects the new record.
+                self.actions.push(crate::Action::FetchKitStatus {
+                    intent: crate::KitStatusIntent::Open,
+                });
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn handle_kits(
+        &mut self,
+        event: &tuika::event::Event,
+        rows: Vec<crate::CatalogProviderRow>,
+        installed: Vec<crate::InstalledKitRow>,
+        recommended: Vec<crate::RecommendedKitRow>,
+        mut state: tuika::components::SelectState,
+        busy: bool,
+        error: Option<String>,
+        notice: Option<String>,
+    ) {
+        // While the install runs only Esc works; leaving is safe (the
+        // install keeps running and reports to the transcript).
+        if busy {
+            if matches!(event, tuika::event::Event::Key(key) if key.plain() && key.code == tuika::event::KeyCode::Esc)
+            {
+                self.leave_kits(rows);
+            } else {
+                self.setup = Some(SetupStep::Kits {
+                    rows,
+                    installed,
+                    recommended,
+                    state,
+                    busy,
+                    error,
+                    notice,
+                });
+            }
+            return;
+        }
+        let options = kit_step_options(&installed, &recommended);
+        let total = options.len() + 1;
+        match state.handle(event, total) {
+            tuika::event::InputOutcome::Submitted => {
+                match state.selected().and_then(|index| options.get(index)) {
+                    Some(KitOption::Install { index }) => {
+                        let kit = &recommended[*index];
+                        let Some(source) = kit.source.clone() else {
+                            // Unreachable by construction (options require a
+                            // source); keep the step unchanged if it happens.
+                            self.setup = Some(SetupStep::Kits {
+                                rows,
+                                installed,
+                                recommended,
+                                state,
+                                busy,
+                                error,
+                                notice,
+                            });
+                            return;
+                        };
+                        self.actions.push(crate::Action::InstallKit {
+                            name: kit.name.clone(),
+                            source,
+                        });
+                        self.setup = Some(SetupStep::Kits {
+                            rows,
+                            installed,
+                            recommended,
+                            state,
+                            busy: true,
+                            error: None,
+                            notice: None,
+                        });
+                    }
+                    // The trailing Back row (or no selection).
+                    _ => self.leave_kits(rows),
+                }
+            }
+            tuika::event::InputOutcome::Cancelled => self.leave_kits(rows),
+            _ => {
+                self.setup = Some(SetupStep::Kits {
+                    rows,
+                    installed,
+                    recommended,
+                    state,
+                    busy,
+                    error,
+                    notice,
+                });
+            }
+        }
+    }
+
+    /// Esc/Back from the kit step: Home when it was entered from Home,
+    /// closed when the first-run offer opened it directly.
+    fn leave_kits(&mut self, rows: Vec<crate::CatalogProviderRow>) {
+        if rows.is_empty() {
+            self.setup = None;
+        } else {
+            self.open_home(rows);
+        }
+    }
+}
+
+fn any_recommended_missing(
+    installed: &[crate::InstalledKitRow],
+    recommended: &[crate::RecommendedKitRow],
+) -> bool {
+    recommended
+        .iter()
+        .any(|kit| !installed.iter().any(|record| record.name == kit.name))
 }
 
 fn error_summary(title: &str, body: &[String]) -> String {

--- a/crates/verlet-chat/src/lib.rs
+++ b/crates/verlet-chat/src/lib.rs
@@ -78,6 +78,13 @@ pub enum Action {
     /// Delete the provider's stored credential; the host answers with
     /// [`ChatEvent::CredentialCleared`] (or an error notice).
     ClearCredential { provider_id: String },
+    /// Read the installed-kit records and probe the recommended kit
+    /// sources; the host answers with [`ChatEvent::KitStatus`].
+    FetchKitStatus { intent: KitStatusIntent },
+    /// Install a kit from a local directory through the `verlet kit
+    /// install` pipeline; the host answers with
+    /// [`ChatEvent::KitInstallResult`].
+    InstallKit { name: String, source: String },
 }
 
 /// How an OAuth-capable provider signs in.
@@ -116,6 +123,39 @@ pub struct CatalogProviderRow {
     pub model_count: usize,
     /// The model auto-selected after a successful first credential.
     pub default_model: Option<String>,
+}
+
+/// Why kit status was fetched, so [`ChatEvent::KitStatus`] knows whether to
+/// open the setup window's kit step unconditionally or only when the
+/// recommended kit is missing (the first-run offer).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KitStatusIntent {
+    /// Open (or refresh) the kit step.
+    Open,
+    /// First-run offer: open only if a recommended kit is not installed.
+    OfferIfMissing,
+}
+
+/// One installed kit, as read from the host's installed-kit records.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InstalledKitRow {
+    pub name: String,
+    pub version: Option<String>,
+    /// Model-facing tool names, in record order.
+    pub tools: Vec<String>,
+}
+
+/// One kit the host recommends installing. The recommendation list is
+/// hardcoded host-side; the UI only renders it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecommendedKitRow {
+    pub name: String,
+    /// One-line description shown next to the install row.
+    pub blurb: String,
+    /// A kit directory the host found for this kit (first existing
+    /// candidate). None means the source is not on this machine and the
+    /// step shows manual install guidance instead of an Install row.
+    pub source: Option<String>,
 }
 
 /// A custom provider definition submitted from the setup window's form. The
@@ -226,6 +266,20 @@ pub enum ChatEvent {
     },
     /// The provider's stored credential was deleted.
     CredentialCleared { provider_id: String },
+    /// Installed kits plus the host's recommendations: opens (or refreshes)
+    /// the setup window's kit step per the intent.
+    KitStatus {
+        intent: KitStatusIntent,
+        installed: Vec<InstalledKitRow>,
+        recommended: Vec<RecommendedKitRow>,
+    },
+    /// A kit install finished. `receipt` carries the same lines `verlet kit
+    /// install` prints; shown as a transcript notice.
+    KitInstallResult {
+        name: String,
+        error: Option<String>,
+        receipt: Vec<String>,
+    },
     /// The thread's runtime status changed ("idle", "running", ...).
     ThreadStatus(String),
     /// An informational notice for the transcript.

--- a/crates/verlet-chat/src/lib.rs
+++ b/crates/verlet-chat/src/lib.rs
@@ -126,12 +126,14 @@ pub struct CatalogProviderRow {
 }
 
 /// Why kit status was fetched, so [`ChatEvent::KitStatus`] knows whether to
-/// open the setup window's kit step unconditionally or only when the
-/// recommended kit is missing (the first-run offer).
+/// open the setup window's kit step, refresh it in place, or offer it only
+/// when the recommended kit is missing.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum KitStatusIntent {
-    /// Open (or refresh) the kit step.
+    /// Open the kit step after the user selects the Home action.
     Open,
+    /// Refresh an already-open kit step without reopening it from Home.
+    Refresh,
     /// First-run offer: open only if a recommended kit is not installed.
     OfferIfMissing,
 }

--- a/crates/verlet-chat/src/tests.rs
+++ b/crates/verlet-chat/src/tests.rs
@@ -2221,6 +2221,14 @@ fn setup_window_build_is_safe_at_zero_and_tiny_terminal_sizes() {
         }
         let _ = form_app.handle(&key(tuika::KeyCode::Enter));
         let _ = render_at(&mut form_app, true, width, height);
+
+        let mut kits_app = crate::app::App::new(meta());
+        kits_app.apply(crate::ChatEvent::KitStatus {
+            intent: crate::KitStatusIntent::Open,
+            installed: vec![installed_pi_row()],
+            recommended: vec![recommended_pi(Some("dist/pi-kit")), recommended_pi(None)],
+        });
+        let _ = render_at(&mut kits_app, true, width, height);
     }
 }
 
@@ -2248,4 +2256,213 @@ fn fuzzy_filter_matches_subsequences_and_ranks_substrings_first() {
     assert_eq!(hits[0].provider_id, "openai");
     let hits = crate::app::setup::filtered_catalog(&rows, "zzz");
     assert!(hits.is_empty());
+}
+
+fn installed_pi_row() -> crate::InstalledKitRow {
+    crate::InstalledKitRow {
+        name: "pi".to_string(),
+        version: Some("0.1.0".to_string()),
+        tools: ["read", "write", "edit", "find", "grep"]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+    }
+}
+
+fn recommended_pi(source: Option<&str>) -> crate::RecommendedKitRow {
+    crate::RecommendedKitRow {
+        name: "pi".to_string(),
+        blurb: "read, write, edit, find, grep file tools".to_string(),
+        source: source.map(str::to_string),
+    }
+}
+
+/// Home (2 configured providers + 3 action rows) -> "Install tools".
+fn open_kits_from_home(app: &mut crate::app::App) {
+    open_home(app);
+    for _ in 0..4 {
+        let _ = app.handle(&key(tuika::KeyCode::Down));
+    }
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    assert_eq!(
+        app.drain_actions(),
+        vec![crate::Action::FetchKitStatus {
+            intent: crate::KitStatusIntent::Open
+        }]
+    );
+    app.apply(crate::ChatEvent::KitStatus {
+        intent: crate::KitStatusIntent::Open,
+        installed: Vec::new(),
+        recommended: vec![recommended_pi(Some("dist/pi-kit"))],
+    });
+}
+
+#[test]
+fn home_install_tools_row_opens_the_kit_step() {
+    let mut app = app();
+    open_kits_from_home(&mut app);
+    let grid = render(&mut app, true);
+    assert!(grid.contains("Tool kits"), "window title:\n{grid}");
+    assert!(
+        grid.contains("No kits installed yet."),
+        "empty state:\n{grid}"
+    );
+    assert!(grid.contains("Install the pi kit"), "install row:\n{grid}");
+    assert!(grid.contains("Back"), "back row:\n{grid}");
+}
+
+#[test]
+fn kit_install_runs_busy_reports_and_refreshes() {
+    let mut app = app();
+    open_kits_from_home(&mut app);
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    assert_eq!(
+        app.drain_actions(),
+        vec![crate::Action::InstallKit {
+            name: "pi".to_string(),
+            source: "dist/pi-kit".to_string(),
+        }]
+    );
+    let grid = render(&mut app, true);
+    assert!(grid.contains("installing…"), "busy line:\n{grid}");
+    // Everything except Esc is swallowed while the install runs.
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    assert_eq!(app.drain_actions(), Vec::new());
+
+    app.apply(crate::ChatEvent::KitInstallResult {
+        name: "pi".to_string(),
+        error: None,
+        receipt: vec!["published pi-read sha256:aaaa".to_string()],
+    });
+    assert_eq!(
+        app.drain_actions(),
+        vec![crate::Action::FetchKitStatus {
+            intent: crate::KitStatusIntent::Open
+        }]
+    );
+    app.apply(crate::ChatEvent::KitStatus {
+        intent: crate::KitStatusIntent::Open,
+        installed: vec![installed_pi_row()],
+        recommended: vec![recommended_pi(Some("dist/pi-kit"))],
+    });
+    let grid = render(&mut app, true);
+    assert!(
+        grid.contains("pi 0.1.0"),
+        "installed row after refresh:\n{grid}"
+    );
+    assert!(
+        !grid.contains("Install the pi kit"),
+        "installed kit still offered:\n{grid}"
+    );
+    assert!(
+        grid.contains("tools load at the next daemon startup"),
+        "status line:\n{grid}"
+    );
+    // The receipt landed in the transcript behind the modal.
+    let _ = app.handle(&key(tuika::KeyCode::Esc));
+    let grid = render(&mut app, true);
+    assert!(grid.contains("installed kit pi"), "notice title:\n{grid}");
+    assert!(
+        grid.contains("published pi-read sha256:aaaa"),
+        "receipt line:\n{grid}"
+    );
+}
+
+#[test]
+fn kit_install_failure_renders_inline_and_does_not_refresh() {
+    let mut app = app();
+    open_kits_from_home(&mut app);
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    let _ = app.drain_actions();
+    app.apply(crate::ChatEvent::KitInstallResult {
+        name: "pi".to_string(),
+        error: Some("fixture gate failed".to_string()),
+        receipt: Vec::new(),
+    });
+    assert_eq!(app.drain_actions(), Vec::new());
+    let grid = render(&mut app, true);
+    assert!(grid.contains("fixture gate failed"), "error line:\n{grid}");
+    assert!(
+        grid.contains("Install the pi kit"),
+        "retry row after failure:\n{grid}"
+    );
+}
+
+#[test]
+fn kit_step_esc_returns_to_home_and_missing_source_shows_guidance() {
+    let mut app = app();
+    open_kits_from_home(&mut app);
+    let _ = app.handle(&key(tuika::KeyCode::Esc));
+    let grid = render(&mut app, true);
+    assert!(grid.contains("Providers"), "back to home:\n{grid}");
+
+    // Reopen with no local kit directory: no install row, manual guidance.
+    let _ = app.handle(&key(tuika::KeyCode::Esc));
+    app.apply(crate::ChatEvent::KitStatus {
+        intent: crate::KitStatusIntent::Open,
+        installed: Vec::new(),
+        recommended: vec![recommended_pi(None)],
+    });
+    let grid = render(&mut app, true);
+    assert!(
+        grid.contains("verlet kit install"),
+        "manual guidance:\n{grid}"
+    );
+    assert!(
+        !grid.contains("Install the pi kit"),
+        "sourceless install row:\n{grid}"
+    );
+}
+
+#[test]
+fn first_run_model_selection_offers_the_kit_once() {
+    let mut app = app();
+    app.apply(crate::ChatEvent::NoConfiguredProviders);
+    let _ = app.drain_actions();
+    // Dismiss the first-run catalog window so the offer opens over nothing.
+    app.apply(crate::ChatEvent::ProviderCatalog {
+        providers: catalog_rows(),
+    });
+    let _ = app.handle(&key(tuika::KeyCode::Esc));
+
+    app.apply(crate::ChatEvent::ModelSelected {
+        provider_id: "anthropic".to_string(),
+        model: "claude-best".to_string(),
+    });
+    assert_eq!(
+        app.drain_actions(),
+        vec![crate::Action::FetchKitStatus {
+            intent: crate::KitStatusIntent::OfferIfMissing
+        }]
+    );
+    app.apply(crate::ChatEvent::KitStatus {
+        intent: crate::KitStatusIntent::OfferIfMissing,
+        installed: Vec::new(),
+        recommended: vec![recommended_pi(Some("dist/pi-kit"))],
+    });
+    let grid = render(&mut app, true);
+    assert!(grid.contains("Tool kits"), "offer opened:\n{grid}");
+    // Opened by the offer (no Home rows behind it): Esc closes the window.
+    let _ = app.handle(&key(tuika::KeyCode::Esc));
+    let grid = render(&mut app, true);
+    assert!(!grid.contains("Tool kits"), "offer closed:\n{grid}");
+
+    // The offer is one-shot per first-run session.
+    app.apply(crate::ChatEvent::ModelSelected {
+        provider_id: "anthropic".to_string(),
+        model: "claude-best".to_string(),
+    });
+    assert_eq!(app.drain_actions(), Vec::new());
+}
+
+#[test]
+fn kit_offer_stays_closed_when_the_kit_is_already_installed() {
+    let mut app = app();
+    app.apply(crate::ChatEvent::KitStatus {
+        intent: crate::KitStatusIntent::OfferIfMissing,
+        installed: vec![installed_pi_row()],
+        recommended: vec![recommended_pi(Some("dist/pi-kit"))],
+    });
+    let grid = render(&mut app, true);
+    assert!(!grid.contains("Tool kits"), "offer opened anyway:\n{grid}");
 }

--- a/crates/verlet-chat/src/tests.rs
+++ b/crates/verlet-chat/src/tests.rs
@@ -2223,6 +2223,10 @@ fn setup_window_build_is_safe_at_zero_and_tiny_terminal_sizes() {
         let _ = render_at(&mut form_app, true, width, height);
 
         let mut kits_app = crate::app::App::new(meta());
+        kits_app.setup = Some(crate::app::setup::SetupStep::Home {
+            rows: Vec::new(),
+            state: tuika::components::SelectState::new(),
+        });
         kits_app.apply(crate::ChatEvent::KitStatus {
             intent: crate::KitStatusIntent::Open,
             installed: vec![installed_pi_row()],
@@ -2230,6 +2234,25 @@ fn setup_window_build_is_safe_at_zero_and_tiny_terminal_sizes() {
         });
         let _ = render_at(&mut kits_app, true, width, height);
     }
+}
+
+#[test]
+fn tiny_kit_dialog_prioritizes_the_selectable_rows_over_info() {
+    let mut app = app();
+    app.setup = Some(crate::app::setup::SetupStep::Home {
+        rows: Vec::new(),
+        state: tuika::components::SelectState::new(),
+    });
+    app.apply(crate::ChatEvent::KitStatus {
+        intent: crate::KitStatusIntent::Open,
+        installed: vec![installed_pi_row()],
+        recommended: vec![recommended_kit("other", Some("dist/other-kit"))],
+    });
+    let grid = render_at(&mut app, true, 40, 6);
+    assert!(
+        grid.contains("Install"),
+        "selectable row was hidden:\n{grid}"
+    );
 }
 
 #[test]
@@ -2270,8 +2293,12 @@ fn installed_pi_row() -> crate::InstalledKitRow {
 }
 
 fn recommended_pi(source: Option<&str>) -> crate::RecommendedKitRow {
+    recommended_kit("pi", source)
+}
+
+fn recommended_kit(name: &str, source: Option<&str>) -> crate::RecommendedKitRow {
     crate::RecommendedKitRow {
-        name: "pi".to_string(),
+        name: name.to_string(),
         blurb: "read, write, edit, find, grep file tools".to_string(),
         source: source.map(str::to_string),
     }
@@ -2337,11 +2364,11 @@ fn kit_install_runs_busy_reports_and_refreshes() {
     assert_eq!(
         app.drain_actions(),
         vec![crate::Action::FetchKitStatus {
-            intent: crate::KitStatusIntent::Open
+            intent: crate::KitStatusIntent::Refresh
         }]
     );
     app.apply(crate::ChatEvent::KitStatus {
-        intent: crate::KitStatusIntent::Open,
+        intent: crate::KitStatusIntent::Refresh,
         installed: vec![installed_pi_row()],
         recommended: vec![recommended_pi(Some("dist/pi-kit"))],
     });
@@ -2396,8 +2423,8 @@ fn kit_step_esc_returns_to_home_and_missing_source_shows_guidance() {
     let grid = render(&mut app, true);
     assert!(grid.contains("Providers"), "back to home:\n{grid}");
 
-    // Reopen with no local kit directory: no install row, manual guidance.
-    let _ = app.handle(&key(tuika::KeyCode::Esc));
+    // Refresh from Home with no local kit directory: no install row, manual
+    // guidance.
     app.apply(crate::ChatEvent::KitStatus {
         intent: crate::KitStatusIntent::Open,
         installed: Vec::new(),
@@ -2456,6 +2483,32 @@ fn first_run_model_selection_offers_the_kit_once() {
 }
 
 #[test]
+fn repeated_first_run_gate_events_cannot_rearm_the_kit_offer() {
+    let mut app = app();
+    app.apply(crate::ChatEvent::NoConfiguredProviders);
+    let _ = app.drain_actions();
+    app.apply(crate::ChatEvent::ModelSelected {
+        provider_id: "anthropic".to_string(),
+        model: "claude-best".to_string(),
+    });
+    assert!(matches!(
+        app.drain_actions().as_slice(),
+        [crate::Action::FetchKitStatus {
+            intent: crate::KitStatusIntent::OfferIfMissing
+        }]
+    ));
+
+    app.setup = None;
+    app.apply(crate::ChatEvent::NoConfiguredProviders);
+    let _ = app.drain_actions();
+    app.apply(crate::ChatEvent::ModelSelected {
+        provider_id: "openai".to_string(),
+        model: "gpt-best".to_string(),
+    });
+    assert_eq!(app.drain_actions(), Vec::new());
+}
+
+#[test]
 fn kit_offer_stays_closed_when_the_kit_is_already_installed() {
     let mut app = app();
     app.apply(crate::ChatEvent::KitStatus {
@@ -2465,4 +2518,277 @@ fn kit_offer_stays_closed_when_the_kit_is_already_installed() {
     });
     let grid = render(&mut app, true);
     assert!(!grid.contains("Tool kits"), "offer opened anyway:\n{grid}");
+}
+
+fn setup_step_name(step: Option<&crate::app::setup::SetupStep>) -> &'static str {
+    match step {
+        None => "none",
+        Some(crate::app::setup::SetupStep::AwaitCatalog { .. }) => "await-catalog",
+        Some(crate::app::setup::SetupStep::Home { .. }) => "home",
+        Some(crate::app::setup::SetupStep::ProviderMenu { .. }) => "provider-menu",
+        Some(crate::app::setup::SetupStep::Catalog { .. }) => "catalog",
+        Some(crate::app::setup::SetupStep::Credential { .. }) => "credential",
+        Some(crate::app::setup::SetupStep::KeyInput { .. }) => "key-input",
+        Some(crate::app::setup::SetupStep::LoginWait { .. }) => "login-wait",
+        Some(crate::app::setup::SetupStep::CustomForm { .. }) => "custom-form",
+        Some(crate::app::setup::SetupStep::Kits { .. }) => "kits",
+        Some(crate::app::setup::SetupStep::AwaitModels { .. }) => "await-models",
+    }
+}
+
+#[test]
+fn kit_install_result_never_clobbers_an_unrelated_setup_step() {
+    let rows = catalog_rows();
+    let provider = rows[0].clone();
+    let steps = vec![
+        (
+            "await-catalog",
+            crate::app::setup::SetupStep::AwaitCatalog {
+                intent: crate::app::setup::CatalogIntent::Home,
+            },
+        ),
+        (
+            "home",
+            crate::app::setup::SetupStep::Home {
+                rows: rows.clone(),
+                state: tuika::components::SelectState::new(),
+            },
+        ),
+        (
+            "provider-menu",
+            crate::app::setup::SetupStep::ProviderMenu {
+                rows: rows.clone(),
+                provider: provider.clone(),
+                state: tuika::components::SelectState::new(),
+                busy: false,
+                error: None,
+            },
+        ),
+        (
+            "catalog",
+            crate::app::setup::SetupStep::Catalog {
+                rows: rows.clone(),
+                filter: "open".to_string(),
+                state: tuika::components::SelectState::new(),
+            },
+        ),
+        (
+            "credential",
+            crate::app::setup::SetupStep::Credential {
+                rows: rows.clone(),
+                provider: provider.clone(),
+                origin: crate::app::setup::CredentialOrigin::Catalog,
+                state: tuika::components::SelectState::new(),
+                error: None,
+            },
+        ),
+        (
+            "key-input",
+            crate::app::setup::SetupStep::KeyInput {
+                rows: rows.clone(),
+                provider: provider.clone(),
+                origin: crate::app::setup::CredentialOrigin::Catalog,
+                value: "secret".to_string(),
+                busy: true,
+                error: None,
+            },
+        ),
+        (
+            "login-wait",
+            crate::app::setup::SetupStep::LoginWait {
+                rows: rows.clone(),
+                provider: provider.clone(),
+                origin: crate::app::setup::CredentialOrigin::Catalog,
+                method: crate::LoginMethod::Browser,
+                device_code: None,
+            },
+        ),
+        (
+            "custom-form",
+            crate::app::setup::SetupStep::CustomForm {
+                rows,
+                form: Box::new(crate::app::setup::CustomForm::new()),
+                editing: None,
+                busy: crate::app::setup::CustomBusy::Upserting,
+                error: None,
+            },
+        ),
+        (
+            "await-models",
+            crate::app::setup::SetupStep::AwaitModels {
+                provider_id: "anthropic".to_string(),
+            },
+        ),
+    ];
+
+    for (expected, step) in steps {
+        let mut app = app();
+        app.setup = Some(step);
+        app.apply(crate::ChatEvent::KitInstallResult {
+            name: "pi".to_string(),
+            error: None,
+            receipt: vec!["installed kit pi".to_string()],
+        });
+        assert_eq!(
+            setup_step_name(app.setup.as_ref()),
+            expected,
+            "step {expected} was clobbered"
+        );
+    }
+}
+
+#[test]
+fn stale_open_status_does_not_resurrect_a_dismissed_window_or_cover_a_picker() {
+    let mut dismissed = app();
+    open_home(&mut dismissed);
+    for _ in 0..4 {
+        let _ = dismissed.handle(&key(tuika::KeyCode::Down));
+    }
+    let _ = dismissed.handle(&key(tuika::KeyCode::Enter));
+    assert!(matches!(
+        dismissed.drain_actions().as_slice(),
+        [crate::Action::FetchKitStatus {
+            intent: crate::KitStatusIntent::Open
+        }]
+    ));
+    let _ = dismissed.handle(&key(tuika::KeyCode::Esc));
+    dismissed.apply(crate::ChatEvent::KitStatus {
+        intent: crate::KitStatusIntent::Open,
+        installed: Vec::new(),
+        recommended: vec![recommended_pi(Some("dist/pi-kit"))],
+    });
+    assert!(dismissed.setup.is_none(), "dismissed window reopened");
+
+    let mut picker = app();
+    picker.apply(crate::ChatEvent::Models(configured_model_rows()));
+    picker.apply(crate::ChatEvent::KitStatus {
+        intent: crate::KitStatusIntent::Open,
+        installed: Vec::new(),
+        recommended: vec![recommended_pi(Some("dist/pi-kit"))],
+    });
+    assert!(picker.setup.is_none(), "kit step covered the model picker");
+    assert!(picker.picker.is_some(), "model picker was lost");
+}
+
+#[test]
+fn kit_status_refresh_clamps_a_selection_after_options_shrink() {
+    let mut app = app();
+    open_home(&mut app);
+    app.apply(crate::ChatEvent::KitStatus {
+        intent: crate::KitStatusIntent::Open,
+        installed: Vec::new(),
+        recommended: vec![
+            recommended_pi(Some("dist/pi-kit")),
+            recommended_kit("other", Some("dist/other-kit")),
+        ],
+    });
+    let _ = app.handle(&key(tuika::KeyCode::Down));
+    app.apply(crate::ChatEvent::KitStatus {
+        intent: crate::KitStatusIntent::Open,
+        installed: vec![installed_pi_row()],
+        recommended: vec![recommended_pi(Some("dist/pi-kit"))],
+    });
+    let Some(crate::app::setup::SetupStep::Kits { state, .. }) = app.setup.as_ref() else {
+        panic!("kit step closed");
+    };
+    assert_eq!(state.selected(), Some(0));
+}
+
+#[test]
+fn leaving_and_reopening_kits_does_not_allow_a_second_install() {
+    let mut app = app();
+    open_kits_from_home(&mut app);
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    assert!(matches!(
+        app.drain_actions().as_slice(),
+        [crate::Action::InstallKit { .. }]
+    ));
+    let _ = app.handle(&key(tuika::KeyCode::Esc));
+    for _ in 0..4 {
+        let _ = app.handle(&key(tuika::KeyCode::Down));
+    }
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    assert!(matches!(
+        app.drain_actions().as_slice(),
+        [crate::Action::FetchKitStatus {
+            intent: crate::KitStatusIntent::Open
+        }]
+    ));
+    app.apply(crate::ChatEvent::KitStatus {
+        intent: crate::KitStatusIntent::Open,
+        installed: Vec::new(),
+        recommended: vec![recommended_pi(Some("dist/pi-kit"))],
+    });
+    assert!(render(&mut app, true).contains("installing…"));
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    assert_eq!(app.drain_actions(), Vec::new());
+}
+
+#[test]
+fn post_install_status_refresh_does_not_reopen_kits_after_leaving() {
+    let mut app = app();
+    open_kits_from_home(&mut app);
+    let _ = app.handle(&key(tuika::KeyCode::Enter));
+    let _ = app.drain_actions();
+    app.apply(crate::ChatEvent::KitInstallResult {
+        name: "pi".to_string(),
+        error: None,
+        receipt: vec!["installed kit pi".to_string()],
+    });
+    let actions = app.drain_actions();
+    let [crate::Action::FetchKitStatus { intent }] = actions.as_slice() else {
+        panic!("successful install did not request one status refresh");
+    };
+    let intent = *intent;
+    let _ = app.handle(&key(tuika::KeyCode::Esc));
+    assert_eq!(setup_step_name(app.setup.as_ref()), "home");
+    app.apply(crate::ChatEvent::KitStatus {
+        intent,
+        installed: vec![installed_pi_row()],
+        recommended: vec![recommended_pi(Some("dist/pi-kit"))],
+    });
+    assert_eq!(setup_step_name(app.setup.as_ref()), "home");
+}
+
+#[test]
+fn kit_step_from_an_empty_home_still_returns_to_home() {
+    let mut app = app();
+    app.setup = Some(crate::app::setup::SetupStep::Home {
+        rows: Vec::new(),
+        state: tuika::components::SelectState::new(),
+    });
+    app.apply(crate::ChatEvent::KitStatus {
+        intent: crate::KitStatusIntent::Open,
+        installed: Vec::new(),
+        recommended: vec![recommended_pi(Some("dist/pi-kit"))],
+    });
+    let _ = app.handle(&key(tuika::KeyCode::Esc));
+    assert_eq!(setup_step_name(app.setup.as_ref()), "home");
+}
+
+#[test]
+fn many_installed_kits_do_not_push_the_selectable_rows_out_of_the_dialog() {
+    let mut app = app();
+    open_home(&mut app);
+    let installed = (0..24)
+        .map(|index| crate::InstalledKitRow {
+            name: format!("installed-kit-{index}-{}", "very-long-name".repeat(4)),
+            version: Some("123.456.789".to_string()),
+            tools: vec!["extremely_long_tool_name".repeat(4)],
+        })
+        .collect();
+    app.apply(crate::ChatEvent::KitStatus {
+        intent: crate::KitStatusIntent::Open,
+        installed,
+        recommended: vec![recommended_pi(Some("dist/pi-kit"))],
+    });
+    for no_color in [false, true] {
+        let grid = render(&mut app, no_color);
+        assert!(grid.contains("Install the pi kit"), "install row:\n{grid}");
+        assert!(grid.contains("Back"), "back row:\n{grid}");
+        assert!(
+            grid.contains("more kit rows"),
+            "truncation summary:\n{grid}"
+        );
+    }
 }

--- a/crates/verlet-chat/src/ui.rs
+++ b/crates/verlet-chat/src/ui.rs
@@ -291,6 +291,8 @@ fn modal(
                         error.as_deref(),
                         notice.as_deref(),
                         theme,
+                        content_w,
+                        area.height.saturating_sub(5),
                     );
                     (
                         "Tool kits".to_string(),
@@ -476,6 +478,8 @@ fn setup_kits(
     error: Option<&str>,
     notice: Option<&str>,
     theme: &tuika::style::Theme,
+    width: u16,
+    available_height: u16,
 ) -> (tuika::view::Element, u16) {
     let mut info: Vec<ratatui::text::Line<'static>> = Vec::new();
     if installed.is_empty() {
@@ -490,50 +494,103 @@ fn setup_kits(
             .as_deref()
             .map(|version| format!(" {version}"))
             .unwrap_or_default();
+        let label = format!("{}{version}", kit.name);
+        let label_w = width.saturating_sub(2) / 2;
+        let label = fit_columns(&label, label_w);
+        let label_pad = label_w.saturating_sub(tuika::width::str_cols(&label));
+        let tools = fit_columns(
+            &kit.tools.join(" "),
+            width.saturating_sub(label_w).saturating_sub(2),
+        );
         info.push(ratatui::text::Line::from(vec![
             ratatui::text::Span::styled(
-                format!("{}{version}  ", kit.name),
+                format!("{label}{:width$}  ", "", width = usize::from(label_pad)),
                 ratatui::style::Style::default().fg(theme.text),
             ),
-            ratatui::text::Span::styled(kit.tools.join(" "), theme.muted_style()),
+            ratatui::text::Span::styled(tools, theme.muted_style()),
         ]));
     }
     for kit in recommended {
         if kit.source.is_none() && !installed.iter().any(|record| record.name == kit.name) {
             info.push(ratatui::text::Line::from(ratatui::text::Span::styled(
-                format!(
-                    "{} kit source not found here; run: verlet kit install <kit-dir>",
-                    kit.name
+                fit_columns(
+                    &format!(
+                        "{} kit source not found here; run: verlet kit install <kit-dir>",
+                        kit.name
+                    ),
+                    width,
                 ),
                 theme.muted_style(),
             )));
         }
     }
     let options = crate::app::setup::kit_step_options(installed, recommended);
+    let count = options.len() + 1;
+    let scrollbar_w = u16::from(count > MAX_MODAL_ROWS);
+    let usable = width
+        .saturating_sub(SELECT_MARKER_W)
+        .saturating_sub(scrollbar_w);
+    let label_w = options
+        .iter()
+        .map(|option| {
+            let crate::app::setup::KitOption::Install { index } = option;
+            tuika::width::str_cols(&format!("Install the {} kit", recommended[*index].name))
+        })
+        .chain(std::iter::once(tuika::width::str_cols("Back")))
+        .max()
+        .unwrap_or(0)
+        .min(usable.saturating_sub(2) / 2);
     let mut lines: Vec<ratatui::text::Line<'static>> = options
         .iter()
         .map(|option| {
             let crate::app::setup::KitOption::Install { index } = option;
             let kit = &recommended[*index];
+            let label = fit_columns(&format!("Install the {} kit", kit.name), label_w);
+            let label_pad = label_w.saturating_sub(tuika::width::str_cols(&label));
             ratatui::text::Line::from(vec![
                 ratatui::text::Span::styled(
-                    format!("Install the {} kit  ", kit.name),
+                    format!("{label}{:width$}  ", "", width = usize::from(label_pad)),
                     ratatui::style::Style::default().fg(theme.accent_alt),
                 ),
-                ratatui::text::Span::styled(kit.blurb.clone(), theme.muted_style()),
+                ratatui::text::Span::styled(
+                    fit_columns(&kit.blurb, usable.saturating_sub(label_w).saturating_sub(2)),
+                    theme.muted_style(),
+                ),
             ])
         })
         .collect();
+    let back = fit_columns("Back", label_w);
+    let back_pad = label_w.saturating_sub(tuika::width::str_cols(&back));
     lines.push(ratatui::text::Line::from(vec![
         ratatui::text::Span::styled(
-            "Back  ",
+            format!("{back}{:width$}  ", "", width = usize::from(back_pad)),
             ratatui::style::Style::default().fg(theme.accent_alt),
         ),
-        ratatui::text::Span::styled("leave tools".to_string(), theme.muted_style()),
+        ratatui::text::Span::styled(
+            fit_columns(
+                "leave tools",
+                usable.saturating_sub(label_w).saturating_sub(2),
+            ),
+            theme.muted_style(),
+        ),
     ]));
-    let info_h = info.len() as u16;
     let count = lines.len() as u16;
-    let list = tuika::components::SelectList::new(lines, state).viewport(MAX_MODAL_ROWS as u16);
+    let has_status = busy || error.is_some() || notice.is_some();
+    let capacity = available_height.min(MAX_MODAL_ROWS as u16 + u16::from(has_status));
+    let list_h = count.min(capacity);
+    let status_h = u16::from(has_status).min(capacity.saturating_sub(list_h));
+    let info_h = (info.len() as u16).min(capacity.saturating_sub(list_h).saturating_sub(status_h));
+    let hidden_info_rows = info.len().saturating_sub(usize::from(info_h));
+    info.truncate(usize::from(info_h));
+    if hidden_info_rows > 0
+        && let Some(last) = info.last_mut()
+    {
+        *last = ratatui::text::Line::from(ratatui::text::Span::styled(
+            format!("… {} more kit rows", hidden_info_rows + 1),
+            theme.muted_style(),
+        ));
+    }
+    let list = tuika::components::SelectList::new(lines, state).viewport(list_h);
     let mut column = tuika::components::Flex::column();
     if info_h > 0 {
         column = column.fixed(
@@ -541,28 +598,35 @@ fn setup_kits(
             tuika::view::element(tuika::components::Text::new(info)),
         );
     }
-    column = column.grow(1, tuika::view::element(list));
-    let mut height = info_h + count;
-    if busy {
+    column = column.fixed(list_h, tuika::view::element(list));
+    let mut height = info_h + list_h;
+    if status_h > 0 && busy {
         column = column.fixed(
             1,
             tuika::view::element(tuika::components::Text::new(vec![
                 ratatui::text::Line::from(ratatui::text::Span::styled(
-                    "installing… builds and proves each tool, this can take a while",
+                    fit_columns(
+                        "installing… builds and proves each tool, this can take a while",
+                        width,
+                    ),
                     theme.muted_style(),
                 )),
             ])),
         );
         height += 1;
-    } else if let Some(message) = error {
+    } else if status_h > 0
+        && let Some(message) = error
+    {
         column = column.fixed(1, modal_error(message, theme));
         height += 1;
-    } else if let Some(message) = notice {
+    } else if status_h > 0
+        && let Some(message) = notice
+    {
         column = column.fixed(
             1,
             tuika::view::element(tuika::components::Text::new(vec![
                 ratatui::text::Line::from(ratatui::text::Span::styled(
-                    message.to_string(),
+                    fit_columns(message, width),
                     ratatui::style::Style::default().fg(theme.accent),
                 )),
             ])),

--- a/crates/verlet-chat/src/ui.rs
+++ b/crates/verlet-chat/src/ui.rs
@@ -274,6 +274,31 @@ fn modal(
                         ],
                     )
                 }
+                crate::app::setup::SetupStep::Kits {
+                    installed,
+                    recommended,
+                    state,
+                    busy,
+                    error,
+                    notice,
+                    ..
+                } => {
+                    let (content, rows_h) = setup_kits(
+                        installed,
+                        recommended,
+                        state,
+                        *busy,
+                        error.as_deref(),
+                        notice.as_deref(),
+                        theme,
+                    );
+                    (
+                        "Tool kits".to_string(),
+                        content,
+                        rows_h,
+                        vec![("↑↓", "move"), ("⏎", "select"), ("esc", "back")],
+                    )
+                }
             }
         } else if let Some(picker) = app.picker.as_ref() {
             let (content, rows_h) = model_picker(picker, theme, content_w);
@@ -436,6 +461,112 @@ fn setup_provider_menu(
         height += 1;
     } else if let Some(message) = error {
         column = column.fixed(1, modal_error(message, theme));
+        height += 1;
+    }
+    (tuika::view::element(column), height)
+}
+
+/// The tool-kit step: installed kits, the recommended installs, and the
+/// install/back list.
+fn setup_kits(
+    installed: &[crate::InstalledKitRow],
+    recommended: &[crate::RecommendedKitRow],
+    state: &tuika::components::SelectState,
+    busy: bool,
+    error: Option<&str>,
+    notice: Option<&str>,
+    theme: &tuika::style::Theme,
+) -> (tuika::view::Element, u16) {
+    let mut info: Vec<ratatui::text::Line<'static>> = Vec::new();
+    if installed.is_empty() {
+        info.push(ratatui::text::Line::from(ratatui::text::Span::styled(
+            "No kits installed yet.",
+            theme.muted_style(),
+        )));
+    }
+    for kit in installed {
+        let version = kit
+            .version
+            .as_deref()
+            .map(|version| format!(" {version}"))
+            .unwrap_or_default();
+        info.push(ratatui::text::Line::from(vec![
+            ratatui::text::Span::styled(
+                format!("{}{version}  ", kit.name),
+                ratatui::style::Style::default().fg(theme.text),
+            ),
+            ratatui::text::Span::styled(kit.tools.join(" "), theme.muted_style()),
+        ]));
+    }
+    for kit in recommended {
+        if kit.source.is_none() && !installed.iter().any(|record| record.name == kit.name) {
+            info.push(ratatui::text::Line::from(ratatui::text::Span::styled(
+                format!(
+                    "{} kit source not found here; run: verlet kit install <kit-dir>",
+                    kit.name
+                ),
+                theme.muted_style(),
+            )));
+        }
+    }
+    let options = crate::app::setup::kit_step_options(installed, recommended);
+    let mut lines: Vec<ratatui::text::Line<'static>> = options
+        .iter()
+        .map(|option| {
+            let crate::app::setup::KitOption::Install { index } = option;
+            let kit = &recommended[*index];
+            ratatui::text::Line::from(vec![
+                ratatui::text::Span::styled(
+                    format!("Install the {} kit  ", kit.name),
+                    ratatui::style::Style::default().fg(theme.accent_alt),
+                ),
+                ratatui::text::Span::styled(kit.blurb.clone(), theme.muted_style()),
+            ])
+        })
+        .collect();
+    lines.push(ratatui::text::Line::from(vec![
+        ratatui::text::Span::styled(
+            "Back  ",
+            ratatui::style::Style::default().fg(theme.accent_alt),
+        ),
+        ratatui::text::Span::styled("leave tools".to_string(), theme.muted_style()),
+    ]));
+    let info_h = info.len() as u16;
+    let count = lines.len() as u16;
+    let list = tuika::components::SelectList::new(lines, state).viewport(MAX_MODAL_ROWS as u16);
+    let mut column = tuika::components::Flex::column();
+    if info_h > 0 {
+        column = column.fixed(
+            info_h,
+            tuika::view::element(tuika::components::Text::new(info)),
+        );
+    }
+    column = column.grow(1, tuika::view::element(list));
+    let mut height = info_h + count;
+    if busy {
+        column = column.fixed(
+            1,
+            tuika::view::element(tuika::components::Text::new(vec![
+                ratatui::text::Line::from(ratatui::text::Span::styled(
+                    "installing… builds and proves each tool, this can take a while",
+                    theme.muted_style(),
+                )),
+            ])),
+        );
+        height += 1;
+    } else if let Some(message) = error {
+        column = column.fixed(1, modal_error(message, theme));
+        height += 1;
+    } else if let Some(message) = notice {
+        column = column.fixed(
+            1,
+            tuika::view::element(tuika::components::Text::new(vec![
+                ratatui::text::Line::from(ratatui::text::Span::styled(
+                    message.to_string(),
+                    ratatui::style::Style::default().fg(theme.accent),
+                )),
+            ])),
+        );
         height += 1;
     }
     (tuika::view::element(column), height)

--- a/crates/verlet-kernel/src/cli/chat.rs
+++ b/crates/verlet-kernel/src/cli/chat.rs
@@ -509,21 +509,21 @@ impl ChatDriver {
                         });
                     }
                 } else {
-                    match kit_status_rows() {
-                        Ok((installed, recommended)) => {
-                            let _ = events.send(verlet_chat::ChatEvent::KitStatus {
+                    let task_events = events.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let event = match kit_status_rows() {
+                            Ok((installed, recommended)) => verlet_chat::ChatEvent::KitStatus {
                                 intent,
                                 installed,
                                 recommended,
-                            });
-                        }
-                        Err(message) => {
-                            let _ = events.send(verlet_chat::ChatEvent::Error {
+                            },
+                            Err(message) => verlet_chat::ChatEvent::Error {
                                 title: "could not read installed kits".to_string(),
                                 body: vec![message],
-                            });
-                        }
-                    }
+                            },
+                        };
+                        let _ = task_events.send(event);
+                    });
                 }
             }
             verlet_chat::Action::InstallKit { name, source } => {
@@ -917,7 +917,12 @@ fn kit_status_rows() -> Result<
                 .collect(),
         })
         .collect();
-    let recommended = RECOMMENDED_KITS
+    let recommended = recommended_kit_rows(std::path::Path::new("."));
+    Ok((installed, recommended))
+}
+
+fn recommended_kit_rows(project_root: &std::path::Path) -> Vec<verlet_chat::RecommendedKitRow> {
+    RECOMMENDED_KITS
         .iter()
         .map(|(name, blurb, candidates)| verlet_chat::RecommendedKitRow {
             name: (*name).to_string(),
@@ -925,14 +930,14 @@ fn kit_status_rows() -> Result<
             source: candidates
                 .iter()
                 .find(|candidate| {
-                    std::path::Path::new(candidate)
+                    project_root
+                        .join(candidate)
                         .join(verlet_operations::kit_package::KIT_MANIFEST_FILE_NAME)
                         .is_file()
                 })
                 .map(|candidate| (*candidate).to_string()),
         })
-        .collect();
-    Ok((installed, recommended))
+        .collect()
 }
 
 /// The spawned kit install: the same pipeline as `verlet kit install

--- a/crates/verlet-kernel/src/cli/chat.rs
+++ b/crates/verlet-kernel/src/cli/chat.rs
@@ -58,7 +58,7 @@ async fn run_chat_console(
     let client = client.ok_or_else(|| {
         crate::cli::usage_error("chat command did not receive an instance connection")
     })?;
-    run_chat_client(client, options.prompt, "project instance".to_string()).await
+    run_chat_client(client, options.prompt, "project instance".to_string(), true).await
 }
 
 async fn run_attached_chat(
@@ -76,7 +76,7 @@ async fn run_attached_chat(
                     chat_connect_config(invocation),
                 )
                 .await?;
-                run_chat_client(client, options.prompt, label).await
+                run_chat_client(client, options.prompt, label, false).await
             }
             #[cfg(not(unix))]
             {
@@ -93,7 +93,7 @@ async fn run_attached_chat(
                 chat_connect_config(invocation),
             )
             .await?;
-            run_chat_client(client, options.prompt, label).await
+            run_chat_client(client, options.prompt, label, false).await
         }
     }
 }
@@ -138,6 +138,7 @@ async fn run_chat_client<S>(
     mut client: crate::adapters::operator_client::OperatorClient<S>,
     initial_prompt: Option<String>,
     connection_label: String,
+    local_kits: bool,
 ) -> crate::kernel::runtime_host::VerletResult<()>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
@@ -166,7 +167,7 @@ where
         let _ = event_tx.send(event);
     }
 
-    let mut driver = ChatDriver::new(thread.id)?;
+    let mut driver = ChatDriver::new(thread.id, local_kits)?;
 
     let run_result = {
         let ui = verlet_chat::runner::run_ui(&mut app, no_color, action_tx, event_rx);
@@ -240,6 +241,13 @@ struct ChatDriver {
     oauth_client: crate::openai_codex::OpenAICodexOAuthClient,
     pending_login: Option<PendingLogin>,
     next_login_id: u64,
+    /// Kit installs run against the cwd-relative registry roots, which only
+    /// match the daemon's roots for the local project-instance connection.
+    /// False for `--attach` sessions.
+    local_kits: bool,
+    /// The in-flight kit install, if any. Never aborted: install is not
+    /// cancellable mid-way, and the record write is atomic.
+    kit_install: Option<tokio::task::JoinHandle<()>>,
 }
 
 struct PendingLogin {
@@ -271,7 +279,7 @@ enum LoginTaskEvent {
 }
 
 impl ChatDriver {
-    fn new(thread_id: String) -> crate::kernel::runtime_host::VerletResult<Self> {
+    fn new(thread_id: String, local_kits: bool) -> crate::kernel::runtime_host::VerletResult<Self> {
         let oauth_client = crate::openai_codex::OpenAICodexOAuthClient::new()
             .map_err(|err| crate::cli::usage_error(err.to_string()))?;
         Ok(Self {
@@ -280,6 +288,8 @@ impl ChatDriver {
             oauth_client,
             pending_login: None,
             next_login_id: 0,
+            local_kits,
+            kit_install: None,
         })
     }
 
@@ -483,6 +493,66 @@ impl ChatDriver {
                     .model_provider_auth_delete_typed(&provider_id)
                     .await?;
                 let _ = events.send(verlet_chat::ChatEvent::CredentialCleared { provider_id });
+            }
+            verlet_chat::Action::FetchKitStatus { intent } => {
+                if !self.local_kits {
+                    // The first-run offer stays silent on attached sessions;
+                    // an explicit open explains why there is nothing here.
+                    if intent == verlet_chat::KitStatusIntent::Open {
+                        let _ = events.send(verlet_chat::ChatEvent::Error {
+                            title: "kit install needs the instance host".to_string(),
+                            body: vec![
+                                "this session is attached to another instance".to_string(),
+                                "run: verlet kit install <kit-dir> where the instance runs"
+                                    .to_string(),
+                            ],
+                        });
+                    }
+                } else {
+                    match kit_status_rows() {
+                        Ok((installed, recommended)) => {
+                            let _ = events.send(verlet_chat::ChatEvent::KitStatus {
+                                intent,
+                                installed,
+                                recommended,
+                            });
+                        }
+                        Err(message) => {
+                            let _ = events.send(verlet_chat::ChatEvent::Error {
+                                title: "could not read installed kits".to_string(),
+                                body: vec![message],
+                            });
+                        }
+                    }
+                }
+            }
+            verlet_chat::Action::InstallKit { name, source } => {
+                let error = if !self.local_kits {
+                    Some(
+                        "kit install needs the instance host; run verlet kit install there"
+                            .to_string(),
+                    )
+                } else if self
+                    .kit_install
+                    .as_ref()
+                    .is_some_and(|task| !task.is_finished())
+                {
+                    Some("a kit install is already running".to_string())
+                } else {
+                    None
+                };
+                if let Some(error) = error {
+                    let _ = events.send(verlet_chat::ChatEvent::KitInstallResult {
+                        name,
+                        error: Some(error),
+                        receipt: Vec::new(),
+                    });
+                } else {
+                    let task_events = events.clone();
+                    self.kit_install = Some(tokio::spawn(async move {
+                        run_kit_install_task(name, source, task_events).await;
+                    }));
+                }
             }
         }
         Ok(())
@@ -805,6 +875,94 @@ async fn run_login_task(
         provider_id,
         result,
     });
+}
+
+/// The kits the setup window recommends: `(kit name, blurb, candidate
+/// directories probed in order)`. All paths are cwd-relative, like the
+/// registry roots; there is no hosted fetch lane yet (EMO-611), so a kit
+/// whose directory is absent renders as manual-install guidance.
+const RECOMMENDED_KITS: [(&str, &str, [&str; 2]); 1] = [(
+    "pi",
+    "read, write, edit, find, grep file tools",
+    ["dist/pi-kit", "agent-tools/pi-kit"],
+)];
+
+fn kit_roots() -> (std::path::PathBuf, std::path::PathBuf) {
+    let registry_root = crate::cli::tool::default_registry_root();
+    let kits_root =
+        verlet_operations::kit_package::kits_root_for_operations_registry_root(&registry_root);
+    (registry_root, kits_root)
+}
+
+fn kit_status_rows() -> Result<
+    (
+        Vec<verlet_chat::InstalledKitRow>,
+        Vec<verlet_chat::RecommendedKitRow>,
+    ),
+    String,
+> {
+    let (_, kits_root) = kit_roots();
+    let records = verlet_operations::kit_package::InstalledKitStore::new(kits_root)
+        .list()
+        .map_err(|err| err.to_string())?;
+    let installed = records
+        .into_iter()
+        .map(|record| verlet_chat::InstalledKitRow {
+            name: record.name,
+            version: record.version,
+            tools: record
+                .tools
+                .into_iter()
+                .map(|tool| tool.tool_name)
+                .collect(),
+        })
+        .collect();
+    let recommended = RECOMMENDED_KITS
+        .iter()
+        .map(|(name, blurb, candidates)| verlet_chat::RecommendedKitRow {
+            name: (*name).to_string(),
+            blurb: (*blurb).to_string(),
+            source: candidates
+                .iter()
+                .find(|candidate| {
+                    std::path::Path::new(candidate)
+                        .join(verlet_operations::kit_package::KIT_MANIFEST_FILE_NAME)
+                        .is_file()
+                })
+                .map(|candidate| (*candidate).to_string()),
+        })
+        .collect();
+    Ok((installed, recommended))
+}
+
+/// The spawned kit install: the same pipeline as `verlet kit install
+/// <source>` run in the project directory, reported as one
+/// [`verlet_chat::ChatEvent::KitInstallResult`].
+async fn run_kit_install_task(
+    name: String,
+    source: String,
+    events: tokio::sync::mpsc::UnboundedSender<verlet_chat::ChatEvent>,
+) {
+    let (registry_root, kits_root) = kit_roots();
+    let event = match crate::cli::kit::install_kit_from(
+        std::path::Path::new(&source),
+        &registry_root,
+        &kits_root,
+    )
+    .await
+    {
+        Ok(outcome) => verlet_chat::ChatEvent::KitInstallResult {
+            name: outcome.installed.name.clone(),
+            error: None,
+            receipt: outcome.receipt_lines(),
+        },
+        Err(err) => verlet_chat::ChatEvent::KitInstallResult {
+            name,
+            error: Some(err.to_string()),
+            receipt: Vec::new(),
+        },
+    };
+    let _ = events.send(event);
 }
 
 fn redact_secret_values<const N: usize>(mut message: String, secrets: [&String; N]) -> String {

--- a/crates/verlet-kernel/src/cli/chat/tests.rs
+++ b/crates/verlet-kernel/src/cli/chat/tests.rs
@@ -1492,3 +1492,31 @@ async fn kit_actions_on_attached_sessions_explain_instead_of_installing() {
     client.close().await.unwrap();
     server.await.unwrap();
 }
+
+#[test]
+fn pi_kit_recommendation_probe_prefers_dist_then_checked_in_source() {
+    let root = std::env::temp_dir().join(format!("verlet-chat-kit-probe-{}", uuid::Uuid::now_v7()));
+    let dist = root.join("dist/pi-kit");
+    let checked_in = root.join("agent-tools/pi-kit");
+    std::fs::create_dir_all(&dist).unwrap();
+    std::fs::create_dir_all(&checked_in).unwrap();
+    for directory in [&dist, &checked_in] {
+        std::fs::write(
+            directory.join(verlet_operations::kit_package::KIT_MANIFEST_FILE_NAME),
+            "",
+        )
+        .unwrap();
+    }
+
+    let rows = crate::cli::chat::recommended_kit_rows(&root);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].name, "pi");
+    assert_eq!(rows[0].source.as_deref(), Some("dist/pi-kit"));
+
+    std::fs::remove_file(dist.join(verlet_operations::kit_package::KIT_MANIFEST_FILE_NAME))
+        .unwrap();
+    let rows = crate::cli::chat::recommended_kit_rows(&root);
+    assert_eq!(rows[0].source.as_deref(), Some("agent-tools/pi-kit"));
+
+    std::fs::remove_dir_all(&root).unwrap();
+}

--- a/crates/verlet-kernel/src/cli/chat/tests.rs
+++ b/crates/verlet-kernel/src/cli/chat/tests.rs
@@ -126,7 +126,7 @@ async fn drive_actions(
         action_tx.send(action).unwrap();
     }
     drop(action_tx);
-    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string()).unwrap();
+    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string(), true).unwrap();
     driver
         .drive(&mut client, action_rx, event_tx)
         .await
@@ -294,7 +294,7 @@ fn notification(
 }
 
 fn driver() -> crate::cli::chat::ChatDriver {
-    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string()).unwrap();
+    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string(), true).unwrap();
     driver.active_turn_id = Some("turn-1".to_string());
     driver
 }
@@ -1153,7 +1153,7 @@ async fn device_login_emits_code_then_sends_oauth_credential_over_rpc() {
     .await;
     let (action_tx, action_rx) = tokio::sync::mpsc::unbounded_channel();
     let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
-    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string()).unwrap();
+    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string(), true).unwrap();
     driver.oauth_client =
         crate::openai_codex::OpenAICodexOAuthClient::with_test_endpoints(&oauth.base_url).unwrap();
 
@@ -1208,7 +1208,7 @@ async fn second_start_login_while_pending_reports_error_without_spawning() {
     let (mut client, _, server) = mock_operator_client(Vec::new()).await;
     let (action_tx, action_rx) = tokio::sync::mpsc::unbounded_channel();
     let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
-    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string()).unwrap();
+    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string(), true).unwrap();
     driver.oauth_client =
         crate::openai_codex::OpenAICodexOAuthClient::with_test_endpoints(&base_url).unwrap();
 
@@ -1259,7 +1259,7 @@ async fn stale_login_completion_after_cancel_is_ignored() {
     let (mut client, requests, server) = mock_operator_client(Vec::new()).await;
     let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
     let (login_tx, _) = tokio::sync::mpsc::unbounded_channel();
-    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string()).unwrap();
+    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string(), true).unwrap();
     driver.pending_login = Some(crate::cli::chat::PendingLogin {
         id: 7,
         task: tokio::spawn(std::future::pending()),
@@ -1304,7 +1304,7 @@ async fn set_provider_key_while_login_pending_is_rejected_without_rpc() {
     let (mut client, requests, server) = mock_operator_client(Vec::new()).await;
     let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
     let (login_tx, _) = tokio::sync::mpsc::unbounded_channel();
-    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string()).unwrap();
+    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string(), true).unwrap();
     driver.pending_login = Some(crate::cli::chat::PendingLogin {
         id: 11,
         task: tokio::spawn(std::future::pending()),
@@ -1435,6 +1435,59 @@ async fn bootstrap_with_a_configured_provider_skips_the_first_run_gate() {
     assert_eq!(session.initial_events, Vec::new());
     assert_eq!(session.model_label, "anthropic/claude");
     assert_eq!(requests.lock().unwrap().len(), 3);
+
+    client.close().await.unwrap();
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn kit_actions_on_attached_sessions_explain_instead_of_installing() {
+    let (mut client, requests, server) = mock_operator_client(Vec::new()).await;
+    let (action_tx, action_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
+    for action in [
+        // The first-run offer stays silent; an explicit open explains.
+        verlet_chat::Action::FetchKitStatus {
+            intent: verlet_chat::KitStatusIntent::OfferIfMissing,
+        },
+        verlet_chat::Action::FetchKitStatus {
+            intent: verlet_chat::KitStatusIntent::Open,
+        },
+        verlet_chat::Action::InstallKit {
+            name: "pi".to_string(),
+            source: "dist/pi-kit".to_string(),
+        },
+    ] {
+        action_tx.send(action).unwrap();
+    }
+    drop(action_tx);
+    let mut driver = crate::cli::chat::ChatDriver::new("thread-1".to_string(), false).unwrap();
+    driver
+        .drive(&mut client, action_rx, event_tx)
+        .await
+        .unwrap();
+
+    let mut events = Vec::new();
+    while let Ok(event) = event_rx.try_recv() {
+        events.push(event);
+    }
+    assert_eq!(events.len(), 2, "events: {events:?}");
+    let verlet_chat::ChatEvent::Error { title, .. } = &events[0] else {
+        panic!("expected an error event, got {:?}", events[0]);
+    };
+    assert_eq!(title, "kit install needs the instance host");
+    let verlet_chat::ChatEvent::KitInstallResult { name, error, .. } = &events[1] else {
+        panic!("expected an install result, got {:?}", events[1]);
+    };
+    assert_eq!(name, "pi");
+    assert!(
+        error
+            .as_deref()
+            .is_some_and(|message| message.contains("instance host")),
+        "error: {error:?}"
+    );
+    // Kit actions never touch the app-server connection.
+    assert!(requests.lock().unwrap().is_empty());
 
     client.close().await.unwrap();
     server.await.unwrap();

--- a/crates/verlet-kernel/src/cli/kit.rs
+++ b/crates/verlet-kernel/src/cli/kit.rs
@@ -96,10 +96,62 @@ async fn kit_install(
     args: Vec<std::ffi::OsString>,
 ) -> crate::kernel::runtime_host::VerletResult<()> {
     let options = parse_kit_install_args(args)?;
-    let source = verlet_operations::kit_package::KitSource::load(&options.kit_path)?;
+    let outcome = install_kit_from(
+        &options.kit_path,
+        &options.registry_root,
+        &options.kits_root,
+    )
+    .await?;
+    for line in outcome.receipt_lines() {
+        println!("{line}");
+    }
+    Ok(())
+}
+
+/// What one kit install produced, for receipts. The chat setup window and
+/// the CLI print the same [`Self::receipt_lines`].
+pub(crate) struct KitInstallOutcome {
+    pub installed: verlet_operations::kit_package::InstalledKitRecord,
+    pub published: Vec<verlet_operations::operation_store::PublishedOperationRecord>,
+    pub record_path: std::path::PathBuf,
+}
+
+impl KitInstallOutcome {
+    pub(crate) fn receipt_lines(&self) -> Vec<String> {
+        let mut lines = vec![
+            format!("installed kit {}", self.installed.name),
+            format!(
+                "version {}",
+                self.installed.version.as_deref().unwrap_or("<none>")
+            ),
+            format!("source sha256:{}", self.installed.source_hash),
+        ];
+        for record in &self.published {
+            lines.push(format!(
+                "published {} sha256:{}",
+                record.name, record.active_artifact_hash
+            ));
+        }
+        for tool in &self.installed.tools {
+            lines.push(format!("tool {} {}", tool.tool_name, tool.operation_ref));
+        }
+        lines.push(format!("record {}", self.record_path.display()));
+        lines.push("default manifest refreshes at the next daemon startup".to_string());
+        lines
+    }
+}
+
+/// The install pipeline behind both `verlet kit install` and the chat setup
+/// window's kit step (EMO-611). See [`kit_install`] for the ordering
+/// contract.
+pub(crate) async fn install_kit_from(
+    kit_path: &std::path::Path,
+    registry_root: &std::path::Path,
+    kits_root: &std::path::Path,
+) -> crate::kernel::runtime_host::VerletResult<KitInstallOutcome> {
+    let source = verlet_operations::kit_package::KitSource::load(kit_path)?;
     let members = source.member_packages()?;
-    let registry =
-        verlet_operations::operation_store::LocalOperationRegistry::new(&options.registry_root);
+    let registry = verlet_operations::operation_store::LocalOperationRegistry::new(registry_root);
     let mut published = Vec::with_capacity(members.len());
     for member in members {
         let member_name = member.manifest.identity.name.clone();
@@ -155,29 +207,17 @@ async fn kit_install(
         installed_at_ms: wall_clock_ms(),
         tools,
     };
-    let store = verlet_operations::kit_package::InstalledKitStore::new(&options.kits_root);
+    let store = verlet_operations::kit_package::InstalledKitStore::new(kits_root);
     store
         .save(&installed)
         .map_err(|err| kit_install_record_error(err.into(), &published))?;
 
-    println!("installed kit {}", installed.name);
-    println!(
-        "version {}",
-        installed.version.as_deref().unwrap_or("<none>")
-    );
-    println!("source sha256:{}", installed.source_hash);
-    for record in &published {
-        println!(
-            "published {} sha256:{}",
-            record.name, record.active_artifact_hash
-        );
-    }
-    for tool in &installed.tools {
-        println!("tool {} {}", tool.tool_name, tool.operation_ref);
-    }
-    println!("record {}", store.record_path(&installed.name).display());
-    println!("default manifest refreshes at the next daemon startup");
-    Ok(())
+    let record_path = store.record_path(&installed.name);
+    Ok(KitInstallOutcome {
+        installed,
+        published,
+        record_path,
+    })
 }
 
 /// Human list: one line per kit (name, version, tool count, source); with

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -117,6 +117,15 @@ upstream data.
   RPC boundary; OpenAI Codex browser/device OAuth runs in the chat client
   process before the completed credential is sent to the server. See
   [Provider Setup](provider-setup.md).
+- The setup window's "Install tools" row (and a one-shot first-run offer
+  after the first model lands) opens the tool-kit step: it lists installed
+  kits and offers to install the recommended pi kit from a local kit
+  directory (`dist/pi-kit` or `agent-tools/pi-kit`, probed in that order,
+  relative to the project directory). The install runs the `verlet kit
+  install` pipeline in the chat client process, so it works only for the
+  local project-instance connection, not `--attach` sessions; installed
+  tools load at the next daemon startup. See
+  [WASM Operation Dev Kit](wasm-operation-dev-kit.md) for the kit format.
 - `/models` opens a modal picker backed by a fresh `model/list` request.
   Selecting a row calls `model/select`; missing credentials are reported by
   the app-server without changing the active model. While a modal window is

--- a/docs/wasm-operation-dev-kit.md
+++ b/docs/wasm-operation-dev-kit.md
@@ -251,6 +251,11 @@ the daemon again and the removed kit's tools are gone from the default
 manifest. Tool rows are sorted by kit name and tool name, and duplicate model
 tool names across kits fail daemon startup instead of shadowing one another.
 
+The chat TUI wraps the same pipeline: the `/setup` window's "Install tools"
+step (and its one-shot first-run offer) runs `verlet kit install` for the
+recommended pi kit from a local kit directory. See
+[Chat](chat.md).
+
 ### Pi File Tools Kit
 
 `agent-tools/pi-kit/` is the first checked-in kit. It packages the four Wasm


### PR DESCRIPTION
Chat onboarding for tool kits (EMO-611).

The setup window gains a "Tool kits" step. It is reachable from a new third Home action row ("Install tools") and from a one-shot first-run offer that fires after the first non-local model selection when no recommended kit is installed. The step lists installed kits, offers to install the recommended pi kit when a local source directory is present (probed at `dist/pi-kit`, then `agent-tools/pi-kit`), and shows manual `verlet kit install <kit-dir>` guidance when it is not.

Installs run in the chat host process through the same pipeline as `verlet kit install` (refactored into `install_kit_from` with a `KitInstallOutcome` whose `receipt_lines()` is byte-identical to the old CLI output). The install runs as a spawned task so the UI stays responsive; the receipt lands in the transcript with the caveat that tools load at the next daemon startup. Attached (`--attach`) sessions get an explanation instead of an install that would land on the wrong host.

Includes the review-pass fixes: setup-step preservation on install results, a distinct Refresh intent so stale status responses cannot reopen a dismissed window, App-scope busy state so leaving and reopening the step cannot start a second install, selection clamping after list shrink, an explicit height budget so selectable rows survive tiny terminals, an explicit kit-step origin for Esc routing, blocking-executor filesystem reads on the driver path, and a spent latch for the one-shot offer.

Verification: full `scripts/verify.sh` green on macOS (1316 kernel tests, 42 CLI tests, clippy, both smoke binaries) and `scripts/verify-linux.sh` green on the final tree.
