### PR TITLE
Harden Pi file tools against oversized and non-text files (EMO-620)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,13 @@
   replayed, and surface operations are not also exposed through raw
   virtual-bash operation commands.
 - Pi-kit file search now skips non-UTF-8, NUL-containing, and oversized files
-  during grep walks, bounds grep, read, edit, and find ignore-file reads to
-  16 KiB, rejects mismatched file and directory path kinds through structured
-  tool errors, and keeps native and wasm output envelopes identical for those
-  cases. The ceiling is sized so a maximal guest read completes within half the
-  standard execution fuel budget.
+  during grep walks, bounds grep, read, edit, and find ignore-file reads to 8 MiB,
+  rejects mismatched file and directory path kinds through structured tool
+  errors, and keeps native and wasm output envelopes identical for those cases.
+  The default Wasm fuel budget is now 10 billion: measured file processing costs
+  about 154 fuel per byte, so a maximal read fits several times over and
+  multi-file grep walks across tens of MiB complete while runaway guests remain
+  bounded to seconds of CPU.
 
 ## v0.5.1 (2026-08-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   JSON objects, bound values are validated when bindings are created or
   replayed, and surface operations are not also exposed through raw
   virtual-bash operation commands.
+- Pi-kit file search now skips non-UTF-8, NUL-containing, and oversized files
+  during grep walks, bounds grep, read, and find ignore-file reads to 8 MiB,
+  rejects mismatched file and directory path kinds through structured tool
+  errors, and keeps native and wasm output envelopes identical for those cases.
 
 ## v0.5.1 (2026-08-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,11 @@
   replayed, and surface operations are not also exposed through raw
   virtual-bash operation commands.
 - Pi-kit file search now skips non-UTF-8, NUL-containing, and oversized files
-  during grep walks, bounds grep, read, edit, and find ignore-file reads to 8 MiB,
-  rejects mismatched file and directory path kinds through structured tool
-  errors, and keeps native and wasm output envelopes identical for those cases.
+  during grep walks, bounds grep, read, edit, and find ignore-file reads to
+  16 KiB, rejects mismatched file and directory path kinds through structured
+  tool errors, and keeps native and wasm output envelopes identical for those
+  cases. The ceiling is sized so a maximal guest read completes within half the
+  standard execution fuel budget.
 
 ## v0.5.1 (2026-08-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
   replayed, and surface operations are not also exposed through raw
   virtual-bash operation commands.
 - Pi-kit file search now skips non-UTF-8, NUL-containing, and oversized files
-  during grep walks, bounds grep, read, and find ignore-file reads to 8 MiB,
+  during grep walks, bounds grep, read, edit, and find ignore-file reads to 8 MiB,
   rejects mismatched file and directory path kinds through structured tool
   errors, and keeps native and wasm output envelopes identical for those cases.
 

--- a/agent-tools/README.md
+++ b/agent-tools/README.md
@@ -62,10 +62,11 @@ transport failures use a non-OK ABI status. Read, find, and grep need only an
 attached VFS. Write and edit also declare and require the `fs.write` grant.
 
 Known wasm-lane divergence: the guest ABI reports symlinks as kind `Other`
-(neither file nor directory), so the walker skips symlinked entries and direct
-read rejects symlink paths that the native `StdFs` lane would follow. The ABI
-exposes no follow-symlink distinction; resolving this needs a host-side change,
-tracked separately.
+(neither file nor directory), so the walker skips symlinked file entries that
+the native `StdFs` lane includes. Both walkers skip symlinked directories.
+Direct read rejects symlink paths that the native lane follows when the target
+remains inside its root. The ABI exposes no follow-symlink distinction;
+resolving this needs a host-side change, tracked separately.
 
 Each module directory is a standalone Cargo workspace with its own lockfile,
 a `cdylib` library target, and `panic = "abort"` in the release profile. This
@@ -100,7 +101,11 @@ cargo build --manifest-path agent-tools/wasm/read/Cargo.toml \
   stage.
 - **Bounded text scanning.** Grep skips files that are not valid UTF-8 text,
   contain NUL, or exceed the shared 8 MiB per-file read limit. Read returns a
-  structured error for files over that limit, and find skips ignore-rule files
-  over it. Pi delegates grep to `rg` without this size ceiling and its read and
-  grep context paths can load whole files. The limit trades search completeness
-  for deterministic memory use in native and wasm lanes.
+  structured error for files over that limit; offset/limit cannot bypass the
+  ceiling because the current ABI has no seek or ranged-read operation. Find
+  skips ignore-rule files over the ceiling. Edit preserves whole-file atomicity
+  under the same ceiling and returns a structured error without changing or
+  silently skipping an oversized target. Pi delegates grep to `rg` without this
+  size ceiling and its read and grep context paths can load whole files. The
+  limit trades search completeness for deterministic memory use in native and
+  wasm lanes.

--- a/agent-tools/README.md
+++ b/agent-tools/README.md
@@ -100,12 +100,14 @@ cargo build --manifest-path agent-tools/wasm/read/Cargo.toml \
   the kernel invocation layer and is deferred until the wasm integration
   stage.
 - **Bounded text scanning.** Grep skips files that are not valid UTF-8 text,
-  contain NUL, or exceed the shared 16 KiB per-file read limit. Read returns a
+  contain NUL, or exceed the shared 8 MiB per-file read limit. Read returns a
   structured error for files over that limit; offset/limit cannot bypass the
   ceiling because the current ABI has no seek or ranged-read operation. Find
   skips ignore-rule files over the ceiling. Edit preserves whole-file atomicity
   under the same ceiling and returns a structured error without changing or
   silently skipping an oversized target. Pi delegates grep to `rg` without this
   size ceiling and its read and grep context paths can load whole files. The
-  shared limit is the largest measured power-of-two ceiling whose maximal file
-  completes in the guest lane within half the standard execution fuel budget.
+  Wasm fuel budget is a runaway guard, sized from the measured guest cost of
+  about 154 fuel per file byte so an 8 MiB read fits several times over and
+  multi-file grep walks across tens of MiB complete while runaway guests remain
+  bounded to seconds of CPU.

--- a/agent-tools/README.md
+++ b/agent-tools/README.md
@@ -100,12 +100,12 @@ cargo build --manifest-path agent-tools/wasm/read/Cargo.toml \
   the kernel invocation layer and is deferred until the wasm integration
   stage.
 - **Bounded text scanning.** Grep skips files that are not valid UTF-8 text,
-  contain NUL, or exceed the shared 8 MiB per-file read limit. Read returns a
+  contain NUL, or exceed the shared 16 KiB per-file read limit. Read returns a
   structured error for files over that limit; offset/limit cannot bypass the
   ceiling because the current ABI has no seek or ranged-read operation. Find
   skips ignore-rule files over the ceiling. Edit preserves whole-file atomicity
   under the same ceiling and returns a structured error without changing or
   silently skipping an oversized target. Pi delegates grep to `rg` without this
   size ceiling and its read and grep context paths can load whole files. The
-  limit trades search completeness for deterministic memory use in native and
-  wasm lanes.
+  shared limit is the largest measured power-of-two ceiling whose maximal file
+  completes in the guest lane within half the standard execution fuel budget.

--- a/agent-tools/README.md
+++ b/agent-tools/README.md
@@ -62,9 +62,10 @@ transport failures use a non-OK ABI status. Read, find, and grep need only an
 attached VFS. Write and edit also declare and require the `fs.write` grant.
 
 Known wasm-lane divergence: the guest ABI reports symlinks as kind `Other`
-(neither file nor directory), so the walker skips symlinked entries that the
-native `StdFs` lane would follow. The ABI exposes no follow-symlink
-distinction; resolving this needs a host-side change, tracked separately.
+(neither file nor directory), so the walker skips symlinked entries and direct
+read rejects symlink paths that the native `StdFs` lane would follow. The ABI
+exposes no follow-symlink distinction; resolving this needs a host-side change,
+tracked separately.
 
 Each module directory is a standalone Cargo workspace with its own lockfile,
 a `cdylib` library target, and `panic = "abort"` in the release profile. This
@@ -97,3 +98,9 @@ cargo build --manifest-path agent-tools/wasm/read/Cargo.toml \
 - **Mutation-queue deferral.** Same-path write/edit serialization belongs to
   the kernel invocation layer and is deferred until the wasm integration
   stage.
+- **Bounded text scanning.** Grep skips files that are not valid UTF-8 text,
+  contain NUL, or exceed the shared 8 MiB per-file read limit. Read returns a
+  structured error for files over that limit, and find skips ignore-rule files
+  over it. Pi delegates grep to `rg` without this size ceiling and its read and
+  grep context paths can load whole files. The limit trades search completeness
+  for deterministic memory use in native and wasm lanes.

--- a/agent-tools/pi-kit/edit/verlet.tool.toml
+++ b/agent-tools/pi-kit/edit/verlet.tool.toml
@@ -15,7 +15,7 @@ max_output_bytes = 262144
 
 [[operations]]
 name = "edit"
-description = "Atomically apply replacements to a file up to 16 KiB with Pi diff output and error envelopes."
+description = "Atomically apply replacements to a file up to 8 MiB with Pi diff output and error envelopes."
 input_schema = "schemas/edit.input.json"
 output_schema = "schemas/edit.output.json"
 required_capabilities = ["fs.write"]

--- a/agent-tools/pi-kit/edit/verlet.tool.toml
+++ b/agent-tools/pi-kit/edit/verlet.tool.toml
@@ -15,7 +15,7 @@ max_output_bytes = 262144
 
 [[operations]]
 name = "edit"
-description = "Apply one or more old/new text replacements with Pi diff output and error envelopes."
+description = "Atomically apply replacements to a file up to 8 MiB with Pi diff output and error envelopes."
 input_schema = "schemas/edit.input.json"
 output_schema = "schemas/edit.output.json"
 required_capabilities = ["fs.write"]

--- a/agent-tools/pi-kit/edit/verlet.tool.toml
+++ b/agent-tools/pi-kit/edit/verlet.tool.toml
@@ -15,7 +15,7 @@ max_output_bytes = 262144
 
 [[operations]]
 name = "edit"
-description = "Atomically apply replacements to a file up to 8 MiB with Pi diff output and error envelopes."
+description = "Atomically apply replacements to a file up to 16 KiB with Pi diff output and error envelopes."
 input_schema = "schemas/edit.input.json"
 output_schema = "schemas/edit.output.json"
 required_capabilities = ["fs.write"]

--- a/agent-tools/pi-kit/read/verlet.tool.toml
+++ b/agent-tools/pi-kit/read/verlet.tool.toml
@@ -15,7 +15,7 @@ max_output_bytes = 262144
 
 [[operations]]
 name = "read"
-description = "Read a file with Pi line offset/limit semantics and Pi truncation notices."
+description = "Read a file up to 8 MiB with Pi line offset/limit semantics and truncation notices."
 input_schema = "schemas/read.input.json"
 output_schema = "schemas/read.output.json"
 required_capabilities = []

--- a/agent-tools/pi-kit/read/verlet.tool.toml
+++ b/agent-tools/pi-kit/read/verlet.tool.toml
@@ -15,7 +15,7 @@ max_output_bytes = 262144
 
 [[operations]]
 name = "read"
-description = "Read a file up to 8 MiB with Pi line offset/limit semantics and truncation notices."
+description = "Read a file up to 16 KiB with Pi line offset/limit semantics and truncation notices."
 input_schema = "schemas/read.input.json"
 output_schema = "schemas/read.output.json"
 required_capabilities = []

