### PR TITLE
Refresh guest and fixture lockfiles for v0.5.1

### DIFF
--- a/agent-tools/wasm/edit/Cargo.lock
+++ b/agent-tools/wasm/edit/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/agent-tools/wasm/read/Cargo.lock
+++ b/agent-tools/wasm/read/Cargo.lock
@@ -230,7 +230,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/agent-tools/wasm/search/Cargo.lock
+++ b/agent-tools/wasm/search/Cargo.lock
@@ -307,7 +307,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/agent-tools/wasm/write/Cargo.lock
+++ b/agent-tools/wasm/write/Cargo.lock
@@ -230,7 +230,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/verlet-kernel/tests/fixtures/wasm-counter-coupling-handrolled/Cargo.lock
+++ b/crates/verlet-kernel/tests/fixtures/wasm-counter-coupling-handrolled/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/verlet-kernel/tests/fixtures/wasm-csv-profile/Cargo.lock
+++ b/crates/verlet-kernel/tests/fixtures/wasm-csv-profile/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/verlet-kernel/tests/fixtures/wasm-employee-lookup/Cargo.lock
+++ b/crates/verlet-kernel/tests/fixtures/wasm-employee-lookup/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/verlet-kernel/tests/fixtures/wasm-vfs-tools/Cargo.lock
+++ b/crates/verlet-kernel/tests/fixtures/wasm-vfs-tools/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/wasm-counter-coupling/Cargo.lock
+++ b/examples/wasm-counter-coupling/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tools/file-read/Cargo.lock
+++ b/tools/file-read/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tools/http-fetch/Cargo.lock
+++ b/tools/http-fetch/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tools/json-query/Cargo.lock
+++ b/tools/json-query/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verlet-guest-sdk"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "verlet-guest-sdk-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Follow-up to #151: the standalone wasm guest and fixture crates carry their own lockfiles, which pick up the workspace version bump on first build. Diff is 24 version lines, 0.5.0 to 0.5.1, nothing else. Same follow-up shape as the v0.5.0 release.