### PR TITLE
Skip special files during Pi search walks (EMO-622)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,15 @@
   replayed, and surface operations are not also exposed through raw
   virtual-bash operation commands.
 - Pi-kit file search now skips non-UTF-8, NUL-containing, and oversized files
-  during grep walks, bounds grep, read, edit, and find ignore-file reads to 8 MiB,
+  during grep walks, skips Unix special files and per-file read failures during
+  directory walks, bounds grep, read, edit, and find ignore-file reads to 8 MiB,
   rejects mismatched file and directory path kinds through structured tool
   errors, and keeps native and wasm output envelopes identical for those cases.
-  The default Wasm fuel budget is now 10 billion: measured file processing costs
-  about 154 fuel per byte, so a maximal read fits several times over and
-  multi-file grep walks across tens of MiB complete while runaway guests remain
-  bounded to seconds of CPU.
+  Directly named grep files still surface read errors. The default Wasm fuel
+  budget is now 10 billion: measured file processing costs about 154 fuel per
+  byte, so a maximal read fits several times over and multi-file grep walks
+  across tens of MiB complete while runaway guests remain bounded to seconds of
+  CPU.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,12 @@
   directory walks, bounds grep, read, edit, and find ignore-file reads to 8 MiB,
   rejects mismatched file and directory path kinds through structured tool
   errors, and keeps native and wasm output envelopes identical for those cases.
-  Directly named grep files still surface read errors. The default Wasm fuel
-  budget is now 10 billion: measured file processing costs about 154 fuel per
-  byte, so a maximal read fits several times over and multi-file grep walks
-  across tens of MiB complete while runaway guests remain bounded to seconds of
-  CPU.
+  Directly named grep files still surface read errors, and directly named
+  special files are rejected before opening so FIFOs never wait for a peer.
+  The default Wasm fuel budget is now 10 billion: measured file processing
+  costs about 154 fuel per byte, so a maximal read fits several times over and
+  multi-file grep walks across tens of MiB complete while runaway guests remain
+  bounded to seconds of CPU.
 
 ### Fixes
 

--- a/agent-tools/README.md
+++ b/agent-tools/README.md
@@ -64,9 +64,11 @@ attached VFS. Write and edit also declare and require the `fs.write` grant.
 Known wasm-lane divergence: the guest ABI reports symlinks as kind `Other`
 (neither file nor directory), so the walker skips symlinked file entries that
 the native `StdFs` lane includes. Both walkers skip symlinked directories.
-Direct read rejects symlink paths that the native lane follows when the target
-remains inside its root. The ABI exposes no follow-symlink distinction;
-resolving this needs a host-side change, tracked separately.
+Unix sockets, FIFOs, block devices, and character devices are also reported as
+`Other` by host-backed VFS mounts and skipped by both walkers. Direct read
+rejects symlink paths that the native lane follows when the target remains
+inside its root. The ABI exposes no follow-symlink distinction; resolving this
+needs a host-side change, tracked separately.
 
 Each module directory is a standalone Cargo workspace with its own lockfile,
 a `cdylib` library target, and `panic = "abort"` in the release profile. This
@@ -100,14 +102,17 @@ cargo build --manifest-path agent-tools/wasm/read/Cargo.toml \
   the kernel invocation layer and is deferred until the wasm integration
   stage.
 - **Bounded text scanning.** Grep skips files that are not valid UTF-8 text,
-  contain NUL, or exceed the shared 8 MiB per-file read limit. Read returns a
-  structured error for files over that limit; offset/limit cannot bypass the
+  contain NUL, exceed the shared 8 MiB per-file read limit, have a non-regular
+  stat kind, or fail when read after a directory walk selected them. The last
+  case covers races and backend kinds that cannot be classified before open.
+  A directly named single-file grep still returns its read error. Read returns
+  a structured error for files over the limit; offset/limit cannot bypass the
   ceiling because the current ABI has no seek or ranged-read operation. Find
-  skips ignore-rule files over the ceiling. Edit preserves whole-file atomicity
-  under the same ceiling and returns a structured error without changing or
-  silently skipping an oversized target. Pi delegates grep to `rg` without this
-  size ceiling and its read and grep context paths can load whole files. The
-  Wasm fuel budget is a runaway guard, sized from the measured guest cost of
-  about 154 fuel per file byte so an 8 MiB read fits several times over and
-  multi-file grep walks across tens of MiB complete while runaway guests remain
-  bounded to seconds of CPU.
+  skips special entries and ignore-rule files that are oversized or fail while
+  being read. Edit preserves whole-file atomicity under the same ceiling and
+  returns a structured error without changing or silently skipping an
+  oversized target. Pi delegates grep to `rg` without this size ceiling and its
+  read and grep context paths can load whole files. The Wasm fuel budget is a
+  runaway guard, sized from the measured guest cost of about 154 fuel per file
+  byte so an 8 MiB read fits several times over and multi-file grep walks across
+  tens of MiB complete while runaway guests remain bounded to seconds of CPU.

--- a/agent-tools/README.md
+++ b/agent-tools/README.md
@@ -109,10 +109,12 @@ cargo build --manifest-path agent-tools/wasm/read/Cargo.toml \
   a structured error for files over the limit; offset/limit cannot bypass the
   ceiling because the current ABI has no seek or ranged-read operation. Find
   skips special entries and ignore-rule files that are oversized or fail while
