### PR TITLE
Name the release test's bare remote branch so clones can push main

### DIFF
--- a/scripts/release-test.sh
+++ b/scripts/release-test.sh
@@ -466,7 +466,7 @@ EOF
   git -C "$ROOT" add .
   git -C "$ROOT" commit --no-gpg-sign -qm 'fixture release state'
   git -C "$ROOT" tag v0.5.1
-  git init -q --bare "$REMOTE_REPO"
+  git init -q --bare -b main "$REMOTE_REPO"
   git -C "$ROOT" remote add origin "$REMOTE_REPO"
   git -C "$ROOT" push -q -u origin main --tags
 


### PR DESCRIPTION
Fixes the red script-tests job on main after #168.

The release test created its bare remote with no branch name, so on a runner without a global git config the remote HEAD pointed at a nonexistent `master`, clones of it had no `main`, and four fixtures failed with "src refspec main does not match any". The bare remote is now created with `-b main`. Reproduced and verified locally with `GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null`.
