### PR TITLE
Fix phantom empty-name tool calls in OpenAI Responses stream assembly

### DIFF
--- a/crates/verlet-kernel/src/adapters/agent_loop.rs
+++ b/crates/verlet-kernel/src/adapters/agent_loop.rs
@@ -6854,21 +6854,33 @@ fn response_from_stream_events(
             } => {
                 if !tool_calls.contains_key(&id) {
                     tool_order.push(id.clone());
+                }
+                let started_name = if tool_calls
+                    .get(&id)
+                    .and_then(|pending| pending.name.as_ref())
+                    .is_none()
+                {
+                    name.clone()
+                } else {
+                    None
+                };
+                let call_id = id.clone();
+                let pending = tool_calls.entry(id).or_default();
+                if let Some(name) = &name {
+                    pending.name = Some(name.clone());
+                }
+                pending.arguments.push_str(&arguments_delta);
+                if let Some(name) = started_name {
                     crate::kernel::runtime_host::runtime_events::emit_runtime_event(
                         events,
                         coordinates,
                         crate::kernel::runtime_host::runtime_events::RuntimeEventKind::ToolCallStarted {
-                            call_id: id.clone(),
-                            name: name.clone().unwrap_or_default(),
+                            call_id,
+                            name,
                             input: serde_json::json!({}),
                         },
                     );
                 }
-                let pending = tool_calls.entry(id).or_default();
-                if name.is_some() {
-                    pending.name = name;
-                }
-                pending.arguments.push_str(&arguments_delta);
             }
             verlet_provider::ProviderStreamEvent::Content { content: incoming } => {
                 if let verlet_history::CanonicalContent::Text {
@@ -6886,8 +6898,12 @@ fn response_from_stream_events(
                     arguments,
                 } = &incoming
                 {
-                    tool_calls.remove(id);
-                    tool_order.retain(|candidate| candidate != id);
+                    for completed_id in std::iter::once(id.as_str()).chain(id.split('|')) {
+                        tool_calls.remove(completed_id);
+                    }
+                    tool_order.retain(|candidate| {
+                        candidate != id && !id.split('|').any(|component| candidate == component)
+                    });
                     crate::kernel::runtime_host::runtime_events::emit_runtime_event(
                         events,
                         coordinates,
@@ -6943,6 +6959,11 @@ fn response_from_stream_events(
         let Some(pending) = tool_calls.remove(&id) else {
             continue;
         };
+        let Some(name) = pending.name else {
+            return Err(stream_assembly_error(format!(
+                "streamed tool call {id} is missing a name"
+            )));
+        };
         let arguments = if pending.arguments.trim().is_empty() {
             serde_json::json!({})
         } else {
@@ -6951,9 +6972,7 @@ fn response_from_stream_events(
             })?
         };
         content.push(verlet_history::CanonicalContent::tool_call(
-            id,
-            pending.name.unwrap_or_default(),
-            arguments,
+            id, name, arguments,
         ));
     }
 

--- a/crates/verlet-kernel/src/adapters/agent_loop.rs
+++ b/crates/verlet-kernel/src/adapters/agent_loop.rs
@@ -6808,6 +6808,20 @@ struct PendingToolCall {
     arguments: String,
 }
 
+fn tool_call_id_aliases(id: &str) -> Vec<&str> {
+    let mut aliases = vec![id];
+    // The canonical OpenAI Responses id packs call_id and item_id with the
+    // first separator. Treat the remainder as one opaque item id.
+    if let Some((call_id, item_id)) = id.split_once('|') {
+        for component in [call_id, item_id] {
+            if !component.is_empty() && !aliases.contains(&component) {
+                aliases.push(component);
+            }
+        }
+    }
+    aliases
+}
+
 fn response_from_stream_events(
     coordinates: &verlet_runtime_contracts::ThreadCoordinates,
     stream_events: Vec<verlet_provider::ProviderStreamEvent>,
@@ -6820,6 +6834,18 @@ fn response_from_stream_events(
     let mut saw_done = false;
     let mut tool_order = Vec::new();
     let mut tool_calls = std::collections::BTreeMap::<String, PendingToolCall>::new();
+    let mut completed_tool_call_ids = std::collections::BTreeSet::new();
+    let mut completed_tool_call_aliases = std::collections::BTreeSet::new();
+    for event in &stream_events {
+        if let verlet_provider::ProviderStreamEvent::Content {
+            content: verlet_history::CanonicalContent::ToolCall { id, .. },
+        } = event
+        {
+            completed_tool_call_ids.insert(id.clone());
+            completed_tool_call_aliases
+                .extend(tool_call_id_aliases(id).into_iter().map(str::to_string));
+        }
+    }
 
     for event in stream_events {
         match event {
@@ -6852,6 +6878,15 @@ fn response_from_stream_events(
                 name,
                 arguments_delta,
             } => {
+                // Completed content is authoritative. Exact-id deltas are the
+                // same call even when named; component aliases are merged only
+                // while nameless so a distinct named call is not erased by an
+                // accidental id collision.
+                if completed_tool_call_ids.contains(&id)
+                    || (name.is_none() && completed_tool_call_aliases.contains(&id))
+                {
+                    continue;
+                }
                 if !tool_calls.contains_key(&id) {
                     tool_order.push(id.clone());
                 }
@@ -6898,12 +6933,8 @@ fn response_from_stream_events(
                     arguments,
                 } = &incoming
                 {
-                    for completed_id in std::iter::once(id.as_str()).chain(id.split('|')) {
-                        tool_calls.remove(completed_id);
-                    }
-                    tool_order.retain(|candidate| {
-                        candidate != id && !id.split('|').any(|component| candidate == component)
-                    });
+                    tool_calls.remove(id);
+                    tool_order.retain(|candidate| candidate != id);
                     crate::kernel::runtime_host::runtime_events::emit_runtime_event(
                         events,
                         coordinates,

--- a/crates/verlet-kernel/src/adapters/agent_loop/tests.rs
+++ b/crates/verlet-kernel/src/adapters/agent_loop/tests.rs
@@ -3090,6 +3090,100 @@ async fn stream_assembly_requires_terminal_done() {
     }));
 }
 
+#[test]
+fn stream_assembly_merges_item_id_deltas_into_combined_completed_tool_call() {
+    let coordinates =
+        verlet_runtime_contracts::ThreadCoordinates::new("tenant_a", "user_1", "session_1");
+    let (events, mut runtime_events) = tokio::sync::broadcast::channel(8);
+
+    let response = super::response_from_stream_events(
+        &coordinates,
+        vec![
+            verlet_provider::ProviderStreamEvent::ToolCallDelta {
+                id: "fc_1".to_string(),
+                name: None,
+                arguments_delta: "{\"path\":\"notes.txt\",".to_string(),
+            },
+            verlet_provider::ProviderStreamEvent::ToolCallDelta {
+                id: "fc_1".to_string(),
+                name: None,
+                arguments_delta: "\"content\":\"hello\"}".to_string(),
+            },
+            verlet_provider::ProviderStreamEvent::Content {
+                content: verlet_history::CanonicalContent::tool_call(
+                    "call_1|fc_1",
+                    "write",
+                    serde_json::json!({"path": "notes.txt", "content": "hello"}),
+                ),
+            },
+            verlet_provider::ProviderStreamEvent::Done {
+                stop_reason: verlet_history::CanonicalStopReason::ToolUse,
+            },
+        ],
+        &events,
+    )
+    .unwrap();
+
+    assert_eq!(
+        response.content,
+        vec![verlet_history::CanonicalContent::tool_call(
+            "call_1|fc_1",
+            "write",
+            serde_json::json!({"path": "notes.txt", "content": "hello"}),
+        )]
+    );
+    let started = std::iter::from_fn(|| runtime_events.try_recv().ok())
+        .filter_map(|event| {
+            match event {
+            crate::kernel::runtime_host::runtime_api::ThreadEvent::Runtime { event, .. } => {
+                match event.kind {
+                    crate::kernel::runtime_host::runtime_events::RuntimeEventKind::ToolCallStarted {
+                        call_id,
+                        name,
+                        ..
+                    } => Some((call_id, name)),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        started,
+        vec![("call_1|fc_1".to_string(), "write".to_string())]
+    );
+}
+
+#[test]
+fn stream_assembly_rejects_nameless_pending_tool_call() {
+    let coordinates =
+        verlet_runtime_contracts::ThreadCoordinates::new("tenant_a", "user_1", "session_1");
+    let (events, _runtime_events) = tokio::sync::broadcast::channel(8);
+
+    let error = super::response_from_stream_events(
+        &coordinates,
+        vec![
+            verlet_provider::ProviderStreamEvent::ToolCallDelta {
+                id: "fc_1".to_string(),
+                name: None,
+                arguments_delta: "{\"path\":\"notes.txt\"}".to_string(),
+            },
+            verlet_provider::ProviderStreamEvent::Done {
+                stop_reason: verlet_history::CanonicalStopReason::ToolUse,
+            },
+        ],
+        &events,
+    )
+    .unwrap_err();
+
+    assert_eq!(
+        error.class,
+        verlet_runtime_contracts::RuntimeModelRequestErrorClass::StreamAssembly
+    );
+    assert_eq!(error.message, "streamed tool call fc_1 is missing a name");
+}
+
 #[tokio::test]
 async fn stream_and_complete_preserve_equivalent_final_history() {
     let complete_client =

--- a/crates/verlet-kernel/src/adapters/agent_loop/tests.rs
+++ b/crates/verlet-kernel/src/adapters/agent_loop/tests.rs
@@ -3184,6 +3184,195 @@ fn stream_assembly_rejects_nameless_pending_tool_call() {
     assert_eq!(error.message, "streamed tool call fc_1 is missing a name");
 }
 
+#[test]
+fn stream_assembly_ignores_item_id_deltas_after_completed_tool_call() {
+    let coordinates =
+        verlet_runtime_contracts::ThreadCoordinates::new("tenant_a", "user_1", "session_1");
+    let (events, mut runtime_events) = tokio::sync::broadcast::channel(8);
+
+    let completed = verlet_history::CanonicalContent::tool_call(
+        "call_1|fc_1",
+        "write",
+        serde_json::json!({"path": "notes.txt"}),
+    );
+    let response = super::response_from_stream_events(
+        &coordinates,
+        vec![
+            verlet_provider::ProviderStreamEvent::Content {
+                content: completed.clone(),
+            },
+            verlet_provider::ProviderStreamEvent::ToolCallDelta {
+                id: "fc_1".to_string(),
+                name: None,
+                arguments_delta: "{\"path\":\"notes.txt\"}".to_string(),
+            },
+            verlet_provider::ProviderStreamEvent::Done {
+                stop_reason: verlet_history::CanonicalStopReason::ToolUse,
+            },
+        ],
+        &events,
+    )
+    .unwrap();
+
+    assert_eq!(response.content, vec![completed]);
+    assert_eq!(
+        std::iter::from_fn(|| runtime_events.try_recv().ok())
+            .filter(|event| matches!(
+                event,
+                crate::kernel::runtime_host::runtime_api::ThreadEvent::Runtime {
+                    event: crate::kernel::runtime_host::runtime_events::RuntimeEvent {
+                        kind: crate::kernel::runtime_host::runtime_events::RuntimeEventKind::ToolCallStarted { .. },
+                        ..
+                    },
+                    ..
+                }
+            ))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn stream_assembly_emits_one_started_event_for_delta_and_completed_call() {
+    let coordinates =
+        verlet_runtime_contracts::ThreadCoordinates::new("tenant_a", "user_1", "session_1");
+    let (events, mut runtime_events) = tokio::sync::broadcast::channel(8);
+
+    let response = super::response_from_stream_events(
+        &coordinates,
+        vec![
+            verlet_provider::ProviderStreamEvent::ToolCallDelta {
+                id: "call_1".to_string(),
+                name: Some("bash".to_string()),
+                arguments_delta: "{\"command\":\"pwd\"}".to_string(),
+            },
+            verlet_provider::ProviderStreamEvent::Content {
+                content: verlet_history::CanonicalContent::tool_call(
+                    "call_1",
+                    "bash",
+                    serde_json::json!({"command": "pwd"}),
+                ),
+            },
+            verlet_provider::ProviderStreamEvent::Done {
+                stop_reason: verlet_history::CanonicalStopReason::ToolUse,
+            },
+        ],
+        &events,
+    )
+    .unwrap();
+
+    assert_eq!(response.content.len(), 1);
+    let started = std::iter::from_fn(|| runtime_events.try_recv().ok())
+        .filter_map(|event| {
+            match event {
+            crate::kernel::runtime_host::runtime_api::ThreadEvent::Runtime { event, .. } => {
+                match event.kind {
+                    crate::kernel::runtime_host::runtime_events::RuntimeEventKind::ToolCallStarted {
+                        call_id,
+                        name,
+                        input,
+                    } => Some((call_id, name, input)),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        started,
+        vec![(
+            "call_1".to_string(),
+            "bash".to_string(),
+            serde_json::json!({"command": "pwd"}),
+        )]
+    );
+}
+
+#[test]
+fn stream_assembly_preserves_named_call_that_collides_with_completed_id_component() {
+    let coordinates =
+        verlet_runtime_contracts::ThreadCoordinates::new("tenant_a", "user_1", "session_1");
+    let (events, mut runtime_events) = tokio::sync::broadcast::channel(8);
+
+    let response = super::response_from_stream_events(
+        &coordinates,
+        vec![
+            verlet_provider::ProviderStreamEvent::ToolCallDelta {
+                id: "call_1".to_string(),
+                name: Some("read".to_string()),
+                arguments_delta: "{\"path\":\"input.txt\"}".to_string(),
+            },
+            verlet_provider::ProviderStreamEvent::Content {
+                content: verlet_history::CanonicalContent::tool_call(
+                    "call_1|fc_1",
+                    "write",
+                    serde_json::json!({"path": "output.txt"}),
+                ),
+            },
+            verlet_provider::ProviderStreamEvent::Done {
+                stop_reason: verlet_history::CanonicalStopReason::ToolUse,
+            },
+        ],
+        &events,
+    )
+    .unwrap();
+
+    assert_eq!(response.content.len(), 2);
+    assert!(response.content.iter().any(|content| matches!(
+        content,
+        verlet_history::CanonicalContent::ToolCall { id, name, arguments }
+            if id == "call_1"
+                && name == "read"
+                && arguments == &serde_json::json!({"path": "input.txt"})
+    )));
+    assert!(response.content.iter().any(|content| matches!(
+        content,
+        verlet_history::CanonicalContent::ToolCall { id, name, arguments }
+            if id == "call_1|fc_1"
+                && name == "write"
+                && arguments == &serde_json::json!({"path": "output.txt"})
+    )));
+    let started_ids = std::iter::from_fn(|| runtime_events.try_recv().ok())
+        .filter_map(|event| {
+            match event {
+            crate::kernel::runtime_host::runtime_api::ThreadEvent::Runtime { event, .. } => {
+                match event.kind {
+                    crate::kernel::runtime_host::runtime_events::RuntimeEventKind::ToolCallStarted {
+                        call_id,
+                        ..
+                    } => Some(call_id),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        started_ids,
+        std::collections::BTreeSet::from(["call_1".to_string(), "call_1|fc_1".to_string(),])
+    );
+}
+
+#[test]
+fn tool_call_id_aliases_split_only_once_and_omit_empty_components() {
+    assert_eq!(super::tool_call_id_aliases("call_1"), vec!["call_1"]);
+    assert_eq!(
+        super::tool_call_id_aliases("call_1|fc_1"),
+        vec!["call_1|fc_1", "call_1", "fc_1"]
+    );
+    assert_eq!(
+        super::tool_call_id_aliases("call_1|namespace|fc_1"),
+        vec!["call_1|namespace|fc_1", "call_1", "namespace|fc_1"]
+    );
+    assert_eq!(super::tool_call_id_aliases("|fc_1"), vec!["|fc_1", "fc_1"]);
+    assert_eq!(
+        super::tool_call_id_aliases("call_1|"),
+        vec!["call_1|", "call_1"]
+    );
+}
+
 #[tokio::test]
 async fn stream_and_complete_preserve_equivalent_final_history() {
     let complete_client =


### PR DESCRIPTION
Fixes EMO-614: the OpenAI Responses stream assembler produced a phantom empty-name duplicate for every streamed function call, which then poisoned the next provider request (HTTP 400) and killed the turn.

Root cause: argument delta events carry only the bare item id (`fc_...`) while the completed item carries the combined id (`call_...|fc_...`); the assembler keyed pending deltas by one and removed by the other, so leftovers flushed as tool calls with an empty name.

Changes:
- Completed tool-call content is authoritative: matching exact-id deltas and nameless component-alias deltas are ignored regardless of arrival order (pre-indexed, so late deltas cannot recreate the phantom).
- A pending call that reaches end of stream without a name is a stream assembly error instead of a dispatched empty-name call.
- ToolCallStarted is emitted once per call with the canonical id: from the completed item for nameless streams, from the first named delta otherwise.
- Component aliases merge only while the delta is nameless, so a distinct named call whose id collides with a component is preserved.

Verification: full scripts/verify.sh green on macOS (1325 passed), Linux lane green via scripts/verify-linux.sh. New regressions cover the delta/done id split, out-of-order delta arrival, single started-event emission, nameless flush error, and id alias parsing edge cases.

Linear: https://linear.app/emotionscientific/issue/EMO-614
