### PR TITLE
Add amd64 release preflight lane (EMO-624)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,9 +211,10 @@ scripts/verify-linux.sh
 
 The default is native `linux/arm64` on Apple Silicon. It covers the Linux OS
 class of path, filesystem, glibc, epoll, signal, and timing bugs; CI's x86_64
-leg remains the architecture authority. Use `scripts/verify-linux.sh --amd64`
-only when reproducing an architecture-specific failure because emulation is
-substantially slower.
+leg remains the per-PR architecture backstop. The release preflight runs
+`scripts/verify-linux.sh --amd64` before tagging. Run that lane on demand for
+changes involving pointer width, atomics, SIMD, architecture-conditional
+dependencies, or Wasm runtime internals. Emulation is substantially slower.
 
 The first run downloads the Rust 1.97.1 Bookworm image (the stable toolchain
 used by CI when this lane was added), installs its toolchain, and builds the

--- a/docs/how-verlet-is-tested.md
+++ b/docs/how-verlet-is-tested.md
@@ -74,6 +74,14 @@ the suite, and environmental excuses are not accepted grounds for a red lane:
 the build system provides bounded, reproducible build lanes precisely so
 that "it failed for unrelated reasons" stops being an available sentence.
 
+The architecture matrix separates fast per-push feedback from slower local
+emulation. The local per-push gates run on macOS arm64 and Linux arm64. Every
+pull request runs the suite remotely on x86_64 Linux. A local x86_64 Linux run
+is also part of the default release preflight before tagging and is available
+on demand through `scripts/verify-linux.sh --amd64`. Run the on-demand lane for
+changes involving pointer width, atomics, SIMD, architecture-conditional
+dependencies, or Wasm runtime internals.
+
 ## The deterministic lane
 
 Concurrency bugs do not reproduce on demand, so a class of tests runs under

--- a/docs/how-verlet-is-tested.md
+++ b/docs/how-verlet-is-tested.md
@@ -74,13 +74,14 @@ the suite, and environmental excuses are not accepted grounds for a red lane:
 the build system provides bounded, reproducible build lanes precisely so
 that "it failed for unrelated reasons" stops being an available sentence.
 
-The architecture matrix separates fast per-push feedback from slower local
-emulation. The local per-push gates run on macOS arm64 and Linux arm64. Every
-pull request runs the suite remotely on x86_64 Linux. A local x86_64 Linux run
-is also part of the default release preflight before tagging and is available
-on demand through `scripts/verify-linux.sh --amd64`. Run the on-demand lane for
-changes involving pointer width, atomics, SIMD, architecture-conditional
-dependencies, or Wasm runtime internals.
+The architecture coverage separates fast routine feedback from slower local
+emulation. Local `scripts/verify.sh` runs natively on macOS arm64, and every
+pull request runs the suite remotely on x86_64 Linux. Linux arm64 is available
+locally through `scripts/verify-linux.sh` for OS-specific checks. A local
+x86_64 Linux run is also part of the default release preflight before tagging
+and is available on demand through `scripts/verify-linux.sh --amd64`. Run the
+on-demand lane for changes involving pointer width, atomics, SIMD,
+architecture-conditional dependencies, or Wasm runtime internals.
 
 ## The deterministic lane
 

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -164,12 +164,12 @@ Pull requests and pushes to `main` run `scripts/verify.sh`. The default CI lane
 checks formatting, runs the locked workspace test suite for all targets, and
 runs the virtual-bash and Wasm smoke binaries.
 
