### PR TITLE
docs: point release scripts and RELEASE.md at the verlet-kernel repository

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,13 +41,13 @@ links the binaries into `~/.local/bin`.
 Install the latest stable release:
 
 ```sh
-curl -fsSL https://github.com/emotionscientific/cooldis-kernel/releases/latest/download/install.sh | sh
+curl -fsSL https://github.com/emotionscientific/verlet-kernel/releases/latest/download/install.sh | sh
 ```
 
 Install a release candidate directly:
 
 ```sh
-curl -fsSL https://github.com/emotionscientific/cooldis-kernel/releases/download/v0.1.0-rc.N/install.sh \
+curl -fsSL https://github.com/emotionscientific/verlet-kernel/releases/download/v0.1.0-rc.N/install.sh \
   | sh -s -- --version 0.1.0-rc.N
 ```
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-REPO="${VERLET_REPO:-emotionscientific/cooldis-kernel}"
+REPO="${VERLET_REPO:-emotionscientific/verlet-kernel}"
 VERSION="${VERLET_VERSION:-}"
 TARGET="${VERLET_TARGET:-}"
 BASE_URL="${VERLET_BASE_URL:-}"
@@ -18,12 +18,12 @@ install.sh - install or update the Verlet CLI/kernel runtime.
 
 Usage:
   sh install.sh [options]
-  curl -fsSL https://github.com/emotionscientific/cooldis-kernel/releases/latest/download/install.sh | sh
+  curl -fsSL https://github.com/emotionscientific/verlet-kernel/releases/latest/download/install.sh | sh
 
 Options:
   --version VERSION       Install a specific release version, for example 0.1.0.
   --target TARGET         Override target triple detection.
-  --repo OWNER/REPO       GitHub repository. Default: emotionscientific/cooldis-kernel.
+  --repo OWNER/REPO       GitHub repository. Default: emotionscientific/verlet-kernel.
   --base-url URL          Release asset base URL.
   --install-root DIR      Versioned install root. Default: ~/.verlet.
   --bin-dir DIR           Symlink directory. Default: ~/.local/bin.

--- a/scripts/release-async.sh
+++ b/scripts/release-async.sh
@@ -89,7 +89,7 @@ print_release_run_url() {
 
   if ! command -v gh >/dev/null 2>&1; then
     printf '\nRelease workflow:\n'
-    printf '  https://github.com/emotionscientific/cooldis-kernel/actions/workflows/release.yml\n'
+    printf '  https://github.com/emotionscientific/verlet-kernel/actions/workflows/release.yml\n'
     return 0
   fi
 
@@ -116,7 +116,7 @@ print_release_run_url() {
     printf '  %s\n' "$url"
   else
     printf '\nRelease workflow should start shortly:\n'
-    printf '  https://github.com/emotionscientific/cooldis-kernel/actions/workflows/release.yml\n'
+    printf '  https://github.com/emotionscientific/verlet-kernel/actions/workflows/release.yml\n'
     printf 'Check with:\n'
     printf '  gh run list --workflow Release --commit %s --limit 5\n' "$head_sha"
   fi

--- a/scripts/verlet-name-allowlist.tsv
+++ b/scripts/verlet-name-allowlist.tsv
@@ -27,7 +27,6 @@
 .github/CODEOWNERS	Repository remote site or external workflow identity is out of scope for EMO-520.
 .github/ISSUE_TEMPLATE/config.yml	Repository remote site or external workflow identity is out of scope for EMO-520.
 CHANGELOG.md	Rename and deprecation-window receipt for v0.3.0.
-RELEASE.md	Repository remote site or external workflow identity is out of scope for EMO-520.
 agent-tools/pi-kit/edit/verlet.tool.toml	Frozen tool-package format ID required by the fixed Pi kit manifest.
 agent-tools/pi-kit/read/verlet.tool.toml	Frozen tool-package format ID required by the fixed Pi kit manifest.
 agent-tools/pi-kit/search/verlet.tool.toml	Frozen tool-package format ID required by the fixed Pi kit manifest.
@@ -175,10 +174,7 @@ examples/wasm-counter-coupling/src/lib.rs	Example or package contract preserves 
 mkdocs.yml	Repository remote site or external workflow identity is out of scope for EMO-520.
 proto/verlet.bridge.v1.proto	Stable persisted storage ABI or wire identifier remains unchanged for compatibility.
 scripts/ci-receipts.sh	Shipped release receipt filenames remain historical.
-scripts/install.sh	Repository remote identity remains load-bearing.
 scripts/verlet-name-allowlist.tsv	The lint's own closed list necessarily spells the frozen identifiers it permits.
-scripts/release-async.sh	Repository remote site or external workflow identity is out of scope for EMO-520.
-scripts/write-release-manifest.sh	Repository remote site or external workflow identity is out of scope for EMO-520.
 skills/verlet-tool-maker/SKILL.md	Example or package contract preserves a stable ABI manifest or receipt identifier.
 tools/file-read/verlet.tool.toml	Example or package contract preserves a stable ABI manifest or receipt identifier.
 tools/http-fetch/verlet.tool.toml	Example or package contract preserves a stable ABI manifest or receipt identifier.

--- a/scripts/write-release-manifest.sh
+++ b/scripts/write-release-manifest.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_DIR="${VERLET_RELEASE_OUT_DIR:-$ROOT/dist}"
-REPO="${GITHUB_REPOSITORY:-emotionscientific/cooldis-kernel}"
+REPO="${GITHUB_REPOSITORY:-emotionscientific/verlet-kernel}"
 TAG="${GITHUB_REF_NAME:-}"
 CHANNEL="${VERLET_RELEASE_CHANNEL:-stable}"
 BASE_URL=""


### PR DESCRIPTION
The release scripts, the install script's default repo, and the RELEASE.md curl examples still named emotionscientific/cooldis-kernel. The GitHub redirect masked it. The four files leave the name-lint allowlist since they no longer carry the old name. Dated ADRs keep their historical names on purpose.