### PR TITLE
Journal terminal turn failures (EMO-616)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 
 ### Fixes
 
+- Terminally failed turns now append one bounded, body-free `turn.failed`
+  outcome to the thread journal with provider attribution and retry count.
 - The serve thread-handle ingress adapter now backs off persistent history-store
   failures to a 60 second retry interval, logs only retry state transitions,
   reports degradation, and reports recovery without exiting the serve process.

--- a/crates/verlet-history/src/lib.rs
+++ b/crates/verlet-history/src/lib.rs
@@ -19,7 +19,8 @@ pub const STREAM_APPEND_ACK_SCHEMA_V1: &str = "cooldis.stream.append_ack/1";
 pub const STREAM_ROUTING_DECISION_SCHEMA_V1: &str = "cooldis.stream.routing_decision/1";
 pub const CONTEXT_READ_PLAN_SCHEMA_V1: &str = "cooldis.context.read_plan/1";
 pub const DEBUG_THREAD_EXPORT_SCHEMA_V1: &str = "cooldis.debug.thread_export/1";
-pub const EVENT_KIND_SCHEMA_VERSION: &str = "cooldis.events/0.4";
+pub const EVENT_KIND_SCHEMA_VERSION: &str = "cooldis.events/0.5";
+pub const TURN_FAILED_MESSAGE_MAX_BYTES: usize = 1024;
 
 pub const COMPACTION_SUMMARY_PREFIX: &str = "Compacted conversation summary:";
 
@@ -198,7 +199,7 @@ impl std::fmt::Display for EventRecordId {
     }
 }
 
-/// Frozen event-kind vocabulary, version `cooldis.events/0.4`.
+/// Frozen event-kind vocabulary, version `cooldis.events/0.5`.
 ///
 /// Laws:
 /// - The vocabulary is append-only: kinds may be added in later versions,
@@ -286,6 +287,9 @@ pub enum EventKind {
     /// A turn reached quiescence.
     #[strum(serialize = "turn.completed")]
     TurnCompleted,
+    /// A turn reached a terminal failure.
+    #[strum(serialize = "turn.failed")]
+    TurnFailed,
     /// A controller requested external approval.
     #[strum(serialize = "approval.requested")]
     ApprovalRequested,
@@ -452,6 +456,62 @@ pub enum AdmissionDecision {
     Observe,
     Reject,
     Coalesce,
+}
+
+/// Closed terminal failure classes recorded by `turn.failed`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnFailureErrorClass {
+    ProviderHttp,
+    ProviderTransport,
+    Runner,
+    Internal,
+}
+
+/// Bounded terminal outcome recorded by `turn.failed`.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TurnFailedPayload {
+    pub turn_id: String,
+    pub error_class: TurnFailureErrorClass,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_status: Option<u16>,
+    pub message: String,
+    pub retries_attempted: u32,
+}
+
+impl TurnFailedPayload {
+    pub fn new(
+        turn_id: impl Into<String>,
+        error_class: TurnFailureErrorClass,
+        provider_id: Option<String>,
+        http_status: Option<u16>,
+        message: impl Into<String>,
+        retries_attempted: u32,
+    ) -> Self {
+        Self {
+            turn_id: turn_id.into(),
+            error_class,
+            provider_id,
+            http_status,
+            message: truncate_utf8_bytes(message.into(), TURN_FAILED_MESSAGE_MAX_BYTES),
+            retries_attempted,
+        }
+    }
+}
+
+fn truncate_utf8_bytes(mut value: String, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value;
+    }
+    let mut boundary = max_bytes;
+    while !value.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    value.truncate(boundary);
+    value
 }
 
 #[derive(
@@ -1321,6 +1381,10 @@ pub fn stream_schema_registry_v1() -> &'static verlet_runtime_contracts::schema:
                 binding_detached_payload_schema_v1(),
             )?;
             registry.register(
+                EventKind::TurnFailed.payload_schema_id(),
+                turn_failed_payload_schema_v1(),
+            )?;
+            registry.register(
                 EventKind::ThreadSpawnRequested.payload_schema_id(),
                 thread_spawn_requested_payload_schema_v1(),
             )?;
@@ -1404,6 +1468,7 @@ fn event_kind_routes_to_model_trace(kind: EventKind) -> bool {
             | EventKind::ToolCallCompleted
             | EventKind::TurnSubmitted
             | EventKind::TurnCompleted
+            | EventKind::TurnFailed
     )
 }
 