-The local per-push architecture matrix is macOS arm64 through
-`scripts/verify.sh` and Linux arm64 through `scripts/verify-linux.sh`. Every
-pull request also runs the suite remotely on x86_64 Linux. The local x86_64
-Linux lane runs by default during the release preflight before tagging and is
-available on demand with `scripts/verify-linux.sh --amd64`. Run the on-demand
-lane for changes involving pointer width, atomics, SIMD,
+Routine verification runs natively on macOS arm64 through `scripts/verify.sh`,
+and every pull request runs the suite remotely on x86_64 Linux. Linux arm64 is
+available locally through `scripts/verify-linux.sh` for OS-specific checks. The
+local x86_64 Linux lane runs by default during the release preflight before
+tagging and is available on demand with `scripts/verify-linux.sh --amd64`. Run
+the on-demand lane for changes involving pointer width, atomics, SIMD,
 architecture-conditional dependencies, or Wasm runtime internals.
 
 Two provider-backed lanes remain opt-in and are disabled in regular CI. Set

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -164,6 +164,14 @@ Pull requests and pushes to `main` run `scripts/verify.sh`. The default CI lane
 checks formatting, runs the locked workspace test suite for all targets, and
 runs the virtual-bash and Wasm smoke binaries.
 
+The local per-push architecture matrix is macOS arm64 through
+`scripts/verify.sh` and Linux arm64 through `scripts/verify-linux.sh`. Every
+pull request also runs the suite remotely on x86_64 Linux. The local x86_64
+Linux lane runs by default during the release preflight before tagging and is
+available on demand with `scripts/verify-linux.sh --amd64`. Run the on-demand
+lane for changes involving pointer width, atomics, SIMD,
+architecture-conditional dependencies, or Wasm runtime internals.
+
 Two provider-backed lanes remain opt-in and are disabled in regular CI. Set
 `VERLET_VERIFY_LIVE_PLUGIN=1` to run the live plugin smoke, or set
 `VERLET_VERIFY_LIVE_S3=1` to run the ignored real-S3 object-store test.

--- a/scripts/release-async-test.sh
+++ b/scripts/release-async-test.sh
@@ -2,8 +2,36 @@
 
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+SOURCE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/release-async-test.XXXXXX")"
+TMP_DIR="$(cd "$TMP_DIR" && pwd -P)"
+ROOT="$TMP_DIR/repo"
+FAKE_BIN="$TMP_DIR/bin"
+DOCKER_MARKER="$TMP_DIR/docker-called"
 FAILURES=0
+RUN_OUTPUT=
+RUN_STATUS=0
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$ROOT/scripts" "$FAKE_BIN"
+cp "$SOURCE_ROOT/Cargo.toml" "$ROOT/Cargo.toml"
+cp "$SOURCE_ROOT/scripts/check-release-tag.sh" \
+  "$SOURCE_ROOT/scripts/release-async.sh" \
+  "$SOURCE_ROOT/scripts/release-version.sh" \
+  "$ROOT/scripts/"
+printf 'fixture\n' >"$ROOT/tracked-marker"
+printf '#!/usr/bin/env bash\n: >%q\nexit 99\n' \
+  "$DOCKER_MARKER" >"$FAKE_BIN/docker"
+chmod +x "$FAKE_BIN/docker"
+git -C "$ROOT" init -q -b main
+git -C "$ROOT" add Cargo.toml scripts tracked-marker
+git -C "$ROOT" -c user.name=release-async-test \
+  -c user.email=release-async-test@example.invalid \
+  commit --no-gpg-sign -qm 'release async test fixture'
 
 source "$ROOT/scripts/release-version.sh"
 
@@ -32,25 +60,103 @@ assert_excludes() {
   fi
 }
 
+assert_status() {
+  local expected=$1
+  local name=$2
+
+  if ((RUN_STATUS != expected)); then
+    fail "$name (expected status $expected, got $RUN_STATUS)"
+    printf '%s\n' "$RUN_OUTPUT" >&2
+  fi
+}
+
+run_release() {
+  if RUN_OUTPUT="$(
+    PATH="$FAKE_BIN:$PATH" DOCKER_MARKER="$DOCKER_MARKER" \
+      "$ROOT/scripts/release-async.sh" "$@" 2>&1
+  )"; then
+    RUN_STATUS=0
+  else
+    RUN_STATUS=$?
+  fi
+}
+
 VERSION="$(read_verlet_workspace_version "$ROOT/Cargo.toml")"
 TAG="v$VERSION-emo-624-test"
 AMD64_STEP="$ROOT/scripts/verify-linux.sh --amd64"
+QUICK_PLAN='build and smoke the host-target release archive'
+FULL_PLAN="$ROOT/scripts/release-v1-candidate.sh"
+SKIP_PLAN='skip the package/full-gate preflight'
 