--- a/agent-tools/pi-kit/read/verlet.tool.toml
+++ b/agent-tools/pi-kit/read/verlet.tool.toml
@@ -15,7 +15,7 @@ max_output_bytes = 262144
 
 [[operations]]
 name = "read"
-description = "Read a file up to 16 KiB with Pi line offset/limit semantics and truncation notices."
+description = "Read a file up to 8 MiB with Pi line offset/limit semantics and truncation notices."
 input_schema = "schemas/read.input.json"
 output_schema = "schemas/read.output.json"
 required_capabilities = []

--- a/agent-tools/tool-core/src/lib.rs
+++ b/agent-tools/tool-core/src/lib.rs
@@ -23,7 +23,7 @@ pub const DEFAULT_MAX_LINES: usize = 2000;
 /// Pi's automatic head-truncation byte limit (50 KiB).
 pub const DEFAULT_MAX_BYTES: usize = 50 * 1024;
 
-/// Maximum bytes one file-search tool reads from a single file (8 MiB).
+/// Maximum bytes one bounded file tool reads from a single file (8 MiB).
 pub const MAX_FILE_BYTES: usize = 8 * 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, serde::Serialize, PartialEq, Eq)]
@@ -187,7 +187,8 @@ pub fn normalize_tool_path(path: &std::path::Path) -> std::path::PathBuf {
 /// Tool cores never re-check confinement.
 pub trait ToolFs {
     fn read_file(&self, path: &std::path::Path) -> Result<Vec<u8>, ToolFsError>;
-    /// Read at most `max_bytes` from one file.
+    /// Read one complete file only when it is at most `max_bytes`; an error
+    /// never exposes a partial buffer.
     fn read_file_bounded(
         &self,
         path: &std::path::Path,
@@ -840,21 +841,38 @@ mod tests {
     }
 
     #[test]
-    fn bounded_reads_stop_at_the_declared_limit() {
+    fn bounded_reads_accept_the_exact_limit_and_return_no_partial_buffer() {
         let root = tempfile::tempdir().unwrap();
-        std::fs::write(root.path().join("large.bin"), vec![b'x'; 1025]).unwrap();
+        std::fs::write(
+            root.path().join("large.bin"),
+            vec![b'x'; crate::MAX_FILE_BYTES],
+        )
+        .unwrap();
         let fs = crate::StdFs::new(root.path()).unwrap();
 
-        let exact =
-            crate::ToolFs::read_file_bounded(&fs, std::path::Path::new("large.bin"), 1025).unwrap();
-        let error = crate::ToolFs::read_file_bounded(&fs, std::path::Path::new("large.bin"), 1024)
-            .unwrap_err();
+        let exact = crate::ToolFs::read_file_bounded(
+            &fs,
+            std::path::Path::new("large.bin"),
+            crate::MAX_FILE_BYTES,
+        )
+        .unwrap();
+        std::fs::write(
+            root.path().join("large.bin"),
+            vec![b'x'; crate::MAX_FILE_BYTES.saturating_add(1)],
+        )
+        .unwrap();
+        let error = crate::ToolFs::read_file_bounded(
+            &fs,
+            std::path::Path::new("large.bin"),
+            crate::MAX_FILE_BYTES,
+        )
+        .unwrap_err();
 
-        assert_eq!(exact.len(), 1025);
+        assert_eq!(exact.len(), crate::MAX_FILE_BYTES);
         assert!(matches!(
             error,
             crate::ToolFsError::FileTooLarge {
-                max_bytes: 1024,
+                max_bytes: crate::MAX_FILE_BYTES,
                 ..
             }
         ));
@@ -873,6 +891,22 @@ mod tests {
         let files = crate::walk_files(std::path::Path::new("."), &fs).unwrap();
 
         assert!(files.iter().any(|file| file.relative_path == "hidden.txt"));
+    }
+
+    #[test]
+    fn walk_applies_ignore_rules_at_the_exact_read_limit() {
+        let root = tempfile::tempdir().unwrap();
+        let mut ignore = b"hidden.txt\n".to_vec();
+        ignore.resize(crate::MAX_FILE_BYTES, b'#');
+        std::fs::write(root.path().join(".gitignore"), ignore).unwrap();
+        std::fs::write(root.path().join("hidden.txt"), "hidden").unwrap();
+        std::fs::write(root.path().join("visible.txt"), "visible").unwrap();
+        let fs = crate::StdFs::new(root.path()).unwrap();
+
+        let files = crate::walk_files(std::path::Path::new("."), &fs).unwrap();
+
+        assert!(!files.iter().any(|file| file.relative_path == "hidden.txt"));
+        assert!(files.iter().any(|file| file.relative_path == "visible.txt"));
     }
 
     #[test]

--- a/agent-tools/tool-core/src/lib.rs
+++ b/agent-tools/tool-core/src/lib.rs
@@ -23,8 +23,8 @@ pub const DEFAULT_MAX_LINES: usize = 2000;
 /// Pi's automatic head-truncation byte limit (50 KiB).
 pub const DEFAULT_MAX_BYTES: usize = 50 * 1024;
 
-/// Maximum bytes one bounded file tool reads from a single file (8 MiB).
-pub const MAX_FILE_BYTES: usize = 8 * 1024 * 1024;
+/// Maximum bytes one bounded file tool reads from a single file (16 KiB).
+pub const MAX_FILE_BYTES: usize = 16 * 1024;
 
 #[derive(Clone, Copy, Debug, serde::Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]

--- a/agent-tools/tool-core/src/lib.rs
+++ b/agent-tools/tool-core/src/lib.rs
@@ -23,6 +23,9 @@ pub const DEFAULT_MAX_LINES: usize = 2000;
 /// Pi's automatic head-truncation byte limit (50 KiB).
 pub const DEFAULT_MAX_BYTES: usize = 50 * 1024;
 
+/// Maximum bytes one file-search tool reads from a single file (8 MiB).
+pub const MAX_FILE_BYTES: usize = 8 * 1024 * 1024;
+
 #[derive(Clone, Copy, Debug, serde::Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum TruncatedBy {
@@ -50,15 +53,14 @@ pub struct TruncationResult {
 /// Port of Pi `core/tools/truncate.ts::truncateHead`.
 pub fn truncate_head(content: &str, max_lines: usize, max_bytes: usize) -> TruncationResult {
     let total_bytes = content.len();
-    let mut lines = if content.is_empty() {
-        Vec::new()
+    let total_lines = if content.is_empty() {
+        0
     } else {
-        content.split('\n').collect::<Vec<_>>()
+        content
+            .split('\n')
+            .count()
+            .saturating_sub(usize::from(content.ends_with('\n')))
     };
-    if content.ends_with('\n') {
-        lines.pop();
-    }
-    let total_lines = lines.len();
 
     if total_lines <= max_lines && total_bytes <= max_bytes {
         return TruncationResult {
@@ -76,10 +78,8 @@ pub fn truncate_head(content: &str, max_lines: usize, max_bytes: usize) -> Trunc
         };
     }
 
-    if lines
-        .first()
-        .is_some_and(|first_line| first_line.len() > max_bytes)
-    {
+    let first_line = content.split_once('\n').map_or(content, |(line, _)| line);
+    if !content.is_empty() && first_line.len() > max_bytes {
         return TruncationResult {
             content: String::new(),
             truncated: true,
@@ -95,22 +95,26 @@ pub fn truncate_head(content: &str, max_lines: usize, max_bytes: usize) -> Trunc
         };
     }
 
-    let mut output_lines = Vec::new();
+    let mut output = String::new();
+    let mut output_lines = 0_usize;
     let mut output_bytes = 0_usize;
     let mut truncated_by = TruncatedBy::Lines;
-    for (index, line) in lines.iter().take(max_lines).enumerate() {
-        let line_bytes = line.len().saturating_add(usize::from(index > 0));
+    for line in content.split_terminator('\n').take(max_lines) {
+        let line_bytes = line.len().saturating_add(usize::from(output_lines > 0));
         if output_bytes.saturating_add(line_bytes) > max_bytes {
             truncated_by = TruncatedBy::Bytes;
             break;
         }
-        output_lines.push(*line);
+        if output_lines > 0 {
+            output.push('\n');
+        }
+        output.push_str(line);
+        output_lines = output_lines.saturating_add(1);
         output_bytes = output_bytes.saturating_add(line_bytes);
     }
-    if output_lines.len() >= max_lines && output_bytes <= max_bytes {
+    if output_lines >= max_lines && output_bytes <= max_bytes {
         truncated_by = TruncatedBy::Lines;
     }
-    let output = output_lines.join("\n");
 
     TruncationResult {
         output_bytes: output.len(),
@@ -119,7 +123,7 @@ pub fn truncate_head(content: &str, max_lines: usize, max_bytes: usize) -> Trunc
         truncated_by: Some(truncated_by),
         total_lines,
         total_bytes,
-        output_lines: output_lines.len(),
+        output_lines,
         last_line_partial: false,
         first_line_exceeds_limit: false,
         max_lines,
@@ -183,6 +187,12 @@ pub fn normalize_tool_path(path: &std::path::Path) -> std::path::PathBuf {
 /// Tool cores never re-check confinement.
 pub trait ToolFs {
     fn read_file(&self, path: &std::path::Path) -> Result<Vec<u8>, ToolFsError>;
+    /// Read at most `max_bytes` from one file.
+    fn read_file_bounded(
+        &self,
+        path: &std::path::Path,
+        max_bytes: usize,
+    ) -> Result<Vec<u8>, ToolFsError>;
     fn write_file(&self, path: &std::path::Path, content: &[u8]) -> Result<(), ToolFsError>;
     /// Create a directory. `recursive` = `mkdir -p`.
     fn mkdir(&self, path: &std::path::Path, recursive: bool) -> Result<(), ToolFsError>;
@@ -210,6 +220,11 @@ pub enum ToolFsError {
     NotFound(std::path::PathBuf),
     #[error("access denied: {0}")]
     Denied(std::path::PathBuf),
+    #[error("file exceeds {max_bytes} byte read limit: {path}")]
+    FileTooLarge {
+        path: std::path::PathBuf,
+        max_bytes: usize,
+    },
     #[error("{0}")]
     Io(String),
 }
@@ -238,6 +253,7 @@ pub struct WalkFile {
     pub path: std::path::PathBuf,
     pub relative_path: String,
     pub is_dir: bool,
+    pub size: u64,
 }
 
 /// Walk a file or directory using only [`ToolFs`].
@@ -260,6 +276,7 @@ pub fn walk_files(root: &std::path::Path, fs: &dyn ToolFs) -> Result<Vec<WalkFil
             path: root.to_path_buf(),
             relative_path,
             is_dir: false,
+            size: stat.size,
         }]);
     }
     if !stat.is_dir {
@@ -312,6 +329,7 @@ fn walk_directory(
                 path: path.clone(),
                 relative_path: format!("{}/", relative_path_string(&relative)),
                 is_dir: true,
+                size: 0,
             });
             let matcher_count = ignore_matchers.len();
             add_ignore_file(fs, &path, &path.join(".gitignore"), ignore_matchers)?;
@@ -328,6 +346,7 @@ fn walk_directory(
                     path,
                     relative_path: relative_path_string(&relative),
                     is_dir: false,
+                    size: stat.size,
                 });
             }
         }
@@ -341,11 +360,20 @@ fn add_ignore_file(
     ignore_path: &std::path::Path,
     ignore_matchers: &mut Vec<ignore::gitignore::Gitignore>,
 ) -> Result<(), ToolError> {
-    if !fs.exists(ignore_path)? {
+    let stat = match fs.stat(ignore_path) {
+        Ok(stat) => stat,
+        Err(ToolFsError::NotFound(_)) => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    if !stat.is_file || stat.size > u64::try_from(MAX_FILE_BYTES).unwrap_or(u64::MAX) {
         return Ok(());
     }
 
-    let bytes = fs.read_file(ignore_path)?;
+    let bytes = match fs.read_file_bounded(ignore_path, MAX_FILE_BYTES) {
+        Ok(bytes) => bytes,
+        Err(ToolFsError::FileTooLarge { .. }) => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
     let content = String::from_utf8_lossy(&bytes);
     let mut builder = ignore::gitignore::GitignoreBuilder::new(match_root);
     for (index, line) in content.lines().enumerate() {
@@ -505,6 +533,27 @@ impl ToolFs for StdFs {
     fn read_file(&self, path: &std::path::Path) -> Result<Vec<u8>, ToolFsError> {
         let resolved = self.resolve(path)?;
         std::fs::read(resolved).map_err(|error| map_io_error(path, error))
+    }
+
+    fn read_file_bounded(
+        &self,
+        path: &std::path::Path,
+        max_bytes: usize,
+    ) -> Result<Vec<u8>, ToolFsError> {
+        let resolved = self.resolve(path)?;
+        let file = std::fs::File::open(resolved).map_err(|error| map_io_error(path, error))?;
+        let read_limit = u64::try_from(max_bytes.saturating_add(1)).unwrap_or(u64::MAX);
+        let mut reader = std::io::Read::take(file, read_limit);
+        let mut bytes = Vec::with_capacity(max_bytes.min(64 * 1024));
+        std::io::Read::read_to_end(&mut reader, &mut bytes)
+            .map_err(|error| map_io_error(path, error))?;
+        if bytes.len() > max_bytes {
+            return Err(ToolFsError::FileTooLarge {
+                path: path.to_path_buf(),
+                max_bytes,
+            });
+        }
+        Ok(bytes)
     }
 
     fn write_file(&self, path: &std::path::Path, content: &[u8]) -> Result<(), ToolFsError> {
@@ -788,6 +837,42 @@ mod tests {
 
         assert!(matches!(prefix_collision, crate::ToolFsError::Denied(_)));
         assert!(matches!(missing_tail, crate::ToolFsError::Denied(_)));
+    }
+
+    #[test]
+    fn bounded_reads_stop_at_the_declared_limit() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("large.bin"), vec![b'x'; 1025]).unwrap();
+        let fs = crate::StdFs::new(root.path()).unwrap();
+
+        let exact =
+            crate::ToolFs::read_file_bounded(&fs, std::path::Path::new("large.bin"), 1025).unwrap();
+        let error = crate::ToolFs::read_file_bounded(&fs, std::path::Path::new("large.bin"), 1024)
+            .unwrap_err();
+
+        assert_eq!(exact.len(), 1025);
+        assert!(matches!(
+            error,
+            crate::ToolFsError::FileTooLarge {
+                max_bytes: 1024,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn walk_skips_oversized_ignore_rules_without_reading_unbounded_content() {
+        let root = tempfile::tempdir().unwrap();
+        let mut ignore = vec![b'#'; crate::MAX_FILE_BYTES.saturating_add(1)];
+        ignore.push(b'\n');
+        ignore.extend_from_slice(b"hidden.txt\n");
+        std::fs::write(root.path().join(".gitignore"), ignore).unwrap();
+        std::fs::write(root.path().join("hidden.txt"), "visible").unwrap();
+        let fs = crate::StdFs::new(root.path()).unwrap();
+
+        let files = crate::walk_files(std::path::Path::new("."), &fs).unwrap();
+
+        assert!(files.iter().any(|file| file.relative_path == "hidden.txt"));
     }
 
     #[test]

--- a/agent-tools/tool-core/src/lib.rs
+++ b/agent-tools/tool-core/src/lib.rs
@@ -23,8 +23,8 @@ pub const DEFAULT_MAX_LINES: usize = 2000;
 /// Pi's automatic head-truncation byte limit (50 KiB).
 pub const DEFAULT_MAX_BYTES: usize = 50 * 1024;
 
-/// Maximum bytes one bounded file tool reads from a single file (16 KiB).
-pub const MAX_FILE_BYTES: usize = 16 * 1024;
+/// Maximum bytes one bounded file tool reads from a single file (8 MiB).
+pub const MAX_FILE_BYTES: usize = 8 * 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, serde::Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]

--- a/agent-tools/tool-edit/src/lib.rs
+++ b/agent-tools/tool-edit/src/lib.rs
@@ -21,7 +21,7 @@
 //!   matching normalizes CRLF to LF for comparison.
 //! - Invalid UTF-8 decodes lossily for matching; untouched lines are spliced
 //!   back from their original bytes.
-//! - Edit keeps its whole-file atomic behavior under the shared 16 KiB ceiling.
+//! - Edit keeps its whole-file atomic behavior under the shared 8 MiB ceiling.
 //!   Oversized targets return a structured error and are never silently
 //!   skipped or partially changed.
 

--- a/agent-tools/tool-edit/src/lib.rs
+++ b/agent-tools/tool-edit/src/lib.rs
@@ -494,6 +494,12 @@ fn edit_access_error(
     let message = match error {
         verlet_tool_core::ToolFsError::NotFound(_) => "Error code: ENOENT".to_owned(),
         verlet_tool_core::ToolFsError::Denied(_) => "Error code: EACCES".to_owned(),
+        verlet_tool_core::ToolFsError::FileTooLarge { path, max_bytes } => {
+            format!(
+                "file exceeds {max_bytes} byte read limit: {}",
+                path.display()
+            )
+        }
         verlet_tool_core::ToolFsError::Io(message) => message,
     };
     verlet_tool_core::ToolError::Failed(format!("Could not edit file: {path}. {message}."))

--- a/agent-tools/tool-edit/src/lib.rs
+++ b/agent-tools/tool-edit/src/lib.rs
@@ -21,6 +21,9 @@
 //!   matching normalizes CRLF to LF for comparison.
 //! - Invalid UTF-8 decodes lossily for matching; untouched lines are spliced
 //!   back from their original bytes.
+//! - Edit keeps its whole-file atomic behavior under the shared 8 MiB ceiling.
+//!   Oversized targets return a structured error and are never silently
+//!   skipped or partially changed.
 
 use unicode_normalization::UnicodeNormalization as _;
 
@@ -330,10 +333,21 @@ pub fn run(
     let path_display = input_path.display().to_string();
     let path = verlet_tool_core::normalize_tool_path(&input_path);
 
-    if let Err(error) = fs.stat(&path) {
-        return Err(edit_access_error(&path_display, error));
+    let stat = fs
+        .stat(&path)
+        .map_err(|error| edit_access_error(&path_display, error))?;
+    if stat.size > u64::try_from(verlet_tool_core::MAX_FILE_BYTES).unwrap_or(u64::MAX) {
+        return Err(edit_access_error(
+            &path_display,
+            verlet_tool_core::ToolFsError::FileTooLarge {
+                path,
+                max_bytes: verlet_tool_core::MAX_FILE_BYTES,
+            },
+        ));
     }
-    let bytes = fs.read_file(&path)?;
+    let bytes = fs
+        .read_file_bounded(&path, verlet_tool_core::MAX_FILE_BYTES)
+        .map_err(|error| edit_access_error(&path_display, error))?;
     let (bom, text_bytes) = if bytes.starts_with(&[0xef, 0xbb, 0xbf]) {
         (&bytes[..3], &bytes[3..])
     } else {
@@ -494,12 +508,10 @@ fn edit_access_error(
     let message = match error {
         verlet_tool_core::ToolFsError::NotFound(_) => "Error code: ENOENT".to_owned(),
         verlet_tool_core::ToolFsError::Denied(_) => "Error code: EACCES".to_owned(),
-        verlet_tool_core::ToolFsError::FileTooLarge { path, max_bytes } => {
-            format!(
-                "file exceeds {max_bytes} byte read limit: {}",
-                path.display()
-            )
-        }
+        verlet_tool_core::ToolFsError::FileTooLarge { path, max_bytes } => format!(
+            "file exceeds {max_bytes} byte edit limit: {}; split the file or use bash to apply a bounded change",
+            path.display()
+        ),
         verlet_tool_core::ToolFsError::Io(message) => message,
     };
     verlet_tool_core::ToolError::Failed(format!("Could not edit file: {path}. {message}."))
@@ -1099,6 +1111,38 @@ mod tests {
         assert_eq!(
             empty.to_string(),
             "Could not find the exact text in empty.txt. The old text must match exactly including all whitespace and newlines."
+        );
+    }
+
+    #[test]
+    fn rejects_targets_over_the_ceiling_without_silently_skipping_or_changing_them() {
+        let root = tempfile::tempdir().unwrap();
+        let padding_line = format!("{}\n", "x".repeat(1024));
+        let padding = padding_line.repeat(
+            verlet_tool_core::MAX_FILE_BYTES
+                .saturating_div(padding_line.len())
+                .saturating_add(1),
+        );
+        let content = format!("target\n{padding}");
+        assert!(content.len() > verlet_tool_core::MAX_FILE_BYTES);
+        std::fs::write(root.path().join("oversized.txt"), &content).unwrap();
+
+        let error = crate::run(
+            args("oversized.txt", &[("target", "edited")]),
+            &fs(root.path()),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "Could not edit file: oversized.txt. file exceeds {} byte edit limit: oversized.txt; split the file or use bash to apply a bounded change.",
+                verlet_tool_core::MAX_FILE_BYTES
+            )
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("oversized.txt")).unwrap(),
+            content
         );
     }
 

--- a/agent-tools/tool-edit/src/lib.rs
+++ b/agent-tools/tool-edit/src/lib.rs
@@ -21,7 +21,7 @@
 //!   matching normalizes CRLF to LF for comparison.
 //! - Invalid UTF-8 decodes lossily for matching; untouched lines are spliced
 //!   back from their original bytes.
-//! - Edit keeps its whole-file atomic behavior under the shared 8 MiB ceiling.
+//! - Edit keeps its whole-file atomic behavior under the shared 16 KiB ceiling.
 //!   Oversized targets return a structured error and are never silently
 //!   skipped or partially changed.
 

--- a/agent-tools/tool-glob/src/lib.rs
+++ b/agent-tools/tool-glob/src/lib.rs
@@ -17,6 +17,7 @@
 //!   `/`-separated, and sorted
 //!   lexicographically (Pi preserves backend process order; we pin deterministic
 //!   order instead — recorded deviation).
+//! - Ignore-rule files over the shared 8 MiB file limit are skipped.
 //! - `limit` (default 1000) and the 50 KiB complete-line head limit emit Pi's
 //!   actionable notices.
 
@@ -84,6 +85,18 @@ pub fn run(
         .compile_matcher();
     let input_root = args.path.unwrap_or_else(|| std::path::PathBuf::from("."));
     let root = verlet_tool_core::normalize_tool_path(&input_root);
+    let root_stat = fs.stat(&root).map_err(|error| match error {
+        verlet_tool_core::ToolFsError::NotFound(_) => {
+            verlet_tool_core::ToolError::Failed(format!("Path not found: {}", root.display()))
+        }
+        error => error.into(),
+    })?;
+    if !root_stat.is_dir {
+        return Err(verlet_tool_core::ToolError::Failed(format!(
+            "Not a directory: {}",
+            root.display()
+        )));
+    }
     let files = verlet_tool_core::walk_files(&root, fs).map_err(|error| match error {
         verlet_tool_core::ToolError::Fs(verlet_tool_core::ToolFsError::NotFound(_)) => {
             verlet_tool_core::ToolError::Failed(format!("Path not found: {}", root.display()))
@@ -207,6 +220,18 @@ mod tests {
     fn model_facing_contract_is_named_find() {
         // Pi behavior sheet item 34; source: core/tools/find.ts:123-133.
         assert_eq!(crate::contract().name, "find");
+    }
+
+    #[test]
+    fn a_file_search_root_is_a_structured_error() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file.txt"), "content").unwrap();
+        let mut search = args("**", None);
+        search.path = Some(std::path::PathBuf::from("file.txt"));
+
+        let error = crate::run(search, &fs(root.path())).unwrap_err();
+
+        assert_eq!(error.to_string(), "Not a directory: file.txt");
     }
 
     #[test]
@@ -405,6 +430,14 @@ mod tests {
             path: &std::path::Path,
         ) -> Result<Vec<u8>, verlet_tool_core::ToolFsError> {
             verlet_tool_core::ToolFs::read_file(&self.inner, path)
+        }
+
+        fn read_file_bounded(
+            &self,
+            path: &std::path::Path,
+            max_bytes: usize,
+        ) -> Result<Vec<u8>, verlet_tool_core::ToolFsError> {
+            verlet_tool_core::ToolFs::read_file_bounded(&self.inner, path, max_bytes)
         }
 
         fn write_file(

--- a/agent-tools/tool-glob/src/lib.rs
+++ b/agent-tools/tool-glob/src/lib.rs
@@ -17,7 +17,7 @@
 //!   `/`-separated, and sorted
 //!   lexicographically (Pi preserves backend process order; we pin deterministic
 //!   order instead — recorded deviation).
-//! - Ignore-rule files over the shared 16 KiB file limit are skipped.
+//! - Ignore-rule files over the shared 8 MiB file limit are skipped.
 //! - `limit` (default 1000) and the 50 KiB complete-line head limit emit Pi's
 //!   actionable notices.
 

--- a/agent-tools/tool-glob/src/lib.rs
+++ b/agent-tools/tool-glob/src/lib.rs
@@ -17,7 +17,7 @@
 //!   `/`-separated, and sorted
 //!   lexicographically (Pi preserves backend process order; we pin deterministic
 //!   order instead — recorded deviation).
-//! - Ignore-rule files over the shared 8 MiB file limit are skipped.
+//! - Ignore-rule files over the shared 16 KiB file limit are skipped.
 //! - `limit` (default 1000) and the 50 KiB complete-line head limit emit Pi's
 //!   actionable notices.
 

--- a/agent-tools/tool-grep/src/lib.rs
+++ b/agent-tools/tool-grep/src/lib.rs
@@ -19,7 +19,7 @@
 //! - `limit` (default 100) caps match count; search stops early when
 //!   reached and emits Pi's actionable notice.
 //! - Final text is complete-line head-truncated at 50 KiB.
-//! - Non-UTF-8 files, files containing NUL, and files over 8 MiB are skipped.
+//! - Non-UTF-8 files, files containing NUL, and files over 16 KiB are skipped.
 //! - Deterministic file order (same as glob's sort), so identical state
 //!   yields identical output on every backend.
 
@@ -676,16 +676,18 @@ mod tests {
         // Pi behavior sheet item 25; source: core/tools/grep.ts:338-366.
         let root = tempfile::tempdir().unwrap();
         let line = format!("{}hit\n", "🙂".repeat(crate::MAX_LINE_CHARS + 1));
-        let line_count = 2200;
-        std::fs::write(root.path().join("large.txt"), line.repeat(line_count)).unwrap();
+        let file_count = 60;
+        for index in 0..file_count {
+            std::fs::write(root.path().join(format!("large-{index:02}.txt")), &line).unwrap();
+        }
         let mut search = args("hit");
-        search.limit = Some(line_count as i64);
+        search.limit = Some(file_count);
 
         let output = crate::run(search, &fs(root.path())).unwrap();
 
         assert!(output.truncated);
         assert!(output.text.ends_with(
-            "\n\n[2200 matches limit reached. Use limit=4400 for more, or refine pattern. 50.0KB limit reached. Some lines truncated to 500 chars. Use read tool to see full lines]"
+            "\n\n[60 matches limit reached. Use limit=120 for more, or refine pattern. 50.0KB limit reached. Some lines truncated to 500 chars. Use read tool to see full lines]"
         ));
     }
 

--- a/agent-tools/tool-grep/src/lib.rs
+++ b/agent-tools/tool-grep/src/lib.rs
@@ -497,6 +497,7 @@ mod tests {
         let recording = RecordingFs {
             inner: fs(root.path()),
             reads: std::cell::RefCell::new(Vec::new()),
+            replacement_on_bounded_read: std::cell::RefCell::new(None),
         };
         let mut search = args("hit");
         search.limit = Some(1);
@@ -545,7 +546,9 @@ mod tests {
     #[test]
     fn skips_non_utf8_files() {
         let root = tempfile::tempdir().unwrap();
-        std::fs::write(root.path().join("invalid.txt"), b"\xffhit\n").unwrap();
+        let mut invalid = vec![b'x'; 4 * 1024];
+        invalid.extend_from_slice(b"\xffhit\n");
+        std::fs::write(root.path().join("invalid.txt"), invalid).unwrap();
         std::fs::write(root.path().join("text.txt"), b"hit\n").unwrap();
 
         let output = crate::run(args("hit"), &fs(root.path())).unwrap();
@@ -563,6 +566,7 @@ mod tests {
         let recording = RecordingFs {
             inner: fs(root.path()),
             reads: std::cell::RefCell::new(Vec::new()),
+            replacement_on_bounded_read: std::cell::RefCell::new(None),
         };
 
         let output = crate::run(args("hit"), &recording).unwrap();
@@ -573,6 +577,30 @@ mod tests {
             .borrow()
             .iter()
             .any(|path| path.ends_with("oversized.txt")));
+    }
+
+    #[test]
+    fn a_file_that_grows_after_stat_is_skipped_without_searching_a_partial_buffer() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("changing.txt"), b"hit\n").unwrap();
+        let recording = RecordingFs {
+            inner: fs(root.path()),
+            reads: std::cell::RefCell::new(Vec::new()),
+            replacement_on_bounded_read: std::cell::RefCell::new(Some(vec![
+                b'x';
+                verlet_tool_core::MAX_FILE_BYTES
+                    .saturating_add(1)
+            ])),
+        };
+
+        let output = crate::run(args("hit"), &recording).unwrap();
+
+        assert_eq!(output.text, "No matches found");
+        assert_eq!(output.match_count, 0);
+        assert_eq!(
+            recording.reads.borrow().as_slice(),
+            &[std::path::PathBuf::from("./changing.txt")]
+        );
     }
 
     #[test]
@@ -742,6 +770,7 @@ mod tests {
     struct RecordingFs {
         inner: verlet_tool_core::StdFs,
         reads: std::cell::RefCell<Vec<std::path::PathBuf>>,
+        replacement_on_bounded_read: std::cell::RefCell<Option<Vec<u8>>>,
     }
 
     impl verlet_tool_core::ToolFs for RecordingFs {
@@ -759,6 +788,9 @@ mod tests {
             max_bytes: usize,
         ) -> Result<Vec<u8>, verlet_tool_core::ToolFsError> {
             self.reads.borrow_mut().push(path.to_path_buf());
+            if let Some(replacement) = self.replacement_on_bounded_read.borrow_mut().take() {
+                std::fs::write(self.inner.root.join(path), replacement).unwrap();
+            }
             verlet_tool_core::ToolFs::read_file_bounded(&self.inner, path, max_bytes)
         }
 

--- a/agent-tools/tool-grep/src/lib.rs
+++ b/agent-tools/tool-grep/src/lib.rs
@@ -19,13 +19,12 @@
 //! - `limit` (default 100) caps match count; search stops early when
 //!   reached and emits Pi's actionable notice.
 //! - Final text is complete-line head-truncated at 50 KiB.
-//! - Binary files (NUL in first 8KB) are skipped.
+//! - Non-UTF-8 files, files containing NUL, and files over 8 MiB are skipped.
 //! - Deterministic file order (same as glob's sort), so identical state
 //!   yields identical output on every backend.
 
 pub const DEFAULT_LIMIT: i64 = 100;
 pub const MAX_LINE_CHARS: usize = 500;
-const BINARY_SNIFF_BYTES: usize = 8 * 1024;
 
 #[derive(Clone, Debug, serde::Deserialize)]
 pub struct GrepArgs {
@@ -132,8 +131,15 @@ pub fn run(
             continue;
         }
 
-        let bytes = fs.read_file(&file.path)?;
-        if bytes.iter().take(BINARY_SNIFF_BYTES).any(|byte| *byte == 0) {
+        if file.size > u64::try_from(verlet_tool_core::MAX_FILE_BYTES).unwrap_or(u64::MAX) {
+            continue;
+        }
+        let bytes = match fs.read_file_bounded(&file.path, verlet_tool_core::MAX_FILE_BYTES) {
+            Ok(bytes) => bytes,
+            Err(verlet_tool_core::ToolFsError::FileTooLarge { .. }) => continue,
+            Err(error) => return Err(error.into()),
+        };
+        if std::str::from_utf8(&bytes).is_err() || bytes.contains(&0) {
             continue;
         }
 
@@ -144,7 +150,9 @@ pub fn run(
             .bom_sniffing(false)
             .max_matches(Some(remaining));
         let mut searcher = searcher_builder.build();
-        let mut sink = MatchLineSink { lines: Vec::new() };
+        let mut sink = MatchLineSink {
+            matches: Vec::new(),
+        };
         searcher
             .search_slice(&matcher, &bytes, &mut sink)
             .map_err(|error| {
@@ -155,22 +163,21 @@ pub fn run(
             })?;
 
         match_count =
-            match_count.saturating_add(u64::try_from(sink.lines.len()).unwrap_or(u64::MAX));
-        let lines = file_lines(&bytes);
+            match_count.saturating_add(u64::try_from(sink.matches.len()).unwrap_or(u64::MAX));
         if context == 0 {
-            for line_number in sink.lines {
+            for matched in sink.matches {
                 let (row, truncated) = render_line(
                     &file.relative_path,
-                    line_number,
+                    matched.line_number,
                     true,
-                    line_at(&lines, line_number),
+                    &matched.bytes,
                 );
                 rows.push(row);
                 lines_truncated |= truncated;
             }
         } else {
             let (file_blocks, truncated) =
-                render_context_blocks(&file.relative_path, &lines, &sink.lines, context);
+                render_context_blocks(&file.relative_path, &bytes, &sink.matches, context);
             blocks.extend(file_blocks);
             lines_truncated |= truncated;
         }
@@ -241,7 +248,12 @@ pub fn run(
 }
 
 struct MatchLineSink {
-    lines: Vec<u64>,
+    matches: Vec<MatchLine>,
+}
+
+struct MatchLine {
+    line_number: u64,
+    bytes: Vec<u8>,
 }
 
 impl grep_searcher::Sink for MatchLineSink {
@@ -253,7 +265,12 @@ impl grep_searcher::Sink for MatchLineSink {
         matched: &grep_searcher::SinkMatch<'_>,
     ) -> Result<bool, Self::Error> {
         if let Some(line_number) = matched.line_number() {
-            self.lines.push(line_number);
+            let bytes = matched
+                .bytes()
+                .strip_suffix(b"\n")
+                .unwrap_or_else(|| matched.bytes())
+                .to_vec();
+            self.matches.push(MatchLine { line_number, bytes });
         }
         Ok(true)
     }
@@ -261,18 +278,19 @@ impl grep_searcher::Sink for MatchLineSink {
 
 fn render_context_blocks(
     path: &str,
-    lines: &[&[u8]],
-    matches: &[u64],
+    bytes: &[u8],
+    matches: &[MatchLine],
     context: usize,
 ) -> (Vec<Vec<String>>, bool) {
     if matches.is_empty() {
         return (Vec::new(), false);
     }
-    let line_count = u64::try_from(lines.len()).unwrap_or(u64::MAX);
+    let line_count = file_line_count(bytes);
     let context = u64::try_from(context).unwrap_or(u64::MAX);
     let mut blocks = Vec::new();
     let mut any_truncated = false;
-    for &line_number in matches {
+    for matched in matches {
+        let line_number = matched.line_number;
         let start = line_number.saturating_sub(context).max(1);
         let end = line_number.saturating_add(context).min(line_count);
         let mut block = Vec::new();
@@ -281,7 +299,7 @@ fn render_context_blocks(
                 path,
                 current,
                 current == line_number,
-                line_at(lines, current),
+                line_at(bytes, current),
             );
             block.push(row);
             any_truncated |= truncated;
@@ -306,17 +324,21 @@ fn render_line(path: &str, line_number: u64, is_match: bool, bytes: &[u8]) -> (S
     (row, was_truncated)
 }
 
-fn line_at<'a>(lines: &'a [&'a [u8]], line_number: u64) -> &'a [u8] {
+fn line_at(bytes: &[u8], line_number: u64) -> &[u8] {
     let index = usize::try_from(line_number.saturating_sub(1)).unwrap_or(usize::MAX);
-    lines.get(index).copied().unwrap_or_default()
+    bytes
+        .split(|byte| *byte == b'\n')
+        .nth(index)
+        .unwrap_or_default()
 }
 
-fn file_lines(bytes: &[u8]) -> Vec<&[u8]> {
-    let mut lines = bytes.split(|byte| *byte == b'\n').collect::<Vec<_>>();
-    if bytes.ends_with(b"\n") {
-        lines.pop();
-    }
-    lines
+fn file_line_count(bytes: &[u8]) -> u64 {
+    let count = bytes
+        .iter()
+        .filter(|byte| **byte == b'\n')
+        .count()
+        .saturating_add(usize::from(!bytes.ends_with(b"\n")));
+    u64::try_from(count).unwrap_or(u64::MAX)
 }
 
 #[cfg(test)]
@@ -495,7 +517,7 @@ mod tests {
     }
 
     #[test]
-    fn skips_binary_files_with_a_nul_in_the_first_eight_kibibytes() {
+    fn skips_binary_files_containing_nul() {
         let root = tempfile::tempdir().unwrap();
         std::fs::write(root.path().join("binary.dat"), b"hit\0more").unwrap();
         std::fs::write(root.path().join("text.txt"), b"hit\n").unwrap();
@@ -507,42 +529,50 @@ mod tests {
     }
 
     #[test]
-    fn a_nul_after_the_binary_sniff_window_does_not_skip_the_file() {
+    fn skips_nul_anywhere_in_a_file() {
         let root = tempfile::tempdir().unwrap();
         let mut content = vec![b'x'; 8 * 1024];
         content.extend_from_slice(b"\0hit\n");
         std::fs::write(root.path().join("late-nul.dat"), content).unwrap();
+        std::fs::write(root.path().join("text.txt"), b"hit\n").unwrap();
 
         let output = crate::run(args("hit"), &fs(root.path())).unwrap();
 
-        assert_eq!(
-            output.text,
-            "late-nul.dat:1: ".to_owned()
-                + &"x".repeat(500)
-                + "... [truncated]\n\n[Some lines truncated to 500 chars. Use read tool to see full lines]"
-        );
+        assert_eq!(output.text, "text.txt:1: hit");
         assert_eq!(output.match_count, 1);
     }
 
     #[test]
-    fn renders_non_utf8_match_lines_lossily_without_confusing_char_and_byte_caps() {
+    fn skips_non_utf8_files() {
         let root = tempfile::tempdir().unwrap();
-        let mut content = "🙂".repeat(crate::MAX_LINE_CHARS).into_bytes();
-        content.extend_from_slice(&[0xff]);
-        content.extend_from_slice(b"hit\n");
-        std::fs::write(root.path().join("invalid.txt"), content).unwrap();
+        std::fs::write(root.path().join("invalid.txt"), b"\xffhit\n").unwrap();
+        std::fs::write(root.path().join("text.txt"), b"hit\n").unwrap();
 
         let output = crate::run(args("hit"), &fs(root.path())).unwrap();
 
-        assert_eq!(
-            output.text,
-            format!(
-                "invalid.txt:1: {}... [truncated]\n\n[Some lines truncated to 500 chars. Use read tool to see full lines]",
-                "🙂".repeat(crate::MAX_LINE_CHARS / 2)
-            )
-        );
-        assert!(output.text.len() > crate::MAX_LINE_CHARS);
-        assert!(output.text.len() < verlet_tool_core::MAX_RESULT_BYTES);
+        assert_eq!(output.text, "text.txt:1: hit");
+        assert_eq!(output.match_count, 1);
+    }
+
+    #[test]
+    fn skips_oversized_files_without_reading_them() {
+        let root = tempfile::tempdir().unwrap();
+        let oversized = vec![b'x'; verlet_tool_core::MAX_FILE_BYTES.saturating_add(1)];
+        std::fs::write(root.path().join("oversized.txt"), oversized).unwrap();
+        std::fs::write(root.path().join("text.txt"), b"hit\n").unwrap();
+        let recording = RecordingFs {
+            inner: fs(root.path()),
+            reads: std::cell::RefCell::new(Vec::new()),
+        };
+
+        let output = crate::run(args("hit"), &recording).unwrap();
+
+        assert_eq!(output.text, "text.txt:1: hit");
+        assert!(!recording
+            .reads
+            .borrow()
+            .iter()
+            .any(|path| path.ends_with("oversized.txt")));
     }
 
     #[test]
@@ -721,6 +751,15 @@ mod tests {
         ) -> Result<Vec<u8>, verlet_tool_core::ToolFsError> {
             self.reads.borrow_mut().push(path.to_path_buf());
             verlet_tool_core::ToolFs::read_file(&self.inner, path)
+        }
+
+        fn read_file_bounded(
+            &self,
+            path: &std::path::Path,
+            max_bytes: usize,
+        ) -> Result<Vec<u8>, verlet_tool_core::ToolFsError> {
+            self.reads.borrow_mut().push(path.to_path_buf());
+            verlet_tool_core::ToolFs::read_file_bounded(&self.inner, path, max_bytes)
         }
 
         fn write_file(

--- a/agent-tools/tool-grep/src/lib.rs
+++ b/agent-tools/tool-grep/src/lib.rs
@@ -19,7 +19,7 @@
 //! - `limit` (default 100) caps match count; search stops early when
 //!   reached and emits Pi's actionable notice.
 //! - Final text is complete-line head-truncated at 50 KiB.
-//! - Non-UTF-8 files, files containing NUL, and files over 16 KiB are skipped.
+//! - Non-UTF-8 files, files containing NUL, and files over 8 MiB are skipped.
 //! - Deterministic file order (same as glob's sort), so identical state
 //!   yields identical output on every backend.
 
@@ -676,18 +676,16 @@ mod tests {
         // Pi behavior sheet item 25; source: core/tools/grep.ts:338-366.
         let root = tempfile::tempdir().unwrap();
         let line = format!("{}hit\n", "🙂".repeat(crate::MAX_LINE_CHARS + 1));
-        let file_count = 60;
-        for index in 0..file_count {
-            std::fs::write(root.path().join(format!("large-{index:02}.txt")), &line).unwrap();
-        }
+        let line_count = 2200;
+        std::fs::write(root.path().join("large.txt"), line.repeat(line_count)).unwrap();
         let mut search = args("hit");
-        search.limit = Some(file_count);
+        search.limit = Some(line_count as i64);
 
         let output = crate::run(search, &fs(root.path())).unwrap();
 
         assert!(output.truncated);
         assert!(output.text.ends_with(
-            "\n\n[60 matches limit reached. Use limit=120 for more, or refine pattern. 50.0KB limit reached. Some lines truncated to 500 chars. Use read tool to see full lines]"
+            "\n\n[2200 matches limit reached. Use limit=4400 for more, or refine pattern. 50.0KB limit reached. Some lines truncated to 500 chars. Use read tool to see full lines]"
         ));
     }
 

--- a/agent-tools/tool-read/src/lib.rs
+++ b/agent-tools/tool-read/src/lib.rs
@@ -13,7 +13,7 @@
 //! - Caller limits and automatic truncation use Pi's exact continuation text.
 //! - Line accounting follows Pi's newline split: an empty file is one empty
 //!   logical line, and a terminal newline creates a final empty line.
-//! - Files over the shared 16 KiB limit return a structured tool error; the
+//! - Files over the shared 8 MiB limit return a structured tool error; the
 //!   4 MiB result cap remains a final structured-result backstop.
 
 #[derive(Clone, Debug, serde::Deserialize)]
@@ -344,14 +344,19 @@ mod tests {
     }
 
     #[test]
-    fn the_shared_file_ceiling_precedes_pi_first_line_truncation() {
+    fn reports_an_oversized_first_line_with_pi_text() {
+        // Pi behavior sheet item 9; source: core/tools/read.ts:297-301.
         let root = tempfile::tempdir().unwrap();
         let content = vec![b'x'; verlet_tool_core::DEFAULT_MAX_BYTES + 1];
         std::fs::write(root.path().join("large.txt"), content).unwrap();
 
-        let error = crate::run(args("large.txt", None, None), &fs(root.path())).unwrap_err();
+        let output = crate::run(args("large.txt", None, None), &fs(root.path())).unwrap();
 
-        assert!(error.to_string().contains("byte read limit: large.txt"));
+        assert_eq!(
+            output.text,
+            "[Line 1 is 50.0KB, exceeds 50.0KB limit. Use bash: sed -n '1p' large.txt | head -c 51200]"
+        );
+        assert!(output.truncation.unwrap().first_line_exceeds_limit);
     }
 
     #[test]
@@ -365,14 +370,17 @@ mod tests {
     }
 
     #[test]
-    fn the_shared_file_ceiling_precedes_pi_byte_truncation() {
+    fn byte_truncation_uses_complete_lines_and_pi_notice() {
+        // Pi behavior sheet item 9; source: core/tools/read.ts:294-312.
         let root = tempfile::tempdir().unwrap();
         let line = format!("{}\n", "x".repeat(1024));
         std::fs::write(root.path().join("large.txt"), line.repeat(60)).unwrap();
 
-        let error = crate::run(args("large.txt", None, None), &fs(root.path())).unwrap_err();
+        let output = crate::run(args("large.txt", None, None), &fs(root.path())).unwrap();
 
-        assert!(error.to_string().contains("byte read limit: large.txt"));
+        assert!(output.text.ends_with(
+            "\n\n[Showing lines 1-49 of 61 (50.0KB limit). Use offset=50 to continue.]"
+        ));
     }
 
     #[test]
@@ -417,16 +425,17 @@ mod tests {
     fn automatically_truncates_at_two_thousand_lines_with_pi_notice() {
         // Pi behavior sheet item 9; source: core/tools/read.ts:294-312.
         let root = tempfile::tempdir().unwrap();
-        let content = std::iter::repeat_n("x", 2001)
+        let content = (1..=2001)
+            .map(|line| format!("line {line}"))
             .collect::<Vec<_>>()
             .join("\n");
         std::fs::write(root.path().join("large.txt"), content).unwrap();
 
         let output = crate::run(args("large.txt", None, None), &fs(root.path())).unwrap();
 
-        assert!(output
-            .text
-            .ends_with("x\n\n[Showing lines 1-2000 of 2001. Use offset=2001 to continue.]"));
+        assert!(output.text.ends_with(
+            "line 2000\n\n[Showing lines 1-2000 of 2001. Use offset=2001 to continue.]"
+        ));
     }
 
     #[test]

--- a/agent-tools/tool-read/src/lib.rs
+++ b/agent-tools/tool-read/src/lib.rs
@@ -13,7 +13,8 @@
 //! - Caller limits and automatic truncation use Pi's exact continuation text.
 //! - Line accounting follows Pi's newline split: an empty file is one empty
 //!   logical line, and a terminal newline creates a final empty line.
-//! - The 4 MiB result cap remains only as a final structured-result backstop.
+//! - Files over the shared 8 MiB limit return a structured tool error; the
+//!   4 MiB result cap remains a final structured-result backstop.
 
 #[derive(Clone, Debug, serde::Deserialize)]
 pub struct ReadArgs {
@@ -65,17 +66,36 @@ pub fn run(
 ) -> Result<ReadOutput, verlet_tool_core::ToolError> {
     let input_path = args.path;
     let path = verlet_tool_core::normalize_tool_path(&input_path);
-    let bytes = fs.read_file(&path)?;
-    let content = String::from_utf8_lossy(&bytes);
-    let lines = content.split('\n').collect::<Vec<_>>();
-    let total_lines = u64::try_from(lines.len()).unwrap_or(u64::MAX);
+    let stat = fs.stat(&path)?;
+    if stat.is_dir {
+        return Err(verlet_tool_core::ToolError::Failed(format!(
+            "Path is a directory: {}",
+            path.display()
+        )));
+    }
+    if !stat.is_file {
+        return Err(verlet_tool_core::ToolError::Failed(format!(
+            "Path is not a file: {}",
+            path.display()
+        )));
+    }
+    if stat.size > u64::try_from(verlet_tool_core::MAX_FILE_BYTES).unwrap_or(u64::MAX) {
+        return Err(verlet_tool_core::ToolFsError::FileTooLarge {
+            path,
+            max_bytes: verlet_tool_core::MAX_FILE_BYTES,
+        }
+        .into());
+    }
+    let bytes = fs.read_file_bounded(&path, verlet_tool_core::MAX_FILE_BYTES)?;
+    let total_line_count = file_line_count(&bytes);
+    let total_lines = u64::try_from(total_line_count).unwrap_or(u64::MAX);
     let requested_offset = args.offset;
     let start_index_i64 = match requested_offset {
         Some(offset) if offset != 0 => offset.saturating_sub(1).max(0),
         _ => 0,
     };
 
-    if i128::from(start_index_i64) >= lines.len() as i128 {
+    if i128::from(start_index_i64) >= total_line_count as i128 {
         return Err(offset_past_end(requested_offset.unwrap_or(1), total_lines));
     }
 
@@ -84,18 +104,19 @@ pub fn run(
     let (end_index, user_limit_end) = match args.limit {
         Some(limit) => {
             let numeric_end =
-                (start_index_i64 as i128 + i128::from(limit)).min(lines.len() as i128);
+                (start_index_i64 as i128 + i128::from(limit)).min(total_line_count as i128);
             let slice_end = if numeric_end < 0 {
-                (lines.len() as i128 + numeric_end).max(0)
+                (total_line_count as i128 + numeric_end).max(0)
             } else {
                 numeric_end
             }
-            .clamp(0, lines.len() as i128) as usize;
+            .clamp(0, total_line_count as i128) as usize;
             (slice_end.max(start_index), Some(numeric_end))
         }
-        None => (lines.len(), None),
+        None => (total_line_count, None),
     };
-    let selected_content = lines[start_index..end_index].join("\n");
+    let selected_bytes = line_range(&bytes, start_index, end_index, total_line_count);
+    let selected_content = String::from_utf8_lossy(selected_bytes);
     let truncation = verlet_tool_core::truncate_head(
         &selected_content,
         verlet_tool_core::DEFAULT_MAX_LINES,
@@ -107,7 +128,9 @@ pub fn run(
     let mut truncation_details = None;
 
     if truncation.first_line_exceeds_limit {
-        let first_line_size = lines.get(start_index).map_or(0, |line| line.len());
+        let first_line_size = selected_content
+            .split_once('\n')
+            .map_or(selected_content.len(), |(line, _)| line.len());
         text = format!(
             "[Line {start_line} is {}, exceeds {} limit. Use bash: sed -n '{start_line}p' {} | head -c {}]",
             verlet_tool_core::format_size(first_line_size),
@@ -135,8 +158,8 @@ pub fn run(
         truncation_details = Some(truncation);
     } else if let Some(numeric_end) = user_limit_end {
         text = truncation.content;
-        if numeric_end < lines.len() as i128 {
-            let remaining = lines.len() as i128 - numeric_end;
+        if numeric_end < total_line_count as i128 {
+            let remaining = total_line_count as i128 - numeric_end;
             let next_offset = numeric_end + 1;
             text.push_str(&format!(
                 "\n\n[{remaining} more lines in file. Use offset={next_offset} to continue.]"
@@ -156,6 +179,39 @@ pub fn run(
         total_lines,
         truncation: truncation_details,
     })
+}
+
+fn file_line_count(bytes: &[u8]) -> usize {
+    bytes
+        .iter()
+        .filter(|byte| **byte == b'\n')
+        .count()
+        .saturating_add(1)
+}
+
+fn line_range(bytes: &[u8], start_index: usize, end_index: usize, total_lines: usize) -> &[u8] {
+    let start = line_start_byte(bytes, start_index);
+    if end_index <= start_index {
+        return &bytes[start..start];
+    }
+    let end = if end_index >= total_lines {
+        bytes.len()
+    } else {
+        line_start_byte(bytes, end_index).saturating_sub(1)
+    };
+    &bytes[start..end.max(start)]
+}
+
+fn line_start_byte(bytes: &[u8], line_index: usize) -> usize {
+    if line_index == 0 {
+        return 0;
+    }
+    bytes
+        .iter()
+        .enumerate()
+        .filter(|(_, byte)| **byte == b'\n')
+        .nth(line_index.saturating_sub(1))
+        .map_or(bytes.len(), |(index, _)| index.saturating_add(1))
 }
 
 fn offset_past_end(offset: i64, total_lines: u64) -> verlet_tool_core::ToolError {
@@ -249,12 +305,29 @@ mod tests {
     }
 
     #[test]
-    fn a_directory_reaches_the_backend_read_error() {
+    fn a_directory_is_a_structured_tool_error() {
         let root = tempfile::tempdir().unwrap();
 
         let error = crate::run(args(".", None, None), &fs(root.path())).unwrap_err();
 
-        assert!(!error.to_string().contains("is not a file"));
+        assert_eq!(error.to_string(), "Path is a directory: .");
+    }
+
+    #[test]
+    fn an_oversized_file_is_a_structured_tool_error() {
+        let root = tempfile::tempdir().unwrap();
+        let content = vec![b'x'; verlet_tool_core::MAX_FILE_BYTES.saturating_add(1)];
+        std::fs::write(root.path().join("oversized.txt"), content).unwrap();
+
+        let error = crate::run(args("oversized.txt", None, None), &fs(root.path())).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "file exceeds {} byte read limit: oversized.txt",
+                verlet_tool_core::MAX_FILE_BYTES
+            )
+        );
     }
 
     #[test]

--- a/agent-tools/tool-read/src/lib.rs
+++ b/agent-tools/tool-read/src/lib.rs
@@ -13,7 +13,7 @@
 //! - Caller limits and automatic truncation use Pi's exact continuation text.
 //! - Line accounting follows Pi's newline split: an empty file is one empty
 //!   logical line, and a terminal newline creates a final empty line.
-//! - Files over the shared 8 MiB limit return a structured tool error; the
+//! - Files over the shared 16 KiB limit return a structured tool error; the
 //!   4 MiB result cap remains a final structured-result backstop.
 
 #[derive(Clone, Debug, serde::Deserialize)]
@@ -344,19 +344,14 @@ mod tests {
     }
 
     #[test]
-    fn reports_an_oversized_first_line_with_pi_text() {
-        // Pi behavior sheet item 9; source: core/tools/read.ts:297-301.
+    fn the_shared_file_ceiling_precedes_pi_first_line_truncation() {
         let root = tempfile::tempdir().unwrap();
         let content = vec![b'x'; verlet_tool_core::DEFAULT_MAX_BYTES + 1];
         std::fs::write(root.path().join("large.txt"), content).unwrap();
 
-        let output = crate::run(args("large.txt", None, None), &fs(root.path())).unwrap();
+        let error = crate::run(args("large.txt", None, None), &fs(root.path())).unwrap_err();
 
-        assert_eq!(
-            output.text,
-            "[Line 1 is 50.0KB, exceeds 50.0KB limit. Use bash: sed -n '1p' large.txt | head -c 51200]"
-        );
-        assert!(output.truncation.unwrap().first_line_exceeds_limit);
+        assert!(error.to_string().contains("byte read limit: large.txt"));
     }
 
     #[test]
@@ -370,17 +365,14 @@ mod tests {
     }
 
     #[test]
-    fn byte_truncation_uses_complete_lines_and_pi_notice() {
-        // Pi behavior sheet item 9; source: core/tools/read.ts:294-312.
+    fn the_shared_file_ceiling_precedes_pi_byte_truncation() {
         let root = tempfile::tempdir().unwrap();
         let line = format!("{}\n", "x".repeat(1024));
         std::fs::write(root.path().join("large.txt"), line.repeat(60)).unwrap();
 
-        let output = crate::run(args("large.txt", None, None), &fs(root.path())).unwrap();
+        let error = crate::run(args("large.txt", None, None), &fs(root.path())).unwrap_err();
 
-        assert!(output.text.ends_with(
-            "\n\n[Showing lines 1-49 of 61 (50.0KB limit). Use offset=50 to continue.]"
-        ));
+        assert!(error.to_string().contains("byte read limit: large.txt"));
     }
 
     #[test]
@@ -425,17 +417,16 @@ mod tests {
     fn automatically_truncates_at_two_thousand_lines_with_pi_notice() {
         // Pi behavior sheet item 9; source: core/tools/read.ts:294-312.
         let root = tempfile::tempdir().unwrap();
-        let content = (1..=2001)
-            .map(|line| format!("line {line}"))
+        let content = std::iter::repeat_n("x", 2001)
             .collect::<Vec<_>>()
             .join("\n");
         std::fs::write(root.path().join("large.txt"), content).unwrap();
 
         let output = crate::run(args("large.txt", None, None), &fs(root.path())).unwrap();
 
-        assert!(output.text.ends_with(
-            "line 2000\n\n[Showing lines 1-2000 of 2001. Use offset=2001 to continue.]"
-        ));
+        assert!(output
+            .text
+            .ends_with("x\n\n[Showing lines 1-2000 of 2001. Use offset=2001 to continue.]"));
     }
 
     #[test]

--- a/agent-tools/tool-read/src/lib.rs
+++ b/agent-tools/tool-read/src/lib.rs
@@ -80,13 +80,14 @@ pub fn run(
         )));
     }
     if stat.size > u64::try_from(verlet_tool_core::MAX_FILE_BYTES).unwrap_or(u64::MAX) {
-        return Err(verlet_tool_core::ToolFsError::FileTooLarge {
-            path,
-            max_bytes: verlet_tool_core::MAX_FILE_BYTES,
-        }
-        .into());
+        return Err(oversized_file_error(&path));
     }
-    let bytes = fs.read_file_bounded(&path, verlet_tool_core::MAX_FILE_BYTES)?;
+    let bytes = fs
+        .read_file_bounded(&path, verlet_tool_core::MAX_FILE_BYTES)
+        .map_err(|error| match error {
+            verlet_tool_core::ToolFsError::FileTooLarge { path, .. } => oversized_file_error(&path),
+            error => error.into(),
+        })?;
     let total_line_count = file_line_count(&bytes);
     let total_lines = u64::try_from(total_line_count).unwrap_or(u64::MAX);
     let requested_offset = args.offset;
@@ -220,6 +221,14 @@ fn offset_past_end(offset: i64, total_lines: u64) -> verlet_tool_core::ToolError
     ))
 }
 
+fn oversized_file_error(path: &std::path::Path) -> verlet_tool_core::ToolError {
+    verlet_tool_core::ToolError::Failed(format!(
+        "file exceeds {} byte read limit: {}; offset/limit cannot bypass this limit, use bash to inspect a bounded range or split the file",
+        verlet_tool_core::MAX_FILE_BYTES,
+        path.display()
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     fn fs(root: &std::path::Path) -> verlet_tool_core::StdFs {
@@ -314,20 +323,24 @@ mod tests {
     }
 
     #[test]
-    fn an_oversized_file_is_a_structured_tool_error() {
+    fn an_oversized_file_is_an_actionable_structured_error_for_every_window() {
         let root = tempfile::tempdir().unwrap();
         let content = vec![b'x'; verlet_tool_core::MAX_FILE_BYTES.saturating_add(1)];
         std::fs::write(root.path().join("oversized.txt"), content).unwrap();
 
-        let error = crate::run(args("oversized.txt", None, None), &fs(root.path())).unwrap_err();
+        let filesystem = fs(root.path());
+        let error = crate::run(args("oversized.txt", None, None), &filesystem).unwrap_err();
+        let window_error =
+            crate::run(args("oversized.txt", Some(1), Some(1)), &filesystem).unwrap_err();
 
         assert_eq!(
             error.to_string(),
             format!(
-                "file exceeds {} byte read limit: oversized.txt",
+                "file exceeds {} byte read limit: oversized.txt; offset/limit cannot bypass this limit, use bash to inspect a bounded range or split the file",
                 verlet_tool_core::MAX_FILE_BYTES
             )
         );
+        assert_eq!(window_error.to_string(), error.to_string());
     }
 
     #[test]

--- a/agent-tools/wasm/abi-fs/src/lib.rs
+++ b/agent-tools/wasm/abi-fs/src/lib.rs
@@ -17,6 +17,8 @@ pub struct AbiFs {
     root: std::path::PathBuf,
 }
 
+const READ_CHUNK_BYTES: usize = 64 * 1024;
+
 impl AbiFs {
     /// `root` is the VFS directory that relative tool paths resolve
     /// against. The embedder passes it in the operation input; the runtime
@@ -144,7 +146,7 @@ impl verlet_tool_core::ToolFs for AbiFs {
         let handle = verlet_guest_sdk::open_file_read(resolved)
             .map_err(|status| map_status(path, status))?;
         let mut bytes = Vec::new();
-        let mut buffer = [0_u8; 1024];
+        let mut buffer = [0_u8; READ_CHUNK_BYTES];
         loop {
             match verlet_guest_sdk::read_file(handle, &mut buffer) {
                 Ok(0) => break,
@@ -169,7 +171,7 @@ impl verlet_tool_core::ToolFs for AbiFs {
         let handle = verlet_guest_sdk::open_file_read(resolved)
             .map_err(|status| map_status(path, status))?;
         let mut bytes = Vec::with_capacity(max_bytes.min(64 * 1024));
-        let mut buffer = [0_u8; 1024];
+        let mut buffer = [0_u8; READ_CHUNK_BYTES];
         loop {
             match verlet_guest_sdk::read_file(handle, &mut buffer) {
                 Ok(0) => break,

--- a/agent-tools/wasm/abi-fs/src/lib.rs
+++ b/agent-tools/wasm/abi-fs/src/lib.rs
@@ -159,6 +159,40 @@ impl verlet_tool_core::ToolFs for AbiFs {
         Ok(bytes)
     }
 
+    fn read_file_bounded(
+        &self,
+        path: &std::path::Path,
+        max_bytes: usize,
+    ) -> Result<Vec<u8>, verlet_tool_core::ToolFsError> {
+        let resolved = self.resolve(path);
+        let resolved = path_str(path, &resolved)?;
+        let handle = verlet_guest_sdk::open_file_read(resolved)
+            .map_err(|status| map_status(path, status))?;
+        let mut bytes = Vec::with_capacity(max_bytes.min(64 * 1024));
+        let mut buffer = [0_u8; 1024];
+        loop {
+            match verlet_guest_sdk::read_file(handle, &mut buffer) {
+                Ok(0) => break,
+                Ok(read) if read <= max_bytes.saturating_sub(bytes.len()) => {
+                    bytes.extend_from_slice(&buffer[..read]);
+                }
+                Ok(_) => {
+                    let _ = verlet_guest_sdk::close_file(handle);
+                    return Err(verlet_tool_core::ToolFsError::FileTooLarge {
+                        path: path.to_path_buf(),
+                        max_bytes,
+                    });
+                }
+                Err(status) => {
+                    let _ = verlet_guest_sdk::close_file(handle);
+                    return Err(map_status(path, status));
+                }
+            }
+        }
+        verlet_guest_sdk::close_file(handle).map_err(|status| map_status(path, status))?;
+        Ok(bytes)
+    }
+
     /// `open_file_write` + `write_file` + `close_file`; the close is the
     /// commit point (whole-file replace). Parent directories are the tool
     /// core's job (`mkdir` first), matching the ABI contract.

--- a/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
+++ b/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
@@ -1484,7 +1484,7 @@ async fn wasm_vfs_write_guest_requires_declared_capability_before_execution() {
 #[tokio::test]
 async fn wasm_pi_read_matches_native_envelope_and_surfaces_tool_errors() {
     let (vfs, native) = pi_tool_fixture().await;
-    let exact_limit = vec![b'x'; verlet_tool_core::MAX_FILE_BYTES];
+    let exact_limit = b"x\n".repeat(verlet_tool_core::MAX_FILE_BYTES / 2);
     write_pi_tool_fixture_file(&vfs, &native, "project/exact-limit.txt", &exact_limit).await;
     let oversized = b"oversized\n".repeat(
         verlet_tool_core::MAX_FILE_BYTES
@@ -1533,20 +1533,7 @@ async fn wasm_pi_read_matches_native_envelope_and_surfaces_tool_errors() {
         &native_fs,
     )
     .unwrap();
-    // Isolate the ToolFs boundary from the global Wasm fuel policy. Copying
-    // the full accepted 8 MiB through today's sequential ABI exceeds the
-    // default store fuel even though AbiFs returns the correct complete
-    // buffer; changing that runtime policy is an architecture decision.
-    let boundary_factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
-        verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(
-            wasm_read_tool_guest(),
-        ))
-        .with_vfs(vfs)
-        .with_fuel(None)
-        .with_fuel_yield_interval(None),
-    )
-    .unwrap();
-    let exact_limit = boundary_factory
+    let exact_limit = factory
         .invoke_operation_bytes(
             "read",
             pi_tool_input(serde_json::json!({"path": "project/exact-limit.txt"})),

--- a/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
+++ b/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
@@ -1484,6 +1484,8 @@ async fn wasm_vfs_write_guest_requires_declared_capability_before_execution() {
 #[tokio::test]
 async fn wasm_pi_read_matches_native_envelope_and_surfaces_tool_errors() {
     let (vfs, native) = pi_tool_fixture().await;
+    let exact_limit = vec![b'x'; verlet_tool_core::MAX_FILE_BYTES];
+    write_pi_tool_fixture_file(&vfs, &native, "project/exact-limit.txt", &exact_limit).await;
     let oversized = b"oversized\n".repeat(
         verlet_tool_core::MAX_FILE_BYTES
             .saturating_div(b"oversized\n".len())
@@ -1501,7 +1503,7 @@ async fn wasm_pi_read_matches_native_envelope_and_surfaces_tool_errors() {
         verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(
             wasm_read_tool_guest(),
         ))
-        .with_vfs(vfs),
+        .with_vfs(vfs.clone()),
     )
     .unwrap();
     let manifest = factory.validate_operation_artifact().await.unwrap();
@@ -1521,6 +1523,40 @@ async fn wasm_pi_read_matches_native_envelope_and_surfaces_tool_errors() {
 
     assert_eq!(output.output, tool_success_envelope(native_output));
     assert_eq!(output.operation.name, "read");
+
+    let native_exact_limit = verlet_tool_read::run(
+        verlet_tool_read::ReadArgs {
+            path: std::path::PathBuf::from("project/exact-limit.txt"),
+            offset: None,
+            limit: None,
+        },
+        &native_fs,
+    )
+    .unwrap();
+    // Isolate the ToolFs boundary from the global Wasm fuel policy. Copying
+    // the full accepted 8 MiB through today's sequential ABI exceeds the
+    // default store fuel even though AbiFs returns the correct complete
+    // buffer; changing that runtime policy is an architecture decision.
+    let boundary_factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
+        verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(
+            wasm_read_tool_guest(),
+        ))
+        .with_vfs(vfs)
+        .with_fuel(None)
+        .with_fuel_yield_interval(None),
+    )
+    .unwrap();
+    let exact_limit = boundary_factory
+        .invoke_operation_bytes(
+            "read",
+            pi_tool_input(serde_json::json!({"path": "project/exact-limit.txt"})),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        exact_limit.output,
+        tool_success_envelope(native_exact_limit)
+    );
 
     let native_error = verlet_tool_read::run(
         verlet_tool_read::ReadArgs {
@@ -1573,6 +1609,11 @@ async fn wasm_pi_read_matches_native_envelope_and_surfaces_tool_errors() {
         &native_fs,
     )
     .unwrap_err();
+    let expected_oversized_error = format!(
+        "file exceeds {} byte read limit: project/oversized.txt; offset/limit cannot bypass this limit, use bash to inspect a bounded range or split the file",
+        verlet_tool_core::MAX_FILE_BYTES
+    );
+    assert_eq!(native_oversized_error.to_string(), expected_oversized_error);
     let oversized = factory
         .invoke_operation_bytes(
             "read",
@@ -1582,14 +1623,78 @@ async fn wasm_pi_read_matches_native_envelope_and_surfaces_tool_errors() {
         .unwrap();
     assert_eq!(
         oversized.output,
-        tool_error_envelope(native_oversized_error.to_string())
+        tool_error_envelope(expected_oversized_error.clone())
+    );
+    let oversized_window = factory
+        .invoke_operation_bytes(
+            "read",
+            pi_tool_input(serde_json::json!({
+                "path": "project/oversized.txt",
+                "offset": 1,
+                "limit": 1,
+            })),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        oversized_window.output,
+        tool_error_envelope(expected_oversized_error)
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn wasm_pi_read_rejects_an_in_scope_symlink_that_native_read_follows() {
+    let (vfs, native) = pi_tool_fixture().await;
+    vfs.symlink(
+        std::path::Path::new("input.txt"),
+        std::path::Path::new("/workspace/project/input-link.txt"),
+    )
+    .await
+    .unwrap();
+    std::os::unix::fs::symlink("input.txt", native.path().join("project/input-link.txt")).unwrap();
+    let native_fs = verlet_tool_core::StdFs::new(native.path()).unwrap();
+    let native_output = verlet_tool_read::run(
+        verlet_tool_read::ReadArgs {
+            path: std::path::PathBuf::from("project/input-link.txt"),
+            offset: None,
+            limit: None,
+        },
+        &native_fs,
+    )
+    .unwrap();
+    let factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
+        verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(
+            wasm_read_tool_guest(),
+        ))
+        .with_vfs(vfs),
+    )
+    .unwrap();
+
+    let wasm_output = factory
+        .invoke_operation_bytes(
+            "read",
+            pi_tool_input(serde_json::json!({"path": "project/input-link.txt"})),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(native_output.text, "alpha\nneedle beta\ngamma\n");
+    assert_eq!(
+        wasm_output.output,
+        tool_error_envelope("Path is not a file: project/input-link.txt")
     );
 }
 
 #[tokio::test]
 async fn wasm_pi_find_and_grep_match_native_envelopes_and_tool_errors() {
     let (vfs, native) = pi_tool_fixture().await;
-    write_pi_tool_fixture_file(&vfs, &native, "project/non-utf8.bin", b"\xffneedle\n").await;
+    let mut invalid_utf8 = vec![b'x'; 4 * 1024];
+    invalid_utf8.extend_from_slice(b"\xffneedle\n");
+    write_pi_tool_fixture_file(&vfs, &native, "project/mid-invalid-utf8.bin", &invalid_utf8).await;
+    let mut late_nul = vec![b'x'; 8 * 1024];
+    late_nul.extend_from_slice(b"\0needle\n");
+    write_pi_tool_fixture_file(&vfs, &native, "project/late-nul.bin", &late_nul).await;
     let oversized = b"needle\n".repeat(
         verlet_tool_core::MAX_FILE_BYTES
             .saturating_div(b"needle\n".len())
@@ -1804,6 +1909,21 @@ async fn wasm_pi_write_matches_native_mutation_and_maps_io_into_envelope() {
 #[tokio::test]
 async fn wasm_pi_edit_matches_native_mutation_and_validation_envelope() {
     let (vfs, native) = pi_tool_fixture().await;
+    let padding_line = format!("{}\n", "x".repeat(1024));
+    let padding = padding_line.repeat(
+        verlet_tool_core::MAX_FILE_BYTES
+            .saturating_div(padding_line.len())
+            .saturating_add(1),
+    );
+    let oversized_content = format!("target\n{padding}");
+    assert!(oversized_content.len() > verlet_tool_core::MAX_FILE_BYTES);
+    write_pi_tool_fixture_file(
+        &vfs,
+        &native,
+        "project/oversized-edit.txt",
+        oversized_content.as_bytes(),
+    )
+    .await;
     let native_fs = verlet_tool_core::StdFs::new(native.path()).unwrap();
     let raw_args = serde_json::json!({
         "path": "project/input.txt",
@@ -1811,6 +1931,15 @@ async fn wasm_pi_edit_matches_native_mutation_and_validation_envelope() {
     });
     let native_args = verlet_tool_edit::parse_cli_args(raw_args.clone()).unwrap();
     let native_output = verlet_tool_edit::run(native_args, &native_fs).unwrap();
+    let oversized_args = serde_json::json!({
+        "path": "project/oversized-edit.txt",
+        "edits": [{"oldText": "target", "newText": "edited"}],
+    });
+    let native_oversized_error = verlet_tool_edit::run(
+        verlet_tool_edit::parse_cli_args(oversized_args.clone()).unwrap(),
+        &native_fs,
+    )
+    .unwrap_err();
     let factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
         verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(
             wasm_edit_tool_guest(),
@@ -1833,6 +1962,23 @@ async fn wasm_pi_edit_matches_native_mutation_and_validation_envelope() {
             .await
             .unwrap(),
         b"alpha\nneedle delta\ngamma\n"
+    );
+
+    let oversized_output = factory
+        .invoke_operation_bytes("edit", pi_tool_input(oversized_args))
+        .await
+        .unwrap();
+    assert_eq!(
+        oversized_output.output,
+        tool_error_envelope(native_oversized_error.to_string())
+    );
+    assert!(
+        vfs.read_file(std::path::Path::new(
+            "/workspace/project/oversized-edit.txt"
+        ))
+        .await
+        .unwrap()
+        .starts_with(b"target\n")
     );
 
     let invalid_args = serde_json::json!({"path": "project/input.txt"});

--- a/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
+++ b/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
@@ -655,6 +655,25 @@ async fn pi_tool_fixture() -> (std::sync::Arc<verlet_vfs::VerletVfs>, tempfile::
     (vfs, native)
 }
 
+async fn write_pi_tool_fixture_file(
+    vfs: &std::sync::Arc<verlet_vfs::VerletVfs>,
+    native: &tempfile::TempDir,
+    relative: &str,
+    content: &[u8],
+) {
+    let vfs_path = std::path::Path::new("/workspace").join(relative);
+    if let Some(parent) = vfs_path.parent() {
+        vfs.mkdir(parent, true).await.unwrap();
+    }
+    vfs.write_file(&vfs_path, content).await.unwrap();
+
+    let native_path = native.path().join(relative);
+    if let Some(parent) = native_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(native_path, content).unwrap();
+}
+
 fn pi_tool_input(args: serde_json::Value) -> Vec<u8> {
     serde_json::to_vec(&serde_json::json!({
         "root": "/workspace",
@@ -1463,8 +1482,14 @@ async fn wasm_vfs_write_guest_requires_declared_capability_before_execution() {
 }
 
 #[tokio::test]
-async fn wasm_pi_read_matches_native_envelope_and_surfaces_missing_file() {
+async fn wasm_pi_read_matches_native_envelope_and_surfaces_tool_errors() {
     let (vfs, native) = pi_tool_fixture().await;
+    let oversized = b"oversized\n".repeat(
+        verlet_tool_core::MAX_FILE_BYTES
+            .saturating_div(b"oversized\n".len())
+            .saturating_add(1),
+    );
+    write_pi_tool_fixture_file(&vfs, &native, "project/oversized.txt", &oversized).await;
     let native_fs = verlet_tool_core::StdFs::new(native.path()).unwrap();
     let args = verlet_tool_read::ReadArgs {
         path: std::path::PathBuf::from("project/input.txt"),
@@ -1517,11 +1542,66 @@ async fn wasm_pi_read_matches_native_envelope_and_surfaces_missing_file() {
         missing.output,
         tool_error_envelope(native_error.to_string())
     );
+
+    let native_directory_error = verlet_tool_read::run(
+        verlet_tool_read::ReadArgs {
+            path: std::path::PathBuf::from("project"),
+            offset: None,
+            limit: None,
+        },
+        &native_fs,
+    )
+    .unwrap_err();
+    let directory = factory
+        .invoke_operation_bytes(
+            "read",
+            pi_tool_input(serde_json::json!({"path": "project"})),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        directory.output,
+        tool_error_envelope(native_directory_error.to_string())
+    );
+
+    let native_oversized_error = verlet_tool_read::run(
+        verlet_tool_read::ReadArgs {
+            path: std::path::PathBuf::from("project/oversized.txt"),
+            offset: None,
+            limit: None,
+        },
+        &native_fs,
+    )
+    .unwrap_err();
+    let oversized = factory
+        .invoke_operation_bytes(
+            "read",
+            pi_tool_input(serde_json::json!({"path": "project/oversized.txt"})),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        oversized.output,
+        tool_error_envelope(native_oversized_error.to_string())
+    );
 }
 
 #[tokio::test]
 async fn wasm_pi_find_and_grep_match_native_envelopes_and_tool_errors() {
     let (vfs, native) = pi_tool_fixture().await;
+    write_pi_tool_fixture_file(&vfs, &native, "project/non-utf8.bin", b"\xffneedle\n").await;
+    let oversized = b"needle\n".repeat(
+        verlet_tool_core::MAX_FILE_BYTES
+            .saturating_div(b"needle\n".len())
+            .saturating_add(1),
+    );
+    write_pi_tool_fixture_file(
+        &vfs,
+        &native,
+        "project/build/oversized.artifact",
+        &oversized,
+    )
+    .await;
     let native_fs = verlet_tool_core::StdFs::new(native.path()).unwrap();
     let factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
         verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(
@@ -1570,6 +1650,30 @@ async fn wasm_pi_find_and_grep_match_native_envelopes_and_tool_errors() {
     assert_eq!(
         find_error.output,
         tool_error_envelope(native_find_error.to_string())
+    );
+
+    let native_find_kind_error = verlet_tool_glob::run(
+        verlet_tool_glob::GlobArgs {
+            pattern: "**".to_owned(),
+            path: Some(std::path::PathBuf::from("project/input.txt")),
+            limit: None,
+        },
+        &native_fs,
+    )
+    .unwrap_err();
+    let find_kind_error = factory
+        .invoke_operation_bytes(
+            "find",
+            pi_tool_input(serde_json::json!({
+                "pattern": "**",
+                "path": "project/input.txt",
+            })),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        find_kind_error.output,
+        tool_error_envelope(native_find_kind_error.to_string())
     );
 
     let native_grep = verlet_tool_grep::run(

--- a/crates/verlet-wasm/src/lib.rs
+++ b/crates/verlet-wasm/src/lib.rs
@@ -5,7 +5,7 @@ pub const DEFAULT_OPERATION_NAME: &str = "handle_turn";
 pub const DEFAULT_MAX_INPUT_BYTES: usize = 1_048_576;
 pub const DEFAULT_MAX_OUTPUT_BYTES: usize = 1_048_576;
 pub const DEFAULT_MEMORY_LIMIT_BYTES: usize = 64 * 1_048_576;
-pub const DEFAULT_FUEL: u64 = 10_000_000;
+pub const DEFAULT_FUEL: u64 = 10_000_000_000;
 pub const DEFAULT_FUEL_YIELD_INTERVAL: u64 = 10_000;
 
 pub type VerletWasmResult<T> = Result<T, VerletWasmError>;


### PR DESCRIPTION
Hardens the Pi file tools against files that previously crashed the wasm search guest (EMO-620, found in live end-to-end testing when grep over a directory hit multi-MB binaries).

What changed:

- Grep skips files that are not valid UTF-8 text, contain NUL bytes, or exceed a shared 8 MiB per-file read ceiling. Read and edit return structured, actionable errors for oversized files; edit stays whole-file atomic and never partially changes an oversized target. Find bounds ignore-file reads the same way.
- Mismatched file and directory path kinds return structured tool errors instead of trapping the guest. The wasm read path rejects symlinks (the guest ABI reports them as kind Other); the native and wasm divergence is documented and pinned by tests.
- Native and wasm output envelopes stay byte-identical for all of these cases, asserted by differential tests, including an exact-8 MiB boundary case, torn-buffer and stat/read race coverage, and mid-file invalid UTF-8 and late-NUL fixtures.
- The default wasm fuel budget rises from 10M to 10B. Measurement showed guest file processing costs about 154 fuel per byte, so the old budget only afforded about 65 KiB of legitimate work per invocation and a file near the 8 MiB ceiling would exhaust fuel after passing the size check. The budget is a runaway guard, not a throughput constraint; 10B fits a maximal single-file read several times over and still bounds a runaway guest to seconds of CPU. The fuel yield cadence is unchanged. The exact-boundary differential test runs under the standard default configuration to pin ceiling and budget together.
- README documents the bounded-scanning divergence from Pi (Pi delegates grep to rg with no size ceiling).

Review pass (thread on the Linear issue) found and fixed one High (edit could still trap the guest on oversized targets) plus error-message and coverage gaps; the intermediate 16 KiB ceiling commit from the measurement step is superseded in this branch by the fuel revision and disappears in the squash.

Verification: full workspace suite green on macOS and Linux lanes (2603 tests), dist rebuilt.

Linear: EMO-620