@@ -1846,6 +1911,24 @@ fn binding_attachment_config_schema_v1() -> serde_json::Value {
 
 fn binding_effect_class_schema_v1() -> serde_json::Value {
     serde_json::json!({"enum": ["pure", "idempotent", "at-most-once"]})
+}
+
+pub fn turn_failed_payload_schema_v1() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "required": ["turn_id", "error_class", "message", "retries_attempted"],
+        "additionalProperties": false,
+        "properties": {
+            "turn_id": {"type": "string"},
+            "error_class": {
+                "enum": ["provider_http", "provider_transport", "runner", "internal"]
+            },
+            "provider_id": {"type": "string"},
+            "http_status": {"type": "integer"},
+            "message": {"type": "string"},
+            "retries_attempted": {"type": "integer"}
+        }
+    })
 }
 
 fn thread_spawned_payload_schema_v1() -> serde_json::Value {

--- a/crates/verlet-history/src/tests.rs
+++ b/crates/verlet-history/src/tests.rs
@@ -535,6 +535,7 @@ fn event_kind_parse_round_trips_and_fails_closed() {
         "turn.waiting",
         "turn.resumed",
         "turn.completed",
+        "turn.failed",
         "approval.requested",
         "approval.resolved",
         "mandate.started",
@@ -566,7 +567,7 @@ fn event_kind_parse_round_trips_and_fails_closed() {
         "io.egress.failed",
         "admission.decided",
     ];
-    assert_eq!(crate::EVENT_KIND_SCHEMA_VERSION, "cooldis.events/0.4");
+    assert_eq!(crate::EVENT_KIND_SCHEMA_VERSION, "cooldis.events/0.5");
     let kinds = <crate::EventKind as strum::VariantArray>::VARIANTS;
     let actual: Vec<&str> = kinds.iter().map(|kind| kind.as_ref()).collect();
     assert_eq!(actual, expected);
@@ -589,14 +590,16 @@ fn event_kind_parse_round_trips_and_fails_closed() {
 }
 
 #[test]
-fn v03_journal_event_kinds_remain_decodable_after_v04_bump() {
-    let v03_kinds = [
+fn v04_journal_event_kinds_remain_decodable_after_v05_bump() {
+    let v04_kinds = [
         "session.entry.appended",
         "context.compile.completed",
         "context.summary.completed",
         "context.read_plan.set",
         "manifest.compile.completed",
         "manifest.bind.completed",
+        "binding.attached",
+        "binding.detached",
         "tool.universe.discovery.completed",
         "tool.universe.call.completed",
         "tool.call.requested",
@@ -638,10 +641,10 @@ fn v03_journal_event_kinds_remain_decodable_after_v04_bump() {
         "io.egress.failed",
         "admission.decided",
     ];
-    let coordinates = coords("tenant_a", "user_1", "v03-journal");
+    let coordinates = coords("tenant_a", "user_1", "v04-journal");
     let stream_id = crate::EventStreamId::for_thread(&coordinates);
 
-    for (index, encoded_kind) in v03_kinds.into_iter().enumerate() {
+    for (index, encoded_kind) in v04_kinds.into_iter().enumerate() {
         let kind = encoded_kind.parse::<crate::EventKind>().unwrap();
         let record = crate::EventRecord::from_new(
             stream_id.clone(),
@@ -658,9 +661,48 @@ fn v03_journal_event_kinds_remain_decodable_after_v04_bump() {
 
         assert_eq!(
             decoded.kind, kind,
-            "failed to decode v0.3 kind {encoded_kind}"
+            "failed to decode v0.4 kind {encoded_kind}"
         );
     }
+}
+
+#[test]
+fn turn_failed_payload_serializes_closed_class_and_truncates_utf8_message() {
+    let payload = crate::TurnFailedPayload::new(
+        "turn-1",
+        crate::TurnFailureErrorClass::ProviderHttp,
+        Some("openai".to_string()),
+        Some(400),
+        "é".repeat(600),
+        2,
+    );
+
+    assert_eq!(payload.message.as_bytes().len(), 1024);
+    assert!(payload.message.is_char_boundary(payload.message.len()));
+    assert_eq!(
+        serde_json::to_value(&payload).unwrap(),
+        serde_json::json!({
+            "turn_id": "turn-1",
+            "error_class": "provider_http",
+            "provider_id": "openai",
+            "http_status": 400,
+            "message": "é".repeat(512),
+            "retries_attempted": 2,
+        })
+    );
+
+    let decoded: crate::TurnFailedPayload =
+        serde_json::from_value(serde_json::to_value(payload).unwrap()).unwrap();
+    assert_eq!(
+        decoded.error_class,
+        crate::TurnFailureErrorClass::ProviderHttp
+    );
+    crate::stream_schema_registry_v1()
+        .validate(
+            &crate::EventKind::TurnFailed.payload_schema_id(),
+            &serde_json::to_value(decoded).unwrap(),
+        )
+        .unwrap();
 }
 
 #[test]
@@ -672,6 +714,10 @@ fn event_kind_payload_schema_ids_are_frozen_for_stream_schema_v1() {
     assert_eq!(
         crate::EventKind::BindingDetached.payload_schema_id(),
         "cooldis.event.binding.detached/1"
+    );
+    assert_eq!(
+        crate::EventKind::TurnFailed.payload_schema_id(),
+        "cooldis.event.turn.failed/1"
     );
     assert_eq!(
         crate::EventKind::ContextCompileCompleted.payload_schema_id(),
@@ -1538,6 +1584,44 @@ fn stream_routing_decision_v1_separates_runtime_and_model_trace_profiles() {
         Some("controller:placement")
     );
     assert_eq!(decision.keys.stream_id, record.stream_id);
+}
+
+#[test]
+fn turn_failed_routes_as_model_trace_without_analytics_aggregation() {
+    let coordinates = coords("tenant_a", "user_1", "session_1");
+    let record = crate::EventRecord::from_new(
+        crate::EventStreamId::for_thread(&coordinates),
+        crate::EventSequence::new(10),
+        crate::NewEventRecord::discharged(
+            coordinates,
+            crate::EventKind::TurnFailed,
+            serde_json::to_value(crate::TurnFailedPayload::new(
+                "turn-1",
+                crate::TurnFailureErrorClass::Runner,
+                None,
+                None,
+                "runner failed",
+                0,
+            ))
+            .unwrap(),
+            crate::EventProvenance {
+                discharged_by: Some("propagator:agent-loop".to_string()),
+                ..crate::EventProvenance::default()
+            },
+        ),
+    );
+
+    let decision = record.route_decision_v1();
+    assert!(
+        decision
+            .routes
+            .contains(&crate::StreamRouteProfile::ModelTrace)
+    );
+    assert!(
+        !decision
+            .routes
+            .contains(&crate::StreamRouteProfile::AnalyticsAggregate)
+    );
 }
 
 #[test]

--- a/crates/verlet-history/src/tests.rs
+++ b/crates/verlet-history/src/tests.rs
@@ -1600,7 +1600,7 @@ fn turn_failed_routes_as_model_trace_without_analytics_aggregation() {
                 crate::TurnFailureErrorClass::Runner,
                 None,
                 None,
-                "runner failed",
+                "x".repeat(crate::TURN_FAILED_MESSAGE_MAX_BYTES + 100),
                 0,
             ))
             .unwrap(),
@@ -1618,9 +1618,26 @@ fn turn_failed_routes_as_model_trace_without_analytics_aggregation() {
             .contains(&crate::StreamRouteProfile::ModelTrace)
     );
     assert!(
+        decision
+            .routes
+            .contains(&crate::StreamRouteProfile::BrowserSafeProjection)
+    );
+    assert!(
         !decision
             .routes
             .contains(&crate::StreamRouteProfile::AnalyticsAggregate)
+    );
+    let envelope = record.to_stream_record_v1();
+    let projected: crate::TurnFailedPayload =
+        serde_json::from_value(envelope.payload.clone()).unwrap();
+    assert_eq!(
+        projected.message.len(),
+        crate::TURN_FAILED_MESSAGE_MAX_BYTES
+    );
+    assert_eq!(
+        envelope.payload,
+        serde_json::to_value(projected).unwrap(),
+        "browser-safe and model-trace routing must carry only the bounded journal payload"
     );
 }
 

--- a/crates/verlet-kernel/src/adapters/agent_loop.rs
+++ b/crates/verlet-kernel/src/adapters/agent_loop.rs
@@ -870,7 +870,7 @@ impl AgentLoop {
             crate::kernel::runtime_host::runtime_api::ThreadEvent,
         >,
         fold_intra_turn_steers: bool,
-    ) -> crate::kernel::runtime_host::VerletResult<verlet_history::CanonicalMessage> {
+    ) -> Result<verlet_history::CanonicalMessage, TerminalTurnFailure> {
         let coordinates = turn_context.coordinates();
         let context = services.build_session_context(coordinates).await?;
         let source_cuts = context.source_cuts.clone();
@@ -1339,7 +1339,16 @@ async fn run_idle_provider_command(
                 input.provider = Some(turn_endpoint.config.provider.clone());
                 input.model = Some(turn_endpoint.config.model.clone());
             }
-            if let Err(err) = run_auto_compaction_if_needed(
+            let failed_turn = FailedTurnTransition {
+                coordinates,
+                services,
+                turn_id: &turn_id,
+                source_event_id: None,
+                thread_id,
+                events,
+                status,
+            };
+            if let Err(failure) = run_auto_compaction_if_needed(
                 runtime,
                 &turn_endpoint,
                 thread_context,
@@ -1351,14 +1360,7 @@ async fn run_idle_provider_command(
             )
             .await
             {
-                fail_provider_turn(
-                    coordinates,
-                    thread_id,
-                    events,
-                    status,
-                    "compaction",
-                    err.to_string(),
-                );
+                failed_turn.fail("compaction", failure).await;
                 return true;
             }
             let (turn_source_event_id, turn_delivery_start_sequence, turn_anchor_timestamp_ms) =
@@ -1377,13 +1379,7 @@ async fn run_idle_provider_command(
                         {
                             Ok(submitted) => submitted,
                             Err(err) => {
-                                let _ = status.send(verlet_runtime_contracts::ThreadStatus::Failed);
-                                let _ = events.send(
-                                    crate::kernel::runtime_host::runtime_api::ThreadEvent::Failed {
-                                        thread_id,
-                                        message: err.to_string(),
-                                    },
-                                );
+                                failed_turn.fail_message("history", err.to_string()).await;
                                 return true;
                             }
                         };
@@ -1392,13 +1388,7 @@ async fn run_idle_provider_command(
                         (submitted.id, submitted.sequence, submitted.created_at_ms)
                     }
                     Err(err) => {
-                        let _ = status.send(verlet_runtime_contracts::ThreadStatus::Failed);
-                        let _ = events.send(
-                            crate::kernel::runtime_host::runtime_api::ThreadEvent::Failed {
-                                thread_id,
-                                message: err.to_string(),
-                            },
-                        );
+                        failed_turn.fail_message("history", err.to_string()).await;
                         return true;
                     }
                 };
@@ -1446,14 +1436,14 @@ async fn run_idle_provider_command(
                     let _ = status.send(verlet_runtime_contracts::ThreadStatus::Idle);
                     false
                 }
-                Err(err) => {
+                Err(failure) => {
                     fail_provider_turn(
                         coordinates,
                         thread_id,
                         events,
                         status,
                         "compaction",
-                        err.to_string(),
+                        failure.message,
                     );
                     true
                 }
@@ -1514,14 +1504,17 @@ async fn run_idle_provider_command(
                     false
                 }
                 Err(err) => {
-                    fail_provider_turn(
+                    FailedTurnTransition {
                         coordinates,
+                        services,
+                        turn_id: &turn_id,
+                        source_event_id: None,
                         thread_id,
                         events,
                         status,
-                        "tool_resume",
-                        err.to_string(),
-                    );
+                    }
+                    .fail_message("tool_resume", err.to_string())
+                    .await;
                     true
                 }
             }
@@ -1578,7 +1571,7 @@ async fn run_auto_compaction_if_needed(
     services: &crate::kernel::runtime_host::runtime_services::RuntimeServices,
     thread_id: verlet_runtime_contracts::ThreadId,
     events: &tokio::sync::broadcast::Sender<crate::kernel::runtime_host::runtime_api::ThreadEvent>,
-) -> crate::kernel::runtime_host::VerletResult<()> {
+) -> Result<(), TerminalTurnFailure> {
     let Some(max_text_bytes) = runtime.compaction_policy.auto_max_context_text_bytes else {
         return Ok(());
     };
@@ -1676,7 +1669,7 @@ async fn run_compaction(
     services: &crate::kernel::runtime_host::runtime_services::RuntimeServices,
     thread_id: verlet_runtime_contracts::ThreadId,
     events: &tokio::sync::broadcast::Sender<crate::kernel::runtime_host::runtime_api::ThreadEvent>,
-) -> crate::kernel::runtime_host::VerletResult<()> {
+) -> Result<(), TerminalTurnFailure> {
     let input = crate::kernel::runtime_host::turn::TurnInput::text("");
     let turn_context = runtime.turn_context(
         thread_context,
@@ -1805,7 +1798,7 @@ async fn generate_compaction_summary(
     turn_context: &crate::kernel::runtime_host::turn::TurnContext,
     services: &crate::kernel::runtime_host::runtime_services::RuntimeServices,
     events: &tokio::sync::broadcast::Sender<crate::kernel::runtime_host::runtime_api::ThreadEvent>,
-) -> crate::kernel::runtime_host::VerletResult<String> {
+) -> Result<String, TerminalTurnFailure> {
     let context = services
         .build_session_context(turn_context.coordinates())
         .await?;
@@ -1857,9 +1850,76 @@ struct ExecutedProviderResponse {
 }
 
 #[derive(Clone, Debug)]
+struct TerminalTurnFailure {
+    error_class: verlet_history::TurnFailureErrorClass,
+    provider_id: Option<String>,
+    http_status: Option<u16>,
+    message: String,
+    journal_message: String,
+    retries_attempted: u32,
+}
+
+impl TerminalTurnFailure {
+    fn from_code(code: &str, message: String) -> Self {
+        let error_class = if code == "history" {
+            verlet_history::TurnFailureErrorClass::Internal
+        } else {
+            verlet_history::TurnFailureErrorClass::Runner
+        };
+        Self {
+            error_class,
+            provider_id: None,
+            http_status: None,
+            journal_message: message.clone(),
+            message,
+            retries_attempted: 0,
+        }
+    }
+
+    fn provider(
+        provider_id: String,
+        error: ModelRequestAttemptError,
+        retries_attempted: u32,
+    ) -> Self {
+        Self {
+            error_class: error.terminal_class,
+            provider_id: Some(provider_id),
+            http_status: error.http_status,
+            message: error.message,
+            journal_message: error.journal_message,
+            retries_attempted,
+        }
+    }
+}
+
+impl From<crate::kernel::runtime_host::VerletError> for TerminalTurnFailure {
+    fn from(error: crate::kernel::runtime_host::VerletError) -> Self {
+        let error_class = match &error {
+            crate::kernel::runtime_host::VerletError::RuntimeExecution(_)
+            | crate::kernel::runtime_host::VerletError::RuntimeFactory(_) => {
+                verlet_history::TurnFailureErrorClass::Runner
+            }
+            _ => verlet_history::TurnFailureErrorClass::Internal,
+        };
+        let message = error.to_string();
+        Self {
+            error_class,
+            provider_id: None,
+            http_status: None,
+            journal_message: message.clone(),
+            message,
+            retries_attempted: 0,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
 struct ModelRequestAttemptError {
     class: verlet_runtime_contracts::RuntimeModelRequestErrorClass,
+    terminal_class: verlet_history::TurnFailureErrorClass,
+    http_status: Option<u16>,
     message: String,
+    journal_message: String,
 }
 
 impl ModelRequestAttemptError {
@@ -1890,7 +1950,7 @@ async fn execute_provider_request(
     mode: verlet_provider::ProviderRequestMode,
     purpose: verlet_runtime_contracts::RuntimeModelRequestPurpose,
     events: &tokio::sync::broadcast::Sender<crate::kernel::runtime_host::runtime_api::ThreadEvent>,
-) -> crate::kernel::runtime_host::VerletResult<ExecutedProviderResponse> {
+) -> Result<ExecutedProviderResponse, TerminalTurnFailure> {
     let request_mode = mode;
     let mode = runtime_request_mode(mode);
     let mut endpoints = Vec::with_capacity(runtime.model_request_fallbacks.len() + 1);
@@ -1902,6 +1962,7 @@ async fn execute_provider_request(
     let retry_policy = runtime.model_request_retry_policy;
     let attempts = retry_policy.attempts();
     let mut last_error = None;
+    let mut retries_attempted = 0;
 
     'endpoints: for (endpoint_index, endpoint) in endpoints.iter().enumerate() {
         let request = request_for_endpoint(request, &endpoint.config);
@@ -2018,12 +2079,15 @@ async fn execute_provider_request(
                             tokio::select! {
                                 _ = tokio::time::sleep(std::time::Duration::from_millis(delay_ms)) => {}
                                 _ = turn_context.cancellation.cancelled() => {
-                                    return Err(crate::kernel::runtime_host::VerletError::RuntimeExecution(
-                                        verlet_provider::ProviderError::Cancelled.to_string(),
+                                    return Err(TerminalTurnFailure::provider(
+                                        request.provider.clone(),
+                                        classify_provider_error(verlet_provider::ProviderError::Cancelled),
+                                        retries_attempted,
                                     ));
                                 }
                             }
                         }
+                        retries_attempted += 1;
                         continue;
                     }
 
@@ -2051,23 +2115,30 @@ async fn execute_provider_request(
                                 error: error.message.clone(),
                             },
                         );
-                        last_error = Some(error);
+                        last_error = Some((request.provider.clone(), error));
                         continue 'endpoints;
                     }
 
-                    return Err(crate::kernel::runtime_host::VerletError::RuntimeExecution(
-                        error.message,
+                    return Err(TerminalTurnFailure::provider(
+                        request.provider.clone(),
+                        error,
+                        retries_attempted,
                     ));
                 }
             }
         }
     }
 
-    Err(crate::kernel::runtime_host::VerletError::RuntimeExecution(
-        last_error
-            .map(|error| error.message)
-            .unwrap_or_else(|| "provider request did not run".to_string()),
-    ))
+    Err(last_error
+        .map(|(provider_id, error)| {
+            TerminalTurnFailure::provider(provider_id, error, retries_attempted)
+        })
+        .unwrap_or_else(|| {
+            TerminalTurnFailure::from_code(
+                "runtime_execution",
+                "provider request did not run".to_string(),
+            )
+        }))
 }
 
 async fn execute_provider_request_attempt(
@@ -2133,37 +2204,72 @@ fn model_request_id(
 
 fn classify_provider_error(error: verlet_provider::ProviderError) -> ModelRequestAttemptError {
     let message = error.to_string();
-    let class = match error {
-        verlet_provider::ProviderError::Cancelled => {
-            verlet_runtime_contracts::RuntimeModelRequestErrorClass::Cancelled
-        }
+    let (class, terminal_class, http_status, journal_message) = match error {
+        verlet_provider::ProviderError::Cancelled => (
+            verlet_runtime_contracts::RuntimeModelRequestErrorClass::Cancelled,
+            verlet_history::TurnFailureErrorClass::Runner,
+            None,
+            "provider request cancelled".to_string(),
+        ),
         verlet_provider::ProviderError::UnsupportedCapability { .. }
-        | verlet_provider::ProviderError::ApiMismatch { .. } => {
-            verlet_runtime_contracts::RuntimeModelRequestErrorClass::UnsupportedCapability
-        }
-        verlet_provider::ProviderError::Http(_) => {
-            verlet_runtime_contracts::RuntimeModelRequestErrorClass::Retryable
-        }
-        verlet_provider::ProviderError::HttpStatus { status, .. } if status.as_u16() == 429 => {
-            verlet_runtime_contracts::RuntimeModelRequestErrorClass::RateLimited
-        }
+        | verlet_provider::ProviderError::ApiMismatch { .. } => (
+            verlet_runtime_contracts::RuntimeModelRequestErrorClass::UnsupportedCapability,
+            verlet_history::TurnFailureErrorClass::Runner,
+            None,
+            message.clone(),
+        ),
+        verlet_provider::ProviderError::Http(_) => (
+            verlet_runtime_contracts::RuntimeModelRequestErrorClass::Retryable,
+            verlet_history::TurnFailureErrorClass::ProviderTransport,
+            None,
+            message.clone(),
+        ),
+        verlet_provider::ProviderError::HttpStatus { status, .. } if status.as_u16() == 429 => (
+            verlet_runtime_contracts::RuntimeModelRequestErrorClass::RateLimited,
+            verlet_history::TurnFailureErrorClass::ProviderHttp,
+            Some(status.as_u16()),
+            format!("provider HTTP status {}", status.as_u16()),
+        ),
         verlet_provider::ProviderError::HttpStatus { status, .. }
             if status.is_server_error() || matches!(status.as_u16(), 408 | 409 | 425) =>
         {
-            verlet_runtime_contracts::RuntimeModelRequestErrorClass::Retryable
+            (
+                verlet_runtime_contracts::RuntimeModelRequestErrorClass::Retryable,
+                verlet_history::TurnFailureErrorClass::ProviderHttp,
+                Some(status.as_u16()),
+                format!("provider HTTP status {}", status.as_u16()),
+            )
         }
-        verlet_provider::ProviderError::Decode(_)
-        | verlet_provider::ProviderError::HttpStatus { .. } => {
-            verlet_runtime_contracts::RuntimeModelRequestErrorClass::Fatal
-        }
+        verlet_provider::ProviderError::Decode(_) => (
+            verlet_runtime_contracts::RuntimeModelRequestErrorClass::Fatal,
+            verlet_history::TurnFailureErrorClass::ProviderTransport,
+            None,
+            message.clone(),
+        ),
+        verlet_provider::ProviderError::HttpStatus { status, .. } => (
+            verlet_runtime_contracts::RuntimeModelRequestErrorClass::Fatal,
+            verlet_history::TurnFailureErrorClass::ProviderHttp,
+            Some(status.as_u16()),
+            format!("provider HTTP status {}", status.as_u16()),
+        ),
     };
-    ModelRequestAttemptError { class, message }
+    ModelRequestAttemptError {
+        class,
+        terminal_class,
+        http_status,
+        message,
+        journal_message,
+    }
 }
 
 fn stream_assembly_error(message: impl Into<String>) -> ModelRequestAttemptError {
+    let message = message.into();
     ModelRequestAttemptError {
         class: verlet_runtime_contracts::RuntimeModelRequestErrorClass::StreamAssembly,
-        message: message.into(),
+        terminal_class: verlet_history::TurnFailureErrorClass::ProviderTransport,
+        http_status: None,
+        journal_message: message.clone(),
+        message,
     }
 }
 
@@ -2276,6 +2382,15 @@ async fn run_provider_turn(
 ) -> bool {
     runtime.retain_turn_endpoint(&turn_id, endpoint);
     let mut endpoint_retention = TurnEndpointRetention::new(runtime, &turn_id);
+    let failed_turn = FailedTurnTransition {
+        coordinates,
+        services,
+        turn_id: &turn_id,
+        source_event_id: Some(turn_source_event_id),
+        thread_id,
+        events,
+        status,
+    };
     let mut tool_rounds = match persisted_tool_rounds_for_turn(
         services,
         coordinates,
@@ -2286,14 +2401,7 @@ async fn run_provider_turn(
     {
         Ok(tool_rounds) => tool_rounds,
         Err(err) => {
-            fail_provider_turn(
-                coordinates,
-                thread_id,
-                events,
-                status,
-                "history",
-                err.to_string(),
-            );
+            failed_turn.fail_message("history", err.to_string()).await;
             return true;
         }
     };
@@ -2311,14 +2419,7 @@ async fn run_provider_turn(
                 .unwrap_or(crate::agent::agent_tool_router::DEFAULT_TOOL_CANCELLATION_GRACE),
             Ok(None) => crate::agent::agent_tool_router::DEFAULT_TOOL_CANCELLATION_GRACE,
             Err(err) => {
-                fail_provider_turn(
-                    coordinates,
-                    thread_id,
-                    events,
-                    status,
-                    "history",
-                    err.to_string(),
-                );
+                failed_turn.fail_message("history", err.to_string()).await;
                 return true;
             }
         };
@@ -2344,14 +2445,9 @@ async fn run_provider_turn(
         if let Err(err) =
             append_hook_mutation_witnesses(services, coordinates, outcome.mutation_witnesses).await
         {
-            fail_provider_turn(
-                coordinates,
-                thread_id,
-                events,
-                status,
-                "hook_pipeline",
-                err.to_string(),
-            );
+            failed_turn
+                .fail_message("hook_pipeline", err.to_string())
+                .await;
             return true;
         }
         if let Err(err) = append_hook_contexts(
@@ -2363,14 +2459,9 @@ async fn run_provider_turn(
         )
         .await
         {
-            fail_provider_turn(
-                coordinates,
-                thread_id,
-                events,
-                status,
-                "hook_pipeline",
-                err.to_string(),
-            );
+            failed_turn
+                .fail_message("hook_pipeline", err.to_string())
+                .await;
             return true;
         }
         if outcome.should_stop {
@@ -2397,14 +2488,7 @@ async fn run_provider_turn(
             {
                 Ok(pending) => pending,
                 Err(err) => {
-                    fail_provider_turn(
-                        coordinates,
-                        thread_id,
-                        events,
-                        status,
-                        "history",
-                        err.to_string(),
-                    );
+                    failed_turn.fail_message("history", err.to_string()).await;
                     return true;
                 }
             };
@@ -2420,14 +2504,7 @@ async fn run_provider_turn(
             match pending_witnessed_tool_batch_for_turn(services, coordinates, &turn_id).await {
                 Ok(batch) => batch,
                 Err(err) => {
-                    fail_provider_turn(
-                        coordinates,
-                        thread_id,
-                        events,
-                        status,
-                        "history",
-                        err.to_string(),
-                    );
+                    failed_turn.fail_message("history", err.to_string()).await;
                     return true;
                 }
             };
@@ -2458,14 +2535,9 @@ async fn run_provider_turn(
                 }
                 ToolBatchAwaitOutcome::Completed(Ok(_)) => {}
                 ToolBatchAwaitOutcome::Completed(Err(err)) => {
-                    fail_provider_turn(
-                        coordinates,
-                        thread_id,
-                        events,
-                        status,
-                        "tool_router",
-                        err.to_string(),
-                    );
+                    failed_turn
+                        .fail_message("tool_router", err.to_string())
+                        .await;
                     return true;
                 }
                 ToolBatchAwaitOutcome::Cancelled { reason } => {
@@ -2502,7 +2574,7 @@ async fn run_provider_turn(
                     return true;
                 }
                 ToolBatchAwaitOutcome::Failed { code, reason } => {
-                    fail_provider_turn(coordinates, thread_id, events, status, code, reason);
+                    failed_turn.fail_message(code, reason).await;
                     return true;
                 }
             }
@@ -2514,6 +2586,7 @@ async fn run_provider_turn(
         let mut failed = false;
         let mut failure_code = None;
         let mut failure_reason = None;
+        let mut terminal_failure = None;
         let mut emit_failure_signal = false;
         let mut terminal_join_recorded = false;
         let mut continue_after_tools = false;
@@ -2598,7 +2671,7 @@ async fn run_provider_turn(
                         return true;
                     }
                     ActiveProviderCommandOutcome::Failed { code, reason } => {
-                        fail_provider_turn(coordinates, thread_id, events, status, code, reason);
+                        failed_turn.fail_message(code, reason).await;
                         return true;
                     }
                 }
@@ -2840,14 +2913,7 @@ async fn run_provider_turn(
                                             return true;
                                         }
                                         ToolBatchAwaitOutcome::Failed { code, reason } => {
-                                            fail_provider_turn(
-                                                coordinates,
-                                                thread_id,
-                                                events,
-                                                status,
-                                                code,
-                                                reason,
-                                            );
+                                            failed_turn.fail_message(code, reason).await;
                                             return true;
                                         }
                                     }
@@ -2864,7 +2930,8 @@ async fn run_provider_turn(
                 Err(err) => {
                     failed = true;
                     failure_code = Some("runtime_execution");
-                    failure_reason = Some(err.to_string());
+                    failure_reason = Some(err.message.clone());
+                    terminal_failure = Some(err);
                     emit_failure_signal = true;
                     append_terminal_join_until_recorded(
                         services,
@@ -2895,6 +2962,7 @@ async fn run_provider_turn(
         if failed {
             let reason = failure_reason
                 .unwrap_or_else(|| "provider turn failed without reason detail".to_string());
+            let code = failure_code.unwrap_or("runtime_execution");
             if !terminal_join_recorded {
                 append_terminal_join_until_recorded(
                     services,
@@ -2916,14 +2984,13 @@ async fn run_provider_turn(
                     },
                 );
             }
-            fail_provider_turn(
-                coordinates,
-                thread_id,
-                events,
-                status,
-                failure_code.unwrap_or("runtime_execution"),
-                reason,
-            );
+            failed_turn
+                .fail(
+                    code,
+                    terminal_failure
+                        .unwrap_or_else(|| TerminalTurnFailure::from_code(code, reason)),
+                )
+                .await;
             return true;
         }
         if suspended_after_tools {
@@ -2953,14 +3020,7 @@ async fn run_provider_turn(
                 Some(turn_source_event_id),
             )
             .await;
-            fail_provider_turn(
-                coordinates,
-                thread_id,
-                events,
-                status,
-                "hook_pipeline",
-                reason,
-            );
+            failed_turn.fail_message("hook_pipeline", reason).await;
             return true;
         }
         if let Err(err) =
@@ -2975,7 +3035,7 @@ async fn run_provider_turn(
                 Some(turn_source_event_id),
             )
             .await;
-            fail_provider_turn(coordinates, thread_id, events, status, "history", reason);
+            failed_turn.fail_message("history", reason).await;
             return true;
         }
         crate::kernel::runtime_host::runtime_events::emit_runtime_event(
@@ -3448,6 +3508,49 @@ fn fail_provider_turn(
     );
     let _ = events
         .send(crate::kernel::runtime_host::runtime_api::ThreadEvent::Failed { thread_id, message });
+}
+
+struct FailedTurnTransition<'a> {
+    coordinates: &'a verlet_runtime_contracts::ThreadCoordinates,
+    services: &'a crate::kernel::runtime_host::runtime_services::RuntimeServices,
+    turn_id: &'a str,
+    source_event_id: Option<verlet_history::EventRecordId>,
+    thread_id: verlet_runtime_contracts::ThreadId,
+    events:
+        &'a tokio::sync::broadcast::Sender<crate::kernel::runtime_host::runtime_api::ThreadEvent>,
+    status: &'a tokio::sync::watch::Sender<verlet_runtime_contracts::ThreadStatus>,
+}
+
+impl FailedTurnTransition<'_> {
+    async fn fail(&self, code: &'static str, failure: TerminalTurnFailure) {
+        if let Err(err) = append_turn_failed_event(
+            self.services,
+            self.coordinates,
+            self.turn_id,
+            self.source_event_id,
+            &failure,
+        )
+        .await
+        {
+            eprintln!(
+                "verlet agent loop could not persist turn.failed for turn {}: {err}",
+                self.turn_id
+            );
+        }
+        fail_provider_turn(
+            self.coordinates,
+            self.thread_id,
+            self.events,
+            self.status,
+            code,
+            failure.message,
+        );
+    }
+
+    async fn fail_message(&self, code: &'static str, message: String) {
+        self.fail(code, TerminalTurnFailure::from_code(code, message))
+            .await;
+    }
 }
 
 async fn append_terminal_join_until_recorded(
@@ -5698,6 +5801,66 @@ async fn append_turn_completed_event(
         )
         .await?;
     Ok(completed)
+}
+
+async fn append_turn_failed_event(
+    services: &crate::kernel::runtime_host::runtime_services::RuntimeServices,
+    coordinates: &verlet_runtime_contracts::ThreadCoordinates,
+    turn_id: &str,
+    source_event_id: Option<verlet_history::EventRecordId>,
+    failure: &TerminalTurnFailure,
+) -> crate::kernel::runtime_host::VerletResult<verlet_history::EventRecord> {
+    let existing = services
+        .runtime_store()
+        .read_events(
+            &verlet_history::EventStreamId::for_thread(coordinates),
+            None,
+        )
+        .await
+        .map_err(|err| crate::kernel::runtime_host::VerletError::History(err.to_string()))?
+        .into_iter()
+        .filter(|event| {
+            event.kind == verlet_history::EventKind::TurnFailed
+                && event
+                    .payload
+                    .get("turn_id")
+                    .and_then(serde_json::Value::as_str)
+                    == Some(turn_id)
+        })
+        .max_by_key(|event| event.sequence.get());
+    if let Some(existing) = existing {
+        return Ok(existing);
+    }
+    let payload = verlet_history::TurnFailedPayload::new(
+        turn_id,
+        failure.error_class,
+        failure.provider_id.clone(),
+        failure.http_status,
+        failure.journal_message.clone(),
+        failure.retries_attempted,
+    );
+    let payload = serde_json::to_value(payload).map_err(|err| {
+        crate::kernel::runtime_host::VerletError::History(format!(
+            "turn.failed payload codec failed: {err}"
+        ))
+    })?;
+    services
+        .append_thread_event(
+            coordinates,
+            verlet_history::NewEventRecord::discharged(
+                coordinates.clone(),
+                verlet_history::EventKind::TurnFailed,
+                payload,
+                verlet_history::EventProvenance {
+                    source_streams: vec![verlet_history::EventStreamId::for_thread(coordinates)],
+                    source_event_ids: source_event_id.into_iter().collect(),
+                    discharged_by: Some("propagator:agent-loop".to_string()),
+                    function: Some("turn_fail/v1".to_string()),
+                    ..verlet_history::EventProvenance::default()
+                },
+            ),
+        )
+        .await
 }
 
 async fn append_turn_resumed_event(

--- a/crates/verlet-kernel/src/adapters/agent_loop.rs
+++ b/crates/verlet-kernel/src/adapters/agent_loop.rs
@@ -2204,61 +2204,63 @@ fn model_request_id(
 
 fn classify_provider_error(error: verlet_provider::ProviderError) -> ModelRequestAttemptError {
     let message = error.to_string();
-    let (class, terminal_class, http_status, journal_message) = match error {
-        verlet_provider::ProviderError::Cancelled => (
-            verlet_runtime_contracts::RuntimeModelRequestErrorClass::Cancelled,
-            verlet_history::TurnFailureErrorClass::Runner,
-            None,
-            "provider request cancelled".to_string(),
-        ),
+    match error {
+        verlet_provider::ProviderError::Cancelled => ModelRequestAttemptError {
+            class: verlet_runtime_contracts::RuntimeModelRequestErrorClass::Cancelled,
+            terminal_class: verlet_history::TurnFailureErrorClass::Runner,
+            http_status: None,
+            message,
+            journal_message: "provider request cancelled".to_string(),
+        },
         verlet_provider::ProviderError::UnsupportedCapability { .. }
-        | verlet_provider::ProviderError::ApiMismatch { .. } => (
-            verlet_runtime_contracts::RuntimeModelRequestErrorClass::UnsupportedCapability,
-            verlet_history::TurnFailureErrorClass::Runner,
-            None,
-            message.clone(),
-        ),
-        verlet_provider::ProviderError::Http(_) => (
-            verlet_runtime_contracts::RuntimeModelRequestErrorClass::Retryable,
-            verlet_history::TurnFailureErrorClass::ProviderTransport,
-            None,
-            message.clone(),
-        ),
-        verlet_provider::ProviderError::HttpStatus { status, .. } if status.as_u16() == 429 => (
-            verlet_runtime_contracts::RuntimeModelRequestErrorClass::RateLimited,
-            verlet_history::TurnFailureErrorClass::ProviderHttp,
-            Some(status.as_u16()),
-            format!("provider HTTP status {}", status.as_u16()),
-        ),
+        | verlet_provider::ProviderError::ApiMismatch { .. } => ModelRequestAttemptError {
+            class: verlet_runtime_contracts::RuntimeModelRequestErrorClass::UnsupportedCapability,
+            terminal_class: verlet_history::TurnFailureErrorClass::Runner,
+            http_status: None,
+            message,
+            journal_message: "provider request capability unsupported".to_string(),
+        },
+        verlet_provider::ProviderError::Http(_) => ModelRequestAttemptError {
+            class: verlet_runtime_contracts::RuntimeModelRequestErrorClass::Retryable,
+            terminal_class: verlet_history::TurnFailureErrorClass::ProviderTransport,
+            http_status: None,
+            message,
+            journal_message: "provider HTTP transport failed".to_string(),
+        },
+        verlet_provider::ProviderError::HttpStatus { status, .. } if status.as_u16() == 429 => {
+            ModelRequestAttemptError {
+                class: verlet_runtime_contracts::RuntimeModelRequestErrorClass::RateLimited,
+                terminal_class: verlet_history::TurnFailureErrorClass::ProviderHttp,
+                http_status: Some(status.as_u16()),
+                message,
+                journal_message: format!("provider HTTP status {}", status.as_u16()),
+            }
+        }
         verlet_provider::ProviderError::HttpStatus { status, .. }
             if status.is_server_error() || matches!(status.as_u16(), 408 | 409 | 425) =>
         {
-            (
-                verlet_runtime_contracts::RuntimeModelRequestErrorClass::Retryable,
-                verlet_history::TurnFailureErrorClass::ProviderHttp,
-                Some(status.as_u16()),
-                format!("provider HTTP status {}", status.as_u16()),
-            )
+            ModelRequestAttemptError {
+                class: verlet_runtime_contracts::RuntimeModelRequestErrorClass::Retryable,
+                terminal_class: verlet_history::TurnFailureErrorClass::ProviderHttp,
+                http_status: Some(status.as_u16()),
+                message,
+                journal_message: format!("provider HTTP status {}", status.as_u16()),
+            }
         }
-        verlet_provider::ProviderError::Decode(_) => (
-            verlet_runtime_contracts::RuntimeModelRequestErrorClass::Fatal,
-            verlet_history::TurnFailureErrorClass::ProviderTransport,
-            None,
-            message.clone(),
-        ),
-        verlet_provider::ProviderError::HttpStatus { status, .. } => (
-            verlet_runtime_contracts::RuntimeModelRequestErrorClass::Fatal,
-            verlet_history::TurnFailureErrorClass::ProviderHttp,
-            Some(status.as_u16()),
-            format!("provider HTTP status {}", status.as_u16()),
-        ),
-    };
-    ModelRequestAttemptError {
-        class,
-        terminal_class,
-        http_status,
-        message,
-        journal_message,
+        verlet_provider::ProviderError::Decode(_) => ModelRequestAttemptError {
+            class: verlet_runtime_contracts::RuntimeModelRequestErrorClass::Fatal,
+            terminal_class: verlet_history::TurnFailureErrorClass::ProviderTransport,
+            http_status: None,
+            message,
+            journal_message: "provider response decode failed".to_string(),
+        },
+        verlet_provider::ProviderError::HttpStatus { status, .. } => ModelRequestAttemptError {
+            class: verlet_runtime_contracts::RuntimeModelRequestErrorClass::Fatal,
+            terminal_class: verlet_history::TurnFailureErrorClass::ProviderHttp,
+            http_status: Some(status.as_u16()),
+            message,
+            journal_message: format!("provider HTTP status {}", status.as_u16()),
+        },
     }
 }
 
@@ -2268,7 +2270,7 @@ fn stream_assembly_error(message: impl Into<String>) -> ModelRequestAttemptError
         class: verlet_runtime_contracts::RuntimeModelRequestErrorClass::StreamAssembly,
         terminal_class: verlet_history::TurnFailureErrorClass::ProviderTransport,
         http_status: None,
-        journal_message: message.clone(),
+        journal_message: "provider stream assembly failed".to_string(),
         message,
     }
 }
@@ -5810,27 +5812,6 @@ async fn append_turn_failed_event(
     source_event_id: Option<verlet_history::EventRecordId>,
     failure: &TerminalTurnFailure,
 ) -> crate::kernel::runtime_host::VerletResult<verlet_history::EventRecord> {
-    let existing = services
-        .runtime_store()
-        .read_events(
-            &verlet_history::EventStreamId::for_thread(coordinates),
-            None,
-        )
-        .await
-        .map_err(|err| crate::kernel::runtime_host::VerletError::History(err.to_string()))?
-        .into_iter()
-        .filter(|event| {
-            event.kind == verlet_history::EventKind::TurnFailed
-                && event
-                    .payload
-                    .get("turn_id")
-                    .and_then(serde_json::Value::as_str)
-                    == Some(turn_id)
-        })
-        .max_by_key(|event| event.sequence.get());
-    if let Some(existing) = existing {
-        return Ok(existing);
-    }
     let payload = verlet_history::TurnFailedPayload::new(
         turn_id,
         failure.error_class,
@@ -5844,23 +5825,63 @@ async fn append_turn_failed_event(
             "turn.failed payload codec failed: {err}"
         ))
     })?;
-    services
-        .append_thread_event(
-            coordinates,
-            verlet_history::NewEventRecord::discharged(
-                coordinates.clone(),
-                verlet_history::EventKind::TurnFailed,
-                payload,
-                verlet_history::EventProvenance {
-                    source_streams: vec![verlet_history::EventStreamId::for_thread(coordinates)],
-                    source_event_ids: source_event_id.into_iter().collect(),
-                    discharged_by: Some("propagator:agent-loop".to_string()),
-                    function: Some("turn_fail/v1".to_string()),
-                    ..verlet_history::EventProvenance::default()
-                },
-            ),
-        )
-        .await
+    let stream_id = verlet_history::EventStreamId::for_thread(coordinates);
+    let record = verlet_history::NewEventRecord::discharged(
+        coordinates.clone(),
+        verlet_history::EventKind::TurnFailed,
+        payload,
+        verlet_history::EventProvenance {
+            source_streams: vec![stream_id.clone()],
+            source_event_ids: source_event_id.into_iter().collect(),
+            discharged_by: Some("propagator:agent-loop".to_string()),
+            function: Some("turn_fail/v1".to_string()),
+            ..verlet_history::EventProvenance::default()
+        },
+    );
+    loop {
+        let events = services
+            .runtime_store()
+            .read_events(&stream_id, None)
+            .await
+            .map_err(|err| crate::kernel::runtime_host::VerletError::History(err.to_string()))?;
+        if let Some(existing) = events.iter().find(|event| {
+            event.kind == verlet_history::EventKind::TurnFailed
+                && event
+                    .payload
+                    .get("turn_id")
+                    .and_then(serde_json::Value::as_str)
+                    == Some(turn_id)
+        }) {
+            return Ok(existing.clone());
+        }
+        let expected_next_sequence = events
+            .last()
+            .map(|event| verlet_history::EventSequence::new(event.sequence.get().saturating_add(1)))
+            .unwrap_or_else(|| verlet_history::EventSequence::new(1));
+        match services
+            .runtime_store()
+            .append_events_fenced(&stream_id, expected_next_sequence, vec![record.clone()])
+            .await
+        {
+            Ok(mut appended) if appended.len() == 1 => {
+                let appended = appended.remove(0);
+                services.run_bound_couplings(vec![appended.clone()]).await?;
+                return Ok(appended);
+            }
+            Ok(appended) => {
+                return Err(crate::kernel::runtime_host::VerletError::History(format!(
+                    "turn.failed fenced append returned {} records",
+                    appended.len()
+                )));
+            }
+            Err(verlet_history::HistoryError::AppendFenceConflict { .. }) => continue,
+            Err(err) => {
+                return Err(crate::kernel::runtime_host::VerletError::History(
+                    err.to_string(),
+                ));
+            }
+        }
+    }
 }
 
 async fn append_turn_resumed_event(

--- a/crates/verlet-kernel/src/adapters/agent_loop/tests.rs
+++ b/crates/verlet-kernel/src/adapters/agent_loop/tests.rs
@@ -3016,12 +3016,179 @@ async fn retry_exhaustion_journals_exactly_one_turn_failed() {
     );
     assert_eq!(payload.provider_id.as_deref(), Some("openai"));
     assert_eq!(payload.http_status, None);
-    assert!(payload.message.contains("outage-3"));
+    assert_eq!(payload.message, "provider HTTP transport failed");
     assert_eq!(payload.retries_attempted, 2);
 }
 
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn cancellation_during_provider_retry_sleep_journals_no_turn_failed() {
+    let client = std::sync::Arc::new(ScriptedClient::new(vec![
+        ScriptedResponse::Error(verlet_provider::ProviderError::Http(
+            "temporary outage".to_string(),
+        )),
+        ScriptedResponse::Response(response_text("unused reply")),
+    ]));
+    let mut config = crate::adapters::agent_loop::AgentLoopConfig::new(
+        verlet_history::ProviderApi::OpenAIResponses,
+        "openai",
+        "gpt-test",
+    );
+    config.max_tokens = 128;
+    let factory = std::sync::Arc::new(
+        crate::adapters::agent_loop::AgentLoopFactory::new(config, client.clone())
+            .with_model_request_retry_policy(
+                crate::adapters::agent_loop::ModelRequestRetryPolicy::fixed(2, 60_000),
+            ),
+    );
+    let host = crate::kernel::runtime_host::RuntimeHost::new(factory);
+    let store = host.runtime_store();
+    let thread = host
+        .start_thread(
+            verlet_runtime_contracts::ThreadCoordinates::new(
+                "tenant_a",
+                "user_1",
+                "cancel-retry-sleep",
+            ),
+            verlet_runtime_contracts::ThreadTopology::root(),
+        )
+        .await
+        .unwrap();
+    let mut events = thread.subscribe_events();
+
+    host.submit(thread.context().coordinates.thread_id, "turn-1", "hello")
+        .await
+        .unwrap();
+    loop {
+        let event = events.recv().await.unwrap();
+        if matches!(
+            event,
+            crate::kernel::runtime_host::runtime_api::ThreadEvent::Runtime {
+                event: crate::kernel::runtime_host::runtime_events::RuntimeEvent {
+                    kind: crate::kernel::runtime_host::runtime_events::RuntimeEventKind::ModelRequestRetryScheduled { .. },
+                    ..
+                },
+                ..
+            }
+        ) {
+            break;
+        }
+    }
+    host.cancel(thread.context().coordinates.thread_id, "cancel retry sleep")
+        .await
+        .unwrap();
+    assert_cancelled(&mut events, "cancel retry sleep").await;
+
+    assert_eq!(
+        thread.status(),
+        verlet_runtime_contracts::ThreadStatus::Idle
+    );
+    assert_eq!(client.requests().len(), 1);
+    assert!(
+        turn_failed_events(store.as_ref(), &thread.context().coordinates)
+            .await
+            .is_empty()
+    );
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn concurrent_turn_failure_replay_appends_exactly_one_outcome() {
+    let inner = std::sync::Arc::new(verlet_history::InMemorySessionStore::new());
+    let store = std::sync::Arc::new(
+        crate::support::fault::FaultingRuntimeStore::new(inner.clone())
+            .delay_nth_after("read_events", 1, tokio::time::Duration::from_millis(1))
+            .delay_nth_after("read_events", 2, tokio::time::Duration::from_millis(1)),
+    );
+    let services = crate::kernel::runtime_host::runtime_services::RuntimeServices::new(
+        store.clone(),
+        crate::kernel::runtime_host::runtime_services::RuntimeExecutionPolicy::default(),
+    );
+    let coordinates = verlet_runtime_contracts::ThreadCoordinates::new(
+        "tenant_a",
+        "user_1",
+        "concurrent-turn-failure",
+    );
+    let failure = crate::adapters::agent_loop::TerminalTurnFailure::provider(
+        "openai".to_string(),
+        crate::adapters::agent_loop::classify_provider_error(
+            verlet_provider::ProviderError::HttpStatus {
+                status: reqwest::StatusCode::BAD_GATEWAY,
+                body: "upstream body".to_string(),
+            },
+        ),
+        1,
+    );
+
+    let first_services = services.clone();
+    let first_coordinates = coordinates.clone();
+    let first_failure = failure.clone();
+    let first = tokio::spawn(async move {
+        crate::adapters::agent_loop::append_turn_failed_event(
+            &first_services,
+            &first_coordinates,
+            "turn-1",
+            None,
+            &first_failure,
+        )
+        .await
+    });
+    let second_services = services.clone();
+    let second_coordinates = coordinates.clone();
+    let second_failure = failure.clone();
+    let second = tokio::spawn(async move {
+        crate::adapters::agent_loop::append_turn_failed_event(
+            &second_services,
+            &second_coordinates,
+            "turn-1",
+            None,
+            &second_failure,
+        )
+        .await
+    });
+
+    while store.call_count("read_events") < 2 {
+        tokio::task::yield_now().await;
+    }
+    tokio::time::advance(tokio::time::Duration::from_millis(1)).await;
+    let (first, second) = tokio::join!(first, second);
+    let first = first.unwrap().unwrap();
+    let second = second.unwrap().unwrap();
+
+    let failed = turn_failed_events(inner.as_ref(), &coordinates).await;
+    assert_eq!(failed.len(), 1);
+    assert_eq!(first.id, failed[0].id);
+    assert_eq!(second.id, failed[0].id);
+}
+
+#[test]
+fn provider_journal_messages_do_not_preserve_transport_decode_or_stream_details() {
+    for (error, expected) in [
+        (
+            verlet_provider::ProviderError::Http(
+                "request to https://user:secret@example.test failed".to_string(),
+            ),
+            "provider HTTP transport failed",
+        ),
+        (
+            verlet_provider::ProviderError::Decode(
+                "raw response body and header Authorization: secret".to_string(),
+            ),
+            "provider response decode failed",
+        ),
+    ] {
+        let classified = crate::adapters::agent_loop::classify_provider_error(error);
+        assert_eq!(classified.journal_message, expected);
+        assert_ne!(classified.message, classified.journal_message);
+    }
+
+    let stream = crate::adapters::agent_loop::stream_assembly_error(
+        "raw streamed response body and stack trace",
+    );
+    assert_eq!(stream.journal_message, "provider stream assembly failed");
+    assert_ne!(stream.message, stream.journal_message);
+}
+
 #[tokio::test]
-async fn terminal_provider_message_is_journaled_at_most_1024_bytes() {
+async fn terminal_provider_transport_message_is_normalized() {
     let client = std::sync::Arc::new(ScriptedClient::new(vec![ScriptedResponse::Error(
         verlet_provider::ProviderError::Http("x".repeat(2_048)),
     )]));
@@ -3045,13 +3212,7 @@ async fn terminal_provider_message_is_journaled_at_most_1024_bytes() {
     assert_eq!(failed.len(), 1);
     let payload: verlet_history::TurnFailedPayload =
         serde_json::from_value(failed[0].payload.clone()).unwrap();
-    assert_eq!(payload.message.as_bytes().len(), 1024);
-    assert!(payload.message.is_char_boundary(payload.message.len()));
-    assert!(
-        payload
-            .message
-            .starts_with("provider HTTP request failed: ")
-    );
+    assert_eq!(payload.message, "provider HTTP transport failed");
 }
 
 #[tokio::test]

--- a/crates/verlet-kernel/src/adapters/agent_loop/tests.rs
+++ b/crates/verlet-kernel/src/adapters/agent_loop/tests.rs
@@ -2853,6 +2853,50 @@ async fn runtime_emits_model_request_failed_on_provider_error() {
     }));
 }
 
+#[tokio::test]
+async fn terminal_provider_http_error_journals_one_body_free_turn_failed() {
+    let client = std::sync::Arc::new(ScriptedClient::new(vec![ScriptedResponse::Error(
+        verlet_provider::ProviderError::HttpStatus {
+            status: reqwest::StatusCode::BAD_REQUEST,
+            body: "raw-response-body-must-not-be-journaled".to_string(),
+        },
+    )]));
+    let host = crate::kernel::runtime_host::RuntimeHost::new(runtime_factory(client));
+    let store = host.runtime_store();
+    let thread = host
+        .start_thread(
+            verlet_runtime_contracts::ThreadCoordinates::new("tenant_a", "user_1", "session_1"),
+            verlet_runtime_contracts::ThreadTopology::root(),
+        )
+        .await
+        .unwrap();
+    let mut events = thread.subscribe_events();
+
+    host.submit(thread.context().coordinates.thread_id, "turn-1", "hello")
+        .await
+        .unwrap();
+    assert_failed_with_runtime_events(&mut events, "raw-response-body-must-not-be-journaled").await;
+
+    let failed = turn_failed_events(store.as_ref(), &thread.context().coordinates).await;
+    assert_eq!(failed.len(), 1);
+    let payload: verlet_history::TurnFailedPayload =
+        serde_json::from_value(failed[0].payload.clone()).unwrap();
+    assert_eq!(payload.turn_id, "turn-1");
+    assert_eq!(
+        payload.error_class,
+        verlet_history::TurnFailureErrorClass::ProviderHttp
+    );
+    assert_eq!(payload.provider_id.as_deref(), Some("openai"));
+    assert_eq!(payload.http_status, Some(400));
+    assert_eq!(payload.message, "provider HTTP status 400");
+    assert_eq!(payload.retries_attempted, 0);
+    assert!(
+        !serde_json::to_string(&failed[0].payload)
+            .unwrap()
+            .contains("raw-response-body-must-not-be-journaled")
+    );
+}
+
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn model_request_retries_retryable_provider_error() {
     let inner = std::sync::Arc::new(RecordingClient::with_responses(vec![response_text(
@@ -2879,6 +2923,7 @@ async fn model_request_retries_retryable_provider_error() {
         factory,
         std::sync::Arc::new(verlet_history::InMemorySessionStore::new()),
     );
+    let store = host.runtime_store();
     let thread = host
         .start_thread(
             verlet_runtime_contracts::ThreadCoordinates::new("tenant_a", "user_1", "session_1"),
@@ -2892,6 +2937,7 @@ async fn model_request_retries_retryable_provider_error() {
         .await
         .unwrap();
     let runtime_events = assert_output_with_runtime_events(&mut events, "retry reply").await;
+    assert_completed_terminal(&mut events).await;
 
     assert_eq!(client.call_count("complete"), 2);
     assert_eq!(inner.requests().len(), 1);
@@ -2917,6 +2963,95 @@ async fn model_request_retries_retryable_provider_error() {
             }
         )
     }));
+    assert!(
+        turn_failed_events(store.as_ref(), &thread.context().coordinates)
+            .await
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn retry_exhaustion_journals_exactly_one_turn_failed() {
+    let client = std::sync::Arc::new(ScriptedClient::new(vec![
+        ScriptedResponse::Error(verlet_provider::ProviderError::Http("outage-1".to_string())),
+        ScriptedResponse::Error(verlet_provider::ProviderError::Http("outage-2".to_string())),
+        ScriptedResponse::Error(verlet_provider::ProviderError::Http("outage-3".to_string())),
+    ]));
+    let mut config = crate::adapters::agent_loop::AgentLoopConfig::new(
+        verlet_history::ProviderApi::OpenAIResponses,
+        "openai",
+        "gpt-test",
+    );
+    config.max_tokens = 128;
+    let factory = std::sync::Arc::new(
+        crate::adapters::agent_loop::AgentLoopFactory::new(config, client.clone())
+            .with_model_request_retry_policy(
+                crate::adapters::agent_loop::ModelRequestRetryPolicy::fixed(3, 0),
+            ),
+    );
+    let host = crate::kernel::runtime_host::RuntimeHost::new(factory);
+    let store = host.runtime_store();
+    let thread = host
+        .start_thread(
+            verlet_runtime_contracts::ThreadCoordinates::new("tenant_a", "user_1", "session_1"),
+            verlet_runtime_contracts::ThreadTopology::root(),
+        )
+        .await
+        .unwrap();
+    let mut events = thread.subscribe_events();
+
+    host.submit(thread.context().coordinates.thread_id, "turn-1", "hello")
+        .await
+        .unwrap();
+    assert_failed_with_runtime_events(&mut events, "outage-3").await;
+
+    assert_eq!(client.requests().len(), 3);
+    let failed = turn_failed_events(store.as_ref(), &thread.context().coordinates).await;
+    assert_eq!(failed.len(), 1);
+    let payload: verlet_history::TurnFailedPayload =
+        serde_json::from_value(failed[0].payload.clone()).unwrap();
+    assert_eq!(
+        payload.error_class,
+        verlet_history::TurnFailureErrorClass::ProviderTransport
+    );
+    assert_eq!(payload.provider_id.as_deref(), Some("openai"));
+    assert_eq!(payload.http_status, None);
+    assert!(payload.message.contains("outage-3"));
+    assert_eq!(payload.retries_attempted, 2);
+}
+
+#[tokio::test]
+async fn terminal_provider_message_is_journaled_at_most_1024_bytes() {
+    let client = std::sync::Arc::new(ScriptedClient::new(vec![ScriptedResponse::Error(
+        verlet_provider::ProviderError::Http("x".repeat(2_048)),
+    )]));
+    let host = crate::kernel::runtime_host::RuntimeHost::new(runtime_factory(client));
+    let store = host.runtime_store();
+    let thread = host
+        .start_thread(
+            verlet_runtime_contracts::ThreadCoordinates::new("tenant_a", "user_1", "session_1"),
+            verlet_runtime_contracts::ThreadTopology::root(),
+        )
+        .await
+        .unwrap();
+    let mut events = thread.subscribe_events();
+
+    host.submit(thread.context().coordinates.thread_id, "turn-1", "hello")
+        .await
+        .unwrap();
+    assert_failed_with_runtime_events(&mut events, "provider HTTP request failed").await;
+
+    let failed = turn_failed_events(store.as_ref(), &thread.context().coordinates).await;
+    assert_eq!(failed.len(), 1);
+    let payload: verlet_history::TurnFailedPayload =
+        serde_json::from_value(failed[0].payload.clone()).unwrap();
+    assert_eq!(payload.message.as_bytes().len(), 1024);
+    assert!(payload.message.is_char_boundary(payload.message.len()));
+    assert!(
+        payload
+            .message
+            .starts_with("provider HTTP request failed: ")
+    );
 }
 
 #[tokio::test]
@@ -9262,6 +9397,22 @@ fn wat_bytes(bytes: &[u8]) -> String {
 
 fn is_canonical_message_entry(entry: &verlet_history::SessionEntry) -> bool {
     matches!(entry.kind, verlet_history::SessionEntryKind::Message { .. })
+}
+
+async fn turn_failed_events(
+    store: &dyn verlet_history::RuntimeStore,
+    coordinates: &verlet_runtime_contracts::ThreadCoordinates,
+) -> Vec<verlet_history::EventRecord> {
+    store
+        .read_events(
+            &verlet_history::EventStreamId::for_thread(coordinates),
+            None,
+        )
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|event| event.kind == verlet_history::EventKind::TurnFailed)
+        .collect()
 }
 
 fn temp_db_path(prefix: &str) -> std::path::PathBuf {

--- a/crates/verlet-kernel/src/adapters/app_server/connection.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/connection.rs
@@ -3701,11 +3701,13 @@ impl crate::adapters::app_server::VerletAppServer {
         for event in control_events
             .iter()
             .filter(|event| event.kind == verlet_history::EventKind::TurnResumed)
-            .chain(
-                thread_events
-                    .iter()
-                    .filter(|event| event.kind == verlet_history::EventKind::TurnCompleted),
-            )
+            .chain(thread_events.iter().filter(|event| {
+                matches!(
+                    event.kind,
+                    verlet_history::EventKind::TurnCompleted
+                        | verlet_history::EventKind::TurnFailed
+                )
+            }))
         {
             if let Some(turn_id) = event
                 .payload

--- a/crates/verlet-kernel/src/adapters/app_server/tests.rs
+++ b/crates/verlet-kernel/src/adapters/app_server/tests.rs
@@ -11472,6 +11472,70 @@ async fn thread_events_list_pages_filters_and_reports_clear_errors() {
         waiting["data"][0]["approvalId"].as_str(),
         Some("approval-1")
     );
+    session_store
+        .append_events(
+            &control_stream_id,
+            vec![verlet_history::NewEventRecord::discharged(
+                lifecycle.coordinates.clone(),
+                verlet_history::EventKind::TurnWaiting,
+                serde_json::json!({
+                    "schema": verlet_history::EventKind::TurnWaiting.payload_schema_id(),
+                    "turn_id": "turn-failed",
+                    "subject": { "turn_id": "turn-failed", "call_id": "call-failed" },
+                    "snapshot_id": "snapshot-failed",
+                    "waiting_on_event_id": suspended_event_id.to_string(),
+                    "reason": "synthetic failed wait",
+                    "continuation": "tool.call",
+                }),
+                verlet_history::EventProvenance {
+                    source_streams: vec![thread_stream_id.clone()],
+                    source_event_ids: vec![suspended_event_id],
+                    discharged_by: Some("scheduler:test-failed-wait".to_string()),
+                    function: Some("tool_wait/v1".to_string()),
+                    ..verlet_history::EventProvenance::default()
+                },
+            )],
+        )
+        .await
+        .unwrap();
+    session_store
+        .append_events(
+            &thread_stream_id,
+            vec![verlet_history::NewEventRecord::discharged(
+                lifecycle.coordinates.clone(),
+                verlet_history::EventKind::TurnFailed,
+                serde_json::to_value(verlet_history::TurnFailedPayload::new(
+                    "turn-failed",
+                    verlet_history::TurnFailureErrorClass::Runner,
+                    None,
+                    None,
+                    "runner failed",
+                    0,
+                ))
+                .unwrap(),
+                verlet_history::EventProvenance {
+                    source_streams: vec![thread_stream_id.clone()],
+                    discharged_by: Some("propagator:test-failed-turn".to_string()),
+                    function: Some("turn_fail/v1".to_string()),
+                    ..verlet_history::EventProvenance::default()
+                },
+            )],
+        )
+        .await
+        .unwrap();
+    let waiting_after_failure = app
+        .dispatch_request(
+            &connection,
+            "thread/waiting/list",
+            Some(serde_json::json!({ "threadId": thread_id })),
+        )
+        .await
+        .unwrap();
+    assert_eq!(waiting_after_failure["data"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        waiting_after_failure["data"][0]["turnId"].as_str(),
+        Some("turn-pending")
+    );
     let resolved = app
         .dispatch_request(
             &connection,

--- a/crates/verlet-kernel/src/cli/debug_journal/tests.rs
+++ b/crates/verlet-kernel/src/cli/debug_journal/tests.rs
@@ -126,3 +126,61 @@ fn render_debug_journal_keeps_each_record_on_one_compact_line() {
     assert!(rendered.contains(":7\tsession.entry.appended\t"));
     assert!(rendered.contains(r#"{"text":"first\nsecond"}"#));
 }
+
+#[tokio::test]
+async fn turn_failed_kind_filters_a_real_journal_store() {
+    use verlet_history::EventStore as _;
+
+    let root = std::env::temp_dir().join(format!(
+        "verlet-debug-journal-turn-failed-{}",
+        uuid::Uuid::now_v7()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    let journal = root.join("session_history.turso");
+    let store = verlet_history_sqlite::SqliteSessionStore::open(&journal)
+        .await
+        .unwrap();
+    let coordinates = verlet_runtime_contracts::ThreadCoordinates::new("tenant", "user", "session");
+    store
+        .append_events(
+            &verlet_history::EventStreamId::for_thread(&coordinates),
+            vec![verlet_history::NewEventRecord::discharged(
+                coordinates,
+                verlet_history::EventKind::TurnFailed,
+                serde_json::to_value(verlet_history::TurnFailedPayload::new(
+                    "turn-1",
+                    verlet_history::TurnFailureErrorClass::ProviderHttp,
+                    Some("openai".to_string()),
+                    Some(503),
+                    "provider HTTP status 503",
+                    2,
+                ))
+                .unwrap(),
+                verlet_history::EventProvenance {
+                    discharged_by: Some("test:debug-journal".to_string()),
+                    function: Some("turn_fail/v1".to_string()),
+                    ..verlet_history::EventProvenance::default()
+                },
+            )],
+        )
+        .await
+        .unwrap();
+    drop(store);
+
+    let options = crate::cli::debug_journal::parse_debug_journal_args(vec![
+        "--kind".into(),
+        "turn.failed".into(),
+        "--journal".into(),
+        journal.clone().into_os_string(),
+    ])
+    .unwrap();
+    assert_eq!(options.kind, Some(verlet_history::EventKind::TurnFailed));
+    let records = crate::cli::debug_journal::load_debug_journal_direct(&journal, &options)
+        .await
+        .unwrap();
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].kind, verlet_history::EventKind::TurnFailed);
+    assert_eq!(records[0].payload["turn_id"], "turn-1");
+    let _ = std::fs::remove_dir_all(root);
+}

--- a/crates/verlet-kernel/src/daemon/recovery_sweep.rs
+++ b/crates/verlet-kernel/src/daemon/recovery_sweep.rs
@@ -333,6 +333,10 @@ pub(crate) fn project_child_terminal_record(
             verlet_history::ThreadTerminalState::Failed,
             Some("child thread failed"),
         ),
+        verlet_history::EventKind::TurnFailed => (
+            verlet_history::ThreadTerminalState::Failed,
+            Some("child turn failed"),
+        ),
         _ => return None,
     };
     Some(ChildTerminalTruth {
@@ -1188,6 +1192,34 @@ mod tests {
         )
         .await;
 
+        let failed_parent = coordinates("tenant", "user", "failed-parent");
+        let failed_child = coordinates("tenant", "user", "failed-child");
+        seed_thread_binding(&store, &failed_parent, &failed_child, "failed-dispatch").await;
+        store
+            .append_events(
+                &verlet_history::EventStreamId::for_thread(&failed_child),
+                vec![verlet_history::NewEventRecord::discharged(
+                    failed_child.clone(),
+                    verlet_history::EventKind::TurnFailed,
+                    serde_json::to_value(verlet_history::TurnFailedPayload::new(
+                        "thread-spawn-failed-dispatch",
+                        verlet_history::TurnFailureErrorClass::ProviderHttp,
+                        Some("openai".to_string()),
+                        Some(503),
+                        "provider HTTP status 503",
+                        2,
+                    ))
+                    .unwrap(),
+                    verlet_history::EventProvenance {
+                        discharged_by: Some("runtime:test-child".to_string()),
+                        function: Some("turn_fail/v1".to_string()),
+                        ..verlet_history::EventProvenance::default()
+                    },
+                )],
+            )
+            .await
+            .unwrap();
+
         let dead_parent = coordinates("tenant", "user", "dead-parent");
         let dead_child = coordinates("tenant", "user", "dead-child");
         seed_thread_binding(&store, &dead_parent, &dead_child, "dead-dispatch").await;
@@ -1210,7 +1242,7 @@ mod tests {
         assert_eq!(
             sweep.run_once().await.unwrap(),
             crate::daemon::recovery_sweep::StartupRecoveryReceipt {
-                thread_joins: 2,
+                thread_joins: 3,
                 process_outcomes: 0,
             }
         );
@@ -1237,6 +1269,16 @@ mod tests {
                 .result_digest
                 .as_deref()
                 .is_some_and(|reason| reason.contains("runtime death"))
+        );
+        let durable_failure = joined_payloads(&store, &failed_parent).await;
+        assert_eq!(durable_failure.len(), 1);
+        assert_eq!(
+            durable_failure[0].0.terminal_state,
+            verlet_history::ThreadTerminalState::Failed
+        );
+        assert_eq!(
+            durable_failure[0].0.result_digest.as_deref(),
+            Some("child turn failed")
         );
         assert!(joined_payloads(&store, &queued_parent).await.is_empty());
         assert_eq!(

--- a/crates/verlet-kernel/src/daemon/remote_store/process_executor.rs
+++ b/crates/verlet-kernel/src/daemon/remote_store/process_executor.rs
@@ -658,7 +658,8 @@ fn fold_remote_status(
         }
         verlet_history::EventKind::LoopDenied
         | verlet_history::EventKind::LoopBlocked
-        | verlet_history::EventKind::LoopBudgetExhausted => {
+        | verlet_history::EventKind::LoopBudgetExhausted
+        | verlet_history::EventKind::TurnFailed => {
             Some(verlet_runtime_contracts::ThreadStatus::Failed)
         }
         verlet_history::EventKind::TurnSubmitted => {
@@ -1245,9 +1246,27 @@ mod tests {
         );
     }
 
+    #[test]
+    fn turn_failed_folds_remote_status_to_failed() {
+        let request = request_fixture();
+        let record = child_record(
+            &request,
+            verlet_history::EventKind::TurnFailed,
+            "spawn-turn",
+        );
+        assert_eq!(
+            crate::daemon::remote_store::process_executor::fold_remote_status(&[record]),
+            Some(verlet_runtime_contracts::ThreadStatus::Failed)
+        );
+    }
+
     #[tokio::test]
     async fn spawn_turn_failure_terminals_settle_with_emo426_state_projection() {
         for (kind, expected) in [
+            (
+                verlet_history::EventKind::TurnFailed,
+                verlet_history::ThreadTerminalState::Failed,
+            ),
             (
                 verlet_history::EventKind::LoopDenied,
                 verlet_history::ThreadTerminalState::Failed,

--- a/crates/verlet-kernel/src/kernel/runtime_host/runtime_services.rs
+++ b/crates/verlet-kernel/src/kernel/runtime_host/runtime_services.rs
@@ -367,7 +367,7 @@ impl RuntimeServices {
         Ok(appended)
     }
 
-    async fn run_bound_couplings(
+    pub(crate) async fn run_bound_couplings(
         &self,
         appended: Vec<verlet_history::EventRecord>,
     ) -> crate::kernel::runtime_host::VerletResult<()> {

--- a/docs/format-ids.md
+++ b/docs/format-ids.md
@@ -7,7 +7,7 @@ stored data or change interface hashes, so they never rename.
 
 The frozen families are:
 
-- event vocabulary version `cooldis.events/0.4`, event payload schema IDs under
+- event vocabulary version `cooldis.events/0.5`, event payload schema IDs under
   `cooldis.event.*`, and the `cooldis.stream.*`, `cooldis.context.*`, and
   `cooldis.debug.*` schema-ID namespaces;
 - operation names recorded in receipts, including `cooldis.thread_spawn`,

--- a/scripts/verlet-name-allowlist.tsv
+++ b/scripts/verlet-name-allowlist.tsv
@@ -1,6 +1,6 @@
 # path	reason
 @source-pattern	cooldis\.events/0\.3	Frozen event-kind vocabulary version.
-@source-pattern	(^|[^[:alnum:]_.-])cooldis\.events/0\.4([^[:alnum:]_.-]|$)	Frozen event-kind vocabulary version.
+@source-pattern	(^|[^[:alnum:]_.-])cooldis\.events/0\.5([^[:alnum:]_.-]|$)	Frozen event-kind vocabulary version.
 @source-pattern	cooldis\.event\.	Frozen event payload schema-ID namespace.
 @source-pattern	cooldis\.stream\.	Frozen stream schema-ID namespace.
 @source-pattern	cooldis\.context\.[a-z0-9_.-]+/[0-9]+	Frozen context schema IDs.


### PR DESCRIPTION
Fixes EMO-616: a turn that died on a provider error left no trace in the event journal; the thread went to `systemError` with the cause visible only in the TUI. The journal is the product's truth story, so a terminal turn failure now leaves exactly one record.

## Changes

- New `turn.failed` event kind joins the turn lifecycle family (vocabulary bumped to `cooldis.events/0.5`, append-only; existing records decode unchanged).
- Bounded, body-free payload: turn id, closed error class (`provider_http`, `provider_transport`, `runner`, `internal`), optional provider id and HTTP status, message hard-truncated to 1024 bytes, retry count. Journal messages are static class summaries; detailed operator-facing errors are unchanged and no provider body, header, or credential text can enter the record.
- Anti-storm by contract: one event per failed turn, emitted at the terminal transition. A retried-then-successful turn journals nothing; routine interrupts and cancels journal nothing. Both are pinned by tests.
- Exactly-once under concurrency: the append is fenced against the stream tail, so recovery replay or concurrent actors converge on one durable event.
- Downstream projections recognize the event: startup recovery folds it to a Failed terminal state, remote status settles to Failed, and waiting-list projections close for failed turns.
- `verlet debug journal --kind turn.failed` works end to end against live and cold stores.

## Verification

Full nextest suite green (2619 passed), `scripts/verify.sh` and `scripts/verify-linux.sh` both green on this branch. Review pass found and fixed two High findings (exactly-once race, sensitive detail in journal messages) before this PR.