-default_output="$($ROOT/scripts/release-async.sh "$TAG" --dry-run)"
-assert_contains "$default_output" "$AMD64_STEP" \
-  'default dry run includes amd64 verification'
+assert_plan() {
+  local name=$1
+  local amd64=$2
+  local local_plan=$3
+  shift 3
 
-skip_amd64_output="$($ROOT/scripts/release-async.sh "$TAG" --dry-run --skip-amd64)"
-assert_excludes "$skip_amd64_output" "$AMD64_STEP" \
-  '--skip-amd64 suppresses amd64 verification'
+  run_release "$TAG" --dry-run "$@"
+  assert_status 0 "$name exits successfully"
+  if [[ "$amd64" == "1" ]]; then
+    assert_contains "$RUN_OUTPUT" "$AMD64_STEP" "$name includes amd64 verification"
+  else
+    assert_excludes "$RUN_OUTPUT" "$AMD64_STEP" "$name excludes amd64 verification"
+  fi
+  assert_contains "$RUN_OUTPUT" "$local_plan" "$name prints the local gate plan"
+  if [[ "$local_plan" != "$QUICK_PLAN" ]]; then
+    assert_excludes "$RUN_OUTPUT" "$QUICK_PLAN" "$name excludes the quick plan"
+  fi
+  if [[ "$local_plan" != "$FULL_PLAN" ]]; then
+    assert_excludes "$RUN_OUTPUT" "$FULL_PLAN" "$name excludes the full plan"
+  fi
+  if [[ "$local_plan" != "$SKIP_PLAN" ]]; then
+    assert_excludes "$RUN_OUTPUT" "$SKIP_PLAN" "$name excludes the skip plan"
+  fi
+}
 
-skip_local_output="$($ROOT/scripts/release-async.sh "$TAG" --dry-run --skip-local-gate)"
-assert_excludes "$skip_local_output" "$AMD64_STEP" \
-  '--skip-local-gate suppresses amd64 verification'
+assert_plan 'default dry run' 1 "$QUICK_PLAN"
+assert_plan 'full-gate dry run' 1 "$FULL_PLAN" --full-gate
+assert_plan 'skip-amd64 dry run' 0 "$QUICK_PLAN" --skip-amd64
+assert_plan 'skip-amd64 full-gate dry run' 0 "$FULL_PLAN" \
+  --skip-amd64 --full-gate
+assert_plan 'skip-local-gate dry run' 0 "$SKIP_PLAN" --skip-local-gate
+assert_plan 'skip-local-gate full-gate dry run' 0 "$SKIP_PLAN" \
+  --skip-local-gate --full-gate
+assert_plan 'both skips dry run' 0 "$SKIP_PLAN" \
+  --skip-amd64 --skip-local-gate
+assert_plan 'both skips full-gate dry run' 0 "$SKIP_PLAN" \
+  --skip-amd64 --skip-local-gate --full-gate
 
-help_output="$($ROOT/scripts/release-async.sh --help)"
-assert_contains "$help_output" '--skip-amd64' 'help names --skip-amd64'
-assert_contains "$help_output" 'x86_64 Linux' 'help names the amd64 lane'
+printf 'dirty\n' >>"$ROOT/tracked-marker"
+run_release "$TAG" --dry-run --skip-amd64
+assert_status 0 'dry run accepts a dirty worktree'
+assert_contains "$RUN_OUTPUT" 'would require a clean git worktree' \
+  'dirty dry run reports the real-run requirement'
+git -C "$ROOT" restore tracked-marker
+
+git -C "$ROOT" checkout --detach -q
+run_release "$TAG" --dry-run --skip-amd64
+assert_status 1 'detached dry run rejects an implicit branch push'
+assert_contains "$RUN_OUTPUT" '--no-push-main is required from a detached HEAD' \
+  'detached dry run explains the required opt-out'
+run_release "$TAG" --dry-run --skip-amd64 --no-push-main
+assert_status 0 'detached dry run accepts --no-push-main'
+assert_contains "$RUN_OUTPUT" 'without pushing a branch' \
+  'detached dry run prints the tag-only push plan'
+
+run_release --help
+assert_status 0 'help exits successfully'
+assert_contains "$RUN_OUTPUT" '--skip-amd64' 'help names --skip-amd64'
+assert_contains "$RUN_OUTPUT" 'x86_64 Linux' 'help names the amd64 lane'
+
+if git -C "$ROOT" rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+  fail 'dry runs do not create the synthetic tag'
+fi
+if [[ -e "$ROOT/dist" ]]; then
+  fail 'dry runs do not create dist output'
+fi
+if [[ -e "$DOCKER_MARKER" ]]; then
+  fail 'dry runs do not invoke Docker'
+fi
 
 if ((FAILURES > 0)); then
   printf 'release-async-test: %s failure(s)\n' "$FAILURES" >&2