-  being read. Edit preserves whole-file atomicity under the same ceiling and
-  returns a structured error without changing or silently skipping an
-  oversized target. Pi delegates grep to `rg` without this size ceiling and its
-  read and grep context paths can load whole files. The Wasm fuel budget is a
-  runaway guard, sized from the measured guest cost of about 154 fuel per file
-  byte so an 8 MiB read fits several times over and multi-file grep walks across
-  tens of MiB complete while runaway guests remain bounded to seconds of CPU.
+  being read. Direct file operations reject special entries before opening
+  them, so a FIFO cannot wait indefinitely for a peer. Edit preserves
+  whole-file atomicity under the same ceiling and returns a structured error
+  without changing or silently skipping an oversized target. Pi delegates grep
+  to `rg` without this size ceiling and its read and grep context paths can load
+  whole files. The Wasm fuel budget is a runaway guard, sized from the measured
+  guest cost of about 154 fuel per file byte so an 8 MiB read fits several times
+  over and multi-file grep walks across tens of MiB complete while runaway
+  guests remain bounded to seconds of CPU.

--- a/agent-tools/tool-core/src/lib.rs
+++ b/agent-tools/tool-core/src/lib.rs
@@ -567,6 +567,7 @@ impl StdFs {
 impl ToolFs for StdFs {
     fn read_file(&self, path: &std::path::Path) -> Result<Vec<u8>, ToolFsError> {
         let resolved = self.resolve(path)?;
+        reject_special_file_open(path, &resolved, false)?;
         std::fs::read(resolved).map_err(|error| map_io_error(path, error))
     }
 
@@ -576,6 +577,7 @@ impl ToolFs for StdFs {
         max_bytes: usize,
     ) -> Result<Vec<u8>, ToolFsError> {
         let resolved = self.resolve(path)?;
+        reject_special_file_open(path, &resolved, false)?;
         let file = std::fs::File::open(resolved).map_err(|error| map_io_error(path, error))?;
         let read_limit = u64::try_from(max_bytes.saturating_add(1)).unwrap_or(u64::MAX);
         let mut reader = std::io::Read::take(file, read_limit);
@@ -593,6 +595,7 @@ impl ToolFs for StdFs {
 
     fn write_file(&self, path: &std::path::Path, content: &[u8]) -> Result<(), ToolFsError> {
         let resolved = self.resolve(path)?;
+        reject_special_file_open(path, &resolved, true)?;
         std::fs::write(resolved, content).map_err(|error| map_io_error(path, error))
     }
 
@@ -648,6 +651,23 @@ impl ToolFs for StdFs {
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
             Err(error) => Err(map_io_error(path, error)),
         }
+    }
+}
+
+#[cfg(feature = "std-fs")]
+fn reject_special_file_open(
+    path: &std::path::Path,
+    resolved: &std::path::Path,
+    allow_missing: bool,
+) -> Result<(), ToolFsError> {
+    match std::fs::metadata(resolved) {
+        Ok(metadata) if !metadata.is_file() && !metadata.is_dir() => Err(ToolFsError::Io(format!(
+            "path is not a regular file: {}",
+            path.display()
+        ))),
+        Ok(_) => Ok(()),
+        Err(error) if allow_missing && error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(map_io_error(path, error)),
     }
 }
 
@@ -910,6 +930,42 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_reads_reject_a_fifo_before_waiting_for_a_writer() {
+        let root = tempfile::tempdir().unwrap();
+        let fifo = root.path().join("named.pipe");
+        assert!(std::process::Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .unwrap()
+            .success());
+        let writer_path = fifo.clone();
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(500));
+            std::fs::write(writer_path, b"late writer").unwrap();
+        });
+        let fs = crate::StdFs::new(root.path()).unwrap();
+
+        let started = std::time::Instant::now();
+        let result = crate::ToolFs::read_file_bounded(
+            &fs,
+            std::path::Path::new("named.pipe"),
+            crate::MAX_FILE_BYTES,
+        );
+        let elapsed = started.elapsed();
+
+        let mut cleanup_reader = std::fs::File::open(&fifo).unwrap();
+        let mut cleanup_bytes = Vec::new();
+        std::io::Read::read_to_end(&mut cleanup_reader, &mut cleanup_bytes).unwrap();
+        writer.join().unwrap();
+        assert!(result.is_err());
+        assert!(
+            elapsed < std::time::Duration::from_millis(250),
+            "{elapsed:?}"
+        );
     }
 
     #[test]

--- a/agent-tools/tool-core/src/lib.rs
+++ b/agent-tools/tool-core/src/lib.rs
@@ -255,6 +255,7 @@ pub struct WalkFile {
     pub relative_path: String,
     pub is_dir: bool,
     pub size: u64,
+    skip_read_errors: bool,
 }
 
 /// Walk a file or directory using only [`ToolFs`].
@@ -278,6 +279,7 @@ pub fn walk_files(root: &std::path::Path, fs: &dyn ToolFs) -> Result<Vec<WalkFil
             relative_path,
             is_dir: false,
             size: stat.size,
+            skip_read_errors: false,
         }]);
     }
     if !stat.is_dir {
@@ -331,6 +333,7 @@ fn walk_directory(
                 relative_path: format!("{}/", relative_path_string(&relative)),
                 is_dir: true,
                 size: 0,
+                skip_read_errors: true,
             });
             let matcher_count = ignore_matchers.len();
             add_ignore_file(fs, &path, &path.join(".gitignore"), ignore_matchers)?;
@@ -348,11 +351,43 @@ fn walk_directory(
                     relative_path: relative_path_string(&relative),
                     is_dir: false,
                     size: stat.size,
+                    skip_read_errors: true,
                 });
             }
         }
     }
     Ok(())