--- a/scripts/release-async-test.sh
+++ b/scripts/release-async-test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+FAILURES=0
+
+source "$ROOT/scripts/release-version.sh"
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+assert_contains() {
+  local output=$1
+  local expected=$2
+  local name=$3
+
+  if [[ "$output" != *"$expected"* ]]; then
+    fail "$name"
+  fi
+}
+
+assert_excludes() {
+  local output=$1
+  local unexpected=$2
+  local name=$3
+
+  if [[ "$output" == *"$unexpected"* ]]; then
+    fail "$name"
+  fi
+}
+
+VERSION="$(read_verlet_workspace_version "$ROOT/Cargo.toml")"
+TAG="v$VERSION-emo-624-test"
+AMD64_STEP="$ROOT/scripts/verify-linux.sh --amd64"
+
+default_output="$($ROOT/scripts/release-async.sh "$TAG" --dry-run)"
+assert_contains "$default_output" "$AMD64_STEP" \
+  'default dry run includes amd64 verification'
+
+skip_amd64_output="$($ROOT/scripts/release-async.sh "$TAG" --dry-run --skip-amd64)"
+assert_excludes "$skip_amd64_output" "$AMD64_STEP" \
+  '--skip-amd64 suppresses amd64 verification'
+
+skip_local_output="$($ROOT/scripts/release-async.sh "$TAG" --dry-run --skip-local-gate)"
+assert_excludes "$skip_local_output" "$AMD64_STEP" \
+  '--skip-local-gate suppresses amd64 verification'
+
+help_output="$($ROOT/scripts/release-async.sh --help)"
+assert_contains "$help_output" '--skip-amd64' 'help names --skip-amd64'
+assert_contains "$help_output" 'x86_64 Linux' 'help names the amd64 lane'
+
+if ((FAILURES > 0)); then
+  printf 'release-async-test: %s failure(s)\n' "$FAILURES" >&2
+  exit 1
+fi
+
+printf 'release-async-test: ok\n'

--- a/scripts/release-async.sh
+++ b/scripts/release-async.sh
@@ -200,7 +200,20 @@ if [[ "$SKIP_LOCAL_GATE" != "1" && "$SKIP_AMD64" != "1" ]]; then
 fi
 
 if [[ "$DRY_RUN" == "1" ]]; then
-  printf '\nDry run only. Would run the local release preflight, ensure tag %s at HEAD, then push to %s.\n' "$TAG" "$REMOTE"
+  if [[ "$SKIP_LOCAL_GATE" == "1" ]]; then
+    LOCAL_PREFLIGHT_PLAN="skip the package/full-gate preflight"
+  elif [[ "$FULL_GATE" == "1" ]]; then
+    LOCAL_PREFLIGHT_PLAN="run $ROOT/scripts/release-v1-candidate.sh"
+  else
+    LOCAL_PREFLIGHT_PLAN="build and smoke the host-target release archive"
+  fi
+  if [[ "$PUSH_MAIN" == "1" ]]; then
+    PUSH_PLAN="push branch $BRANCH and tag $TAG to $REMOTE"
+  else
+    PUSH_PLAN="push tag $TAG to $REMOTE without pushing a branch"
+  fi
+  printf '\nDry run only. Would %s, ensure tag %s at HEAD, then %s.\n' \
+    "$LOCAL_PREFLIGHT_PLAN" "$TAG" "$PUSH_PLAN"
   exit 0
 fi
 

--- a/scripts/release-async.sh
+++ b/scripts/release-async.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REMOTE="origin"
 FULL_GATE=0
 SKIP_LOCAL_GATE=0
+SKIP_AMD64=0
 DRY_RUN=0
 PUSH_MAIN=1
 
@@ -17,7 +18,8 @@ Usage:
 
 Options:
   --full-gate         Run scripts/release-v1-candidate.sh instead of the quick package smoke.
-  --skip-local-gate   Skip the local package/full-gate preflight.
+  --skip-local-gate   Skip the package/full-gate and x86_64 Linux preflight steps.
+  --skip-amd64        Skip the x86_64 Linux verification step.
   --no-push-main      Push only the tag, not the current branch.
   --remote NAME       Git remote to push. Default: origin.
   --dry-run           Print the actions without creating or pushing a tag.
@@ -25,11 +27,12 @@ Options:
 
 Default flow:
   1. Validate the release tag against crates/verlet-kernel/Cargo.toml.
-  2. Build the host-target release archive locally.
-  3. Smoke the archive and local installer.
-  4. Create an annotated tag at HEAD if it does not already exist.
-  5. Push the current branch and tag.
-  6. Print the GitHub Release workflow URL and exit without watching.
+  2. Run the full verification suite on x86_64 Linux.
+  3. Build the host-target release archive locally.
+  4. Smoke the archive and local installer.
+  5. Create an annotated tag at HEAD if it does not already exist.
+  6. Push the current branch and tag.
+  7. Print the GitHub Release workflow URL and exit without watching.
 
 Before tagging, refresh the checked-in models.dev catalog snapshot with
 scripts/update-model-catalog.sh and review the diff by hand: catalog base
@@ -130,6 +133,10 @@ while [[ $# -gt 0 ]]; do
       SKIP_LOCAL_GATE=1
       shift
       ;;
+    --skip-amd64)
+      SKIP_AMD64=1
+      shift
+      ;;
     --no-push-main)
       PUSH_MAIN=0
       shift
@@ -186,6 +193,10 @@ HEAD_SHA="$(git rev-parse HEAD)"
 BRANCH="$(git symbolic-ref --quiet --short HEAD || true)"
 if [[ "$PUSH_MAIN" == "1" && -z "$BRANCH" ]]; then
   die "--no-push-main is required from a detached HEAD"
+fi
+
+if [[ "$SKIP_LOCAL_GATE" != "1" && "$SKIP_AMD64" != "1" ]]; then
+  run "$ROOT/scripts/verify-linux.sh" --amd64
 fi
 
 if [[ "$DRY_RUN" == "1" ]]; then


### PR DESCRIPTION
Adds the x86_64 Linux verification lane to the release preflight (EMO-624).

`scripts/release-async.sh` now runs `scripts/verify-linux.sh --amd64` by default before any archive work, so no release tags without a green x86_64 Linux suite. `--skip-amd64` opts out explicitly and `--skip-local-gate` skips it along with the rest of the preflight. The dry-run plan prints the exact steps the chosen flags would run.

Background: the EMO-622 PR was blocked twice by an x86_64-only CI timeout while every local gate was green, because local verification covers macOS arm64 and Linux arm64 only. This makes the release the checkpoint where x86_64 gets a local pass; per-PR x86_64 coverage stays with remote CI.

A new focused `scripts/release-async-test.sh` pins the dry-run and skip-flag contract (all flag combinations, dirty-worktree and detached-HEAD cases, no tags or dist output left behind). Docs now state the architecture coverage plainly and name the on-demand triggers for the amd64 lane (pointer width, atomics, SIMD, arch-conditional dependencies, wasm runtime internals).

Verification: `scripts/release-async-test.sh` and `scripts/verify-linux-test.sh` green; one real `scripts/verify-linux.sh --amd64` run green (1368 tests plus both smokes) with the container cache confirmed keyed by host triple, so arm64 and amd64 lanes coexist.