+}
+
+/// Read a file selected by [`walk_files`] without letting one stale or
+/// unreadable directory entry abort the rest of a walk.
+///
+/// Files named directly as the walk root still surface read errors. Directory
+/// entries that fail after a successful stat are skipped, as are entries that
+/// exceed `max_bytes` either at stat time or while being read.
+pub fn read_walk_file_bounded(
+    file: &WalkFile,
+    fs: &dyn ToolFs,
+    max_bytes: usize,
+) -> Result<Option<Vec<u8>>, ToolError> {
+    if file.is_dir || file.size > u64::try_from(max_bytes).unwrap_or(u64::MAX) {
+        return Ok(None);
+    }
+    read_walk_entry_bounded(fs, &file.path, max_bytes, file.skip_read_errors)
+}
+
+fn read_walk_entry_bounded(
+    fs: &dyn ToolFs,
+    path: &std::path::Path,
+    max_bytes: usize,
+    skip_read_errors: bool,
+) -> Result<Option<Vec<u8>>, ToolError> {
+    match fs.read_file_bounded(path, max_bytes) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(ToolFsError::FileTooLarge { .. }) => Ok(None),
+        Err(_) if skip_read_errors => Ok(None),
+        Err(error) => Err(error.into()),
+    }
 }
 
 fn add_ignore_file(
@@ -370,10 +405,9 @@ fn add_ignore_file(
         return Ok(());
     }
 
-    let bytes = match fs.read_file_bounded(ignore_path, MAX_FILE_BYTES) {
-        Ok(bytes) => bytes,
-        Err(ToolFsError::FileTooLarge { .. }) => return Ok(()),
-        Err(error) => return Err(error.into()),
+    let bytes = match read_walk_entry_bounded(fs, ignore_path, MAX_FILE_BYTES, true)? {
+        Some(bytes) => bytes,
+        None => return Ok(()),
     };
     let content = String::from_utf8_lossy(&bytes);
     let mut builder = ignore::gitignore::GitignoreBuilder::new(match_root);
@@ -947,6 +981,26 @@ mod tests {
             root.path().join("broken-link"),
         )
         .unwrap();
+        let fs = crate::StdFs::new(root.path()).unwrap();
+
+        let files = crate::walk_files(std::path::Path::new("."), &fs).unwrap();
+
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| file.relative_path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["real.txt"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walk_skips_a_unix_socket_and_returns_regular_files() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("real.txt"), "real").unwrap();
+        let _listener =
+            std::os::unix::net::UnixListener::bind(root.path().join("live.sock")).unwrap();
         let fs = crate::StdFs::new(root.path()).unwrap();
 
         let files = crate::walk_files(std::path::Path::new("."), &fs).unwrap();

--- a/agent-tools/tool-edit/src/lib.rs
+++ b/agent-tools/tool-edit/src/lib.rs
@@ -336,6 +336,12 @@ pub fn run(
     let stat = fs
         .stat(&path)
         .map_err(|error| edit_access_error(&path_display, error))?;
+    if !stat.is_file && !stat.is_dir {
+        return Err(edit_access_error(
+            &path_display,
+            verlet_tool_core::ToolFsError::Io("path is not a regular file".to_owned()),
+        ));
+    }
     if stat.size > u64::try_from(verlet_tool_core::MAX_FILE_BYTES).unwrap_or(u64::MAX) {
         return Err(edit_access_error(
             &path_display,
@@ -1159,6 +1165,28 @@ mod tests {
             "Could not edit file: missing.txt. Error code: ENOENT."
         );
         assert!(!directory.to_string().contains("is not a file"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_fifo_is_rejected_before_edit_opens_it() {
+        let root = tempfile::tempdir().unwrap();
+        assert!(std::process::Command::new("mkfifo")
+            .arg(root.path().join("named.pipe"))
+            .status()
+            .unwrap()
+            .success());
+
+        let error = crate::run(
+            args("named.pipe", &[("hello", "goodbye")]),
+            &fs(root.path()),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Could not edit file: named.pipe. path is not a regular file."
+        );
     }
 
     #[test]

--- a/agent-tools/tool-grep/src/lib.rs
+++ b/agent-tools/tool-grep/src/lib.rs
@@ -131,13 +131,13 @@ pub fn run(
             continue;
         }
 
-        if file.size > u64::try_from(verlet_tool_core::MAX_FILE_BYTES).unwrap_or(u64::MAX) {
-            continue;
-        }
-        let bytes = match fs.read_file_bounded(&file.path, verlet_tool_core::MAX_FILE_BYTES) {
-            Ok(bytes) => bytes,
-            Err(verlet_tool_core::ToolFsError::FileTooLarge { .. }) => continue,
-            Err(error) => return Err(error.into()),
+        let bytes = match verlet_tool_core::read_walk_file_bounded(
+            &file,
+            fs,
+            verlet_tool_core::MAX_FILE_BYTES,
+        )? {
+            Some(bytes) => bytes,
+            None => continue,
         };
         if std::str::from_utf8(&bytes).is_err() || bytes.contains(&0) {
             continue;
@@ -498,6 +498,7 @@ mod tests {
             inner: fs(root.path()),
             reads: std::cell::RefCell::new(Vec::new()),
             replacement_on_bounded_read: std::cell::RefCell::new(None),
+            failing_bounded_read: None,
         };
         let mut search = args("hit");
         search.limit = Some(1);
@@ -567,6 +568,7 @@ mod tests {
             inner: fs(root.path()),
             reads: std::cell::RefCell::new(Vec::new()),
             replacement_on_bounded_read: std::cell::RefCell::new(None),
+            failing_bounded_read: None,
         };
 
         let output = crate::run(args("hit"), &recording).unwrap();
@@ -591,6 +593,7 @@ mod tests {
                 verlet_tool_core::MAX_FILE_BYTES
                     .saturating_add(1)
             ])),
+            failing_bounded_read: None,
         };
 
         let output = crate::run(args("hit"), &recording).unwrap();
@@ -627,6 +630,42 @@ mod tests {
         let output = crate::run(search, &fs(root.path())).unwrap();
 
         assert_eq!(output.text, "one.txt:1: hit");
+    }
+
+    #[test]
+    fn a_directory_search_skips_a_file_that_fails_during_read() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("a-unreadable.txt"), "hit\n").unwrap();
+        std::fs::write(root.path().join("visible.txt"), "hit\n").unwrap();
+        let recording = RecordingFs {
+            inner: fs(root.path()),
+            reads: std::cell::RefCell::new(Vec::new()),
+            replacement_on_bounded_read: std::cell::RefCell::new(None),
+            failing_bounded_read: Some(std::path::PathBuf::from("./a-unreadable.txt")),
+        };
+
+        let output = crate::run(args("hit"), &recording).unwrap();
+
+        assert_eq!(output.text, "visible.txt:1: hit");
+        assert_eq!(output.match_count, 1);
+    }
+
+    #[test]
+    fn a_direct_file_search_surfaces_a_read_failure() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("unreadable.txt"), "hit\n").unwrap();
+        let recording = RecordingFs {
+            inner: fs(root.path()),
+            reads: std::cell::RefCell::new(Vec::new()),
+            replacement_on_bounded_read: std::cell::RefCell::new(None),
+            failing_bounded_read: Some(std::path::PathBuf::from("unreadable.txt")),
+        };
+        let mut search = args("hit");
+        search.path = Some(std::path::PathBuf::from("unreadable.txt"));
+
+        let error = crate::run(search, &recording).unwrap_err();
+
+        assert_eq!(error.to_string(), "fixture read failure: unreadable.txt");
     }
 
     #[test]
@@ -771,6 +810,7 @@ mod tests {
         inner: verlet_tool_core::StdFs,
         reads: std::cell::RefCell<Vec<std::path::PathBuf>>,
         replacement_on_bounded_read: std::cell::RefCell<Option<Vec<u8>>>,
+        failing_bounded_read: Option<std::path::PathBuf>,
     }
 
     impl verlet_tool_core::ToolFs for RecordingFs {
@@ -788,6 +828,12 @@ mod tests {
             max_bytes: usize,
         ) -> Result<Vec<u8>, verlet_tool_core::ToolFsError> {
             self.reads.borrow_mut().push(path.to_path_buf());
+            if self.failing_bounded_read.as_deref() == Some(path) {
+                return Err(verlet_tool_core::ToolFsError::Io(format!(
+                    "fixture read failure: {}",
+                    path.display()
+                )));
+            }
             if let Some(replacement) = self.replacement_on_bounded_read.borrow_mut().take() {
                 std::fs::write(self.inner.root.join(path), replacement).unwrap();
             }

--- a/agent-tools/tool-write/src/lib.rs
+++ b/agent-tools/tool-write/src/lib.rs
@@ -50,6 +50,15 @@ pub fn run(
     let input_path = args.path;
     let path = verlet_tool_core::normalize_tool_path(&input_path);
     let replaced = fs.exists(&path).unwrap_or(false);
+    if fs
+        .stat(&path)
+        .is_ok_and(|stat| !stat.is_file && !stat.is_dir)
+    {
+        return Err(verlet_tool_core::ToolError::Failed(format!(
+            "Path is not a file: {}",
+            path.display()
+        )));
+    }
 
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
@@ -144,6 +153,21 @@ mod tests {
         let error = crate::run(args("", "content"), &fs(root.path())).unwrap_err();
 
         assert!(!error.to_string().contains("is not a file"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_a_fifo_before_opening_it() {
+        let root = tempfile::tempdir().unwrap();
+        assert!(std::process::Command::new("mkfifo")
+            .arg(root.path().join("named.pipe"))
+            .status()
+            .unwrap()
+            .success());
+
+        let error = crate::run(args("named.pipe", "blocked"), &fs(root.path())).unwrap_err();
+
+        assert_eq!(error.to_string(), "Path is not a file: named.pipe");
     }
 
     #[test]

--- a/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
+++ b/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
@@ -1819,12 +1819,19 @@ async fn wasm_pi_find_and_grep_match_native_envelopes_and_tool_errors() {
 
 #[cfg(unix)]
 #[tokio::test]
-async fn wasm_pi_grep_walk_skips_a_unix_socket_and_matches_native_envelope() {
+async fn wasm_pi_special_files_match_native_skip_and_error_envelopes() {
     let native = tempfile::tempdir().unwrap();
     let project = native.path().join("project");
     std::fs::create_dir(&project).unwrap();
     std::fs::write(project.join("input.txt"), "hello from text\n").unwrap();
     let _listener = std::os::unix::net::UnixListener::bind(project.join("verlet.sock")).unwrap();
+    assert!(
+        std::process::Command::new("mkfifo")
+            .arg(project.join("named.pipe"))
+            .status()
+            .unwrap()
+            .success()
+    );
     let native_fs = verlet_tool_core::StdFs::new(native.path()).unwrap();
     let native_output = verlet_tool_grep::run(
         verlet_tool_grep::GrepArgs {
@@ -1843,12 +1850,32 @@ async fn wasm_pi_grep_walk_skips_a_unix_socket_and_matches_native_envelope() {
     let native_direct_error = verlet_tool_grep::run(
         verlet_tool_grep::GrepArgs {
             pattern: "hello".to_owned(),
-            path: Some(std::path::PathBuf::from("project/verlet.sock")),
+            path: Some(std::path::PathBuf::from("project/named.pipe")),
             glob: None,
             ignore_case: false,
             literal: false,
             context: None,
             limit: None,
+        },
+        &native_fs,
+    )
+    .unwrap_err();
+    let native_read_error = verlet_tool_read::run(
+        verlet_tool_read::ReadArgs {
+            path: std::path::PathBuf::from("project/named.pipe"),
+            offset: None,
+            limit: None,
+        },
+        &native_fs,
+    )
+    .unwrap_err();
+    let native_edit_error = verlet_tool_edit::run(
+        verlet_tool_edit::EditArgs {
+            path: std::path::PathBuf::from("project/named.pipe"),
+            edits: vec![verlet_tool_edit::Edit {
+                old_text: "hello".to_owned(),
+                new_text: "goodbye".to_owned(),
+            }],
         },
         &native_fs,
     )
@@ -1867,17 +1894,67 @@ async fn wasm_pi_grep_walk_skips_a_unix_socket_and_matches_native_envelope() {
     let vfs = std::sync::Arc::new(verlet_vfs::VerletVfs::new(std::sync::Arc::new(
         bashkit::InMemoryFs::new(),
     )));
-    let host = verlet_vfs::HostFileSystem::read_only(native.path()).unwrap();
+    let host = verlet_vfs::HostFileSystem::read_write(native.path()).unwrap();
     vfs.mount("/workspace", std::sync::Arc::new(host)).unwrap();
-    let factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
+    assert_eq!(
+        vfs.stat(std::path::Path::new("/workspace/project/named.pipe"))
+            .await
+            .unwrap()
+            .file_type,
+        bashkit::FileType::Fifo
+    );
+    // tight-timeout: mounted special-file precheck must complete without a peer
+    let mounted_read = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        vfs.read_file(std::path::Path::new("/workspace/project/named.pipe")),
+    )
+    .await
+    .expect("mounted FIFO read must not wait for a writer");
+    assert!(mounted_read.is_err());
+    let stat_factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
+        verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(
+            wasm_vfs_tools_guest(),
+        ))
+        .with_vfs(vfs.clone()),
+    )
+    .unwrap();
+    let search_factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
         verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(
             wasm_search_tool_guest(),
         ))
-        .with_vfs(vfs),
+        .with_vfs(vfs.clone()),
     )
     .unwrap();
+    let read_factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
+        verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(
+            wasm_read_tool_guest(),
+        ))
+        .with_vfs(vfs.clone()),
+    )
+    .unwrap();
+    let edit_factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
+        verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(
+            wasm_edit_tool_guest(),
+        ))
+        .with_vfs(vfs)
+        .with_capability_grant(verlet_wasm::runner::FS_WRITE_CAPABILITY),
+    )
+    .unwrap();
+    let direct_operation_timeout = std::time::Duration::from_secs(30);
 
-    let walked = factory
+    let stat = tokio::time::timeout(
+        direct_operation_timeout,
+        stat_factory.invoke_operation_bytes("stat", b"/workspace/project/named.pipe".to_vec()),
+    )
+    .await
+    .expect("FIFO stat through the guest ABI must not wait for a peer")
+    .unwrap();
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&stat.output).unwrap(),
+        serde_json::json!({"kind": "other", "size": 0})
+    );
+
+    let walked = search_factory
         .invoke_operation_bytes(
             "grep",
             pi_tool_input(serde_json::json!({"pattern": "hello", "path": "project"})),
@@ -1886,7 +1963,7 @@ async fn wasm_pi_grep_walk_skips_a_unix_socket_and_matches_native_envelope() {
         .unwrap();
     assert_eq!(walked.output, tool_success_envelope(native_output));
 
-    let find = factory
+    let find = search_factory
         .invoke_operation_bytes(
             "find",
             pi_tool_input(serde_json::json!({"pattern": "**", "path": "project"})),
@@ -1895,19 +1972,55 @@ async fn wasm_pi_grep_walk_skips_a_unix_socket_and_matches_native_envelope() {
         .unwrap();
     assert_eq!(find.output, tool_success_envelope(native_find));
 
-    let direct = factory
-        .invoke_operation_bytes(
+    let direct = tokio::time::timeout(
+        direct_operation_timeout,
+        search_factory.invoke_operation_bytes(
             "grep",
             pi_tool_input(serde_json::json!({
                 "pattern": "hello",
-                "path": "project/verlet.sock",
+                "path": "project/named.pipe",
             })),
-        )
-        .await
-        .unwrap();
+        ),
+    )
+    .await
+    .expect("direct FIFO grep must not wait for a writer")
+    .unwrap();
     assert_eq!(
         direct.output,
         tool_error_envelope(native_direct_error.to_string())
+    );
+
+    let read = tokio::time::timeout(
+        direct_operation_timeout,
+        read_factory.invoke_operation_bytes(
+            "read",
+            pi_tool_input(serde_json::json!({"path": "project/named.pipe"})),
+        ),
+    )
+    .await
+    .expect("direct FIFO read must not wait for a writer")
+    .unwrap();
+    assert_eq!(
+        read.output,
+        tool_error_envelope(native_read_error.to_string())
+    );
+
+    let edit = tokio::time::timeout(
+        direct_operation_timeout,
+        edit_factory.invoke_operation_bytes(
+            "edit",
+            pi_tool_input(serde_json::json!({
+                "path": "project/named.pipe",
+                "edits": [{"oldText": "hello", "newText": "goodbye"}],
+            })),
+        ),
+    )
+    .await
+    .expect("direct FIFO edit must not wait for a writer")
+    .unwrap();
+    assert_eq!(
+        edit.output,
+        tool_error_envelope(native_edit_error.to_string())
     );
 }
 

--- a/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
+++ b/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
@@ -1817,6 +1817,100 @@ async fn wasm_pi_find_and_grep_match_native_envelopes_and_tool_errors() {
     );
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn wasm_pi_grep_walk_skips_a_unix_socket_and_matches_native_envelope() {
+    let native = tempfile::tempdir().unwrap();
+    let project = native.path().join("project");
+    std::fs::create_dir(&project).unwrap();
+    std::fs::write(project.join("input.txt"), "hello from text\n").unwrap();
+    let _listener = std::os::unix::net::UnixListener::bind(project.join("verlet.sock")).unwrap();
+    let native_fs = verlet_tool_core::StdFs::new(native.path()).unwrap();
+    let native_output = verlet_tool_grep::run(
+        verlet_tool_grep::GrepArgs {
+            pattern: "hello".to_owned(),
+            path: Some(std::path::PathBuf::from("project")),
+            glob: None,
+            ignore_case: false,
+            literal: false,
+            context: None,
+            limit: None,
+        },
+        &native_fs,
+    )
+    .unwrap();
+    assert_eq!(native_output.text, "input.txt:1: hello from text");
+    let native_direct_error = verlet_tool_grep::run(
+        verlet_tool_grep::GrepArgs {
+            pattern: "hello".to_owned(),
+            path: Some(std::path::PathBuf::from("project/verlet.sock")),
+            glob: None,
+            ignore_case: false,
+            literal: false,
+            context: None,
+            limit: None,
+        },
+        &native_fs,
+    )
+    .unwrap_err();
+    let native_find = verlet_tool_glob::run(
+        verlet_tool_glob::GlobArgs {
+            pattern: "**".to_owned(),
+            path: Some(std::path::PathBuf::from("project")),
+            limit: None,
+        },
+        &native_fs,
+    )
+    .unwrap();
+    assert_eq!(native_find.paths, vec!["input.txt"]);
+
+    let vfs = std::sync::Arc::new(verlet_vfs::VerletVfs::new(std::sync::Arc::new(
+        bashkit::InMemoryFs::new(),
+    )));
+    let host = verlet_vfs::HostFileSystem::read_only(native.path()).unwrap();
+    vfs.mount("/workspace", std::sync::Arc::new(host)).unwrap();
+    let factory = crate::capabilities::wasm_runner::WasmRuntimeFactory::new(
+        verlet_wasm::WasmRuntimeConfig::new(verlet_wasm::WasmRuntimeArtifact::bytes(
+            wasm_search_tool_guest(),
+        ))
+        .with_vfs(vfs),
+    )
+    .unwrap();
+
+    let walked = factory
+        .invoke_operation_bytes(
+            "grep",
+            pi_tool_input(serde_json::json!({"pattern": "hello", "path": "project"})),
+        )
+        .await
+        .unwrap();
+    assert_eq!(walked.output, tool_success_envelope(native_output));
+
+    let find = factory
+        .invoke_operation_bytes(
+            "find",
+            pi_tool_input(serde_json::json!({"pattern": "**", "path": "project"})),
+        )
+        .await
+        .unwrap();
+    assert_eq!(find.output, tool_success_envelope(native_find));
+
+    let direct = factory
+        .invoke_operation_bytes(
+            "grep",
+            pi_tool_input(serde_json::json!({
+                "pattern": "hello",
+                "path": "project/verlet.sock",
+            })),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        direct.output,
+        tool_error_envelope(native_direct_error.to_string())
+    );
+}
+
 #[tokio::test]
 async fn wasm_pi_write_matches_native_mutation_and_maps_io_into_envelope() {
     let vfs = writable_vfs().await;

--- a/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
+++ b/crates/verlet-kernel/src/capabilities/wasm_runner/tests.rs
@@ -1940,7 +1940,11 @@ async fn wasm_pi_special_files_match_native_skip_and_error_envelopes() {
         .with_capability_grant(verlet_wasm::runner::FS_WRITE_CAPABILITY),
     )
     .unwrap();
-    let direct_operation_timeout = std::time::Duration::from_secs(30);
+    // Hang detector for a FIFO open waiting on a peer, not a perf bound: under
+    // the parallel libtest harness on a 4-vCPU CI runner, concurrent debug
+    // Cranelift compiles of multi-MB guest modules can stall a wrapped call
+    // past 30s (observed twice on x86_64 CI), so this carries 10x headroom.
+    let direct_operation_timeout = std::time::Duration::from_secs(300);
 
     let stat = tokio::time::timeout(
         direct_operation_timeout,

--- a/crates/verlet-vfs/src/lib.rs
+++ b/crates/verlet-vfs/src/lib.rs
@@ -612,7 +612,24 @@ impl bashkit::FileSystem for HostFileSystem {
 
     async fn stat(&self, path: &std::path::Path) -> bashkit::Result<bashkit::Metadata> {
         let _guard = self.operation_lock.lock().await;
-        self.inner.stat(path).await
+        let mut metadata = self.inner.stat(path).await?;
+        #[cfg(unix)]
+        if metadata.file_type == bashkit::FileType::File && metadata.size == 0 {
+            use std::os::unix::fs::FileTypeExt as _;
+
+            let normalized = normalize_vfs_path(path);
+            let relative = normalized.strip_prefix("/").unwrap_or(normalized.as_path());
+            let host_file_type = std::fs::symlink_metadata(self.root.join(relative))?.file_type();
+            if host_file_type.is_socket()
+                || host_file_type.is_fifo()
+                || host_file_type.is_block_device()
+                || host_file_type.is_char_device()
+            {
+                metadata.file_type = bashkit::FileType::Fifo;
+                metadata.size = 0;
+            }
+        }
+        Ok(metadata)
     }
 
     async fn read_dir(&self, path: &std::path::Path) -> bashkit::Result<Vec<bashkit::DirEntry>> {

--- a/crates/verlet-vfs/src/lib.rs
+++ b/crates/verlet-vfs/src/lib.rs
@@ -559,6 +559,46 @@ impl HostFileSystem {
         let _ = path;
         Ok(())
     }
+
+    #[cfg(unix)]
+    fn host_path_is_special(&self, path: &std::path::Path) -> std::io::Result<bool> {
+        use std::os::unix::fs::FileTypeExt as _;
+
+        let normalized = normalize_vfs_path(path);
+        let relative = normalized.strip_prefix("/").unwrap_or(normalized.as_path());
+        let file_type = std::fs::symlink_metadata(self.root.join(relative))?.file_type();
+        Ok(file_type.is_socket()
+            || file_type.is_fifo()
+            || file_type.is_block_device()
+            || file_type.is_char_device())
+    }
+
+    #[cfg(unix)]
+    async fn reject_special_file_open(
+        &self,
+        path: &std::path::Path,
+        allow_missing: bool,
+    ) -> bashkit::Result<()> {
+        match self.inner.stat(path).await {
+            Ok(_) => {}
+            Err(bashkit::Error::Io(error))
+                if allow_missing && error.kind() == std::io::ErrorKind::NotFound =>
+            {
+                return Ok(());
+            }
+            Err(error) => return Err(error),
+        }
+        match self.host_path_is_special(path) {
+            Ok(true) => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("path is not a regular file: {}", path.display()),
+            )
+            .into()),
+            Ok(false) => Ok(()),
+            Err(error) if allow_missing && error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
 }
 
 impl std::fmt::Debug for HostFileSystem {
@@ -585,18 +625,24 @@ impl bashkit::FileSystemExt for HostFileSystem {
 impl bashkit::FileSystem for HostFileSystem {
     async fn read_file(&self, path: &std::path::Path) -> bashkit::Result<Vec<u8>> {
         let _guard = self.operation_lock.lock().await;
+        #[cfg(unix)]
+        self.reject_special_file_open(path, false).await?;
         self.inner.read_file(path).await
     }
 
     async fn write_file(&self, path: &std::path::Path, content: &[u8]) -> bashkit::Result<()> {
         let _guard = self.operation_lock.lock().await;
         self.reject_external_hard_link_mutation(path)?;
+        #[cfg(unix)]
+        self.reject_special_file_open(path, true).await?;
         self.inner.write_file(path, content).await
     }
 
     async fn append_file(&self, path: &std::path::Path, content: &[u8]) -> bashkit::Result<()> {
         let _guard = self.operation_lock.lock().await;
         self.reject_external_hard_link_mutation(path)?;
+        #[cfg(unix)]
+        self.reject_special_file_open(path, true).await?;
         self.inner.append_file(path, content).await
     }
 
@@ -614,27 +660,32 @@ impl bashkit::FileSystem for HostFileSystem {
         let _guard = self.operation_lock.lock().await;
         let mut metadata = self.inner.stat(path).await?;
         #[cfg(unix)]
-        if metadata.file_type == bashkit::FileType::File && metadata.size == 0 {
-            use std::os::unix::fs::FileTypeExt as _;
-
-            let normalized = normalize_vfs_path(path);
-            let relative = normalized.strip_prefix("/").unwrap_or(normalized.as_path());
-            let host_file_type = std::fs::symlink_metadata(self.root.join(relative))?.file_type();
-            if host_file_type.is_socket()
-                || host_file_type.is_fifo()
-                || host_file_type.is_block_device()
-                || host_file_type.is_char_device()
-            {
-                metadata.file_type = bashkit::FileType::Fifo;
-                metadata.size = 0;
-            }
+        if metadata.file_type == bashkit::FileType::File && self.host_path_is_special(path)? {
+            metadata.file_type = bashkit::FileType::Fifo;
+            metadata.size = 0;
         }
         Ok(metadata)
     }
 
     async fn read_dir(&self, path: &std::path::Path) -> bashkit::Result<Vec<bashkit::DirEntry>> {
         let _guard = self.operation_lock.lock().await;
-        self.inner.read_dir(path).await
+        let mut entries = self.inner.read_dir(path).await?;
+        #[cfg(unix)]
+        for entry in &mut entries {
+            if entry.metadata.file_type != bashkit::FileType::File {
+                continue;
+            }
+            match self.host_path_is_special(&path.join(&entry.name)) {
+                Ok(true) => {
+                    entry.metadata.file_type = bashkit::FileType::Fifo;
+                    entry.metadata.size = 0;
+                }
+                Ok(false) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Ok(entries)
     }
 
     async fn exists(&self, path: &std::path::Path) -> bashkit::Result<bool> {
@@ -650,6 +701,8 @@ impl bashkit::FileSystem for HostFileSystem {
     async fn copy(&self, from: &std::path::Path, to: &std::path::Path) -> bashkit::Result<()> {
         let _guard = self.operation_lock.lock().await;
         self.reject_external_hard_link_mutation(to)?;
+        #[cfg(unix)]
+        self.reject_special_file_open(from, false).await?;
         self.inner.copy(from, to).await
     }
 
@@ -680,6 +733,8 @@ impl bashkit::FileSystem for HostFileSystem {
     ) -> bashkit::Result<()> {
         let _guard = self.operation_lock.lock().await;
         self.reject_external_hard_link_mutation(path)?;
+        #[cfg(unix)]
+        self.reject_special_file_open(path, false).await?;
         self.inner.set_modified_time(path, time).await
     }
 }

--- a/crates/verlet-vfs/src/tests.rs
+++ b/crates/verlet-vfs/src/tests.rs
@@ -99,6 +99,20 @@ async fn host_filesystem_rw_is_rooted_and_rejects_symlink_escape() {
 
 #[cfg(unix)]
 #[tokio::test]
+async fn host_filesystem_reports_a_unix_socket_as_a_non_file_kind() {
+    let fixture = unique_host_fs_root("socket-kind");
+    let socket_path = fixture.join("live.sock");
+    let _listener = std::os::unix::net::UnixListener::bind(&socket_path).unwrap();
+    let fs = crate::HostFileSystem::read_only(&fixture).unwrap();
+
+    let metadata = fs.stat(std::path::Path::new("/live.sock")).await.unwrap();
+
+    assert_eq!(metadata.file_type, bashkit::FileType::Fifo);
+    let _ = std::fs::remove_dir_all(fixture);
+}
+
+#[cfg(unix)]
+#[tokio::test]
 async fn host_filesystem_rw_rejects_mutating_a_preexisting_external_hard_link() {
     let fixture = unique_host_fs_root("hard-link");
     let root = fixture.join("root");

--- a/crates/verlet-vfs/src/tests.rs
+++ b/crates/verlet-vfs/src/tests.rs
@@ -106,8 +106,78 @@ async fn host_filesystem_reports_a_unix_socket_as_a_non_file_kind() {
     let fs = crate::HostFileSystem::read_only(&fixture).unwrap();
 
     let metadata = fs.stat(std::path::Path::new("/live.sock")).await.unwrap();
+    let listing = fs.read_dir(std::path::Path::new("/")).await.unwrap();
 
     assert_eq!(metadata.file_type, bashkit::FileType::Fifo);
+    assert_eq!(listing.len(), 1);
+    assert_eq!(listing[0].name, "live.sock");
+    assert_eq!(listing[0].metadata.file_type, bashkit::FileType::Fifo);
+    let _ = std::fs::remove_dir_all(fixture);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn host_filesystem_rejects_fifo_io_without_waiting_for_a_peer() {
+    let fixture = unique_host_fs_root("fifo-io");
+    let fifo_path = fixture.join("named.pipe");
+    assert!(
+        std::process::Command::new("mkfifo")
+            .arg(&fifo_path)
+            .status()
+            .unwrap()
+            .success()
+    );
+    let fs = crate::HostFileSystem::read_write(&fixture).unwrap();
+
+    let metadata = fs.stat(std::path::Path::new("/named.pipe")).await.unwrap();
+    // tight-timeout: special-file precheck must complete without a peer
+    let read = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        fs.read_file(std::path::Path::new("/named.pipe")),
+    )
+    .await
+    .expect("FIFO read must not wait for a writer");
+    // tight-timeout: special-file precheck must complete without a peer
+    let write = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        fs.write_file(std::path::Path::new("/named.pipe"), b"blocked"),
+    )
+    .await
+    .expect("FIFO write must not wait for a reader");
+    // tight-timeout: special-file precheck must complete without a peer
+    let append = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        fs.append_file(std::path::Path::new("/named.pipe"), b"blocked"),
+    )
+    .await
+    .expect("FIFO append must not wait for a reader");
+    // tight-timeout: special-file precheck must complete without a peer
+    let copy = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        fs.copy(
+            std::path::Path::new("/named.pipe"),
+            std::path::Path::new("/copy.txt"),
+        ),
+    )
+    .await
+    .expect("FIFO copy must not wait for a writer");
+    // tight-timeout: special-file precheck must complete without a peer
+    let set_modified_time = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        fs.set_modified_time(
+            std::path::Path::new("/named.pipe"),
+            std::time::SystemTime::now(),
+        ),
+    )
+    .await
+    .expect("FIFO timestamp update must not wait for a writer");
+
+    assert_eq!(metadata.file_type, bashkit::FileType::Fifo);
+    assert!(read.is_err());
+    assert!(write.is_err());
+    assert!(append.is_err());
+    assert!(copy.is_err());
+    assert!(set_modified_time.is_err());
     let _ = std::fs::remove_dir_all(fixture);
 }
 


### PR DESCRIPTION
Fixes EMO-622: a Pi grep walk that met the daemon's own Unix socket (or any special file) aborted the whole call with a filesystem TransportError. For a self-extending agent whose workspace contains its own runtime state, that made search unusable at the project root.

## Changes

- Shared walk helper in tool-core skips non-regular stat kinds and per-file read failures during walks; directly named single-file targets still surface their errors (`skip_read_errors` is set only for directory descendants).
- Host-backed VFS classifies sockets, FIFOs, and block/char devices as non-file kinds in both `stat` and `read_dir` (consistent views); the guest ABI projects them as Other.
- Review pass hardening: direct FIFO opens are rejected up front on every open path (read, bounded read, write, append, copy source, timestamp) across native StdFs, tool-edit, tool-write, and the host VFS, so a named pipe can never block a tool waiting for a peer. Promptness-bounded mkfifo tests pin this.
- Differential coverage uses a real Unix socket listener and real mkfifo; native and wasm envelopes are byte-identical for the new skip and error cases.

## Verification

- Full nextest suite green (2618 passed) plus `scripts/verify.sh` and `scripts/verify-linux.sh` both green on this branch.
- Live repro: `verlet tool run pi-search grep` over a project containing a stale `verlet.sock` returns matches cleanly (previously errored wholesale).

Follow-up: EMO-623 (bashkit file-kind contract expansion so virtual bash stops labeling sockets as FIFOs).
